### PR TITLE
feat(web): delivery-first pipeline order + collapsible stage sections

### DIFF
--- a/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
@@ -68,8 +68,10 @@ export default async function ProjectPipelinePage({
           <Eyebrow>pipeline</Eyebrow>
           <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Pipeline</h1>
           <p className="text-[12.5px] text-(--dim)">
-            {issues.ok ? `${openCount} open issues · closest to shipping on top` : "mirror unavailable"} ·
-            issues live on GitHub — agents are dispatched here
+            {issues.ok
+              ? `${openCount} open issues · closest to shipping on top`
+              : "mirror unavailable"}{" "}
+            · issues live on GitHub — agents are dispatched here
           </p>
         </div>
         {canSync ? <SyncIssuesButton projectId={projectId} /> : null}

--- a/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/issues/page.tsx
@@ -4,6 +4,7 @@ import type { GhIssue } from "@/components/issues/issue-row";
 import { IssueRow } from "@/components/issues/issue-row";
 import { SyncIssuesButton } from "@/components/issues/sync-button";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { StageSection } from "@/components/project/stage-section";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api } from "@/lib/api";
 import {
@@ -15,6 +16,9 @@ import {
 import { fetchAllProjectIssues } from "@/lib/project-issues";
 
 export const metadata = { title: "pipeline" };
+
+/** The list reads delivery-first: what's closest to shipping sits on top. */
+const DELIVERY_FIRST = [...PIPELINE_STAGES].reverse();
 
 function hasPermission(permissions: string[], permission: string) {
   const [resource] = permission.split(":");
@@ -49,12 +53,12 @@ export default async function ProjectPipelinePage({
     ? inbox.data.proposals.filter((x) => !x.projectId || x.projectId === projectId)
     : [];
   const stages = classifyPipeline(items, proposals);
-  const counts = pipelineCounts(stages);
+  const counts = [...pipelineCounts(stages)].reverse();
   const openCount = items.filter((i) => i.state === "open").length;
 
   const visibleStages = activeStage
-    ? PIPELINE_STAGES.filter((s) => s.key === activeStage)
-    : PIPELINE_STAGES;
+    ? DELIVERY_FIRST.filter((s) => s.key === activeStage)
+    : DELIVERY_FIRST;
 
   return (
     <div className="flex flex-col gap-8">
@@ -64,7 +68,7 @@ export default async function ProjectPipelinePage({
           <Eyebrow>pipeline</Eyebrow>
           <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Pipeline</h1>
           <p className="text-[12.5px] text-(--dim)">
-            {issues.ok ? `${openCount} open issues flowing left to right` : "mirror unavailable"} ·
+            {issues.ok ? `${openCount} open issues · closest to shipping on top` : "mirror unavailable"} ·
             issues live on GitHub — agents are dispatched here
           </p>
         </div>
@@ -126,28 +130,20 @@ export default async function ProjectPipelinePage({
           backfill.
         </p>
       ) : (
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-6">
           {visibleStages.map((s) => {
             const stageItems = stages.get(s.key) ?? [];
             return (
-              <section key={s.key} className="flex flex-col gap-3">
-                <div className="flex items-baseline gap-3">
-                  {stageItems.some((p) => p.runState === "failed") ? (
-                    <StatusDot tone="bad" />
-                  ) : s.kind === "human" ? (
-                    <StatusDot tone="human" />
-                  ) : s.kind === "agent" ? (
-                    <StatusDot
-                      tone={stageItems.length > 0 ? "agent" : "machine"}
-                      pulse={stageItems.some((p) => p.runState === "live")}
-                    />
-                  ) : (
-                    <StatusDot tone="ok" />
-                  )}
-                  <h2 className="text-[14px] font-semibold tracking-tight">{s.label}</h2>
-                  <span className="font-mono text-[12px] text-(--dim)">{stageItems.length}</span>
-                  <span className="text-[11.5px] text-(--dim)">{s.sub}</span>
-                </div>
+              <StageSection
+                key={s.key}
+                label={s.label}
+                sub={s.sub}
+                kind={s.kind}
+                total={stageItems.length}
+                liveCount={stageItems.filter((p) => p.runState === "live").length}
+                failedCount={stageItems.filter((p) => p.runState === "failed").length}
+                defaultOpen={activeStage !== null || s.key !== "shipped"}
+              >
                 {stageItems.length === 0 ? (
                   <p className="border border-(--line) px-5 py-3.5 text-[12.5px] text-(--dim)">
                     Nothing here right now.
@@ -164,7 +160,7 @@ export default async function ProjectPipelinePage({
                     ))}
                   </div>
                 )}
-              </section>
+              </StageSection>
             );
           })}
         </div>

--- a/apps/web/components/project/stage-section.tsx
+++ b/apps/web/components/project/stage-section.tsx
@@ -1,0 +1,68 @@
+import { cx, StatusDot } from "@facility/ui";
+import type { StageKind } from "@/lib/pipeline";
+
+/**
+ * A collapsible pipeline stage. Native <details> keeps this a server
+ * component: no client state, and the collapsed-only summary chips are
+ * hidden via `details[open]` CSS alone.
+ */
+export function StageSection({
+  label,
+  sub,
+  kind,
+  total,
+  liveCount,
+  failedCount,
+  defaultOpen,
+  children,
+}: {
+  label: string;
+  sub: string;
+  kind: StageKind;
+  total: number;
+  liveCount: number;
+  failedCount: number;
+  defaultOpen: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <details open={defaultOpen} className="group flex flex-col gap-3">
+      <summary className="flex cursor-pointer list-none items-baseline gap-3 [&::-webkit-details-marker]:hidden">
+        <span
+          aria-hidden
+          className="font-mono text-[11px] text-(--dim) transition-transform group-open:rotate-90"
+        >
+          ▸
+        </span>
+        {failedCount > 0 ? (
+          <StatusDot tone="bad" />
+        ) : kind === "human" ? (
+          <StatusDot tone="human" />
+        ) : kind === "agent" ? (
+          <StatusDot tone={total > 0 ? "agent" : "machine"} pulse={liveCount > 0} />
+        ) : (
+          <StatusDot tone="ok" />
+        )}
+        <h2 className="text-[14px] font-semibold tracking-tight">{label}</h2>
+        <span className="font-mono text-[12px] text-(--dim)">{total}</span>
+        <span className="text-[11.5px] text-(--dim)">{sub}</span>
+        {/* Collapsed-only state summary: what's inside without opening. */}
+        <span className="ml-auto flex items-center gap-3 font-mono text-[11px] group-open:hidden">
+          {liveCount > 0 ? (
+            <span className="inline-flex items-center gap-1.5 text-(--mut)">
+              <StatusDot tone="agent" pulse />
+              {liveCount} running
+            </span>
+          ) : null}
+          {failedCount > 0 ? (
+            <span className={cx("inline-flex items-center gap-1.5", "text-(--bad,--mut)")}>
+              <StatusDot tone="bad" />
+              {failedCount} failed
+            </span>
+          ) : null}
+        </span>
+      </summary>
+      <div className="mt-3">{children}</div>
+    </details>
+  );
+}


### PR DESCRIPTION
Follow-up UX round on the pipeline view (#11/#18), from operating the demo project.

- **Delivery-first order**: the grouped list (and its filter pills) now puts what's closest to shipping on top — Shipped → In review → Building → Ready → Planning → Backlog. The Overview board keeps its left-to-right flow; the list reads as a priority queue.
- **Collapsible stages** via native `<details>` (server-rendered, zero client state). **Shipped starts collapsed**; a collapsed stage shows a header summary — total, N running (pulsing dot), N failed (red dot) — hidden automatically when open via `details[open]` CSS.
- Header copy updated ("closest to shipping on top").

Verified live on the demo deployment; `tsc` + biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)