### PR TITLE
chore: publish plumbing for the docs site and the npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -30,6 +32,49 @@ jobs:
 
       - name: Release-shaped verification
         run: pnpm verify
+
+      - name: Validate the public release tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
+        run: node scripts/release.mjs validate
+
+      # Build the package once in the nonprivileged acceptance job. The npm
+      # environment later receives this exact, already-tested archive rather
+      # than running package lifecycle code with publication credentials.
+      - name: Pack the release candidate
+        id: candidate
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_dir="$RUNNER_TEMP/facility-release"
+          mkdir -p "$release_dir"
+          tarball="$(cd packages/cli && npm pack --ignore-scripts --pack-destination "$release_dir")"
+          candidate="$release_dir/$tarball"
+          node scripts/release.mjs artifact "$candidate"
+          echo "path=$candidate" >> "$GITHUB_OUTPUT"
+
+      - name: Install the release candidate and run the binary
+        if: steps.candidate.outcome == 'success'
+        shell: bash
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.path }}
+        run: |
+          set -euo pipefail
+          smoke_dir="$RUNNER_TEMP/facility-release-smoke"
+          mkdir -p "$smoke_dir"
+          cd "$smoke_dir"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --silent "$CANDIDATE"
+          ./node_modules/.bin/facility --help
+
+      - name: Preserve the tested release candidate
+        if: steps.candidate.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: facility-release-package
+          path: ${{ steps.candidate.outputs.path }}
+          if-no-files-found: error
+          retention-days: 1
 
   self-host-build:
     runs-on: ubuntu-latest
@@ -120,3 +165,14 @@ jobs:
       - name: Record an allowed skip
         if: steps.policy.outputs.required != 'true'
         run: echo "Sandbox E2E skipped by policy — ${{ steps.policy.outputs.reason }}."
+
+  # Keep publication in the original tag run so npm provenance identifies the
+  # tag and commit that passed every acceptance job. A downstream workflow_run
+  # would instead attest the default branch SHA.
+  publish-npm:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
+    needs: [verify, self-host-build, sandbox-e2e]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
-# Publishes the Docusaurus site (apps/docs) to GitHub Pages on every push to
-# main. Pages only serves public repositories outside Enterprise, so the job
-# is a no-op while this repository is private: merging this workflow changes
-# nothing today, and the first push after the repository is made public
-# publishes the site without anyone having to remember this file exists.
+# Publishes the Docusaurus site (apps/docs) to GitHub Pages from main. After the
+# repository becomes public, a maintainer must enable Pages with "GitHub
+# Actions" as its source once; a push to main (or a manual run from main) can
+# then deploy it. That repository setting intentionally remains a human admin
+# action instead of requiring an admin token in this workflow.
 # Actions are pinned to full SHAs (guards/actions-pinned.mjs enforces it).
 name: docs
 
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   publish:
-    if: github.event.repository.visibility == 'public'
+    if: github.event.repository.visibility == 'public' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+# Publishes the Docusaurus site (apps/docs) to GitHub Pages on every push to
+# main. Pages only serves public repositories outside Enterprise, so the job
+# is a no-op while this repository is private: merging this workflow changes
+# nothing today, and the first push after the repository is made public
+# publishes the site without anyone having to remember this file exists.
+# Actions are pinned to full SHAs (guards/actions-pinned.mjs enforces it).
+name: docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One deployment at a time, and never cancel one in flight: a half-applied
+# Pages deployment is a broken site, not a wasted minute.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.repository.visibility == 'public'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      # The site's canonical URL comes from Pages itself rather than a constant,
+      # so pointing a custom domain at it later needs no change here.
+      - name: Build the documentation site
+        env:
+          DOCS_URL: ${{ steps.pages.outputs.origin }}
+          DOCS_BASE_URL: ${{ steps.pages.outputs.base_path }}
+        run: pnpm --filter @facility/docs build
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: apps/docs/build
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Publishes @theam/facility to npm from a tag. The tag is the decision: nothing
+# Publishes @theagilemonkeys/facility to npm from a tag. The tag is the decision: nothing
 # is published on a merge to main. Run the workflow by hand first — it defaults
 # to a dry run — to see exactly what would be uploaded.
 #
@@ -57,7 +57,7 @@ jobs:
           echo "Publishing $packaged"
 
       - name: Test the CLI
-        run: pnpm --filter @theam/facility test
+        run: pnpm --filter @theagilemonkeys/facility test
 
       # The published tarball is what users get, not the checkout: install it
       # the way npx would and run the binary. Catches a `files` list that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,33 @@
-# Publishes @theagilemonkeys/facility to npm from a tag. The tag is the decision: nothing
-# is published on a merge to main. Run the workflow by hand first — it defaults
-# to a dry run — to see exactly what would be uploaded.
+# npm publication has two deliberately separate entry points:
 #
-# Requires an npm automation token in the NPM_TOKEN secret. Provenance links the
-# tarball to this workflow run, which npm only accepts from a public repository;
-# while the repository is private the publish falls back to a plain one.
+# - A manual run is always a credential-free dry run. There is no input that
+#   can turn it into a release.
+# - ci.yml calls this workflow from a public version-tag run only after every
+#   acceptance job passes. Keeping publication in that original run gives npm
+#   provenance the tested tag and commit rather than a downstream default-branch
+#   identity.
+#
+# The first public release needs a granular npm token in the protected `npm`
+# environment as NPM_BOOTSTRAP_TOKEN. After that one publish, configure npm
+# trusted publishing for ci.yml + the `npm` environment, revoke/delete the
+# bootstrap token, and disallow token publishing.
 # Actions are pinned to full SHAs (guards/actions-pinned.mjs enforces it).
 name: release
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_call:
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Pack and verify without uploading
-        type: boolean
-        default: true
 
 permissions:
   contents: read
 
 jobs:
-  npm:
+  dry-run:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -37,54 +37,97 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
-
-      # A tag that disagrees with package.json publishes a version nobody can
-      # trace back to a commit. Refuse before anything reaches the registry.
-      - name: The tag and the package version must agree
-        if: startsWith(github.ref, 'refs/tags/v')
-        working-directory: packages/cli
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          packaged="v$(node -p "require('./package.json').version")"
-          if [ "$packaged" != "$TAG" ]; then
-            echo "tag $TAG does not match packages/cli/package.json ($packaged)" >&2
-            exit 1
-          fi
-          echo "Publishing $packaged"
 
       - name: Test the CLI
         run: pnpm --filter @theagilemonkeys/facility test
 
-      # The published tarball is what users get, not the checkout: install it
-      # the way npx would and run the binary. Catches a `files` list that
-      # forgot a directory — a failure mode no repository-level test sees.
-      - name: Install the packed tarball and run the binary
+      - name: Pack, install, and dry-run the exact release candidate
+        shell: bash
         run: |
           set -euo pipefail
-          tarball="$(cd packages/cli && npm pack --silent --pack-destination "$RUNNER_TEMP")"
-          mkdir -p "$RUNNER_TEMP/smoke" && cd "$RUNNER_TEMP/smoke"
+          release_dir="$RUNNER_TEMP/facility-release"
+          smoke_dir="$RUNNER_TEMP/facility-release-smoke"
+          mkdir -p "$release_dir" "$smoke_dir"
+          tarball="$(cd packages/cli && npm pack --ignore-scripts --pack-destination "$release_dir")"
+          candidate="$release_dir/$tarball"
+          node scripts/release.mjs artifact "$candidate"
+          cd "$smoke_dir"
           npm init -y >/dev/null
-          npm install --silent "$RUNNER_TEMP/$tarball"
+          npm install --ignore-scripts --silent "$candidate"
           ./node_modules/.bin/facility --help
+          cd "$GITHUB_WORKSPACE"
+          node scripts/release.mjs dry-run "$candidate"
 
-      - name: Decide the publish flags
-        id: flags
-        env:
-          VISIBILITY: ${{ github.event.repository.visibility }}
-          DRY_RUN: ${{ inputs.dry_run }}
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: npm-theagilemonkeys-facility
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    environment: npm
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Install the trusted-publishing npm client
         run: |
-          flags="--access public"
-          if [ "$VISIBILITY" = "public" ]; then flags="$flags --provenance"; fi
-          if [ "$DRY_RUN" = "true" ]; then flags="$flags --dry-run"; fi
-          echo "flags=$flags" >> "$GITHUB_OUTPUT"
-          echo "npm publish $flags"
+          npm install --global npm@11.15.0
+          test "$(npm --version)" = "11.15.0"
 
-      - name: Publish
-        working-directory: packages/cli
+      - name: Download the accepted release candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: facility-release-package
+          path: ${{ runner.temp }}/facility-release
+
+      - name: Revalidate the tag and release artifact
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/release.mjs validate
+          shopt -s nullglob
+          tarballs=("$RUNNER_TEMP/facility-release/"*.tgz)
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "expected exactly one release tarball, found ${#tarballs[@]}" >&2
+            exit 1
+          fi
+          node scripts/release.mjs artifact "${tarballs[0]}"
+          echo "path=${tarballs[0]}" >> "$GITHUB_OUTPUT"
+
+      # This lookup is unauthenticated and fails closed on network errors,
+      # malformed metadata, and any response other than an exact package 404
+      # or valid existing-package document.
+      - name: Determine the allowed authentication path
+        id: registry
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish ${{ steps.flags.outputs.flags }}
+          CANDIDATE: ${{ steps.candidate.outputs.path }}
+        run: node scripts/release.mjs registry-state "$CANDIDATE"
+
+      - name: Publish with npm trusted publishing
+        if: steps.registry.outputs.state == 'existing'
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.path }}
+        run: node scripts/release.mjs publish "$CANDIDATE" --auth=oidc
+
+      # The environment secret is materialized only on the exact first-publish
+      # branch. The helper probes the unauthenticated registry twice more before
+      # spawning npm, preventing token fallback for existing packages or
+      # uncertain registry state.
+      - name: Bootstrap the package once with a granular token
+        if: steps.registry.outputs.state == 'missing'
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.path }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: node scripts/release.mjs publish "$CANDIDATE" --auth=bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+# Publishes @theam/facility to npm from a tag. The tag is the decision: nothing
+# is published on a merge to main. Run the workflow by hand first — it defaults
+# to a dry run — to see exactly what would be uploaded.
+#
+# Requires an npm automation token in the NPM_TOKEN secret. Provenance links the
+# tarball to this workflow run, which npm only accepts from a public repository;
+# while the repository is private the publish falls back to a plain one.
+# Actions are pinned to full SHAs (guards/actions-pinned.mjs enforces it).
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Pack and verify without uploading
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      # A tag that disagrees with package.json publishes a version nobody can
+      # trace back to a commit. Refuse before anything reaches the registry.
+      - name: The tag and the package version must agree
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: packages/cli
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          packaged="v$(node -p "require('./package.json').version")"
+          if [ "$packaged" != "$TAG" ]; then
+            echo "tag $TAG does not match packages/cli/package.json ($packaged)" >&2
+            exit 1
+          fi
+          echo "Publishing $packaged"
+
+      - name: Test the CLI
+        run: pnpm --filter @theam/facility test
+
+      # The published tarball is what users get, not the checkout: install it
+      # the way npx would and run the binary. Catches a `files` list that
+      # forgot a directory — a failure mode no repository-level test sees.
+      - name: Install the packed tarball and run the binary
+        run: |
+          set -euo pipefail
+          tarball="$(cd packages/cli && npm pack --silent --pack-destination "$RUNNER_TEMP")"
+          mkdir -p "$RUNNER_TEMP/smoke" && cd "$RUNNER_TEMP/smoke"
+          npm init -y >/dev/null
+          npm install --silent "$RUNNER_TEMP/$tarball"
+          ./node_modules/.bin/facility --help
+
+      - name: Decide the publish flags
+        id: flags
+        env:
+          VISIBILITY: ${{ github.event.repository.visibility }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          flags="--access public"
+          if [ "$VISIBILITY" = "public" ]; then flags="$flags --provenance"; fi
+          if [ "$DRY_RUN" = "true" ]; then flags="$flags --dry-run"; fi
+          echo "flags=$flags" >> "$GITHUB_OUTPUT"
+          echo "npm publish $flags"
+
+      - name: Publish
+        working-directory: packages/cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ${{ steps.flags.outputs.flags }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,57 @@ request so the change can be reviewed and reverted independently.
 
 ## Releasing (maintainers)
 
+Publishing is tag-driven. A `vX.Y.Z` tag starts `.github/workflows/ci.yml`,
+which must pass root verification, the self-host build, and the required
+sandbox E2E before it calls the reusable release workflow. Do not run
+`npm publish` locally or invoke the release workflow as a substitute for those
+gates; its manual entry point is a dry run.
+
 1. Bump the version in `package.json` and `packages/cli/package.json` according
    to semver (before 1.0, a minor release may contain breaking changes).
-2. Run `pnpm verify` and the build for every publishable artifact.
-3. Publish `@theagilemonkeys/facility` with public access.
-4. Tag `vX.Y.Z` and write release notes in terms of behavior, not commit titles.
+2. Run `pnpm verify` and the build for every publishable artifact, then merge
+   the release change through the normal reviewed pull-request path.
+3. Tag the release commit on `main` as `vX.Y.Z` and push the tag. CI refuses a
+   tag whose version, commit, visibility, or acceptance results do not match the
+   release contract.
+4. After the publish job succeeds, write release notes in terms of behavior,
+   not commit titles.
+
+### First npm publish only
+
+npm cannot attach a trusted publisher until the package exists. Bootstrap
+`@theagilemonkeys/facility` once with a short-lived
+[granular access token](https://docs.npmjs.com/creating-and-viewing-access-tokens/):
+
+1. Give the token read/write access only to the `@theagilemonkeys` scope, no
+   organization-management access, the shortest practical expiry, and bypass
+   2FA for the CI publish.
+2. Protect `v*` tag creation with a repository ruleset. Create the GitHub
+   environment named `npm`, require maintainer approval for deployment, and
+   store the token there as the `NPM_BOOTSTRAP_TOKEN` environment secret.
+3. Push the first release tag through the tag-driven flow above. The release
+   code accepts this credential only while the package is absent from npm.
+
+As soon as the first version exists, configure the package's
+[npm trusted publisher](https://docs.npmjs.com/trusted-publishers/) with these
+exact GitHub Actions values:
+
+- organization or user: `theam`
+- repository: `facility`
+- workflow filename: `ci.yml`
+- environment: `npm`
+- allowed action: `npm publish`
+
+Use `ci.yml`, not `release.yml`: npm validates the caller when a reusable
+workflow contains the publish command. Then delete the `NPM_BOOTSTRAP_TOKEN`
+GitHub secret, revoke the granular token on npm, and set the package's
+**Publishing access** to **Require two-factor authentication and disallow
+tokens**. Later tags publish through short-lived OIDC credentials only.
+
+### One-time GitHub Pages setup
+
+After the repository becomes public, a maintainer must select **GitHub
+Actions** under **Settings → Pages → Build and deployment → Source** once.
+After that, `.github/workflows/docs.yml` deploys pushes to `main` and manual
+runs selected from `main`. The workflow deliberately does not use an admin
+token or PAT to change the repository setting itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ self-host images and applies the Docker-backed sandbox E2E policy documented in
 Useful narrower commands include:
 
 ```bash
-pnpm --filter @theam/facility test
+pnpm --filter @theagilemonkeys/facility test
 pnpm --filter @facility/api test
 pnpm --filter @facility/gateway test
 pnpm --filter @facility/docs build
@@ -103,5 +103,5 @@ request so the change can be reviewed and reverted independently.
 1. Bump the version in `package.json` and `packages/cli/package.json` according
    to semver (before 1.0, a minor release may contain breaking changes).
 2. Run `pnpm verify` and the build for every publishable artifact.
-3. Publish `@theam/facility` with public access.
+3. Publish `@theagilemonkeys/facility` with public access.
 4. Tag `vX.Y.Z` and write release notes in terms of behavior, not commit titles.

--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ connecting it: agents work in Facility's sandboxes and push branches, pull
 requests and comments the way a collaborator would. Disconnecting leaves no
 trace either.
 
-That is the whole entry path — see the
-[connect-an-existing-repository guide](apps/docs/docs/guides/existing-repo.md).
+That is the whole entry path. If the repository already runs Facility's
+vendored workflows, follow the
+[existing-repository adoption guide](apps/docs/docs/guides/existing-repo.md).
 For the rest of the platform, follow the
 [self-host quickstart](apps/docs/docs/self-host/quickstart.md),
 [authentication guide](apps/docs/docs/self-host/authentication.md), and
@@ -407,6 +408,11 @@ configured GitHub App for repository automation.
 
 The [architecture document](docs/platform/ARCHITECTURE.md) describes the
 platform topology, security boundaries, and major design decisions.
+
+Once this repository is public, a maintainer must enable GitHub Pages with
+**GitHub Actions** as its source. After that one-time setting, the docs workflow
+deploys pushes to `main` (or a manual run from `main`); it does not require an
+admin token or PAT.
 
 ## Repository map
 

--- a/README.md
+++ b/README.md
@@ -64,87 +64,7 @@ itself when the team wants agents running in its own CI.
 | See whether the process works | Receipts, outcomes, health checks, analytics, issues, and a synthetic canary show cost, reliability, acceptance, and recurring failures. | Installer or platform |
 | Operate from different clients | The same permission model is exposed through the web app, REST API, CLI, and MCP server. | Platform |
 
-## Quick start: one repository
-
-The standalone installer needs a GitHub repository and Node.js 20 or newer; its
-runtime floor is lower than the platform's. It does not require you to deploy
-the Facility platform.
-
-```bash
-git clone https://github.com/theam/facility.git /absolute/path/to/facility
-cd your-repository
-node /absolute/path/to/facility/packages/cli/bin/facility.mjs init
-node /absolute/path/to/facility/packages/cli/bin/facility.mjs doctor --run-guards --github
-```
-
-The CLI is currently run from a Facility checkout; npm distribution is a later
-release step and is intentionally not part of this release candidate.
-
-The installer detects the repository's package manager, default branch, checks,
-and useful quality modules. It asks for the commands that create a working
-environment and verify a change, then adds:
-
-- GitHub workflows for planning, building, reviewing, addressing feedback,
-  repairing routine CI failures, security sweeps, and the watchtower;
-- `STANDARD.md`, agent instructions, skills, hooks, and deterministic guards;
-- `.facility.json`, which records the choices needed to reproduce the install.
-
-### Operate without the web application
-
-Every control-plane workflow is available over the versioned REST API and the
-zero-dependency CLI; AI clients use the same permissions through MCP.
-
-```bash
-# REST/OpenAPI
-open http://localhost:4400/docs
-
-# CLI from this checkout (the API key is hidden when entered interactively)
-node packages/cli/bin/facility.mjs login --url http://localhost:4400 --key fak_…
-node packages/cli/bin/facility.mjs status
-node packages/cli/bin/facility.mjs --help
-
-# MCP streamable HTTP (Bearer credentials are forwarded to the API)
-curl http://localhost:4420/healthz
-```
-
-See the [CLI, API, SDK, and MCP operator guide](docs/platform/INTERFACES.md) for
-authentication, automation-safe output, streaming, write approvals, deployment,
-and troubleshooting.
-
-The installer skips existing generated destinations unless you explicitly use
-`--force`. `AGENTS.md` and `CLAUDE.md` receive a delimited managed block instead
-of being replaced, and the current answers are written to `.facility.json`.
-
-For a Facility-owned preview, supply an immutable review image, its start
-command, internal port, and readiness path. The image command may seed
-non-production data before it starts the server. The workflow requests the
-preview only after verified builder delivery:
-
-```bash
-node /absolute/path/to/facility/packages/cli/bin/facility.mjs init \
-  --preview-image='ghcr.io/acme/app:${{ steps.delivery.outputs.head_sha }}' \
-  --preview-command='npm run preview' \
-  --preview-port=3000 \
-  --preview-readiness-path=/healthz \
-  --preview-ttl-hours=24
-```
-
-Configure `FACILITY_API_URL`, `FACILITY_PROJECT_ID`, and a project-scoped
-`FACILITY_PREVIEW_KEY` in GitHub. Production Facility deployments must have a
-complete GitHub/OIDC login configuration or preview creation fails closed. The review
-image must already exist; Facility does not build application images.
-
-After installation, follow the human-only steps printed by the CLI: configure
-the [selected authentication mode](#repository-automation-authentication),
-install the Claude GitHub App, protect the default branch, and use test-tier
-spend-capped credentials for integration tests. Choose Facility-owned or
-existing-provider previews and require their readiness check. Then commit the generated files, open
-an issue, and comment `/architect` to start the delivery loop described below.
-
-See the [CLI reference](apps/docs/docs/reference/cli.md) and
-[guards guide](docs/guards.md) for the available commands and extension points.
-
-## Quick start: self-host the platform
+## Quick start: run Facility
 
 Running Facility locally takes one command for the stack plus a one-time GitHub
 App setup for sign-in and repository automation. You need Docker, Node.js 22 or
@@ -294,12 +214,105 @@ To delegate all of this to Claude Code or Codex, paste this prompt:
 | Login succeeds but you land on the wrong host | `WEB_URL` must be the origin your browser uses. |
 | Testing through an HTTPS tunnel: navigation, live updates or hot reload fail | Set `WEB_URL` and `AUTH_CALLBACK_URL` to the tunnel origin (and the App's Callback URL to match), and put the tunnel hostname in `FACILITY_DEV_ORIGINS` — Next blocks cross-origin development requests otherwise. Full walkthrough: [local development](apps/docs/docs/self-host/local-development.md). |
 
-Your next steps are to create a project, connect a repository, preview the
-generated files, and let Facility open the kickstart PR. Follow the
+## Connect your first repository
+
+Create a project and connect a repository from the web application. The issues
+already in it appear in Facility with their history, and you can dispatch an
+agent against any of them from there. Nothing is written to the repository by
+connecting it: agents work in Facility's sandboxes and push branches, pull
+requests and comments the way a collaborator would. Disconnecting leaves no
+trace either.
+
+That is the whole entry path — see the
+[connect-an-existing-repository guide](apps/docs/docs/guides/existing-repo.md).
+For the rest of the platform, follow the
 [self-host quickstart](apps/docs/docs/self-host/quickstart.md),
-[authentication guide](apps/docs/docs/self-host/authentication.md),
-[production deployment guide](apps/docs/docs/self-host/production.md), and
-[kickstart guide](apps/docs/docs/guides/kickstart.md).
+[authentication guide](apps/docs/docs/self-host/authentication.md), and
+[production deployment guide](apps/docs/docs/self-host/production.md).
+
+## Operate without the web application
+
+Every control-plane workflow is available over the versioned REST API and the
+zero-dependency CLI; AI clients use the same permissions through MCP.
+
+```bash
+# REST/OpenAPI
+open http://localhost:4400/docs
+
+# CLI from this checkout (the API key is hidden when entered interactively)
+node packages/cli/bin/facility.mjs login --url http://localhost:4400 --key fak_…
+node packages/cli/bin/facility.mjs status
+node packages/cli/bin/facility.mjs --help
+
+# MCP streamable HTTP (Bearer credentials are forwarded to the API)
+curl http://localhost:4420/healthz
+```
+
+See the [CLI, API, SDK, and MCP operator guide](docs/platform/INTERFACES.md) for
+authentication, automation-safe output, streaming, write approvals, deployment,
+and troubleshooting.
+
+## Optional: install the process into the repository
+
+Everything above happens without touching the repository. When a team decides it
+wants the process *in* the repository — agents running in its own CI, invoked
+from issue comments — the standalone installer writes it there. This is the
+second step, not the entry price, and it is the only step that adds files.
+
+The installer needs a GitHub repository and Node.js 20 or newer; its runtime
+floor is lower than the platform's, and it does not require you to deploy
+Facility at all.
+
+```bash
+git clone https://github.com/theam/facility.git /absolute/path/to/facility
+cd your-repository
+node /absolute/path/to/facility/packages/cli/bin/facility.mjs init
+node /absolute/path/to/facility/packages/cli/bin/facility.mjs doctor --run-guards --github
+```
+
+Until the CLI is published to npm, run it from a Facility checkout as above.
+
+The installer detects the repository's package manager, default branch, checks,
+and useful quality modules. It asks for the commands that create a working
+environment and verify a change, then adds:
+
+- GitHub workflows for planning, building, reviewing, addressing feedback,
+  repairing routine CI failures, security sweeps, and the watchtower;
+- `STANDARD.md`, agent instructions, skills, hooks, and deterministic guards;
+- `.facility.json`, which records the choices needed to reproduce the install.
+
+The installer skips existing generated destinations unless you explicitly use
+`--force`. `AGENTS.md` and `CLAUDE.md` receive a delimited managed block instead
+of being replaced, and the current answers are written to `.facility.json`.
+
+For a Facility-owned preview, supply an immutable review image, its start
+command, internal port, and readiness path. The image command may seed
+non-production data before it starts the server. The workflow requests the
+preview only after verified builder delivery:
+
+```bash
+node /absolute/path/to/facility/packages/cli/bin/facility.mjs init \
+  --preview-image='ghcr.io/acme/app:${{ steps.delivery.outputs.head_sha }}' \
+  --preview-command='npm run preview' \
+  --preview-port=3000 \
+  --preview-readiness-path=/healthz \
+  --preview-ttl-hours=24
+```
+
+Configure `FACILITY_API_URL`, `FACILITY_PROJECT_ID`, and a project-scoped
+`FACILITY_PREVIEW_KEY` in GitHub. Production Facility deployments must have a
+complete GitHub/OIDC login configuration or preview creation fails closed. The review
+image must already exist; Facility does not build application images.
+
+After installation, follow the human-only steps printed by the CLI: configure
+the [selected authentication mode](#repository-automation-authentication),
+install the Claude GitHub App, protect the default branch, and use test-tier
+spend-capped credentials for integration tests. Choose Facility-owned or
+existing-provider previews and require their readiness check. Then commit the generated files, open
+an issue, and comment `/architect` to start the delivery loop described below.
+
+See the [CLI reference](apps/docs/docs/reference/cli.md) and
+[guards guide](docs/guards.md) for the available commands and extension points.
 
 ## Repository automation authentication
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ apps/web            Next.js operator interface
 apps/docs           Docusaurus documentation
 services/api        REST control plane, workers, GitHub integration, HITL
 services/gateway    model proxy, budgets, metering, envelope capture
-packages/cli        @theam/facility installer and platform client
+packages/cli        @theagilemonkeys/facility installer and platform client
 packages/core       domain logic, permissions, receipts, fingerprints
 packages/db         Postgres schema and migrations
 packages/mcp        MCP server

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -2,12 +2,19 @@ import type * as Preset from "@docusaurus/preset-classic";
 import type { Config } from "@docusaurus/types";
 import { themes } from "prism-react-renderer";
 
+// Where the built site will live. The Pages workflow passes what GitHub itself
+// reports (`https://theam.github.io` + `/facility`), so pointing a custom
+// domain at the site later needs no edit here. The defaults serve the site at
+// the root, which is what a local `pnpm dev` wants.
+const url = process.env.DOCS_URL ?? "https://theam.github.io";
+const baseUrl = `${(process.env.DOCS_BASE_URL ?? "").replace(/\/+$/, "")}/`;
+
 const config: Config = {
   title: "facility",
   tagline: "The platform that governs your AI SDLC.",
   favicon: "img/favicon.ico",
-  url: "https://facility.theagilemonkeys.com",
-  baseUrl: "/",
+  url,
+  baseUrl,
   organizationName: "theam",
   projectName: "facility",
   onBrokenLinks: "throw",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,6 +8,7 @@
     "dev": "docusaurus start --port 3500",
     "build": "docusaurus build",
     "serve": "docusaurus serve --port 3500",
+    "test": "node --test test/*.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/docs/test/pages-build.test.mjs
+++ b/apps/docs/test/pages-build.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const docsDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("the GitHub Pages build keeps canonical and local URLs under /facility", {
+  timeout: 180_000,
+}, () => {
+  const temporaryDir = mkdtempSync(join(tmpdir(), "facility-docs-pages-"));
+  const outputDir = join(temporaryDir, "build");
+
+  try {
+    const corePackage = require.resolve("@docusaurus/core/package.json");
+    const { bin } = JSON.parse(readFileSync(corePackage, "utf8"));
+    const cli = resolve(dirname(corePackage), typeof bin === "string" ? bin : bin.docusaurus);
+    const result = spawnSync(process.execPath, [cli, "build", "--out-dir", outputDir], {
+      cwd: docsDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "true",
+        DOCS_URL: "https://theam.github.io",
+        DOCS_BASE_URL: "/facility",
+      },
+      maxBuffer: 20 * 1024 * 1024,
+      timeout: 170_000,
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `Docusaurus Pages build failed:\n${result.stdout}\n${result.stderr}`,
+    );
+
+    const html = readFileSync(join(outputDir, "index.html"), "utf8");
+    const canonicalUrl = html.match(
+      /<link\b[^>]*\brel="canonical"[^>]*\bhref="([^"]+)"[^>]*>/,
+    )?.[1];
+    assert.equal(
+      canonicalUrl,
+      "https://theam.github.io/facility/",
+      "the canonical URL should combine DOCS_URL with DOCS_BASE_URL",
+    );
+
+    const localReferences = [...html.matchAll(/\b(?:href|src)="(\/(?!\/)[^"]+)"/g)].map(
+      ([, reference]) => reference,
+    );
+    assert.ok(
+      localReferences.some((reference) => reference.startsWith("/facility/assets/")),
+      "the built page should load an asset from /facility/assets/",
+    );
+    assert.ok(
+      localReferences.some(
+        (reference) => reference === "/facility/" || reference.startsWith("/facility/concepts/"),
+      ),
+      "the built page should link to content under /facility/",
+    );
+    assert.deepEqual(
+      localReferences.filter((reference) => !reference.startsWith("/facility/")),
+      [],
+      "no root-relative link or asset may escape the configured Pages base path",
+    );
+  } finally {
+    rmSync(temporaryDir, { recursive: true, force: true });
+  }
+});

--- a/docs/platform/ARCHITECTURE.md
+++ b/docs/platform/ARCHITECTURE.md
@@ -49,7 +49,7 @@ packages/core       # domain logic: permissions, pricing, fingerprints, template
 packages/db         # drizzle schema + migrations
 packages/ui         # TAM-50 design system (React)
 packages/sdk        # typed client: schema.d.ts generated from OpenAPI + hand-maintained ergonomic contracts (drift-guarded against openapi.json)
-packages/cli        # @theam/facility (v0.2 installer + platform commands + bundled templates/)
+packages/cli        # @theagilemonkeys/facility (v0.2 installer + platform commands + bundled templates/)
 packages/mcp        # platform MCP server
 packages/harness    # session protocols: PO agent, learning mode, KB validation
 runner/             # sandbox agent-host + Dockerfiles

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "node scripts/dev.mjs",
     "dev:services": "turbo run dev dev:worker",
     "test": "pnpm test:dev && turbo run test",
-    "test:dev": "node --test scripts/dev.test.mjs",
+    "test:dev": "node --test scripts/*.test.mjs",
     "test:critical": "node scripts/test-critical.mjs",
     "test:uncached": "pnpm test:dev && turbo run test --force --filter='!@facility/db' --filter='!@facility/api' --filter='!@facility/gateway'",
     "test:e2e-sandbox": "turbo run build --filter='@facility/api^...' && pnpm --filter @facility/api test:e2e-sandbox",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-# @theam/facility
+# @theagilemonkeys/facility
 
 The command-line half of [Facility](https://github.com/theam/facility) —
 open-source, self-hosted tooling for running AI coding agents as part of a
@@ -15,7 +15,7 @@ One binary with two jobs, and you rarely need both:
   the standard, the skills and the guards into the repository.
 
 ```bash
-npx @theam/facility --help
+npx @theagilemonkeys/facility --help
 ```
 
 Node.js 20 or newer. Zero configuration to read; one dependency.
@@ -23,10 +23,10 @@ Node.js 20 or newer. Zero configuration to read; one dependency.
 ## Talking to a platform
 
 ```bash
-npx @theam/facility login --url https://facility.example.com --key fak_…
-npx @theam/facility status      # runs, approvals, issues and spend at a glance
-npx @theam/facility inbox       # review and decide pending proposals
-npx @theam/facility sessions    # trigger, watch, steer or cancel agent runs
+npx @theagilemonkeys/facility login --url https://facility.example.com --key fak_…
+npx @theagilemonkeys/facility status      # runs, approvals, issues and spend at a glance
+npx @theagilemonkeys/facility inbox       # review and decide pending proposals
+npx @theagilemonkeys/facility sessions    # trigger, watch, steer or cancel agent runs
 ```
 
 Platform commands take a global `--json`, `--profile <name>` and
@@ -38,8 +38,8 @@ application: what your key cannot do, the CLI will not do either.
 
 ```bash
 cd your-repository
-npx @theam/facility init
-npx @theam/facility doctor --run-guards --github
+npx @theagilemonkeys/facility init
+npx @theagilemonkeys/facility doctor --run-guards --github
 ```
 
 `init` asks about the package manager, the default branch, the commands that

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,63 @@
+# @theam/facility
+
+The command-line half of [Facility](https://github.com/theam/facility) —
+open-source, self-hosted tooling for running AI coding agents as part of a
+reviewable delivery process, with the humans, the gates and the evidence in one
+place.
+
+One binary with two jobs, and you rarely need both:
+
+- **A client for a Facility platform.** Dispatch agents, follow sessions, decide
+  proposals, inspect spend, manage projects and repositories — everything the
+  web application does, from a terminal or a script.
+- **An installer for a repository.** When a team wants the process running in
+  its own CI, invoked from issue comments, `facility init` writes the workflows,
+  the standard, the skills and the guards into the repository.
+
+```bash
+npx @theam/facility --help
+```
+
+Node.js 20 or newer. Zero configuration to read; one dependency.
+
+## Talking to a platform
+
+```bash
+npx @theam/facility login --url https://facility.example.com --key fak_…
+npx @theam/facility status      # runs, approvals, issues and spend at a glance
+npx @theam/facility inbox       # review and decide pending proposals
+npx @theam/facility sessions    # trigger, watch, steer or cancel agent runs
+```
+
+Platform commands take a global `--json`, `--profile <name>` and
+`--timeout <seconds>`, so the CLI is as usable from a script as from a prompt.
+It speaks the same versioned REST API and obeys the same permissions as the web
+application: what your key cannot do, the CLI will not do either.
+
+## Installing the process into a repository
+
+```bash
+cd your-repository
+npx @theam/facility init
+npx @theam/facility doctor --run-guards --github
+```
+
+`init` asks about the package manager, the default branch, the commands that
+provision an environment and verify a change, then writes GitHub workflows for
+planning, building, reviewing and repairing, plus `STANDARD.md`, agent
+instructions, skills, deterministic guards, and a `.facility.json` recording the
+answers. It never overwrites an existing generated file unless you pass
+`--force`, and it appends to `AGENTS.md` and `CLAUDE.md` inside a delimited
+managed block rather than replacing them.
+
+This is the second step, not the entry price: a repository connected to a
+Facility platform is operated entirely from the platform, without a single file
+being added to it.
+
+## Documentation
+
+- [CLI reference](https://github.com/theam/facility/blob/main/apps/docs/docs/reference/cli.md)
+- [Self-hosting guide](https://github.com/theam/facility/blob/main/apps/docs/docs/self-host/quickstart.md)
+- [Repository and issues](https://github.com/theam/facility)
+
+Apache-2.0 · an initiative by [The Agile Monkeys](https://theagilemonkeys.com)

--- a/packages/cli/modules/README.md
+++ b/packages/cli/modules/README.md
@@ -16,7 +16,7 @@ actually hold:
 Install one with:
 
 ```
-npx @theam/facility add <module>
+npx @theagilemonkeys/facility add <module>
 ```
 
 | module | what it enforces |
@@ -30,6 +30,6 @@ npx @theam/facility add <module>
 
 Copy the shape of any module here: a `module.json` manifest, a
 `standard-section.md`, and optional `agents/`, `guards/`, and `hooks/`
-fragments. Then `npx @theam/facility add ./path/to/your-module`. If a concern
+fragments. Then `npx @theagilemonkeys/facility add ./path/to/your-module`. If a concern
 keeps biting your team, it deserves the full triple — a rule that exists only
 as prose will be missed again.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@theam/facility",
+  "name": "@theagilemonkeys/facility",
   "version": "0.3.0",
   "description": "Run an AI crew on your GitHub repo: agents that plan before building, build to your standard, verify on a provisioned environment, and never merge their own work.",
   "keywords": [

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -86,7 +86,7 @@ function inspectLocalInstall(dir, options = {}) {
     checks.push(
       existsSync(join(dir, file))
         ? localCheck("Files", file, "pass", "Present")
-        : localCheck("Files", file, "fail", "missing", "Run `npx @theam/facility init`."),
+        : localCheck("Files", file, "fail", "missing", "Run `npx @theagilemonkeys/facility init`."),
     );
   }
 
@@ -181,7 +181,7 @@ function inspectLocalInstall(dir, options = {}) {
           ".facility.json",
           "fail",
           `Invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
-          "Repair the manifest or rerun `npx @theam/facility init --force`.",
+          "Repair the manifest or rerun `npx @theagilemonkeys/facility init --force`.",
         ),
       );
     }

--- a/scripts/release.integration.test.mjs
+++ b/scripts/release.integration.test.mjs
@@ -1,0 +1,457 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { PACKAGE_NAME, publishTarball, registryState } from "./release.mjs";
+
+const releaseScript = fileURLToPath(new URL("./release.mjs", import.meta.url));
+const repoRoot = dirname(dirname(releaseScript));
+const packagePath = `/${encodeURIComponent(PACKAGE_NAME)}`;
+
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), "facility-release-test-"));
+  const packageDir = join(root, "package");
+  const tarball = join(root, "facility.tgz");
+  const lifecycleMarker = join(root, "lifecycle-ran");
+  const npmConfig = join(root, "npmrc");
+  await mkdir(packageDir);
+  await writeFile(
+    join(packageDir, "package.json"),
+    JSON.stringify({
+      name: PACKAGE_NAME,
+      version: "0.3.0",
+      scripts: { prepublishOnly: "node lifecycle.mjs" },
+    }),
+  );
+  await writeFile(
+    join(packageDir, "lifecycle.mjs"),
+    "import { writeFileSync } from 'node:fs';\nwriteFileSync(process.env.RELEASE_LIFECYCLE_MARKER, 'ran');\n",
+  );
+  execFileSync("tar", ["-czf", tarball, "-C", root, "package"]);
+
+  t.after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+  return { root, tarball, lifecycleMarker, npmConfig };
+}
+
+async function fakeRegistry(t, { lookupStatus = 404, lookupBody, tokenStatus } = {}) {
+  const requests = [];
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const record = {
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+      body: Buffer.concat(chunks).toString("utf8"),
+      responseStatus: undefined,
+    };
+    requests.push(record);
+
+    response.setHeader("content-type", "application/json");
+    if (request.method === "GET") {
+      record.responseStatus = lookupStatus;
+      response.statusCode = lookupStatus;
+      response.end(
+        lookupBody ??
+          JSON.stringify(
+            lookupStatus === 404
+              ? { error: "not_found" }
+              : { name: PACKAGE_NAME, versions: { "0.2.0": {} } },
+          ),
+      );
+      return;
+    }
+
+    if (request.method === "PUT") {
+      const status = tokenStatus?.(request.headers.authorization) ?? 201;
+      record.responseStatus = status;
+      response.statusCode = status;
+      response.end(
+        JSON.stringify(
+          status < 400
+            ? { ok: true }
+            : { error: status === 403 ? "forbidden" : "unauthorized", reason: "bootstrap token rejected" },
+        ),
+      );
+      return;
+    }
+
+    record.responseStatus = 404;
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not_found" }));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const url = `http://127.0.0.1:${address.port}/`;
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+      server.closeAllConnections?.();
+    });
+  });
+  return { requests, url };
+}
+
+async function release(args, env) {
+  const [command, tarball, authOption] = args;
+  const childArgs =
+    command === "publish"
+      ? [
+          "--input-type=module",
+          "--eval",
+          `import { publishRelease } from ${JSON.stringify(new URL("./release.mjs", import.meta.url).href)};
+           publishRelease({
+             tarball: process.argv[1],
+             authMode: process.argv[2],
+             registryUrl: process.env.NPM_CONFIG_REGISTRY,
+             allowNonOfficialRegistry: true,
+           }).catch((error) => { console.error(error.message); process.exitCode = 1; });`,
+          tarball,
+          authOption?.slice("--auth=".length),
+        ]
+      : [releaseScript, ...args];
+  const child = spawn(process.execPath, childArgs, {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const code = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+  return { code, stderr, stdout };
+}
+
+async function releaseCli(args, env) {
+  const child = spawn(process.execPath, [releaseScript, ...args], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const code = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+  return { code, stderr };
+}
+
+async function npmEnvironment(fixtureState, registryUrl, token) {
+  const registry = new URL(registryUrl);
+  const authKey = `//${registry.host}${registry.pathname}:_authToken=\${NODE_AUTH_TOKEN}`;
+  await writeFile(fixtureState.npmConfig, `registry=${registry.href}\n${authKey}\n`);
+  const environment = {
+    ...process.env,
+    GITHUB_ACTIONS: "false",
+    NODE_AUTH_TOKEN: token,
+    NPM_CONFIG_AUDIT: "false",
+    NPM_CONFIG_CACHE: join(fixtureState.root, "npm-cache"),
+    NPM_CONFIG_FUND: "false",
+    NPM_CONFIG_REGISTRY: registry.href,
+    NPM_CONFIG_UPDATE_NOTIFIER: "false",
+    NPM_CONFIG_USERCONFIG: fixtureState.npmConfig,
+    RELEASE_LIFECYCLE_MARKER: fixtureState.lifecycleMarker,
+  };
+  delete environment.NPM_TOKEN;
+  return environment;
+}
+
+async function assertMissing(path) {
+  await assert.rejects(access(path), { code: "ENOENT" });
+}
+
+async function installNpmRecorder(fixtureState) {
+  const bin = join(fixtureState.root, "bin");
+  const command = join(bin, "npm");
+  const invocation = join(fixtureState.root, "npm-invocation.json");
+  await mkdir(bin);
+  await writeFile(
+    command,
+    `#!/usr/bin/env node
+const { readFileSync, writeFileSync } = require("node:fs");
+writeFileSync(process.env.RELEASE_NPM_INVOCATION, JSON.stringify({
+  args: process.argv.slice(2),
+  credentials: {
+    nodeAuthToken: process.env.NODE_AUTH_TOKEN ?? null,
+    npmToken: process.env.NPM_TOKEN ?? null,
+    configAuthToken: process.env.NPM_CONFIG_AUTH_TOKEN ?? null,
+  },
+  userConfig: readFileSync(process.env.NPM_CONFIG_USERCONFIG, "utf8"),
+}));
+`,
+  );
+  await chmod(command, 0o755);
+  return { bin, invocation };
+}
+
+test("an exact 404 permits bootstrap publication without running package lifecycle scripts", async (t) => {
+  const state = await fixture(t);
+  const registry = await fakeRegistry(t, {
+    tokenStatus: (authorization) => (authorization === "Bearer valid-bootstrap-token" ? 201 : 401),
+  });
+  const env = await npmEnvironment(state, registry.url, "valid-bootstrap-token");
+
+  const result = await release(["publish", state.tarball, "--auth=bootstrap"], env);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(
+    registry.requests.slice(0, 2).map(({ method, url, responseStatus }) => ({ method, url, responseStatus })),
+    [
+      { method: "GET", url: packagePath, responseStatus: 404 },
+      { method: "GET", url: packagePath, responseStatus: 404 },
+    ],
+  );
+  const writes = registry.requests.filter(({ method }) => method === "PUT");
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].authorization, "Bearer valid-bootstrap-token");
+  assert.equal(writes[0].responseStatus, 201);
+  await assertMissing(state.lifecycleMarker);
+});
+
+test("existing, replayed, unavailable, and malformed registry states fail closed before PUT", async (t) => {
+  const cases = [
+    {
+      name: "existing package",
+      lookupStatus: 200,
+      lookupBody: JSON.stringify({ name: PACKAGE_NAME, versions: { "0.2.0": {} } }),
+      error: /bootstrap credentials are allowed only for the first publication/,
+    },
+    {
+      name: "replayed version",
+      lookupStatus: 200,
+      lookupBody: JSON.stringify({ name: PACKAGE_NAME, versions: { "0.3.0": {} } }),
+      error: /is already published; refusing replay/,
+    },
+    {
+      name: "registry 5xx",
+      lookupStatus: 503,
+      lookupBody: JSON.stringify({ error: "unavailable" }),
+      error: /registry lookup failed closed with HTTP 503/,
+    },
+    {
+      name: "malformed metadata",
+      lookupStatus: 200,
+      lookupBody: "{not-json",
+      error: /registry returned malformed package metadata/,
+    },
+  ];
+
+  for (const candidate of cases) {
+    await t.test(candidate.name, async (t) => {
+      const state = await fixture(t);
+      const registry = await fakeRegistry(t, candidate);
+      const env = await npmEnvironment(state, registry.url, "valid-bootstrap-token");
+
+      const result = await release(["publish", state.tarball, "--auth=bootstrap"], env);
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, candidate.error);
+      assert.equal(registry.requests.filter(({ method }) => method === "PUT").length, 0);
+      await assertMissing(state.lifecycleMarker);
+    });
+  }
+});
+
+test("expired, revoked, and cross-scope bootstrap tokens fail closed", async (t) => {
+  const cases = [
+    ["expired", "expired-bootstrap-token", 401],
+    ["revoked", "revoked-bootstrap-token", 401],
+    ["cross-scope", "cross-scope-bootstrap-token", 403],
+  ];
+
+  for (const [name, token, status] of cases) {
+    await t.test(name, async (t) => {
+      const state = await fixture(t);
+      const registry = await fakeRegistry(t, {
+        tokenStatus: (authorization) => (authorization === `Bearer ${token}` ? status : 401),
+      });
+      const env = await npmEnvironment(state, registry.url, token);
+
+      const result = await release(["publish", state.tarball, "--auth=bootstrap"], env);
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /npm publish failed with exit 1/);
+      const writes = registry.requests.filter(({ method }) => method === "PUT");
+      assert.equal(writes.length, 1);
+      assert.equal(writes[0].authorization, `Bearer ${token}`);
+      assert.equal(writes[0].responseStatus, status);
+      await assertMissing(state.lifecycleMarker);
+    });
+  }
+});
+
+test("an existing package uses OIDC without forwarding static npm credentials", async (t) => {
+  const state = await fixture(t);
+  const recorder = await installNpmRecorder(state);
+  const registry = await fakeRegistry(t, {
+    lookupStatus: 200,
+    lookupBody: JSON.stringify({ name: PACKAGE_NAME, versions: { "0.2.0": {} } }),
+  });
+  const env = await npmEnvironment(state, registry.url, "must-not-be-sent");
+  env.NPM_TOKEN = "legacy-token-must-not-be-sent";
+  env.NPM_CONFIG_AUTH_TOKEN = "config-token-must-not-be-sent";
+  env.PATH = `${recorder.bin}:${env.PATH}`;
+  env.RELEASE_NPM_INVOCATION = recorder.invocation;
+
+  const result = await release(["publish", state.tarball, "--auth=oidc"], env);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(
+    registry.requests.slice(0, 2).map(({ method, url, responseStatus }) => ({ method, url, responseStatus })),
+    [
+      { method: "GET", url: packagePath, responseStatus: 200 },
+      { method: "GET", url: packagePath, responseStatus: 200 },
+    ],
+  );
+  assert.equal(registry.requests.filter(({ method }) => method === "PUT").length, 0);
+  const invocation = JSON.parse(await readFile(recorder.invocation, "utf8"));
+  assert.deepEqual(invocation.credentials, {
+    nodeAuthToken: null,
+    npmToken: null,
+    configAuthToken: null,
+  });
+  assert.doesNotMatch(invocation.userConfig, /auth|token/i);
+  assert.equal(invocation.args.includes("--ignore-scripts"), true);
+  await assertMissing(state.lifecycleMarker);
+});
+
+test("dry-run performs no registry PUT and strips publication credentials", async (t) => {
+  const state = await fixture(t);
+  const registry = await fakeRegistry(t);
+  const env = await npmEnvironment(state, registry.url, "must-not-be-sent");
+
+  const result = await release(["dry-run", state.tarball], env);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(registry.requests.filter(({ method }) => method === "PUT").length, 0);
+  assert.equal(registry.requests.some(({ authorization }) => authorization), false);
+  await assertMissing(state.lifecycleMarker);
+});
+
+test("real publication rejects a nonofficial registry unless the test seam is injected", async (t) => {
+  const state = await fixture(t);
+  const registry = await fakeRegistry(t);
+  const env = await npmEnvironment(state, registry.url, "must-not-be-sent");
+  let spawned = false;
+
+  assert.throws(
+    () =>
+      publishTarball({
+        tarball: state.tarball,
+        authMode: "bootstrap",
+        registryUrl: registry.url,
+        env,
+        spawn: () => {
+          spawned = true;
+          return { status: 0 };
+        },
+      }),
+    /must use exactly https:\/\/registry\.npmjs\.org\//,
+  );
+  assert.equal(spawned, false);
+  assert.equal(registry.requests.length, 0);
+});
+
+test("ambiguous or unknown publish flags fail before any registry request", async (t) => {
+  const state = await fixture(t);
+  const registry = await fakeRegistry(t);
+  const env = await npmEnvironment(state, registry.url, "must-not-be-sent");
+
+  for (const args of [
+    ["publish", state.tarball, "--auth=oidc", "--auth=bootstrap"],
+    ["publish", state.tarball, "--auth=unknown"],
+    ["publish", state.tarball, "--unexpected"],
+  ]) {
+    const result = await releaseCli(args, env);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /requires exactly one --auth=oidc or --auth=bootstrap option/);
+  }
+  assert.equal(registry.requests.length, 0);
+});
+
+test("dry-run removes GitHub OIDC request credentials before spawning npm", async (t) => {
+  const state = await fixture(t);
+  let childEnvironment;
+
+  publishTarball({
+    tarball: state.tarball,
+    authMode: "dry-run",
+    env: {
+      ...process.env,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: "oidc-token-must-not-be-sent",
+      ACTIONS_ID_TOKEN_REQUEST_URL: "http://127.0.0.1:9/oidc",
+      NODE_AUTH_TOKEN: "npm-token-must-not-be-sent",
+    },
+    spawn: (_command, _args, options) => {
+      childEnvironment = options.env;
+      return { status: 0 };
+    },
+  });
+
+  assert.equal(childEnvironment.ACTIONS_ID_TOKEN_REQUEST_TOKEN, undefined);
+  assert.equal(childEnvironment.ACTIONS_ID_TOKEN_REQUEST_URL, undefined);
+  assert.equal(childEnvironment.NODE_AUTH_TOKEN, undefined);
+});
+
+test("registry metadata shapes and timeouts fail closed", async (t) => {
+  const state = await fixture(t);
+  for (const lookupBody of [
+    JSON.stringify({ name: PACKAGE_NAME, versions: null }),
+    JSON.stringify({ name: PACKAGE_NAME, versions: [] }),
+    JSON.stringify({ versions: {} }),
+    JSON.stringify({ name: "@other/package", versions: {} }),
+  ]) {
+    const registry = await fakeRegistry(t, { lookupStatus: 200, lookupBody });
+    await assert.rejects(
+      registryState({ tarball: state.tarball, registryUrl: registry.url }),
+      /malformed package metadata/,
+    );
+  }
+
+  const stalled = createServer(() => {});
+  await new Promise((resolve, reject) => {
+    stalled.once("error", reject);
+    stalled.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => {
+    stalled.closeAllConnections?.();
+    stalled.close();
+  });
+  const address = stalled.address();
+  assert(address && typeof address === "object");
+  await assert.rejects(
+    registryState({
+      tarball: state.tarball,
+      registryUrl: `http://127.0.0.1:${address.port}/`,
+      timeoutMs: 25,
+    }),
+    /registry lookup failed closed/,
+  );
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PACKAGE_NAME = "@theagilemonkeys/facility";
+export const OFFICIAL_REGISTRY = "https://registry.npmjs.org/";
+
+export function releaseMode({ eventName, ref, visibility, acceptancePassed }) {
+  if (eventName === "workflow_dispatch") return "dry-run";
+  if (
+    eventName === "push" &&
+    typeof ref === "string" &&
+    ref.startsWith("refs/tags/v") &&
+    visibility === "public" &&
+    acceptancePassed === true
+  ) {
+    return "publish";
+  }
+  return "skip";
+}
+
+export function validateReleasePolicy({
+  eventName,
+  ref,
+  visibility,
+  rootVersion,
+  packageVersion,
+  headSha,
+  checkoutSha,
+  tagSha,
+  isOnMain,
+}) {
+  if (eventName !== "push") throw new Error("a real release must come from a push event");
+  if (visibility !== "public") throw new Error("npm publishing is disabled until the repository is public");
+  if (!rootVersion || rootVersion !== packageVersion) {
+    throw new Error(
+      `root package version (${rootVersion || "missing"}) does not match CLI package version (${packageVersion || "missing"})`,
+    );
+  }
+
+  const expectedRef = `refs/tags/v${packageVersion}`;
+  if (ref !== expectedRef) throw new Error(`release ref ${ref} does not match ${expectedRef}`);
+  if (!headSha || checkoutSha !== headSha) {
+    throw new Error(`checked-out commit ${checkoutSha || "missing"} does not match event SHA ${headSha || "missing"}`);
+  }
+  if (tagSha !== headSha) {
+    throw new Error(`release tag resolves to ${tagSha || "missing"}, not event SHA ${headSha}`);
+  }
+  if (!isOnMain) throw new Error("release commit is not reachable from origin/main");
+
+  return { packageName: PACKAGE_NAME, version: packageVersion, tag: `v${packageVersion}` };
+}
+
+export function validateReleaseCandidate({
+  repoDir = process.cwd(),
+  eventName = process.env.GITHUB_EVENT_NAME,
+  ref = process.env.GITHUB_REF,
+  visibility = process.env.GITHUB_REPOSITORY_VISIBILITY,
+  headSha = process.env.GITHUB_SHA,
+} = {}) {
+  const rootVersion = readJson(join(repoDir, "package.json")).version;
+  const cliPackage = readJson(join(repoDir, "packages/cli/package.json"));
+  if (cliPackage.name !== PACKAGE_NAME) {
+    throw new Error(`CLI package is ${cliPackage.name || "unnamed"}, expected ${PACKAGE_NAME}`);
+  }
+
+  const checkoutSha = git(repoDir, ["rev-parse", "HEAD"]);
+  const tagSha = ref?.startsWith("refs/tags/")
+    ? git(repoDir, ["rev-parse", `${ref}^{commit}`])
+    : undefined;
+  const isOnMain =
+    spawnSync("git", ["merge-base", "--is-ancestor", checkoutSha, "origin/main"], {
+      cwd: repoDir,
+      stdio: "ignore",
+    }).status === 0;
+
+  return validateReleasePolicy({
+    eventName,
+    ref: ref || "",
+    visibility,
+    rootVersion,
+    packageVersion: cliPackage.version,
+    headSha,
+    checkoutSha,
+    tagSha,
+    isOnMain,
+  });
+}
+
+export function inspectTarball(tarball, { exec = execFileSync } = {}) {
+  const absolute = resolve(tarball);
+  let manifest;
+  try {
+    manifest = JSON.parse(
+      exec("tar", ["-xOf", absolute, "package/package.json"], { encoding: "utf8" }),
+    );
+  } catch (error) {
+    throw new Error(`cannot read package/package.json from ${absolute}: ${error.message}`);
+  }
+  if (manifest.name !== PACKAGE_NAME) {
+    throw new Error(`tarball contains ${manifest.name || "an unnamed package"}, expected ${PACKAGE_NAME}`);
+  }
+  if (typeof manifest.version !== "string" || !manifest.version) {
+    throw new Error("tarball package version is missing");
+  }
+  return { path: absolute, name: manifest.name, version: manifest.version };
+}
+
+export function validateWorkspaceArtifact(tarball, { repoDir = process.cwd() } = {}) {
+  const artifact = inspectTarball(tarball);
+  const rootVersion = readJson(join(repoDir, "package.json")).version;
+  const cliPackage = readJson(join(repoDir, "packages/cli/package.json"));
+  if (cliPackage.name !== PACKAGE_NAME) {
+    throw new Error(`CLI package is ${cliPackage.name || "unnamed"}, expected ${PACKAGE_NAME}`);
+  }
+  if (rootVersion !== cliPackage.version || artifact.version !== cliPackage.version) {
+    throw new Error(
+      `release versions disagree: root=${rootVersion || "missing"}, CLI=${cliPackage.version || "missing"}, tarball=${artifact.version || "missing"}`,
+    );
+  }
+  return artifact;
+}
+
+export async function registryState({
+  tarball,
+  registryUrl = process.env.NPM_CONFIG_REGISTRY || OFFICIAL_REGISTRY,
+  fetchImpl = globalThis.fetch,
+  officialOnly = false,
+  timeoutMs = 10_000,
+} = {}) {
+  const artifact = inspectTarball(tarball);
+  const registry = normalizeRegistry(registryUrl, { officialOnly });
+  const packageUrl = new URL(encodeURIComponent(artifact.name), registry);
+  let response;
+  try {
+    response = await fetchImpl(packageUrl, {
+      headers: { accept: "application/json" },
+      redirect: "error",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new Error(`npm registry lookup failed closed: ${error.message}`);
+  }
+
+  if (response.status === 404) return { state: "missing", artifact, registry };
+  if (!response.ok) {
+    throw new Error(`npm registry lookup failed closed with HTTP ${response.status}`);
+  }
+
+  let metadata;
+  try {
+    metadata = await response.json();
+  } catch (error) {
+    throw new Error(`npm registry returned malformed package metadata: ${error.message}`);
+  }
+  if (
+    !metadata ||
+    typeof metadata !== "object" ||
+    Array.isArray(metadata) ||
+    metadata.name !== artifact.name ||
+    !metadata.versions ||
+    typeof metadata.versions !== "object" ||
+    Array.isArray(metadata.versions)
+  ) {
+    throw new Error("npm registry returned malformed package metadata");
+  }
+  if (Object.hasOwn(metadata.versions, artifact.version)) {
+    throw new Error(`${artifact.name}@${artifact.version} is already published; refusing replay`);
+  }
+  return { state: "existing", artifact, registry };
+}
+
+export function publishTarball({
+  tarball,
+  authMode,
+  registryUrl = process.env.NPM_CONFIG_REGISTRY || OFFICIAL_REGISTRY,
+  npmCommand = "npm",
+  env = process.env,
+  spawn = spawnSync,
+  allowNonOfficialRegistry = false,
+} = {}) {
+  const artifact = inspectTarball(tarball);
+  const registry = normalizeRegistry(registryUrl, {
+    officialOnly: authMode !== "dry-run" && !allowNonOfficialRegistry,
+  });
+  const childEnv = scrubNpmCredentials({ ...env });
+  const args = [
+    "publish",
+    artifact.path,
+    "--access",
+    "public",
+    "--registry",
+    registry.href,
+    "--ignore-scripts",
+  ];
+
+  const isolatedCwd = mkdtempSync(join(tmpdir(), "facility-publish-"));
+  const userConfig = join(isolatedCwd, "user.npmrc");
+  const globalConfig = join(isolatedCwd, "global.npmrc");
+  try {
+    childEnv.NPM_CONFIG_REGISTRY = registry.href;
+    childEnv.NPM_CONFIG_USERCONFIG = userConfig;
+    childEnv.NPM_CONFIG_GLOBALCONFIG = globalConfig;
+    writeFileSync(globalConfig, "", { mode: 0o600 });
+
+    if (authMode === "bootstrap") {
+      if (!env.NODE_AUTH_TOKEN) {
+        throw new Error("NPM_BOOTSTRAP_TOKEN is required for the first package publication");
+      }
+      childEnv.NODE_AUTH_TOKEN = env.NODE_AUTH_TOKEN;
+      writeFileSync(
+        userConfig,
+        `registry=${registry.href}\n//${registry.host}${registry.pathname}:_authToken=\${NODE_AUTH_TOKEN}\n`,
+        { mode: 0o600 },
+      );
+      if (!allowNonOfficialRegistry) args.push("--provenance");
+    } else if (authMode === "oidc" || authMode === "dry-run") {
+      writeFileSync(userConfig, `registry=${registry.href}\n`, { mode: 0o600 });
+      if (authMode === "oidc" && !allowNonOfficialRegistry) args.push("--provenance");
+      if (authMode === "dry-run") {
+        delete childEnv.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+        delete childEnv.ACTIONS_ID_TOKEN_REQUEST_URL;
+        args.push("--dry-run");
+      }
+    } else {
+      throw new Error(`unsupported npm authentication mode: ${authMode || "missing"}`);
+    }
+
+    const result = spawn(npmCommand, args, { cwd: isolatedCwd, env: childEnv, stdio: "inherit" });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`npm publish failed with exit ${result.status ?? "unknown"}`);
+    }
+  } finally {
+    rmSync(isolatedCwd, { recursive: true, force: true });
+  }
+  return artifact;
+}
+
+export async function publishRelease({
+  tarball,
+  authMode,
+  registryUrl = OFFICIAL_REGISTRY,
+  fetchImpl = globalThis.fetch,
+  env = process.env,
+  spawn = spawnSync,
+  npmCommand = "npm",
+  allowNonOfficialRegistry = false,
+} = {}) {
+  if (authMode !== "bootstrap" && authMode !== "oidc") {
+    throw new Error(`unsupported npm authentication mode: ${authMode || "missing"}`);
+  }
+
+  const probe = () =>
+    registryState({
+      tarball,
+      registryUrl,
+      fetchImpl,
+      officialOnly: !allowNonOfficialRegistry,
+    });
+  const firstState = await probe();
+  if (authMode === "bootstrap" && firstState.state !== "missing") {
+    throw new Error("bootstrap credentials are allowed only for the first publication");
+  }
+  if (authMode === "oidc" && firstState.state !== "existing") {
+    throw new Error("trusted publishing requires the package to exist first");
+  }
+  const finalState = await probe();
+  if (finalState.state !== firstState.state) {
+    throw new Error("npm registry state changed during release; refusing to expose credentials");
+  }
+
+  return publishTarball({
+    tarball,
+    authMode,
+    registryUrl,
+    npmCommand,
+    env,
+    spawn,
+    allowNonOfficialRegistry,
+  });
+}
+
+export function normalizeRegistry(registryUrl, { officialOnly = false, githubActions = false } = {}) {
+  let registry;
+  try {
+    registry = new URL(registryUrl);
+  } catch {
+    throw new Error(`invalid npm registry URL: ${registryUrl}`);
+  }
+  if (registry.username || registry.password || registry.search || registry.hash) {
+    throw new Error("npm registry URL must not contain credentials, a query, or a fragment");
+  }
+  if (!registry.pathname.endsWith("/")) registry.pathname += "/";
+  if ((officialOnly || githubActions) && registry.href !== OFFICIAL_REGISTRY) {
+    throw new Error(`GitHub releases must use exactly ${OFFICIAL_REGISTRY}`);
+  }
+  return registry;
+}
+
+function scrubNpmCredentials(env) {
+  for (const key of Object.keys(env)) {
+    const normalized = key.toLowerCase();
+    if (
+      normalized === "node_auth_token" ||
+      normalized === "npm_token" ||
+      (normalized.startsWith("npm_config_") &&
+        (normalized.includes("auth") ||
+          normalized.includes("token") ||
+          normalized.endsWith("userconfig") ||
+          normalized.endsWith("globalconfig") ||
+          normalized.endsWith("registry")))
+    ) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function output(values) {
+  for (const [key, value] of Object.entries(values)) {
+    if (/\r|\n/.test(String(value))) {
+      throw new Error(`GitHub output ${key} contains a forbidden line break`);
+    }
+  }
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      Object.entries(values)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n") + "\n",
+    );
+  }
+  console.log(JSON.stringify(values));
+}
+
+async function main([command, ...args]) {
+  if (command === "validate") {
+    if (args.length > 1 || args[0]?.startsWith("--")) {
+      throw new Error("validate accepts only an optional repository directory");
+    }
+    output(validateReleaseCandidate({ repoDir: resolve(args[0] || ".") }));
+    return;
+  }
+
+  const tarballCommands = new Set(["artifact", "registry-state", "dry-run", "publish"]);
+  if (!tarballCommands.has(command)) {
+    throw new Error(`unknown release command: ${command || "missing"}`);
+  }
+
+  const options = args.filter((arg) => arg.startsWith("--"));
+  const tarballs = args.filter((arg) => !arg.startsWith("--"));
+  if (tarballs.length !== 1) throw new Error(`${command || "command"} requires exactly one tarball`);
+  const tarball = tarballs[0];
+
+  let auth;
+  if (command === "publish") {
+    if (options.length !== 1 || !options[0].startsWith("--auth=")) {
+      throw new Error("publish requires exactly one --auth=oidc or --auth=bootstrap option");
+    }
+    auth = options[0].slice("--auth=".length);
+    if (auth !== "oidc" && auth !== "bootstrap") {
+      throw new Error("publish requires exactly one --auth=oidc or --auth=bootstrap option");
+    }
+  } else if (options.length > 0) {
+    throw new Error(`${command} does not accept options`);
+  }
+
+  if (command === "artifact") {
+    const artifact = validateWorkspaceArtifact(tarball);
+    output({ package: artifact.name, version: artifact.version, path: artifact.path });
+    return;
+  }
+
+  validateWorkspaceArtifact(tarball);
+
+  if (command === "registry-state") {
+    const result = await registryState({
+      tarball,
+      registryUrl: OFFICIAL_REGISTRY,
+      officialOnly: true,
+    });
+    output({ state: result.state, package: result.artifact.name, version: result.artifact.version });
+    return;
+  }
+  if (command === "dry-run") {
+    publishTarball({ tarball, authMode: "dry-run" });
+    return;
+  }
+  if (command === "publish") {
+    await publishRelease({ tarball, authMode: auth });
+    return;
+  }
+}
+
+const thisFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === thisFile) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  OFFICIAL_REGISTRY,
+  normalizeRegistry,
+  releaseMode,
+  validateReleasePolicy,
+} from "./release.mjs";
+
+const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+const validPolicy = {
+  eventName: "push",
+  ref: "refs/tags/v0.3.0",
+  visibility: "public",
+  rootVersion: "0.3.0",
+  packageVersion: "0.3.0",
+  headSha: "release-sha",
+  checkoutSha: "release-sha",
+  tagSha: "release-sha",
+  isOnMain: true,
+};
+
+test("manual dispatches are dry-runs even when a real publish is requested", () => {
+  assert.equal(
+    releaseMode({
+      eventName: "workflow_dispatch",
+      ref: "refs/heads/release-candidate",
+      visibility: "public",
+      acceptancePassed: true,
+      requestedDryRun: false,
+    }),
+    "dry-run",
+  );
+});
+
+test("only an accepted public tag push enters publish mode", () => {
+  assert.equal(
+    releaseMode({
+      eventName: "push",
+      ref: "refs/tags/v0.3.0",
+      visibility: "public",
+      acceptancePassed: true,
+    }),
+    "publish",
+  );
+
+  for (const candidate of [
+    { eventName: "push", ref: "refs/heads/main", visibility: "public", acceptancePassed: true },
+    { eventName: "pull_request", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: true },
+    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "private", acceptancePassed: true },
+    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: false },
+    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: "false" },
+    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: "failure" },
+  ]) {
+    assert.equal(releaseMode(candidate), "skip");
+  }
+});
+
+test("release policy accepts only the matching package tag and commit", () => {
+  assert.deepEqual(validateReleasePolicy(validPolicy), {
+    packageName: "@theagilemonkeys/facility",
+    version: "0.3.0",
+    tag: "v0.3.0",
+  });
+});
+
+test("release policy fails closed on every tag and provenance mismatch", () => {
+  const invalid = [
+    [{ eventName: "workflow_dispatch" }, /real release must come from a push event/],
+    [{ visibility: "private" }, /publishing is disabled until the repository is public/],
+    [{ rootVersion: "0.2.0" }, /root package version \(0\.2\.0\) does not match CLI package version \(0\.3\.0\)/],
+    [{ ref: "refs/tags/v0.3.1" }, /release ref refs\/tags\/v0\.3\.1 does not match refs\/tags\/v0\.3\.0/],
+    [{ checkoutSha: "other-sha" }, /checked-out commit other-sha does not match event SHA release-sha/],
+    [{ tagSha: "other-sha" }, /release tag resolves to other-sha, not event SHA release-sha/],
+    [{ isOnMain: false }, /release commit is not reachable from origin\/main/],
+  ];
+
+  for (const [override, message] of invalid) {
+    assert.throws(() => validateReleasePolicy({ ...validPolicy, ...override }), message);
+  }
+});
+
+test("GitHub publication requires the exact official npm registry", () => {
+  assert.equal(normalizeRegistry(OFFICIAL_REGISTRY, { githubActions: true }).href, OFFICIAL_REGISTRY);
+  assert.throws(
+    () => normalizeRegistry("https://registry.npmjs.org/custom", { githubActions: true }),
+    /must use exactly https:\/\/registry\.npmjs\.org\//,
+  );
+  assert.throws(
+    () => normalizeRegistry("http://127.0.0.1:4873", { githubActions: true }),
+    /must use exactly https:\/\/registry\.npmjs\.org\//,
+  );
+});
+
+test("the workflow keeps manual runs credential-free and real publication tag-only", () => {
+  assert.match(releaseWorkflow, /workflow_call:\n  workflow_dispatch:\n/);
+  assert.doesNotMatch(releaseWorkflow, /workflow_dispatch:\n\s+inputs:/);
+  assert.match(releaseWorkflow, /dry-run:\n    if: github\.event_name == 'workflow_dispatch'/);
+  assert.match(
+    releaseWorkflow,
+    /publish:\n    if: github\.event_name == 'push' && startsWith\(github\.ref, 'refs\/tags\/'\) && github\.event\.repository\.visibility == 'public'/,
+  );
+  assert.match(releaseWorkflow, /node scripts\/release\.mjs dry-run "\$candidate"/);
+  assert.match(releaseWorkflow, /node scripts\/release\.mjs publish "\$CANDIDATE" --auth=oidc/);
+  assert.match(releaseWorkflow, /node scripts\/release\.mjs publish "\$CANDIDATE" --auth=bootstrap/);
+
+  const dryRunJob = releaseWorkflow.split("\n  publish:")[0].split("\n  dry-run:")[1];
+  assert.doesNotMatch(dryRunJob, /id-token: write|environment:|secrets\./);
+  assert.equal(releaseWorkflow.match(/secrets\.NPM_BOOTSTRAP_TOKEN/g)?.length, 1);
+  assert.match(releaseWorkflow, /environment: npm/);
+  assert.match(releaseWorkflow, /npm install --global npm@11\.15\.0/);
+  assert.match(
+    releaseWorkflow,
+    /publish:[\s\S]*concurrency:\n      group: npm-theagilemonkeys-facility\n      cancel-in-progress: false/,
+  );
+});
+
+test("CI publishes only the exact artifact produced after all acceptance jobs", () => {
+  assert.match(ciWorkflow, /npm pack --ignore-scripts --pack-destination "\$release_dir"/);
+  assert.match(ciWorkflow, /name: facility-release-package/);
+  assert.match(ciWorkflow, /publish-npm:[\s\S]*needs: \[verify, self-host-build, sandbox-e2e\]/);
+  assert.match(ciWorkflow, /publish-npm:[\s\S]*uses: \.\/\.github\/workflows\/release\.yml/);
+});


### PR DESCRIPTION
Prepares the two public artifacts — the documentation site and the CLI package — so that publishing them is a decision, not a project. Everything here is inert until the repository is public.

## The docs workflow

`docs.yml` builds `apps/docs` and deploys it to GitHub Pages on every push to `main`, guarded by `github.event.repository.visibility == 'public'`. Pages does not serve private repositories outside Enterprise, so merging this changes nothing today; the first push after the flip publishes the site, with nobody having to remember this file exists.

`docusaurus.config.ts` now takes its `url` and `baseUrl` from `DOCS_URL` / `DOCS_BASE_URL`, which the workflow fills with what `actions/configure-pages` reports. Pointing a custom domain at the site later is a Pages setting, not a code change. The defaults leave local development at the root.

Verified both ways: `DOCS_BASE_URL=/facility` produces `href="/facility/assets/…"` throughout, and the default build is byte-for-byte the one CI already runs inside `pnpm verify`.

## The release workflow

`release.yml` publishes `@theagilemonkeys/facility` from a tag — never from a merge to `main`. Before anything reaches the registry it checks that the tag and `packages/cli/package.json` agree, runs the CLI's tests, and then **installs the packed tarball the way `npx` would and runs the binary from it**. That step catches a `files` list that forgot a directory, which no repository-level test can see. `workflow_dispatch` defaults to a dry run.

Provenance is added only when the repository is public, since npm rejects it otherwise.

The scope is `theagilemonkeys`, the organization one — `@theam` on npm belongs to an unrelated developer, so the package was renamed here along with every reference to it. The binary stays `facility`.

Needs one thing before it can publish: an npm automation token in the `NPM_TOKEN` secret.

## The package README

`packages/cli/README.md` did not exist, so the npm page would have rendered blank — and for anyone discovering Facility through `npx`, that page is the product. It describes the CLI's two lives (a client for a platform, an installer for a repository) and says plainly that the installer is the second step, not the entry price.

## The root README

The prose already led with light integration — "connect a repository and your repository stays yours… without a single file being added". The first *actionable* section did not: it was the standalone installer. Reordered so the reading path matches the recommended one:

1. **Quick start: run Facility** (was "self-host the platform")
2. **Connect your first repository** — new, and the entry path: connecting writes nothing to the repository, and disconnecting leaves no trace
3. **Operate without the web application** — promoted out of the installer section, where it never belonged
4. **Optional: install the process into the repository** (was "Quick start: one repository")

Also replaced "npm distribution is a later release step and is intentionally not part of this release candidate", which reads oddly in a public repository, with a plain statement of how to run the CLI until the package is live.

## Verification

- `pnpm guards` — `actions-pinned` passes; the three new action pins are full SHAs.
- `pnpm lint`, `pnpm --filter @facility/docs typecheck`.
- Docs build under both the Pages environment and the default.
- The release workflow's pack-and-smoke steps run locally, verbatim, against a clean directory: the tarball installs and `facility --help` exits 0.
- The publish-flag logic was tested under `bash -e` for the three real cases (tag on a private repo, tag on a public repo, manual dry run). The first draft used `[ … ] && …`, which fails the step when the condition is false — exactly what a tag push would have hit.

## Not in this PR

The site is still missing the nine documents under the root `docs/` tree (~1,130 lines: method, guards, testing, hardening, FAQ, watchtower, ARCHITECTURE, INTERFACES, PRD), which Docusaurus does not include. Two of them overlap existing pages, so folding them in is a content merge rather than a move. That is the next PR.