### PR TITLE
feat: pipeline-first project UX + issue-provenance and planning-checks fixes

### DIFF
--- a/apps/web/app/(app)/(org)/harness/page.tsx
+++ b/apps/web/app/(app)/(org)/harness/page.tsx
@@ -3,7 +3,7 @@ import { HarnessList } from "@/components/harness/harness-list";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { api } from "@/lib/api";
 
-export const metadata = { title: "harness" };
+export const metadata = { title: "skills & rules" };
 
 const KINDS = [
   "skill",
@@ -39,8 +39,10 @@ export default async function HarnessPage({
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col gap-2">
-        <Eyebrow>harness</Eyebrow>
-        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Harness</h1>
+        <Eyebrow>skills &amp; rules</Eyebrow>
+        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">
+          Skills &amp; Rules
+        </h1>
         <p className="text-[12.5px] text-(--dim)">
           {items.length} published item{items.length === 1 ? "" : "s"}
           {kind ? ` · ${kind.replace("_", " ")}` : ""} · immutable once published

--- a/apps/web/app/(app)/(org)/inbox/page.tsx
+++ b/apps/web/app/(app)/(org)/inbox/page.tsx
@@ -6,7 +6,7 @@ import { ErrorNotice, Offline } from "@/components/offline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api, type Outcome } from "@/lib/api";
 
-export const metadata = { title: "inbox" };
+export const metadata = { title: "approvals" };
 
 function fmtAgo(iso: string | null) {
   if (!iso) return "—";
@@ -46,8 +46,8 @@ export default async function InboxPage({
     <div className="flex flex-col gap-8">
       <LiveRefresh seconds={30} />
       <div className="flex flex-col gap-2">
-        <Eyebrow>inbox</Eyebrow>
-        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Inbox</h1>
+        <Eyebrow>approvals</Eyebrow>
+        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Approvals</h1>
         <p className="text-[12.5px] text-(--dim)">
           {proposals.length} gate{proposals.length === 1 ? "" : "s"} · {openPrs.length} PR
           {openPrs.length === 1 ? "" : "s"} to review · {issues.length} issue

--- a/apps/web/app/(app)/(org)/projects/page.tsx
+++ b/apps/web/app/(app)/(org)/projects/page.tsx
@@ -3,8 +3,9 @@ import Link from "next/link";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { PipelineStrip } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
-import { api, type Issue, type Proposal, summarizeSpend, untypedApi } from "@/lib/api";
-import { classifyPipeline, type PipelineIssue } from "@/lib/pipeline";
+import { api, type Issue, type Proposal, summarizeSpend } from "@/lib/api";
+import { classifyPipeline } from "@/lib/pipeline";
+import { fetchAllProjectIssues } from "@/lib/project-issues";
 import { fetchAllRuns, fmtAgo, fmtCost, type RunWithProject } from "@/lib/runs";
 import { ProjectsTabs } from "./tabs";
 
@@ -109,16 +110,13 @@ export default async function ProjectsPage() {
   ]);
   if (offline) return <Offline />;
 
-  // One issues-mirror call per project — fine at dashboard scale; an aggregate
-  // endpoint is the upstream ask if this ever lists dozens of projects.
+  // One paged issues-mirror sweep per project — fine at dashboard scale; an
+  // aggregate endpoint is the upstream ask if this ever lists dozens of projects.
   const issuesByProject = new Map(
     await Promise.all(
       projects.map(async (project) => {
-        const res = await untypedApi<{ items: PipelineIssue[] }>(
-          "GET",
-          `/v1/projects/${project.id}/issues?state=all`,
-        );
-        return [project.id, res.ok ? res.data.items : []] as const;
+        const res = await fetchAllProjectIssues(project.id);
+        return [project.id, res.ok ? res.items : []] as const;
       }),
     ),
   );

--- a/apps/web/app/(app)/(org)/projects/page.tsx
+++ b/apps/web/app/(app)/(org)/projects/page.tsx
@@ -1,41 +1,136 @@
-import { ButtonLink, Cell, Eyebrow, HairlineGrid, Metric, PillTag, StatusDot } from "@facility/ui";
+import { ButtonLink, Cell, Eyebrow, HairlineGrid, PillTag, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { PipelineStrip } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
-import { api, summarizeSpend } from "@/lib/api";
-import { fetchAllRuns, fmtCost } from "@/lib/runs";
+import { api, type Issue, type Proposal, summarizeSpend, untypedApi } from "@/lib/api";
+import { classifyPipeline, type PipelineIssue } from "@/lib/pipeline";
+import { fetchAllRuns, fmtAgo, fmtCost, type RunWithProject } from "@/lib/runs";
+import { ProjectsTabs } from "./tabs";
 
 export const metadata = { title: "projects" };
 
 const LIVE = new Set(["queued", "provisioning", "running"]);
-const DASH = "—";
+const TERMINAL = new Set(["succeeded", "failed", "cancelled"]);
+
+/** Human phrasing for the newest decision waiting on a project, with its age. */
+function decisionLabel(proposal: Proposal): string {
+  const issue = (proposal.payload as { issueNumber?: number } | null)?.issueNumber;
+  const where = issue ? ` — issue #${issue}` : "";
+  const age = proposal.createdAt ? ` · waiting ${fmtAgo(proposal.createdAt)}` : "";
+  switch (proposal.actionType) {
+    case "plan_acceptance":
+      return `Plan waiting for your approval${where}${age}`;
+    default:
+      return `${proposal.actionType.replaceAll("_", " ")} waiting on you${where}${age}`;
+  }
+}
+
+type ProjectPulse = {
+  needsYou: number;
+  decision: string | null;
+  liveModes: string[];
+  lastAt: string | null;
+  lastFailed: string | null;
+};
+
+function pulseFor(
+  projectId: string,
+  runs: RunWithProject[],
+  proposals: Proposal[],
+  issues: Issue[],
+): ProjectPulse {
+  const mine = runs.filter((r) => r.project.id === projectId);
+  const liveModes = mine.filter((r) => LIVE.has(r.status)).map((r) => r.mode);
+  const blocked = mine.filter((r) => r.status === "awaiting_human");
+  const myProposals = proposals.filter((p) => p.projectId === projectId);
+  const myIssues = issues.filter((i) => i.projectId === projectId);
+  const newest = [...mine].sort((a, b) => (b.createdAt ?? "").localeCompare(a.createdAt ?? ""))[0];
+  const newestTerminal = [...mine]
+    .filter((r) => TERMINAL.has(r.status))
+    .sort((a, b) => (b.createdAt ?? "").localeCompare(a.createdAt ?? ""))[0];
+  const newestProposal = [...myProposals].sort((a, b) =>
+    (b.createdAt ?? "").localeCompare(a.createdAt ?? ""),
+  )[0];
+  return {
+    needsYou: myProposals.length + myIssues.length + blocked.length,
+    decision: newestProposal ? decisionLabel(newestProposal) : null,
+    liveModes,
+    lastAt: newest?.createdAt ?? null,
+    lastFailed: newestTerminal?.status === "failed" ? newestTerminal.mode : null,
+  };
+}
+
+function PulseLines({ pulse }: { pulse: ProjectPulse }) {
+  const lines: React.ReactNode[] = [];
+  if (pulse.needsYou > 0) {
+    lines.push(
+      <span key="needs" className="inline-flex items-center gap-1.5 text-(--human)">
+        <StatusDot tone="human" />
+        {pulse.decision ?? `${pulse.needsYou} decisions waiting on you`}
+      </span>,
+    );
+  }
+  if (pulse.liveModes.length > 0) {
+    const label =
+      pulse.liveModes.length === 1
+        ? `${pulse.liveModes[0]} working now`
+        : `${pulse.liveModes.length} agents working now`;
+    lines.push(
+      <span key="live" className="inline-flex items-center gap-1.5 text-(--mut)">
+        <StatusDot tone="agent" pulse />
+        {label}
+      </span>,
+    );
+  } else if (pulse.lastFailed && lines.length < 2) {
+    lines.push(
+      <span key="failed" className="inline-flex items-center gap-1.5 text-(--mut)">
+        <StatusDot tone="bad" />
+        last {pulse.lastFailed} run failed
+      </span>,
+    );
+  }
+  if (lines.length === 0) {
+    lines.push(
+      <span key="idle" className="inline-flex items-center gap-1.5 text-(--dim)">
+        <StatusDot tone="machine" />
+        {pulse.lastAt ? `quiet · last activity ${fmtAgo(pulse.lastAt)}` : "no agent runs yet"}
+      </span>,
+    );
+  }
+  return <div className="flex flex-col gap-2 text-[12px] font-medium">{lines.slice(0, 2)}</div>;
+}
 
 export default async function ProjectsPage() {
-  const [{ offline, error: runsError, projects, runs }, spend, inbox, overview] = await Promise.all(
-    [fetchAllRuns(), api.spend("?groupBy=day"), api.inboxFull(), api.analyticsOverview()],
-  );
+  const [{ offline, error: runsError, projects, runs }, spend, inbox] = await Promise.all([
+    fetchAllRuns(),
+    api.spend("?groupBy=day"),
+    api.inboxFull(),
+  ]);
   if (offline) return <Offline />;
 
-  const liveByProject = new Map<string, number>();
-  const blockedByProject = new Map<string, number>();
-  for (const run of runs) {
-    if (LIVE.has(run.status)) {
-      liveByProject.set(run.project.id, (liveByProject.get(run.project.id) ?? 0) + 1);
-    }
-    if (run.status === "awaiting_human") {
-      blockedByProject.set(run.project.id, (blockedByProject.get(run.project.id) ?? 0) + 1);
-    }
-  }
-  const liveTotal = [...liveByProject.values()].reduce((a, b) => a + b, 0);
+  // One issues-mirror call per project — fine at dashboard scale; an aggregate
+  // endpoint is the upstream ask if this ever lists dozens of projects.
+  const issuesByProject = new Map(
+    await Promise.all(
+      projects.map(async (project) => {
+        const res = await untypedApi<{ items: PipelineIssue[] }>(
+          "GET",
+          `/v1/projects/${project.id}/issues?state=all`,
+        );
+        return [project.id, res.ok ? res.data.items : []] as const;
+      }),
+    ),
+  );
+
+  const proposals = inbox.ok ? inbox.data.proposals : [];
+  const inboxIssues = inbox.ok ? inbox.data.issues : [];
+  const liveTotal = runs.filter((r) => LIVE.has(r.status)).length;
   const needsYou =
-    (inbox.ok ? inbox.data.proposals.length + inbox.data.issues.length : 0) +
-    [...blockedByProject.values()].reduce((a, b) => a + b, 0);
+    proposals.length +
+    inboxIssues.length +
+    runs.filter((r) => r.status === "awaiting_human").length;
   const monthCents = spend.ok ? summarizeSpend(spend.data).totalCents : null;
-  const outcomeTotals = overview.ok ? overview.data.outcomes30d : null;
-  const evidenceCoverage =
-    outcomeTotals && outcomeTotals.total > 0
-      ? Math.round((100 * outcomeTotals.assessed) / outcomeTotals.total)
-      : null;
 
   return (
     <div className="flex flex-col gap-8">
@@ -56,64 +151,9 @@ export default async function ProjectsPage() {
         </ButtonLink>
       </div>
 
-      {runsError ? <ErrorNotice message={`Couldn't load sessions — ${runsError}`} /> : null}
-      {!overview.ok ? (
-        <ErrorNotice message={`Couldn't load outcomes — ${overview.message}`} />
-      ) : null}
+      <ProjectsTabs />
 
-      <section className="flex flex-col gap-4">
-        <Eyebrow>outcomes · 30 days</Eyebrow>
-        <HairlineGrid cols="grid-cols-2 lg:grid-cols-4">
-          <Cell>
-            <Metric
-              label="acceptance"
-              value={
-                overview.ok && overview.data.acceptance30d != null
-                  ? `${overview.data.acceptance30d}%`
-                  : DASH
-              }
-              hint={
-                outcomeTotals
-                  ? `${outcomeTotals.accepted}/${outcomeTotals.assessed} assessed PRs accepted`
-                  : "outcomes didn't load"
-              }
-            />
-          </Cell>
-          <Cell>
-            <Metric
-              label="evidence coverage"
-              value={evidenceCoverage == null ? DASH : `${evidenceCoverage}%`}
-              hint={
-                outcomeTotals
-                  ? `${outcomeTotals.assessed}/${outcomeTotals.total} terminal agent PRs assessed`
-                  : "outcomes didn't load"
-              }
-            />
-          </Cell>
-          <Cell>
-            <Metric
-              label="one-shot"
-              value={
-                overview.ok && overview.data.oneShot30d != null
-                  ? `${overview.data.oneShot30d}%`
-                  : DASH
-              }
-              hint={
-                outcomeTotals
-                  ? `${outcomeTotals.oneShot}/${outcomeTotals.merged} merged PRs`
-                  : "outcomes didn't load"
-              }
-            />
-          </Cell>
-          <Cell>
-            <Metric
-              label="accepted"
-              value={outcomeTotals?.accepted ?? DASH}
-              hint={outcomeTotals ? `${outcomeTotals.merged} merged` : "outcomes didn't load"}
-            />
-          </Cell>
-        </HairlineGrid>
-      </section>
+      {runsError ? <ErrorNotice message={`Couldn't load sessions — ${runsError}`} /> : null}
 
       {projects.length === 0 ? (
         <p className="max-w-lg text-sm leading-relaxed text-(--dim)">
@@ -121,39 +161,40 @@ export default async function ProjectsPage() {
           factory — workflows, guards, skills, the standard.
         </p>
       ) : (
-        <HairlineGrid cols="sm:grid-cols-2 lg:grid-cols-3">
+        <HairlineGrid cols="sm:grid-cols-2">
           {projects.map((project) => {
-            const live = liveByProject.get(project.id) ?? 0;
-            const blocked = blockedByProject.get(project.id) ?? 0;
+            const pulse = pulseFor(project.id, runs, proposals, inboxIssues);
+            const stages = classifyPipeline(
+              issuesByProject.get(project.id) ?? [],
+              proposals.filter((x) => x.projectId === project.id),
+            );
             return (
               <Cell key={project.id} interactive className="p-0">
                 <Link
                   href={`/projects/${project.id}`}
                   className="flex h-full flex-col gap-4 p-6 sm:p-8"
                 >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="font-mono text-[14px] font-medium text-(--ink)">
-                      {project.slug}
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="flex min-w-0 flex-col gap-0.5">
+                      <span className="truncate text-[15px] font-semibold tracking-tight text-(--ink)">
+                        {project.name}
+                      </span>
+                      <span className="truncate font-mono text-[11px] text-(--dim)">
+                        {project.slug}
+                      </span>
                     </span>
                     {project.status === "archived" ? <PillTag>archived</PillTag> : null}
                   </div>
                   <p className="line-clamp-2 flex-1 text-[13px] leading-relaxed text-(--mut)">
                     {project.description ?? "—"}
                   </p>
-                  <div className="flex items-center gap-4 text-[11px] font-medium">
-                    <span className="inline-flex items-center gap-1.5 text-(--mut)">
-                      <StatusDot tone={live > 0 ? "agent" : "machine"} pulse={live > 0} />
-                      {live} live
-                    </span>
-                    {blocked > 0 ? (
-                      <span className="inline-flex items-center gap-1.5 text-(--human)">
-                        <StatusDot tone="human" />
-                        {blocked} blocked
-                      </span>
-                    ) : null}
-                    <span className="ml-auto text-(--dim)">
-                      {project.systemVersion ?? "unpinned"}
-                    </span>
+                  <PulseLines pulse={pulse} />
+                  <div className="border-t border-(--line) pt-3">
+                    <PipelineStrip stages={stages} />
+                  </div>
+                  <div className="flex items-center justify-between text-[11px] text-(--dim)">
+                    <span>{pulse.lastAt ? `last activity ${fmtAgo(pulse.lastAt)}` : " "}</span>
+                    <span>{project.systemVersion ?? "unpinned"}</span>
                   </div>
                 </Link>
               </Cell>

--- a/apps/web/app/(app)/(org)/projects/stats/page.tsx
+++ b/apps/web/app/(app)/(org)/projects/stats/page.tsx
@@ -1,0 +1,106 @@
+import { Cell, Eyebrow, HairlineGrid, Metric } from "@facility/ui";
+import { ErrorNotice } from "@/components/offline";
+import { LiveRefresh } from "@/components/shell/live-refresh";
+import { api, summarizeSpend } from "@/lib/api";
+import { fmtCost } from "@/lib/runs";
+import { ProjectsTabs } from "../tabs";
+
+export const metadata = { title: "stats" };
+
+const DASH = "—";
+
+export default async function ProjectsStatsPage() {
+  const [overview, spend] = await Promise.all([api.analyticsOverview(), api.spend("?groupBy=day")]);
+  const outcomeTotals = overview.ok ? overview.data.outcomes30d : null;
+  const evidenceCoverage =
+    outcomeTotals && outcomeTotals.total > 0
+      ? Math.round((100 * outcomeTotals.assessed) / outcomeTotals.total)
+      : null;
+  const monthCents = spend.ok ? summarizeSpend(spend.data).totalCents : null;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <LiveRefresh seconds={60} />
+      <div className="flex flex-col gap-2">
+        <Eyebrow>projects</Eyebrow>
+        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Stats</h1>
+        <p className="text-[12.5px] text-(--dim)">
+          Delivery outcomes across every project, last 30 days.
+        </p>
+      </div>
+
+      <ProjectsTabs />
+
+      {!overview.ok ? (
+        <ErrorNotice message={`Couldn't load outcomes — ${overview.message}`} />
+      ) : null}
+
+      <section className="flex flex-col gap-4">
+        <Eyebrow>outcomes · 30 days</Eyebrow>
+        <HairlineGrid cols="grid-cols-2 lg:grid-cols-4">
+          <Cell>
+            <Metric
+              label="acceptance"
+              value={
+                overview.ok && overview.data.acceptance30d != null
+                  ? `${overview.data.acceptance30d}%`
+                  : DASH
+              }
+              hint={
+                outcomeTotals
+                  ? `${outcomeTotals.accepted}/${outcomeTotals.assessed} assessed PRs accepted`
+                  : "outcomes didn't load"
+              }
+            />
+          </Cell>
+          <Cell>
+            <Metric
+              label="evidence coverage"
+              value={evidenceCoverage == null ? DASH : `${evidenceCoverage}%`}
+              hint={
+                outcomeTotals
+                  ? `${outcomeTotals.assessed}/${outcomeTotals.total} terminal agent PRs assessed`
+                  : "outcomes didn't load"
+              }
+            />
+          </Cell>
+          <Cell>
+            <Metric
+              label="one-shot"
+              value={
+                overview.ok && overview.data.oneShot30d != null
+                  ? `${overview.data.oneShot30d}%`
+                  : DASH
+              }
+              hint={
+                outcomeTotals
+                  ? `${outcomeTotals.oneShot}/${outcomeTotals.merged} merged PRs`
+                  : "outcomes didn't load"
+              }
+            />
+          </Cell>
+          <Cell>
+            <Metric
+              label="accepted"
+              value={outcomeTotals?.accepted ?? DASH}
+              hint={outcomeTotals ? `${outcomeTotals.merged} merged` : "outcomes didn't load"}
+            />
+          </Cell>
+        </HairlineGrid>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <Eyebrow>spend · month to date</Eyebrow>
+        <HairlineGrid cols="grid-cols-2 lg:grid-cols-4">
+          <Cell>
+            <Metric
+              label="model spend"
+              value={monthCents != null ? fmtCost(monthCents) : DASH}
+              hint="all projects, all agents"
+            />
+          </Cell>
+        </HairlineGrid>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/(org)/projects/tabs.tsx
+++ b/apps/web/app/(app)/(org)/projects/tabs.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { cx } from "@facility/ui";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { href: "/projects", label: "Projects" },
+  { href: "/projects/stats", label: "Stats" },
+];
+
+export function ProjectsTabs() {
+  const pathname = usePathname();
+  return (
+    <nav aria-label="Projects sections" className="flex gap-6 border-b border-(--line)">
+      {TABS.map((tab) => {
+        const active = pathname === tab.href;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={active ? "page" : undefined}
+            className={cx(
+              "-mb-px border-b-2 pb-2.5 text-[13px] transition-colors",
+              active
+                ? "border-(--line-strong) font-medium text-(--ink)"
+                : "border-transparent text-(--mut) hover:text-(--ink)",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/app/(app)/(org)/sessions/page.tsx
+++ b/apps/web/app/(app)/(org)/sessions/page.tsx
@@ -5,7 +5,7 @@ import { LiveRefresh } from "@/components/shell/live-refresh";
 import { fetchAllRuns } from "@/lib/runs";
 import { toSessionRows } from "@/lib/session-rows";
 
-export const metadata = { title: "fleet" };
+export const metadata = { title: "activity" };
 
 const LIVE = new Set(["queued", "provisioning", "running", "awaiting_human"]);
 
@@ -21,8 +21,8 @@ export default async function FleetPage() {
     <div className="flex flex-col gap-8">
       <LiveRefresh seconds={20} />
       <div className="flex flex-col gap-2">
-        <Eyebrow>fleet</Eyebrow>
-        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Sessions</h1>
+        <Eyebrow>activity</Eyebrow>
+        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Activity</h1>
         <p className="text-[12.5px] text-(--dim)">
           {live} live across the org · {rows.length} recorded
         </p>

--- a/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
@@ -1,13 +1,19 @@
-import { Eyebrow, PillTag } from "@facility/ui";
+import { cx, Eyebrow, StatusDot } from "@facility/ui";
 import Link from "next/link";
-import { IssueList } from "@/components/issues/issue-list";
 import type { GhIssue } from "@/components/issues/issue-row";
+import { IssueRow } from "@/components/issues/issue-row";
 import { SyncIssuesButton } from "@/components/issues/sync-button";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api, untypedApi } from "@/lib/api";
+import {
+  classifyPipeline,
+  PIPELINE_STAGES,
+  type PipelineStage,
+  pipelineCounts,
+} from "@/lib/pipeline";
 
-export const metadata = { title: "issues" };
+export const metadata = { title: "pipeline" };
 
 // TODO(sdk): migrate to the typed client once the issue-mirror routes are in
 // the regenerated SDK route map.
@@ -18,18 +24,22 @@ function hasPermission(permissions: string[], permission: string) {
   return permissions.some((p) => p === "*" || p === permission || p === `${resource}:*`);
 }
 
-export default async function ProjectIssuesPage({
+const STAGE_KEYS = new Set(PIPELINE_STAGES.map((s) => s.key));
+
+export default async function ProjectPipelinePage({
   params,
   searchParams,
 }: {
   params: Promise<{ projectId: string }>;
-  searchParams: Promise<{ state?: string }>;
+  searchParams: Promise<{ stage?: string }>;
 }) {
-  const [{ projectId }, { state }] = await Promise.all([params, searchParams]);
-  const activeState = state === "closed" || state === "all" ? state : "open";
-  const [issues, me] = await Promise.all([
-    untypedApi<IssueListResponse>("GET", `/v1/projects/${projectId}/issues?state=${activeState}`),
+  const [{ projectId }, { stage }] = await Promise.all([params, searchParams]);
+  const activeStage =
+    stage && STAGE_KEYS.has(stage as PipelineStage) ? (stage as PipelineStage) : null;
+  const [issues, me, inbox] = await Promise.all([
+    untypedApi<IssueListResponse>("GET", `/v1/projects/${projectId}/issues?state=all`),
     api.me(),
+    api.inboxFull(),
   ]);
 
   if (!issues.ok && issues.offline) return <Offline />;
@@ -38,26 +48,69 @@ export default async function ProjectIssuesPage({
   const canTrigger = hasPermission(permissions, "runs:trigger");
   const canSync = hasPermission(permissions, "repos:write");
   const items = issues.ok ? issues.data.items : [];
+  const proposals = inbox.ok
+    ? inbox.data.proposals.filter((x) => !x.projectId || x.projectId === projectId)
+    : [];
+  const stages = classifyPipeline(items, proposals);
+  const counts = pipelineCounts(stages);
+  const openCount = items.filter((i) => i.state === "open").length;
+
+  const visibleStages = activeStage
+    ? PIPELINE_STAGES.filter((s) => s.key === activeStage)
+    : PIPELINE_STAGES;
 
   return (
     <div className="flex flex-col gap-8">
       <LiveRefresh seconds={30} />
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div className="flex flex-col gap-2">
-          <Eyebrow>issues</Eyebrow>
-          <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Issues</h1>
+          <Eyebrow>pipeline</Eyebrow>
+          <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Pipeline</h1>
           <p className="text-[12.5px] text-(--dim)">
-            {issues.ok ? `${items.length} ${activeState}` : "mirror unavailable"} · read-mirror of
-            GitHub — authoring stays there
+            {issues.ok ? `${openCount} open issues flowing left to right` : "mirror unavailable"} ·
+            issues live on GitHub — agents are dispatched here
           </p>
         </div>
         {canSync ? <SyncIssuesButton projectId={projectId} /> : null}
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {(["open", "closed", "all"] as const).map((s) => (
-          <Link key={s} href={`/projects/${projectId}/issues${s === "open" ? "" : `?state=${s}`}`}>
-            <PillTag active={activeState === s}>{s}</PillTag>
+      <div className="flex flex-wrap items-center gap-2">
+        <Link
+          href={`/projects/${projectId}/issues`}
+          className={cx(
+            "border px-3 py-1.5 text-[12px] font-medium transition-colors",
+            !activeStage
+              ? "border-(--line-strong) text-(--ink)"
+              : "border-(--line) text-(--mut) hover:text-(--ink)",
+          )}
+        >
+          all
+        </Link>
+        {counts.map((s) => (
+          <Link
+            key={s.key}
+            href={`/projects/${projectId}/issues?stage=${s.key}`}
+            className={cx(
+              "inline-flex items-center gap-2 border px-3 py-1.5 text-[12px] font-medium transition-colors",
+              activeStage === s.key
+                ? "border-(--line-strong) text-(--ink)"
+                : "border-(--line) text-(--mut) hover:text-(--ink)",
+            )}
+          >
+            {s.kind === "human" ? <StatusDot tone="human" /> : null}
+            {s.label}
+            <span
+              className={cx(
+                "font-mono text-[11px]",
+                s.count > 0
+                  ? s.kind === "human"
+                    ? "text-(--human)"
+                    : "text-(--ink)"
+                  : "text-(--dim)",
+              )}
+            >
+              {s.count}
+            </span>
           </Link>
         ))}
       </div>
@@ -72,11 +125,52 @@ export default async function ProjectIssuesPage({
         />
       ) : items.length === 0 ? (
         <p className="max-w-lg text-sm leading-relaxed text-(--dim)">
-          Nothing {activeState === "all" ? "mirrored" : activeState} yet. Issues sync from the
-          connected repository automatically; use sync to backfill.
+          Nothing mirrored yet. Issues sync from the connected repository automatically; use sync to
+          backfill.
         </p>
       ) : (
-        <IssueList projectId={projectId} items={items} canTrigger={canTrigger} />
+        <div className="flex flex-col gap-8">
+          {visibleStages.map((s) => {
+            const stageItems = stages.get(s.key) ?? [];
+            return (
+              <section key={s.key} className="flex flex-col gap-3">
+                <div className="flex items-baseline gap-3">
+                  {stageItems.some((p) => p.runState === "failed") ? (
+                    <StatusDot tone="bad" />
+                  ) : s.kind === "human" ? (
+                    <StatusDot tone="human" />
+                  ) : s.kind === "agent" ? (
+                    <StatusDot
+                      tone={stageItems.length > 0 ? "agent" : "machine"}
+                      pulse={stageItems.some((p) => p.runState === "live")}
+                    />
+                  ) : (
+                    <StatusDot tone="ok" />
+                  )}
+                  <h2 className="text-[14px] font-semibold tracking-tight">{s.label}</h2>
+                  <span className="font-mono text-[12px] text-(--dim)">{stageItems.length}</span>
+                  <span className="text-[11.5px] text-(--dim)">{s.sub}</span>
+                </div>
+                {stageItems.length === 0 ? (
+                  <p className="border border-(--line) px-5 py-3.5 text-[12.5px] text-(--dim)">
+                    Nothing here right now.
+                  </p>
+                ) : (
+                  <div className="flex flex-col border border-(--line)">
+                    {stageItems.map((placed) => (
+                      <IssueRow
+                        key={placed.issue.number}
+                        projectId={projectId}
+                        issue={placed.issue}
+                        canTrigger={canTrigger}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
       )}
     </div>
   );

--- a/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
@@ -5,19 +5,16 @@ import { IssueRow } from "@/components/issues/issue-row";
 import { SyncIssuesButton } from "@/components/issues/sync-button";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
-import { api, untypedApi } from "@/lib/api";
+import { api } from "@/lib/api";
 import {
   classifyPipeline,
   PIPELINE_STAGES,
   type PipelineStage,
   pipelineCounts,
 } from "@/lib/pipeline";
+import { fetchAllProjectIssues } from "@/lib/project-issues";
 
 export const metadata = { title: "pipeline" };
-
-// TODO(sdk): migrate to the typed client once the issue-mirror routes are in
-// the regenerated SDK route map.
-type IssueListResponse = { items: GhIssue[]; nextCursor?: string | null };
 
 function hasPermission(permissions: string[], permission: string) {
   const [resource] = permission.split(":");
@@ -37,7 +34,7 @@ export default async function ProjectPipelinePage({
   const activeStage =
     stage && STAGE_KEYS.has(stage as PipelineStage) ? (stage as PipelineStage) : null;
   const [issues, me, inbox] = await Promise.all([
-    untypedApi<IssueListResponse>("GET", `/v1/projects/${projectId}/issues?state=all`),
+    fetchAllProjectIssues<GhIssue>(projectId),
     api.me(),
     api.inboxFull(),
   ]);
@@ -47,7 +44,7 @@ export default async function ProjectPipelinePage({
   const permissions = me.ok ? me.data.permissions : [];
   const canTrigger = hasPermission(permissions, "runs:trigger");
   const canSync = hasPermission(permissions, "repos:write");
-  const items = issues.ok ? issues.data.items : [];
+  const items = issues.ok ? issues.items : [];
   const proposals = inbox.ok
     ? inbox.data.proposals.filter((x) => !x.projectId || x.projectId === projectId)
     : [];

--- a/apps/web/app/(app)/projects/[projectId]/layout.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/layout.tsx
@@ -41,7 +41,7 @@ export default async function ProjectLayout({
   const p = project.data;
   const projectList = projects.ok ? projects.data : [];
   const inboxCount = inbox.ok ? inbox.data.proposals.length + inbox.data.issues.length : undefined;
-  const navProject = { id: p.id, slug: p.slug };
+  const navProject = { id: p.id, slug: p.slug, name: p.name };
 
   return (
     <div className="flex min-h-dvh">

--- a/apps/web/app/(app)/projects/[projectId]/owner/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/owner/page.tsx
@@ -8,7 +8,7 @@ import { api } from "@/lib/api";
 import { fmtAgo, fmtStatus } from "@/lib/runs";
 import { cronToWords } from "@/lib/schedule";
 
-export const metadata = { title: "owner" };
+export const metadata = { title: "project manager" };
 
 const OWNER_NAMES = new Set(["project-owner", "learning"]);
 
@@ -46,8 +46,10 @@ export default async function OwnerPage({ params }: { params: Promise<{ projectI
     <div className="flex flex-col gap-8">
       <LiveRefresh seconds={30} />
       <div className="flex flex-col gap-2">
-        <Eyebrow>owner</Eyebrow>
-        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Project Owner</h1>
+        <Eyebrow>project manager</Eyebrow>
+        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">
+          Project Manager
+        </h1>
         <p className="text-[12.5px] text-(--dim)">
           {ownerAgent
             ? `${ownerAgent.engine}${cron ? ` · ${cronToWords(cron)}` : " · on demand"} · ${

--- a/apps/web/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/page.tsx
@@ -3,8 +3,9 @@ import Link from "next/link";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { PipelineBoard } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
-import { api, summarizeSpend, untypedApi } from "@/lib/api";
-import { classifyPipeline, type PipelineIssue } from "@/lib/pipeline";
+import { api, summarizeSpend } from "@/lib/api";
+import { classifyPipeline } from "@/lib/pipeline";
+import { fetchAllProjectIssues } from "@/lib/project-issues";
 import { fmtAgo, fmtCost, fmtDuration, fmtStatus } from "@/lib/runs";
 
 export const metadata = { title: "overview" };
@@ -60,7 +61,7 @@ export default async function ProjectOverviewPage({
       api.agentsStatus(projectId),
       api.outcomes(`?state=open&projectId=${projectId}&limit=10`),
       api.outcomes(`?state=all&projectId=${projectId}&limit=6`),
-      untypedApi<{ items: PipelineIssue[] }>("GET", `/v1/projects/${projectId}/issues?state=all`),
+      fetchAllProjectIssues(projectId),
     ]);
 
   if (!project.ok) {
@@ -101,9 +102,9 @@ export default async function ProjectOverviewPage({
   const lastOwnerRun = ownerRuns[0];
 
   const recent = items.slice(0, 8);
-  const pipeline = classifyPipeline(ghIssues.ok ? ghIssues.data.items : [], proposals);
+  const pipeline = classifyPipeline(ghIssues.ok ? ghIssues.items : [], proposals);
   const issueTitleByNumber = new Map(
-    (ghIssues.ok ? ghIssues.data.items : []).map((issue) => [issue.number, issue.title]),
+    (ghIssues.ok ? ghIssues.items : []).map((issue) => [issue.number, issue.title]),
   );
   // PR → issue provenance comes from Facility's own runs (a builder run carries
   // both its issue and the PR it shipped) — GitHub only knows via closing

--- a/apps/web/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/page.tsx
@@ -1,9 +1,10 @@
 import { Cell, Divider, Eyebrow, HairlineGrid, Metric, StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
-import { EngineLoop } from "@/components/agents/engine-loop";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { PipelineBoard } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
-import { api, summarizeSpend } from "@/lib/api";
+import { api, summarizeSpend, untypedApi } from "@/lib/api";
+import { classifyPipeline, type PipelineIssue } from "@/lib/pipeline";
 import { fmtAgo, fmtCost, fmtDuration, fmtStatus } from "@/lib/runs";
 
 export const metadata = { title: "overview" };
@@ -49,7 +50,7 @@ export default async function ProjectOverviewPage({
   params: Promise<{ projectId: string }>;
 }) {
   const { projectId } = await params;
-  const [project, runs, spend, health, inbox, agentsStatus, outcomes, allOutcomes] =
+  const [project, runs, spend, health, inbox, agentsStatus, outcomes, allOutcomes, ghIssues] =
     await Promise.all([
       api.project(projectId),
       api.runs(projectId),
@@ -59,6 +60,7 @@ export default async function ProjectOverviewPage({
       api.agentsStatus(projectId),
       api.outcomes(`?state=open&projectId=${projectId}&limit=10`),
       api.outcomes(`?state=all&projectId=${projectId}&limit=6`),
+      untypedApi<{ items: PipelineIssue[] }>("GET", `/v1/projects/${projectId}/issues?state=all`),
     ]);
 
   if (!project.ok) {
@@ -99,6 +101,20 @@ export default async function ProjectOverviewPage({
   const lastOwnerRun = ownerRuns[0];
 
   const recent = items.slice(0, 8);
+  const pipeline = classifyPipeline(ghIssues.ok ? ghIssues.data.items : [], proposals);
+  const issueTitleByNumber = new Map(
+    (ghIssues.ok ? ghIssues.data.items : []).map((issue) => [issue.number, issue.title]),
+  );
+  // PR → issue provenance comes from Facility's own runs (a builder run carries
+  // both its issue and the PR it shipped) — GitHub only knows via closing
+  // keywords, but this is our source of truth for pipeline linkage.
+  const issueByPr = new Map<number, number>();
+  for (const run of items) {
+    const gh = run.gh as { issueNumber?: number; pr?: { number?: number } } | null;
+    if (gh?.pr?.number != null && gh.issueNumber != null) {
+      issueByPr.set(gh.pr.number, gh.issueNumber);
+    }
+  }
   const spendSummary = spend.ok ? summarizeSpend(spend.data) : null;
   const shipped = allOutcomes.ok
     ? allOutcomes.data.filter((outcome) => outcome.terminalAt).slice(0, 5)
@@ -111,9 +127,7 @@ export default async function ProjectOverviewPage({
       <div className="flex flex-col gap-2">
         <Eyebrow>overview</Eyebrow>
         <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
-          <h1 className="font-mono text-[clamp(22px,3.2vw,34px)] font-semibold tracking-tight">
-            {p.slug}
-          </h1>
+          <h1 className="text-[clamp(22px,3.2vw,34px)] font-semibold tracking-tight">{p.name}</h1>
           <span className="inline-flex items-center gap-2 text-[12.5px] text-(--mut)">
             <StatusDot tone={healthTone(healthData?.status)} />
             {healthData ? `health ${healthData.status}` : "health —"}
@@ -128,6 +142,23 @@ export default async function ProjectOverviewPage({
           <p className="max-w-xl text-sm leading-relaxed text-(--mut)">{p.description}</p>
         ) : null}
       </div>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex items-baseline justify-between">
+          <Eyebrow>the pipeline</Eyebrow>
+          <Link
+            href={`/projects/${projectId}/issues`}
+            className="text-[12px] font-medium text-(--mut) hover:text-(--ink)"
+          >
+            open the pipeline →
+          </Link>
+        </div>
+        {ghIssues.ok ? (
+          <PipelineBoard stages={pipeline} projectId={projectId} />
+        ) : (
+          <ErrorNotice message={`Couldn't load the issue mirror — ${ghIssues.message}`} />
+        )}
+      </section>
 
       {needsYou > 0 || watchtower.length > 0 ? (
         <section className="flex flex-col gap-4">
@@ -147,21 +178,29 @@ export default async function ProjectOverviewPage({
                 </span>
               </Link>
             ))}
-            {openPrs.slice(0, 5).map((outcome) => (
-              <a
-                key={outcome.id}
-                href={`https://github.com/${outcome.repo}/pull/${outcome.prNumber}`}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
-              >
-                <StatusDot tone="human" />
-                <span className="font-mono text-[13px] text-(--ink)">
-                  {outcome.repo}#{outcome.prNumber}
-                </span>
-                <span className="text-[12.5px] text-(--mut)">PR awaiting your review ↗</span>
-              </a>
-            ))}
+            {openPrs.slice(0, 5).map((outcome) => {
+              const issueNumber = issueByPr.get(outcome.prNumber);
+              const issueTitle = issueNumber != null ? issueTitleByNumber.get(issueNumber) : null;
+              return (
+                <a
+                  key={outcome.id}
+                  href={`https://github.com/${outcome.repo}/pull/${outcome.prNumber}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
+                >
+                  <StatusDot tone="human" />
+                  <span className="font-mono text-[13px] text-(--ink)">
+                    {outcome.repo}#{outcome.prNumber}
+                  </span>
+                  <span className="truncate text-[12.5px] text-(--mut)">
+                    {issueNumber != null
+                      ? `implements #${issueNumber}${issueTitle ? ` ${issueTitle}` : ""} — PR awaiting your review ↗`
+                      : "PR awaiting your review ↗"}
+                  </span>
+                </a>
+              );
+            })}
             {proposals.slice(0, 5).map((proposal) => (
               <Link
                 key={proposal.id}
@@ -170,10 +209,17 @@ export default async function ProjectOverviewPage({
               >
                 <StatusDot tone="human" />
                 <span className="text-[12px] font-medium text-(--human)">
-                  {proposal.actionType}
+                  {proposal.actionType === "plan_acceptance"
+                    ? "plan approval"
+                    : proposal.actionType.replaceAll("_", " ")}
                 </span>
                 <span className="truncate text-[12.5px] text-(--mut)">
-                  gate waiting for a decision
+                  {(() => {
+                    const n = (proposal.payload as { issueNumber?: number } | null)?.issueNumber;
+                    const title = n != null ? issueTitleByNumber.get(n) : undefined;
+                    if (n != null && title) return `#${n} ${title} — waiting for your decision`;
+                    return "waiting for your decision";
+                  })()}
                 </span>
                 <span className="ml-auto font-mono text-[11px] text-(--dim)">
                   {fmtAgo(proposal.createdAt)}
@@ -238,32 +284,6 @@ export default async function ProjectOverviewPage({
               </Link>
             ))}
           </div>
-        )}
-      </section>
-
-      <section className="flex flex-col gap-4">
-        <div className="flex items-baseline justify-between">
-          <Eyebrow>the engine</Eyebrow>
-          <Link
-            href={`/projects/${projectId}/agents`}
-            className="text-[12px] font-medium text-(--mut) hover:text-(--ink)"
-          >
-            all agents →
-          </Link>
-        </div>
-        {agentRows.length === 0 ? (
-          <p className="text-sm text-(--dim)">
-            No agents configured yet —{" "}
-            <Link
-              href={`/projects/${projectId}/agents/new`}
-              className="text-(--ink) underline underline-offset-4"
-            >
-              create the first one
-            </Link>
-            .
-          </p>
-        ) : (
-          <EngineLoop projectId={projectId} rows={agentRows} compact />
         )}
       </section>
 

--- a/apps/web/app/(app)/projects/[projectId]/sessions/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/sessions/page.tsx
@@ -6,7 +6,7 @@ import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api } from "@/lib/api";
 import { toSessionRows } from "@/lib/session-rows";
 
-export const metadata = { title: "sessions" };
+export const metadata = { title: "runs" };
 
 const LIVE = new Set(["queued", "provisioning", "running", "awaiting_human"]);
 
@@ -32,8 +32,8 @@ export default async function ProjectSessionsPage({
     <div className="flex flex-col gap-8">
       <LiveRefresh seconds={20} />
       <div className="flex flex-col gap-2">
-        <Eyebrow>sessions</Eyebrow>
-        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Sessions</h1>
+        <Eyebrow>runs</Eyebrow>
+        <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Runs</h1>
         <p className="text-[12.5px] text-(--dim)">
           {rows.length} recorded · {liveCount} live
         </p>

--- a/apps/web/components/issues/issue-row.tsx
+++ b/apps/web/components/issues/issue-row.tsx
@@ -4,6 +4,7 @@ import { Button, StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { currentRunOf, prsOf } from "@/lib/pipeline";
 
 export type GhIssue = {
   id: string;
@@ -118,31 +119,45 @@ export function IssueRow({
           </div>
         ) : null}
       </div>
-      {issue.linkedRuns.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-0 sm:pl-10">
-          {issue.linkedRuns.map((run) => (
-            <span key={run.id} className="flex items-center gap-2">
-              <StatusDot tone={toneFor(run.status)} pulse={run.status === "running"} />
-              <Link
-                href={`/projects/${projectId}/sessions/${run.id}`}
-                className="font-mono text-[11px] text-(--mut) hover:text-(--ink)"
-              >
-                {run.mode} · {run.status}
-              </Link>
-              {run.pr?.url ? (
-                <a
-                  href={run.pr.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
+      {(() => {
+        // One run explains the issue's position — history lives in the session
+        // pages, not here. Show the current run + every PR the issue produced.
+        const current = currentRunOf(issue);
+        const prs = prsOf(issue);
+        if (!current && prs.length === 0) return null;
+        const attempts = issue.linkedRuns.length;
+        return (
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-0 sm:pl-10">
+            {current ? (
+              <span className="flex items-center gap-2">
+                <StatusDot tone={toneFor(current.status)} pulse={current.status === "running"} />
+                <Link
+                  href={`/projects/${projectId}/sessions/${current.id}`}
+                  className="font-mono text-[11px] text-(--mut) hover:text-(--ink)"
                 >
-                  PR #{run.pr.number ?? ""} ↗
-                </a>
-              ) : null}
-            </span>
-          ))}
-        </div>
-      ) : null}
+                  {current.mode} · {current.status}
+                </Link>
+                {attempts > 1 ? (
+                  <span className="font-mono text-[10px] text-(--dim)" title="previous attempts">
+                    ({attempts - 1} earlier)
+                  </span>
+                ) : null}
+              </span>
+            ) : null}
+            {prs.map((pr) => (
+              <a
+                key={pr.number}
+                href={pr.url}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
+              >
+                PR #{pr.number} ↗
+              </a>
+            ))}
+          </div>
+        );
+      })()}
       {error ? <p className="font-mono text-[11px] text-(--bad)">{error}</p> : null}
     </div>
   );

--- a/apps/web/components/project/pipeline.tsx
+++ b/apps/web/components/project/pipeline.tsx
@@ -1,0 +1,146 @@
+import { cx, StatusDot } from "@facility/ui";
+import Link from "next/link";
+import {
+  PIPELINE_STAGES,
+  type PipelineIssue,
+  type PipelineStage,
+  type PlacedIssue,
+  pipelineCounts,
+  type StageKind,
+} from "@/lib/pipeline";
+
+/** Human gates get the human (amber) accent; agent stages the working green. */
+function kindBorder(kind: StageKind) {
+  if (kind === "human") return "border-t-2 border-t-(--human)";
+  if (kind === "agent") return "border-t-2 border-t-(--line-strong)";
+  return "border-t-2 border-t-(--ok)";
+}
+
+function kindDot(kind: StageKind, count: number) {
+  if (kind === "human") return <StatusDot tone="human" />;
+  if (kind === "agent")
+    return <StatusDot tone={count > 0 ? "agent" : "machine"} pulse={count > 0} />;
+  return <StatusDot tone="ok" />;
+}
+
+function countTone(kind: StageKind, count: number) {
+  if (count === 0) return "text-(--dim)";
+  if (kind === "human") return "text-(--human)";
+  return "text-(--ink)";
+}
+
+/** The issue's one-run state, as a dot: red = failed, pulsing = live. */
+export function RunStateDot({ placed }: { placed: PlacedIssue }) {
+  if (placed.runState === "failed") return <StatusDot tone="bad" />;
+  if (placed.runState === "live") return <StatusDot tone="agent" pulse />;
+  return null;
+}
+
+/** The full board: one column per stage, issues as chips. The product's centerpiece. */
+export function PipelineBoard({
+  stages,
+  projectId,
+}: {
+  stages: Map<PipelineStage, PlacedIssue[]>;
+  projectId?: string;
+}) {
+  const counts = pipelineCounts(stages);
+  return (
+    <div className="grid grid-cols-2 border border-(--line) sm:grid-cols-3 lg:grid-cols-6">
+      {counts.map((stage, i) => {
+        const items = stages.get(stage.key) ?? [];
+        const header = (
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-baseline gap-2">
+              <span
+                className={cx(
+                  "font-mono text-[20px] font-semibold leading-none",
+                  countTone(stage.kind, stage.count),
+                )}
+              >
+                {stage.count}
+              </span>
+              <span className="text-[12px] font-medium text-(--ink)">{stage.label}</span>
+              {kindDot(stage.kind, stage.count)}
+            </div>
+            <span className="text-[10.5px] leading-snug text-(--dim)">{stage.sub}</span>
+          </div>
+        );
+        return (
+          <div
+            key={stage.key}
+            className={cx(
+              "flex min-h-[132px] flex-col gap-3 p-4",
+              kindBorder(stage.kind),
+              i > 0 && "border-l border-l-(--line)",
+              "max-lg:odd:border-l-0 sm:max-lg:[&:nth-child(3n+1)]:border-l-0",
+            )}
+          >
+            {projectId ? (
+              <Link
+                href={`/projects/${projectId}/issues?stage=${stage.key}`}
+                className="transition-opacity hover:opacity-80"
+              >
+                {header}
+              </Link>
+            ) : (
+              header
+            )}
+            <div className="flex flex-col gap-1.5">
+              {items.slice(0, 3).map((placed) => (
+                <span key={placed.issue.number} className="flex items-center gap-1.5">
+                  <RunStateDot placed={placed} />
+                  <a
+                    href={placed.issue.htmlUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="min-w-0 truncate text-[11.5px] leading-snug text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
+                    title={placed.issue.title}
+                  >
+                    <span className="font-mono text-(--dim)">#{placed.issue.number}</span>{" "}
+                    {placed.issue.title}
+                  </a>
+                  {placed.prs.map((pr) => (
+                    <a
+                      key={pr.number}
+                      href={pr.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="shrink-0 font-mono text-[10.5px] text-(--info,--mut) underline-offset-4 hover:underline"
+                    >
+                      PR&nbsp;#{pr.number}
+                    </a>
+                  ))}
+                </span>
+              ))}
+              {items.length > 3 ? (
+                <span className="text-[10.5px] text-(--dim)">+{items.length - 3} more</span>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** One-line pipeline summary for project cards: the same model, compressed. */
+export function PipelineStrip({
+  stages,
+}: {
+  stages: Map<PipelineStage, PlacedIssue<PipelineIssue>[]>;
+}) {
+  const counts = pipelineCounts(stages);
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[10.5px]">
+      {counts.map((stage) => (
+        <span key={stage.key} className="inline-flex items-baseline gap-1">
+          <span className={countTone(stage.kind, stage.count)}>
+            {stage.count === 0 ? "–" : stage.count}
+          </span>
+          <span className="text-(--dim)">{stage.label.toLowerCase()}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/run/cockpit.tsx
+++ b/apps/web/components/run/cockpit.tsx
@@ -238,11 +238,17 @@ function githubArtifacts(run: Run) {
   const gh = (run.gh ?? {}) as Record<string, unknown>;
   const pr = artifactFrom(gh.pr) ?? artifactFrom(gh.prUrl) ?? artifactFrom(gh.url);
   const issueNumber = typeof gh.issueNumber === "number" ? gh.issueNumber : undefined;
+  // Backlink to the issue this run works on — derive the GitHub URL from the
+  // run's own repo context when the payload doesn't carry one.
+  const issueUrl =
+    typeof gh.owner === "string" && typeof gh.repo === "string" && issueNumber !== undefined
+      ? `https://github.com/${gh.owner}/${gh.repo}/issues/${issueNumber}`
+      : null;
   const issue =
     artifactFrom(gh.issue) ??
     artifactFrom(gh.issueUrl) ??
     artifactFrom(gh.htmlUrl) ??
-    (issueNumber !== undefined ? { text: `#${issueNumber}`, href: null } : null);
+    (issueNumber !== undefined ? { text: `#${issueNumber}`, href: issueUrl } : null);
   return [
     pr ? { label: "PR", text: pr.text, href: pr.href } : null,
     issue ? { label: "issue", text: issue.text, href: issue.href } : null,

--- a/apps/web/components/sessions/session-table.tsx
+++ b/apps/web/components/sessions/session-table.tsx
@@ -18,6 +18,7 @@ export type SessionRow = {
   endedAt: string | null;
   costCents: number | null;
   prUrl: string | null;
+  issueNumber?: number | null;
 };
 
 const LIVE = new Set(["queued", "provisioning", "running"]);
@@ -165,18 +166,30 @@ export function SessionTable({
                   <td className="px-5 py-3 font-mono text-[11px] text-(--dim)">{row.engine}</td>
                   <td className="px-5 py-3 text-[12px] text-(--mut)">{fmtStatus(row.status)}</td>
                   <td className="px-5 py-3">
-                    {row.prUrl ? (
-                      <a
-                        href={row.prUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
-                      >
-                        PR ↗
-                      </a>
-                    ) : (
-                      <span className="font-mono text-[11px] text-(--dim)">—</span>
-                    )}
+                    <span className="flex items-center gap-3">
+                      {row.issueNumber != null ? (
+                        <Link
+                          href={`/projects/${row.projectId}/issues?stage=all`}
+                          className="font-mono text-[11px] text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
+                          title="the issue this run works on"
+                        >
+                          #{row.issueNumber}
+                        </Link>
+                      ) : null}
+                      {row.prUrl ? (
+                        <a
+                          href={row.prUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
+                        >
+                          PR ↗
+                        </a>
+                      ) : null}
+                      {row.issueNumber == null && !row.prUrl ? (
+                        <span className="font-mono text-[11px] text-(--dim)">—</span>
+                      ) : null}
+                    </span>
                   </td>
                   <td className="px-5 py-3 font-mono text-[11px] text-(--mut)">
                     {fmtDuration(row.startedAt, row.endedAt)}

--- a/apps/web/components/shell/nav.tsx
+++ b/apps/web/components/shell/nav.tsx
@@ -5,18 +5,22 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
-export type NavProject = { id: string; slug: string };
+export type NavProject = { id: string; slug: string; name?: string };
 
-type NavItem = { href: string; label: string; badge?: number };
+type NavItem = { href: string; label: string; badge?: number; sub?: string };
 
-/** Org-level destinations — thin by design; the daily loop lives inside a project. */
-export function orgNav(inboxCount?: number): NavItem[] {
+/** Org mode is the projects dashboard; everything else is the platform beneath it. */
+export function orgNav(): NavItem[] {
+  return [{ href: "/projects", label: "Projects" }];
+}
+
+/** Cross-project operator surfaces — secondary by design; explained, not assumed. */
+export function orgPlatformNav(inboxCount?: number): NavItem[] {
   return [
-    { href: "/projects", label: "Projects" },
-    { href: "/sessions", label: "Fleet" },
-    { href: "/inbox", label: "Inbox", badge: inboxCount },
-    { href: "/harness", label: "Harness" },
-    { href: "/audit", label: "Audit" },
+    { href: "/sessions", label: "Activity", sub: "live agent work, all projects" },
+    { href: "/harness", label: "Skills & Rules", sub: "what your agents know" },
+    { href: "/audit", label: "Audit log", sub: "every action, recorded" },
+    { href: "/inbox", label: "Approvals", badge: inboxCount, sub: "decisions waiting on you" },
     { href: "/settings", label: "Settings" },
   ];
 }
@@ -26,9 +30,9 @@ export function projectNav(projectId: string): NavItem[] {
   const base = `/projects/${projectId}`;
   return [
     { href: base, label: "Overview" },
-    { href: `${base}/issues`, label: "Issues" },
-    { href: `${base}/sessions`, label: "Sessions" },
-    { href: `${base}/owner`, label: "Owner" },
+    { href: `${base}/issues`, label: "Pipeline", sub: "issues by stage" },
+    { href: `${base}/sessions`, label: "Runs", sub: "agent work on this project" },
+    { href: `${base}/owner`, label: "Project Manager", sub: "the agent that runs this project" },
     { href: `${base}/agents`, label: "Agents" },
     { href: `${base}/settings`, label: "Settings" },
   ];
@@ -69,7 +73,12 @@ function NavLinks({
             <span className={cx("font-mono text-[10px]", active ? "text-(--ink)" : "text-(--dim)")}>
               {String(i + 1).padStart(2, "0")}
             </span>
-            {item.label}
+            <span className="flex min-w-0 flex-col">
+              {item.label}
+              {item.sub ? (
+                <span className="text-[10px] leading-snug text-(--dim)">{item.sub}</span>
+              ) : null}
+            </span>
             {item.badge ? (
               <span className="ml-auto font-mono text-[11px] text-(--human)">{item.badge}</span>
             ) : null}
@@ -98,17 +107,33 @@ function NavSections({
   onNavigate?: () => void;
 }) {
   if (!project) {
-    return <NavLinks items={orgNav(inboxCount)} onNavigate={onNavigate} />;
-  }
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <SectionLabel>project</SectionLabel>
-        <NavLinks items={projectNav(project.id)} exactFirst onNavigate={onNavigate} />
+    return (
+      <div className="flex flex-col gap-6">
+        <NavLinks items={orgNav()} onNavigate={onNavigate} />
+        <div className="flex flex-col gap-2">
+          <SectionLabel>platform</SectionLabel>
+          <NavLinks items={orgPlatformNav(inboxCount)} onNavigate={onNavigate} />
+        </div>
       </div>
+    );
+  }
+  // Project mode: the sidebar belongs to the project. The way out is explicit
+  // (back link on top) and the section is titled by the project itself.
+  return (
+    <div className="flex flex-col gap-3">
+      <Link
+        href="/projects"
+        onClick={onNavigate}
+        className="flex items-center gap-2 px-5 text-[12px] text-(--mut) transition-colors hover:text-(--ink)"
+      >
+        <span aria-hidden className="font-mono">
+          ←
+        </span>
+        Back to all projects
+      </Link>
       <div className="flex flex-col gap-2">
-        <SectionLabel>org</SectionLabel>
-        <NavLinks items={orgNav(inboxCount)} onNavigate={onNavigate} />
+        <SectionLabel>{project.name ?? project.slug}</SectionLabel>
+        <NavLinks items={projectNav(project.id)} exactFirst onNavigate={onNavigate} />
       </div>
     </div>
   );

--- a/apps/web/lib/pipeline.ts
+++ b/apps/web/lib/pipeline.ts
@@ -1,0 +1,150 @@
+import type { Proposal } from "./api";
+
+/**
+ * The SDLC pipeline, as a classification of GitHub issues. This is the
+ * product's mental model: work flows left to right, humans hold the gates.
+ * GitHub is the source of truth for issues and PRs; Facility is the source
+ * of truth for pipeline state (runs, gates, provenance).
+ */
+export type PipelineStage = "backlog" | "planning" | "ready" | "building" | "review" | "shipped";
+
+/** Who acts in a stage: humans decide, agents work, done is done. */
+export type StageKind = "human" | "agent" | "done";
+
+export const PIPELINE_STAGES: {
+  key: PipelineStage;
+  label: string;
+  sub: string;
+  kind: StageKind;
+}[] = [
+  { key: "backlog", label: "Backlog", sub: "yours — pick up & launch", kind: "human" },
+  { key: "planning", label: "Planning", sub: "architect drafts the plan", kind: "agent" },
+  { key: "ready", label: "Ready", sub: "yours — review the plan", kind: "human" },
+  { key: "building", label: "Building", sub: "builder implements the plan", kind: "agent" },
+  { key: "review", label: "In review", sub: "yours — review the PR & iterate", kind: "human" },
+  { key: "shipped", label: "Shipped", sub: "merged · last 7 days", kind: "done" },
+];
+
+export type LinkedRun = {
+  id: string;
+  mode: string;
+  status: string;
+  engine?: string;
+  pr?: { number?: number; url?: string } | null;
+};
+
+/** The GitHub-issue mirror shape used by the pipeline (subset of the API item). */
+export type PipelineIssue = {
+  number: number;
+  title: string;
+  state: string;
+  htmlUrl?: string;
+  ghUpdatedAt?: string | null;
+  linkedRuns?: LinkedRun[];
+};
+
+/** An issue placed in the pipeline, with its current run and PR provenance. */
+export type PlacedIssue<T extends PipelineIssue = PipelineIssue> = {
+  issue: T;
+  /** live = an agent is on it now · failed = the last attempt broke */
+  runState: "live" | "failed" | null;
+  /** The single run that explains the issue's position — never a history. */
+  currentRun: LinkedRun | null;
+  /** Every PR any linked run produced (an issue may accumulate several). */
+  prs: { number: number; url: string }[];
+};
+
+const LIVE = new Set(["queued", "provisioning", "running"]);
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+function isMode(run: { mode: string }, name: string) {
+  return run.mode === name || run.mode === `codex-${name}`;
+}
+
+function stageForMode(run: LinkedRun): PipelineStage {
+  if (isMode(run, "builder")) return "building";
+  if (isMode(run, "review") || run.mode === "address-review") return "review";
+  return "planning";
+}
+
+/** Run ids are ULID-suffixed (`run_01…`) — lexicographic order is time order. */
+function sortedRuns(issue: PipelineIssue): LinkedRun[] {
+  return [...(issue.linkedRuns ?? [])].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function prsOf(issue: PipelineIssue): { number: number; url: string }[] {
+  const seen = new Map<number, { number: number; url: string }>();
+  for (const run of issue.linkedRuns ?? []) {
+    if (run.pr && typeof run.pr.number === "number" && typeof run.pr.url === "string") {
+      seen.set(run.pr.number, { number: run.pr.number, url: run.pr.url });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.number - b.number);
+}
+
+/** The one run that explains the issue's position: the newest linked run. */
+export function currentRunOf(issue: PipelineIssue): LinkedRun | null {
+  const runs = sortedRuns(issue);
+  return runs.at(-1) ?? null;
+}
+
+/**
+ * Current-run-wins placement of one open issue:
+ * - the newest run is live → its stage (planning/building/review), yellow.
+ * - the newest run failed → its stage, red. Failed attempts never sit in a gate.
+ * - otherwise: delivered builder (PR) → review · plan published → ready → backlog.
+ */
+function placeOpen<T extends PipelineIssue>(
+  issue: T,
+  hasOpenProposal: boolean,
+): { stage: PipelineStage; placed: PlacedIssue<T> } {
+  const runs = sortedRuns(issue);
+  const current = runs.at(-1) ?? null;
+  const prs = prsOf(issue);
+  const base: PlacedIssue<T> = { issue, runState: null, currentRun: current, prs };
+
+  if (current && LIVE.has(current.status)) {
+    return { stage: stageForMode(current), placed: { ...base, runState: "live" } };
+  }
+  if (current && current.status === "failed") {
+    return { stage: stageForMode(current), placed: { ...base, runState: "failed" } };
+  }
+  const builderDelivered = runs.some((r) => isMode(r, "builder") && r.status === "succeeded");
+  if (builderDelivered || prs.length > 0) return { stage: "review", placed: base };
+  const planPublished = runs.some((r) => isMode(r, "architect") && r.status === "succeeded");
+  if (hasOpenProposal || planPublished) return { stage: "ready", placed: base };
+  return { stage: "backlog", placed: base };
+}
+
+export function classifyPipeline<T extends PipelineIssue>(
+  issues: T[],
+  proposals: Proposal[],
+  now = Date.now(),
+): Map<PipelineStage, PlacedIssue<T>[]> {
+  const proposalIssueNumbers = new Set(
+    proposals
+      .map((p) => (p.payload as { issueNumber?: number } | null)?.issueNumber)
+      .filter((n): n is number => typeof n === "number"),
+  );
+  const stages = new Map<PipelineStage, PlacedIssue<T>[]>(PIPELINE_STAGES.map((s) => [s.key, []]));
+  for (const issue of issues) {
+    if (issue.state === "open") {
+      const { stage, placed } = placeOpen(issue, proposalIssueNumbers.has(issue.number));
+      stages.get(stage)?.push(placed);
+    } else if (issue.ghUpdatedAt && now - Date.parse(issue.ghUpdatedAt) < WEEK_MS) {
+      // Closed recently — the mirror doesn't distinguish merged from closed,
+      // so "shipped" is closed-this-week. Good enough until outcomes land.
+      stages.get("shipped")?.push({
+        issue,
+        runState: null,
+        currentRun: currentRunOf(issue),
+        prs: prsOf(issue),
+      });
+    }
+  }
+  return stages;
+}
+
+export function pipelineCounts(stages: Map<PipelineStage, unknown[]>) {
+  return PIPELINE_STAGES.map((s) => ({ ...s, count: stages.get(s.key)?.length ?? 0 }));
+}

--- a/apps/web/lib/pipeline.ts
+++ b/apps/web/lib/pipeline.ts
@@ -40,6 +40,7 @@ export type PipelineIssue = {
   state: string;
   htmlUrl?: string;
   ghUpdatedAt?: string | null;
+  closedAt?: string | null;
   linkedRuns?: LinkedRun[];
 };
 
@@ -131,9 +132,13 @@ export function classifyPipeline<T extends PipelineIssue>(
     if (issue.state === "open") {
       const { stage, placed } = placeOpen(issue, proposalIssueNumbers.has(issue.number));
       stages.get(stage)?.push(placed);
-    } else if (issue.ghUpdatedAt && now - Date.parse(issue.ghUpdatedAt) < WEEK_MS) {
-      // Closed recently — the mirror doesn't distinguish merged from closed,
-      // so "shipped" is closed-this-week. Good enough until outcomes land.
+      continue;
+    }
+    // Shipped = closed this week, by close time — ghUpdatedAt would resurrect
+    // an old closed issue whenever it gets a comment or label. (The mirror
+    // doesn't distinguish merged from closed; good enough until outcomes land.)
+    const closedStamp = issue.closedAt ?? issue.ghUpdatedAt;
+    if (closedStamp && now - Date.parse(closedStamp) < WEEK_MS) {
       stages.get("shipped")?.push({
         issue,
         runState: null,

--- a/apps/web/lib/project-issues.ts
+++ b/apps/web/lib/project-issues.ts
@@ -1,0 +1,43 @@
+import { untypedApi } from "./api";
+import type { PipelineIssue } from "./pipeline";
+
+type IssuePage<T> = { items: T[]; nextCursor?: string | null };
+
+export type ProjectIssuesResult<T> =
+  | { ok: true; items: T[]; truncated: boolean }
+  | { ok: false; offline: boolean; status: number; message: string };
+
+// 20 pages × 100 = 2000 mirrored issues before we stop — far beyond any board
+// we render today, and the truncation is reported instead of silent.
+const MAX_PAGES = 20;
+const PAGE_SIZE = 100;
+
+/**
+ * Fetch the project's complete issue mirror, following pagination. Pipeline
+ * classification over a single default page silently drops older items from
+ * both the stage lists and the counts.
+ */
+export async function fetchAllProjectIssues<T extends PipelineIssue = PipelineIssue>(
+  projectId: string,
+): Promise<ProjectIssuesResult<T>> {
+  const items: T[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const query = new URLSearchParams({ state: "all", limit: String(PAGE_SIZE) });
+    if (cursor) query.set("cursor", cursor);
+    const res = await untypedApi<IssuePage<T>>(
+      "GET",
+      `/v1/projects/${projectId}/issues?${query.toString()}`,
+    );
+    if (!res.ok) {
+      // A partial board beats an empty one, but a first-page failure is real.
+      if (page === 0)
+        return { ok: false, offline: res.offline, status: res.status, message: res.message };
+      return { ok: true, items, truncated: true };
+    }
+    items.push(...res.data.items);
+    cursor = res.data.nextCursor ?? null;
+    if (!cursor) return { ok: true, items, truncated: false };
+  }
+  return { ok: true, items, truncated: true };
+}

--- a/apps/web/lib/session-rows.ts
+++ b/apps/web/lib/session-rows.ts
@@ -18,6 +18,11 @@ function prOf(gh: unknown): string | null {
   return null;
 }
 
+function issueOf(gh: unknown): number | null {
+  const n = gh && typeof gh === "object" ? (gh as { issueNumber?: unknown }).issueNumber : null;
+  return typeof n === "number" ? n : null;
+}
+
 /** Flatten runs into the session-table view model (server-side). */
 export function toSessionRows(
   runs: Array<Run & { project?: { id: string; slug: string } }>,
@@ -36,5 +41,6 @@ export function toSessionRows(
     endedAt: run.endedAt,
     costCents: costOf(run.receipt),
     prUrl: prOf(run.gh),
+    issueNumber: issueOf(run.gh),
   }));
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10379,6 +10379,11 @@
                             "type": "string",
                             "format": "date-time"
                           },
+                          "closedAt": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "date-time"
+                          },
                           "linkedRuns": {
                             "type": "array",
                             "items": {
@@ -10419,6 +10424,7 @@
                           "htmlUrl",
                           "commentsCount",
                           "ghUpdatedAt",
+                          "closedAt",
                           "linkedRuns"
                         ],
                         "additionalProperties": false
@@ -10594,6 +10600,11 @@
                       "type": "string",
                       "format": "date-time"
                     },
+                    "closedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time"
+                    },
                     "linkedRuns": {
                       "type": "array",
                       "items": {
@@ -10682,6 +10693,7 @@
                     "htmlUrl",
                     "commentsCount",
                     "ghUpdatedAt",
+                    "closedAt",
                     "linkedRuns",
                     "bodyMd",
                     "runs"

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -7897,6 +7897,8 @@ export interface operations {
                             commentsCount: number;
                             /** Format: date-time */
                             ghUpdatedAt: string | null;
+                            /** Format: date-time */
+                            closedAt: string | null;
                             linkedRuns: {
                                 id: string;
                                 mode: string;
@@ -8013,6 +8015,8 @@ export interface operations {
                         commentsCount: number;
                         /** Format: date-time */
                         ghUpdatedAt: string | null;
+                        /** Format: date-time */
+                        closedAt: string | null;
                         linkedRuns: {
                             id: string;
                             mode: string;

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -146,16 +146,15 @@ async function main() {
         },
       ]);
     }
-    // Acceptance checks prove shipped changes: they run against the agent's
-    // changed workspace. That covers builder deliveries AND repair modes
-    // (address-review, ci-doctor), which push commits too. Read-only modes
-    // (architect, review, security-sweep, …) change nothing, so running the
-    // project's checks would measure the repo's baseline — e.g. an architect
-    // failing `npm test` on a repo whose bootstrap PR hasn't merged yet. Skip
-    // those with an explicit informational check instead of failing.
-    const shipsChanges =
-      requiresDelivery(bundle.mode) || repairRepositoryMode(normalizedMode(bundle.mode));
-    if (!shipsChanges && bundle.checkCmds.length > 0 && engineCode === 0) {
+    // Acceptance checks prove changed work, so read-only modes (architect,
+    // review, security-sweep) skip them: those runs change nothing, and running
+    // the project's checks would measure the repo's baseline — e.g. an
+    // architect failing `npm test` on a repo whose bootstrap PR hasn't merged
+    // yet. Every other mode keeps the gate: builder deliveries, repair modes
+    // (address-review, ci-doctor — they push commits too), and custom/BYO
+    // modes that use checks as generic acceptance.
+    const readOnlyMode = readOnlyRepositoryMode(normalizedMode(bundle.mode));
+    if (readOnlyMode && bundle.checkCmds.length > 0 && engineCode === 0) {
       await emit([
         {
           type: "check",
@@ -171,9 +170,9 @@ async function main() {
     }
     const checksPassed =
       engineCode === 0 && checksConfigured && progressConfigured
-        ? shipsChanges
-          ? await runChecks(bundle, cwdFor(bundle))
-          : true
+        ? readOnlyMode
+          ? true
+          : await runChecks(bundle, cwdFor(bundle))
         : false;
     const engineAndChecksSucceeded = engineCode === 0 && checksPassed && securityReportConfigured;
     const git = engineAndChecksSucceeded ? await shipGitChanges(bundle) : undefined;

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -146,9 +146,31 @@ async function main() {
         },
       ]);
     }
+    // Acceptance checks prove a delivery: they run against the agent's changed
+    // workspace. Planning-only modes (architect, review, …) change nothing, so
+    // running the project's checks would measure the repo's baseline — e.g. an
+    // architect failing `npm test` on a repo whose bootstrap PR hasn't merged
+    // yet. Skip them with an explicit informational check instead of failing.
+    const deliveryMode = requiresDelivery(bundle.mode);
+    if (!deliveryMode && bundle.checkCmds.length > 0 && engineCode === 0) {
+      await emit([
+        {
+          type: "check",
+          data: {
+            self_reported: false,
+            name: "configured acceptance checks",
+            status: "passed",
+            reason: "skipped_planning_only_mode",
+            note: "checks gate deliveries; this run changes no code",
+          },
+        },
+      ]);
+    }
     const checksPassed =
       engineCode === 0 && checksConfigured && progressConfigured
-        ? await runChecks(bundle, cwdFor(bundle))
+        ? deliveryMode
+          ? await runChecks(bundle, cwdFor(bundle))
+          : true
         : false;
     const engineAndChecksSucceeded = engineCode === 0 && checksPassed && securityReportConfigured;
     const git = engineAndChecksSucceeded ? await shipGitChanges(bundle) : undefined;

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -146,13 +146,16 @@ async function main() {
         },
       ]);
     }
-    // Acceptance checks prove a delivery: they run against the agent's changed
-    // workspace. Planning-only modes (architect, review, …) change nothing, so
-    // running the project's checks would measure the repo's baseline — e.g. an
-    // architect failing `npm test` on a repo whose bootstrap PR hasn't merged
-    // yet. Skip them with an explicit informational check instead of failing.
-    const deliveryMode = requiresDelivery(bundle.mode);
-    if (!deliveryMode && bundle.checkCmds.length > 0 && engineCode === 0) {
+    // Acceptance checks prove shipped changes: they run against the agent's
+    // changed workspace. That covers builder deliveries AND repair modes
+    // (address-review, ci-doctor), which push commits too. Read-only modes
+    // (architect, review, security-sweep, …) change nothing, so running the
+    // project's checks would measure the repo's baseline — e.g. an architect
+    // failing `npm test` on a repo whose bootstrap PR hasn't merged yet. Skip
+    // those with an explicit informational check instead of failing.
+    const shipsChanges =
+      requiresDelivery(bundle.mode) || repairRepositoryMode(normalizedMode(bundle.mode));
+    if (!shipsChanges && bundle.checkCmds.length > 0 && engineCode === 0) {
       await emit([
         {
           type: "check",
@@ -160,15 +163,15 @@ async function main() {
             self_reported: false,
             name: "configured acceptance checks",
             status: "passed",
-            reason: "skipped_planning_only_mode",
-            note: "checks gate deliveries; this run changes no code",
+            reason: "skipped_read_only_mode",
+            note: "checks gate shipped changes; this run changes no code",
           },
         },
       ]);
     }
     const checksPassed =
       engineCode === 0 && checksConfigured && progressConfigured
-        ? deliveryMode
+        ? shipsChanges
           ? await runChecks(bundle, cwdFor(bundle))
           : true
         : false;

--- a/services/api/src/routes/v1/github.ts
+++ b/services/api/src/routes/v1/github.ts
@@ -60,6 +60,7 @@ const GhIssueItemSchema = z.object({
   htmlUrl: z.string(),
   commentsCount: z.number(),
   ghUpdatedAt: DateValue.nullable(),
+  closedAt: DateValue.nullable(),
   linkedRuns: z.array(LinkedRunSchema),
 });
 
@@ -492,6 +493,7 @@ function issueItem(
     htmlUrl: issue.htmlUrl,
     commentsCount: issue.commentsCount,
     ghUpdatedAt: issue.ghUpdatedAt,
+    closedAt: issue.closedAt,
     linkedRuns,
   };
 }

--- a/services/api/src/routes/v1/runs.ts
+++ b/services/api/src/routes/v1/runs.ts
@@ -178,6 +178,17 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
           "plan_acceptance runs can only be created by the approved-plan executor",
         );
       }
+      // Preserve issue provenance across generic dispatch (retries pass the
+      // source run's trigger): without this, a retried issue-run loses its
+      // gh linkage and disappears from the issue's history and the pipeline.
+      const triggerRepo = body.trigger?.repo as { owner?: unknown; name?: unknown } | undefined;
+      const triggerIssue = body.trigger?.issue as { number?: unknown } | undefined;
+      const gh =
+        typeof triggerRepo?.owner === "string" &&
+        typeof triggerRepo?.name === "string" &&
+        typeof triggerIssue?.number === "number"
+          ? { owner: triggerRepo.owner, repo: triggerRepo.name, issueNumber: triggerIssue.number }
+          : {};
       const agent = await resolveRunAgentDef(p.orgId, projectId, body);
       const run = (
         await db
@@ -196,6 +207,7 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
             // like Codex runs even though orchestration correctly used the agent.
             engine: agent.engine,
             trigger: body.trigger ?? {},
+            gh,
             createdBy: { type: p.type, id: p.id },
           })
           .returning()


### PR DESCRIPTION
First batch of UX and correctness work from a week of dogfooding, driven by operating a real project from the UI. Five commits: three UX, two bug fixes found in practice.

## UX — pipeline-first product surface (part of theam/facility#18)

- **Two-mode navigation.** Org mode: `Projects` + a *platform* group (Activity, Skills & Rules, Audit log, Approvals, Settings) with explanatory subtitles — no invented terms without explanation (Fleet→Activity, Harness→Skills & Rules, Inbox→Approvals, Sessions→Runs, Owner→Project Manager). Project mode: one contextual menu titled by the project's name with an explicit "← Back to all projects"; the stacked org menu is gone.
- **Projects dashboard.** Outcome metrics move to a **Stats** tab (plus MTD spend); cards become informative: newest waiting decision with issue + aging ("Plan waiting for your approval — issue theam/facility#2 · waiting 19h"), live agents, last-run failure, and a compact per-stage pipeline strip.
- **The pipeline as centerpiece.** Stages follow the delivery-board convention: `Backlog → Planning → Ready → Building → In review → Shipped`, with **human gates visually distinct** from agent stages. Placement is **current-run-wins**: the newest linked run explains an issue's position — live runs pulse in their agent stage, failed runs sit there marked red (a failed attempt never rests in a human gate). The project Overview opens with the board (the agent config table moved to Agents); the Issues page becomes a **Pipeline view** grouped by stage with counter-filter pills; issue rows show one current run (history collapses to "(N earlier)") plus every PR the issue produced; "needs you" PRs read "implements #N *title*"; runs list and session detail backlink to their issue.

Doctrine encoded in `lib/pipeline.ts`: **GitHub is the source of truth for issues and PRs; Facility is the source of truth for pipeline state** (provenance comes from Facility's own runs, not from parsing GitHub).

## Fixes (found and reproduced live)

- **Closes theam/facility#29** — generic run dispatch (`POST /v1/projects/:id/runs`, used by retry) never derived `gh` from the trigger, so retried issue-runs lost their issue linkage (evidence in the issue).
- **Closes theam/facility#30** — planning-only runs executed delivery acceptance checks against the unmodified workspace and failed on the repo's baseline (architect vs. `npm test` with no `package.json`). Checks now gate deliveries only; planning modes emit an explicit informational skip.

## Verification

- `tsc --noEmit` green on web, api, and runner; `biome check` clean on all touched files (the 1 pre-existing warning on `main` is untouched).
- Live-verified on a deployment with a 13-issue backlog: an issue correctly places in *In review* with its PR theam/facility#15 linked after the provenance fix; runner image rebuilt and the planning-skip check event renders in the session view.
- Full `pnpm verify` left to CI (api suites need the isolated test DBs).

Related: theam/facility#26 (the `check_cmds` landmines this week also motivate connect-time capture), theam/facility#28 (preflight validation — still open, this PR doesn't cover it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
