### PR TITLE
docs: local development guide, tunnel included

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ GitHub Apps → New GitHub App**.
   `AUTH_CALLBACK_URL` in `.env` exactly, byte for byte.
 - Check **"Request user authorization (OAuth) during installation"**.
 - **Webhook**: optional for local evaluation — you can disable it and use the
-  "sync from GitHub" button instead. To receive events locally, point it at a
-  public tunnel that forwards to `http://localhost:4400/webhooks/github` and
-  set a webhook secret.
+  "sync from GitHub" button instead. To receive events on a development
+  machine you need a public URL for your laptop; the
+  [local development guide](apps/docs/docs/self-host/local-development.md)
+  walks through a Cloudflare tunnel and the exact payload URL
+  (`https://<your-host>/api/webhooks/github` — through the `/api` proxy).
 - **Permissions**:
 
   | Scope | Permission | Access |
@@ -290,7 +292,7 @@ To delegate all of this to Claude Code or Codex, paste this prompt:
 | `auth_failed: GitHub identity or installation access could not be verified` | The App lacks the **Email addresses: Read-only** account permission, or your verified GitHub email is unavailable. Fix the permission and re-authorize. |
 | `403 not_invited` / `installation_access_required` | Your GitHub user is not provisioned, or the user/account/installation ids in the bootstrap don't match — re-run step 5 with the real ids. |
 | Login succeeds but you land on the wrong host | `WEB_URL` must be the origin your browser uses. |
-| Testing through an HTTPS tunnel: assets/RSC/HMR fail | Set `WEB_URL` and `AUTH_CALLBACK_URL` to the tunnel origin (and the App's Callback URL to match), and add the tunnel hostname to `allowedDevOrigins` in `apps/web/next.config.ts` — Next blocks cross-origin dev requests otherwise. |
+| Testing through an HTTPS tunnel: navigation, live updates or hot reload fail | Set `WEB_URL` and `AUTH_CALLBACK_URL` to the tunnel origin (and the App's Callback URL to match), and put the tunnel hostname in `FACILITY_DEV_ORIGINS` — Next blocks cross-origin development requests otherwise. Full walkthrough: [local development](apps/docs/docs/self-host/local-development.md). |
 
 Your next steps are to create a project, connect a repository, preview the
 generated files, and let Facility open the kickstart PR. Follow the

--- a/apps/docs/docs/self-host/local-development.md
+++ b/apps/docs/docs/self-host/local-development.md
@@ -1,0 +1,145 @@
+---
+title: Local development
+---
+
+# Running Facility on your machine
+
+`pnpm dev` gives you a working instance in a few minutes. Everything on this
+page is about the part that is not obvious: **GitHub cannot reach your laptop**,
+so some of the product only comes alive once your instance has a public URL.
+
+Read the [quickstart](quickstart) first for the initial run and the
+[GitHub App guide](github-app) for the App itself. This page covers what to do
+after that, on a development machine.
+
+## What works without a public URL
+
+| Capability | Without a tunnel |
+|---|---|
+| Sign in, browse projects, read the knowledge base | Works — the OAuth callback can be `http://localhost:3400/api/auth/callback` |
+| Dispatching agents from the UI | Works — the control plane triggers runs directly |
+| Mirroring issues | Only when you press **sync from GitHub** |
+| Reacting to issues, comments, pull requests, workflow runs | **Does not happen** — those arrive as webhooks |
+| Slash commands in issue comments (`/architect`, `/builder`) | **Do not arrive** |
+
+If you only want to look around, skip the tunnel. If you want the loop to react
+to what happens on GitHub, keep reading.
+
+## One tunnel, pointed at the web app
+
+The web application proxies `/api/*` to the control plane, so a **single**
+tunnel to port `3400` covers the interface, sign-in and webhooks. Do not tunnel
+port `4400` as well.
+
+| What GitHub or your browser needs | URL |
+|---|---|
+| The application | `https://<your-host>/` |
+| OAuth callback | `https://<your-host>/api/auth/callback` |
+| Webhook payload URL | `https://<your-host>/api/webhooks/github` |
+
+The webhook path goes through `/api` because that is the proxy prefix — posting
+to `https://<your-host>/webhooks/github` returns 404, which looks exactly like a
+broken tunnel and is not.
+
+## Starting a tunnel with cloudflared
+
+Install it first: `brew install cloudflared`, or see
+[Cloudflare's downloads](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/).
+
+### Throwaway tunnel — no account, new hostname each time
+
+```bash
+cloudflared tunnel --url http://localhost:3400
+```
+
+It prints a `https://<random>.trycloudflare.com` address. Good enough for an
+afternoon; the hostname changes on every restart, and each change means editing
+the App's callback and webhook URLs and your `.env` again.
+
+### Named tunnel — stable hostname, needs a domain on Cloudflare
+
+Worth the ten minutes if you will use it more than once:
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create facility-dev
+cloudflared tunnel route dns facility-dev dev.example.com
+```
+
+Then write `~/.cloudflared/config.yml`:
+
+```yaml
+tunnel: <the tunnel id printed by create>
+credentials-file: /Users/you/.cloudflared/<tunnel-id>.json
+
+ingress:
+  - hostname: dev.example.com
+    service: http://localhost:3400
+  - service: http_status:404
+```
+
+And run it — this stays in the foreground, so give it its own terminal:
+
+```bash
+cloudflared tunnel run
+```
+
+## Point Facility and the App at the tunnel
+
+In `.env`:
+
+```dotenv
+# The origin your browser uses. Sign-in redirects and the session cookie's
+# Secure flag are derived from it.
+WEB_URL=https://dev.example.com
+AUTH_CALLBACK_URL=https://dev.example.com/api/auth/callback
+
+# Next blocks cross-origin development requests — without this the pages load
+# but client-side navigation, live updates and hot reload fail.
+FACILITY_DEV_ORIGINS=dev.example.com
+```
+
+Leave `PUBLIC_URL` as `http://localhost:4400`: it is the control plane's own
+origin, not the browser-facing one.
+
+In the GitHub App settings:
+
+- **Callback URL** → `https://dev.example.com/api/auth/callback` (byte for byte;
+  a mismatch shows GitHub's `redirect_uri` error page).
+- **Webhook URL** → `https://dev.example.com/api/webhooks/github`, active, with
+  a secret that matches `GITHUB_APP_WEBHOOK_SECRET`.
+
+Restart the stack after changing `.env` — configuration is read at boot.
+
+Verify the whole chain before trusting it:
+
+```bash
+curl -i https://dev.example.com/login                       # 200
+curl -i -X POST https://dev.example.com/api/webhooks/github # 401: the route is
+                                                            # there and refuses
+                                                            # unsigned payloads
+```
+
+Then open the App's **Advanced → Recent deliveries** and redeliver an event: a
+`2xx` means Facility received it.
+
+## Day-to-day
+
+- `pnpm dev` starts everything. Ctrl-C stops the foreground processes; Docker
+  keeps running for next time.
+- The tunnel is separate. Restarting the application does not restart it, and
+  the reverse is also true.
+- After pulling changes that touch `packages/ui` styles, restart the web app —
+  the bundler keeps stale CSS across those edits more often than it should.
+
+## When something looks broken
+
+| Symptom | What it is |
+|---|---|
+| The tunnel returns 502 or 530 while `curl http://localhost:3400` is fine | `cloudflared` lost its connection — often after restarting the dev server while a page held an open event stream. Restart the tunnel. |
+| Every page 404s, including `/login` | The dev server hit its open-file limit while scanning. Look at `apps/web/.next/dev/logs/next-development.log` for `EMFILE`; the errors do not reach the terminal. Raise the limit for the process (`ulimit -n 8192`) and start again. |
+| Pages load but navigation, live updates or hot reload fail through the tunnel | `FACILITY_DEV_ORIGINS` is missing the tunnel hostname. |
+| Manifest errors after switching branches | Stop the web app, delete `apps/web/.next`, start it again. |
+| Issues never update by themselves | No webhook is reaching you. Check the App's recent deliveries, then that the payload URL includes `/api/`. |
+| `501 auth_unconfigured` when signing in | `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` are missing — the configuration requires both or neither. |
+| `403 not_invited` or `installation_access_required` | Your GitHub user is not provisioned on this instance, or the ids given to `facility instance bootstrap` do not match the real ones. |

--- a/apps/docs/docs/self-host/quickstart.md
+++ b/apps/docs/docs/self-host/quickstart.md
@@ -42,7 +42,9 @@ worker, gateway, MCP server, and optional web application together.
 
 Create a GitHub App for the local instance, configure its OAuth callback and
 credentials, and run `facility instance bootstrap` before opening
-`http://localhost:3400`. See [Authentication modes](authentication) for the exact
+`http://localhost:3400`. To let GitHub reach a development machine —
+webhooks, so the loop reacts to issues, comments and pull requests — see
+[Local development](local-development). See [Authentication modes](authentication) for the exact
 callback, permissions, and bootstrap arguments. Local login uses GitHub exactly
 like a self-hosted deployment; there is no public development-login bypass.
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         "self-host/quickstart",
+        "self-host/local-development",
         "self-host/production",
         "self-host/github-app",
         "self-host/aws",

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
A colleague installing Facility on his laptop found there was no guide for the part that actually bites: `pnpm dev` gives you a working instance, and then half the product silently never reacts, because GitHub cannot reach a laptop.

**New page — `self-host/local-development`:**

- **What works without a public URL**, as a table. Signing in, browsing and dispatching agents from the UI all work; mirroring only happens when you press *sync from GitHub*; reacting to issues, comments and pull requests, and slash commands, do not happen at all. Better to say so than to let someone conclude the product is broken.
- **One tunnel, pointed at the web app** (`:3400`), which proxies `/api` to the control plane — so a single tunnel covers the interface, sign-in and webhooks. With the three URLs spelled out.
- **cloudflared** in both flavours: the throwaway `--url` tunnel and a named tunnel with its `config.yml`, with the trade-off stated (a new hostname on every restart means editing the App and `.env` again).
- **The `.env` values** and why `PUBLIC_URL` stays on localhost, plus a `curl` that proves the chain before you trust it.
- **Troubleshooting**: the tunnel dropping when the dev server restarts under an open event stream; the open-file limit that 404s *every* route with the error hidden in `.next/dev/logs/`; stale manifests after a branch switch; the cross-origin block that lets pages load but kills navigation.

**Correction to the README**: it pointed the webhook at `http://localhost:4400/webhooks/github`. Through the proxy the payload URL is `https://<host>/api/webhooks/github` — verified: `/api/webhooks/github` reaches the route and answers 401 to an unsigned payload, while `/webhooks/github` on the web app is a 404 that reads exactly like a broken tunnel.

Docs build passes, so the cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)