### PR TITLE
docs: say plainly that this is early software

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ When a team *wants* the process in the repository — agents running in its own
 CI, invoked from issue comments — Facility installs that too. It is the second
 step, not the entry price.
 
+## Status: early software, published early on purpose
+
+Facility runs the delivery of the team that builds it, and nowhere else yet. It
+is published at this stage deliberately: a platform for governing AI-assisted
+delivery is not something to design in private for a year and then unveil. It
+gets better by being used, argued with, and corrected.
+
+What that means in practice: the database schema moves, the API is versioned
+but young, features arrive ahead of their documentation, and no upgrade path is
+promised between `0.x` releases. Point it at repositories where a bad agent
+pull request is an inconvenience rather than an incident, and read the
+[security model](apps/docs/docs/reference/security.md) and the
+[hardening notes](apps/docs/docs/reference/hardening.md) before pointing it at
+anything else. Apache-2.0 means what it says: no warranty, use at your own
+risk.
+
+Bug reports, questions and pull requests are welcome — see
+[CONTRIBUTING.md](CONTRIBUTING.md). Rough edges are expected, and the ones you
+hit are the ones worth fixing first.
+
 ## Who Facility is for
 
 - **Engineering teams** that want one explicit standard for humans and agents,

--- a/apps/docs/docs/index.md
+++ b/apps/docs/docs/index.md
@@ -10,6 +10,16 @@ signal to production; people decide what ships; every run leaves a receipt.
 Facility is the control plane that makes that operable for an organization —
 not one repo at a time, but as a governed system.
 
+:::warning Early software
+
+Facility runs the delivery of the team that builds it, and nowhere else yet.
+The schema moves, the API is young, features arrive ahead of their
+documentation, and no upgrade path is promised between `0.x` releases. It is
+published this early on purpose — it improves by being used and corrected —
+but Apache-2.0 means what it says: no warranty, use at your own risk.
+
+:::
+
 ## The problem it closes
 
 Wiring an AI agent into a repository is the easy part. The second month is

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,11 @@ npx @theagilemonkeys/facility --help
 
 Node.js 20 or newer. Zero configuration to read; one dependency.
 
+**Early software.** Facility is published while it is still being built: the
+API is young, generated files change shape between `0.x` releases, and no
+upgrade path is promised across them. Apache-2.0 means what it says — no
+warranty, use at your own risk.
+
 ## Talking to a platform
 
 ```bash


### PR DESCRIPTION
Facility is published while it is still being built, and the three surfaces a newcomer actually lands on said nothing about it: the repository README, the documentation home page, and the npm package page (which is `packages/cli/README.md`).

The notice is deliberately not an apology. Publishing early is the choice — a platform for governing AI-assisted delivery improves by being used and corrected, not by being designed in private for a year and unveiled. What a reader needs is the concrete shape of the risk rather than a disclaimer:

- the schema moves, the API is versioned but young, features arrive ahead of their documentation, and no upgrade path is promised between `0.x` releases;
- point it at repositories where a bad agent pull request is an inconvenience, not an incident;
- read the security model and the hardening notes before pointing it at anything else;
- Apache-2.0 means what it says: no warranty, use at your own risk.

The README version closes by inviting the rough edges people hit, since those are the ones worth fixing first.

Verified: both guards pass (`markdown-links` covers the new links), the site builds, and the admonition renders on the docs home page.