### PR TITLE
docs: an AWS runbook that reaches a working instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ COPY --from=build-api /prod/api /app
 # hundred kilobytes of plain ESM whose only dependency, `postgres`, is already
 # here for @facility/db.
 COPY --from=build-api /app/packages/cli /app/cli
+# Regression guard for the deployed operator path: importing the bootstrap
+# command also proves that its production `postgres` dependency resolves.
+RUN node cli/bin/facility.mjs instance bootstrap --help >/dev/null
 EXPOSE 4400
 CMD ["node", "dist/start.js"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,13 @@ RUN pnpm --filter '@facility/mcp' deploy --prod --legacy /prod/mcp
 FROM base AS api
 ENV NODE_ENV=production
 COPY --from=build-api /prod/api /app
+# The CLI travels with the API image so operator commands can be run as one-shot
+# tasks inside the VPC. `facility instance bootstrap` needs the database, and in
+# a reference deployment the database accepts connections only from the service
+# security group — there is nowhere else to run it from. The package is a few
+# hundred kilobytes of plain ESM whose only dependency, `postgres`, is already
+# here for @facility/db.
+COPY --from=build-api /app/packages/cli /app/cli
 EXPOSE 4400
 CMD ["node", "dist/start.js"]
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ GitHub Apps → New GitHub App**.
 - **GitHub App name / Homepage URL**: anything you like.
 - **Callback URL**: `http://localhost:3400/api/auth/callback` — it must match
   `AUTH_CALLBACK_URL` in `.env` exactly, byte for byte.
-- Check **"Request user authorization (OAuth) during installation"**.
+- Leave **"Request user authorization (OAuth) during installation"** unchecked.
+  Facility requests authorization when you sign in after configuring `.env`
+  and restarting the stack.
 - **Webhook**: optional for local evaluation — you can disable it and use the
   "sync from GitHub" button instead. To receive events on a development
   machine you need a public URL for your laptop; the

--- a/apps/docs/docs/reference/architecture.md
+++ b/apps/docs/docs/reference/architecture.md
@@ -137,7 +137,7 @@ corroborates its success.
 ## 7. Deployment
 
 - **Self-host quickstart**: `docker compose up` → postgres, minio, api, worker, gateway, web, and MCP. An administrator binds the dedicated org, owner, GitHub account, and installation with `facility instance bootstrap`; login never auto-creates tenancy.
-- **AWS reference deployment**: Terraform — VPC, RDS Postgres, S3, ECS Fargate services (api/worker/gateway/web), ALB, ECR, Fargate runner tasks, KMS for master key, CloudWatch logs.
+- **AWS reference deployment**: Terraform — VPC, RDS Postgres, S3, ECS Fargate services (api/worker/gateway/web/MCP), ALB, ECR, Fargate runner tasks, KMS for master key, CloudWatch logs.
 - **Any-cloud claim**: everything is containers + PG + S3-API; drivers isolate compute specifics; helm chart is a documented follow-up with the k8s Job driver.
 
 ## 8. What stays deliberately simple (v1)

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -4,74 +4,287 @@ title: AWS (Terraform)
 
 # AWS reference deployment
 
-`infra/terraform/aws` provisions the reference production stack — the same
-one the platform's own validation deployment runs on:
+`infra/terraform/aws` provisions the reference production stack:
 
 - VPC (2 AZ), private subnets for services and RDS
 - RDS Postgres 16, S3 bucket (envelopes/transcripts), ECR repositories
-- ECS Fargate services: `api`, `worker`, `gateway`, `web` behind an ALB
+- ECS Fargate services: `api`, `worker`, `gateway`, `web`, `mcp` behind an ALB
 - Fargate runner tasks for the `aws` sandbox driver
-- KMS-backed secrets (`SECRET_MASTER_KEY` and friends) into task env
+- KMS-backed secrets into task environments
 - CloudWatch log groups per service
 
-```bash
-cd infra/terraform/aws
-terraform init
-terraform apply -var-file=yourorg.tfvars
-```
+Nothing in the services is AWS-specific — this module is a reference, not a
+requirement. The sandbox driver seam (`docker` | `aws`) is where compute
+specifics live; a Kubernetes Job driver is the documented extension point.
 
-The variables file names the domains, identity mode, and GitHub App credentials
-(by secret ARN, not value), instance sizes, and the container image tags —
-build and push images with the repo's `infra/build-images.sh`.
+This page is the deployment sequence. The module
+[README](https://github.com/theam/facility/tree/main/infra/terraform/aws) is
+the variable-by-variable reference.
 
-## Public API and GitHub webhook URL
+## Before you start
 
-The GitHub webhook URL comes from the public API origin; GitHub does not create
-it. After `terraform apply`, print the configured origin:
+Locally: Node.js 22 or newer, pnpm 11, Docker with `buildx`, Terraform, the AWS
+CLI, `jq`, and OpenSSL. Fresh AWS credentials — an old `.env` may carry an
+expired session token, so confirm with `aws sts get-caller-identity` before
+applying anything.
 
-```bash
-terraform output -raw api_url
-```
+On GitHub: the App created and installed on the repositories you will automate,
+with its webhook **inactive**. The App is configured last, once the API is
+reachable, so its first delivery is not lost. See the
+[GitHub App guide](github-app).
 
-Append `/webhooks/github` to the result. For example, an output of
-`https://api.facility.example.com` produces:
+Somewhere safe: Terraform state. Local state is acceptable only for a
+short-lived stack, and only if you keep it until teardown.
 
-```text
-https://api.facility.example.com/webhooks/github
-```
-
-For a validation deployment without a public DNS zone, set
-`enable_cloudfront_api_endpoint = true`; `api_url` and `github_webhook_url` then
-use an AWS-managed CloudFront HTTPS hostname. For production, the configured
-`api_hostname` should resolve to the public ALB and have a valid TLS certificate.
-Set `route53_zone_id` to let this module create the alias, or create an
-equivalent record with an external DNS provider. Configure and install the App
-only after the API is reachable so its initial installation event is delivered. See the
-[GitHub App guide](github-app) for permissions, event subscriptions, secrets,
-and verification.
-
-Any-cloud note: nothing in the services is AWS-specific — this module is a
-reference, not a requirement. The sandbox driver seam (`docker` | `aws`) is
-where compute specifics live; a Kubernetes Job driver is the documented
-extension point.
-
-Once images and the `database_url` secret are populated, run the one-shot
-migrate + seed task (it applies migrations **and** seeds the bundled roles,
-action types, and default sandbox profile that first bootstrap and `facility
-doctor` require — it is idempotent). See the module
-[README](https://github.com/theam/facility/tree/main/infra/terraform/aws#5-run-the-migrate--seed-task-once)
-for the exact `aws ecs run-task` invocation.
-
-Use `sslmode=verify-full` in the RDS connection URL. The production service
-image includes Amazon's global RDS CA bundle so both the API and worker verify
-the database certificate and hostname.
-
-After the ECS services roll and the migrate+seed task has completed, run:
+Never reuse a destroyed environment's name, state, VPC CIDR, bucket, ECR
+repositories, or webhook URL.
 
 ```bash
-node packages/cli/bin/facility.mjs doctor --url https://<api-host> --key fak_...
+git switch main && git pull --ff-only
+corepack enable && pnpm install --frozen-lockfile
+
+export FACILITY_AWS_REGION=us-east-1
+export FACILITY_ENV="prod"
+export FACILITY_PREFIX="facility-${FACILITY_ENV}"
+export FACILITY_IMAGE_TAG="$(git rev-parse --short HEAD)"
+export FACILITY_TF_DIR=infra/terraform/aws
 ```
 
-Do not send production traffic until the doctor reports no `FAIL` checks — it
-verifies DB migrations, object storage, seed essentials, the `sandbox_runner`
-profile (driver + runner), production `auth_config`, and the audit hash chain.
+## 1. Write the variables file, with services at zero
+
+```bash
+cp $FACILITY_TF_DIR/terraform.tfvars.example $FACILITY_TF_DIR/${FACILITY_ENV}.tfvars
+```
+
+Set the hostnames, `auth_identity_provider = "github"` for self-hosting, the
+image tags you are about to push, and — deliberately — no running services:
+
+```hcl
+api_desired_count     = 0
+worker_desired_count  = 0
+gateway_desired_count = 0
+web_desired_count     = 0
+```
+
+The first apply creates repositories, the database, secret containers, the
+network, task definitions and the load balancer **without** starting containers
+whose images and secrets do not exist yet. Starting them early produces a
+crash-loop that is slower to diagnose than it is to avoid.
+
+Without a public DNS zone, set `enable_cloudfront_api_endpoint = true` to get an
+AWS-managed HTTPS origin for the API and the webhook. For production, point
+`api_hostname` at the ALB with a valid certificate, and set `route53_zone_id` if
+Terraform should create the alias record.
+
+No secret values belong in tfvars. The file is gitignored; keep it that way.
+
+## 2. First apply
+
+```bash
+terraform -chdir="$FACILITY_TF_DIR" init
+terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
+```
+
+## 3. Build and push images
+
+The build script defaults to a playground prefix, so `ECR_PREFIX` is mandatory:
+
+```bash
+AWS_REGION="$FACILITY_AWS_REGION" \
+ECR_PREFIX="$FACILITY_PREFIX" \
+IMAGE_TAG="$FACILITY_IMAGE_TAG" \
+CPU_ARCHITECTURE=X86_64 \
+./infra/build-images.sh
+```
+
+Never `latest`: the tag in tfvars must match `FACILITY_IMAGE_TAG` exactly, so
+that what is deployed is identifiable from a commit. Apply again once the images
+exist.
+
+## 4. Populate the secret containers
+
+Terraform creates encrypted containers and never writes values into them.
+
+| Secret | Value |
+|---|---|
+| `database_url` | `postgres://facility:<url-encoded-password>@<rds_endpoint>:5432/facility?sslmode=verify-full` |
+| `secret_master_key` | `openssl rand -base64 32` |
+| `github_oauth_client_id`, `github_oauth_client_secret` | the App's OAuth credentials (`oidc_client_id` / `oidc_client_secret` in broker mode) |
+| `facility_oauth_jwks` | a persistent private ES256 JWK set |
+| `github_app_id`, `github_app_slug`, `github_app_private_key`, `github_app_webhook_secret` | from the App |
+
+`dev_anthropic_api_key` and `dev_openai_api_key` are a local fallback only —
+add provider credentials through Facility after boot instead.
+
+Keep `sslmode=verify-full`. The production image carries Amazon's global RDS CA
+bundle so the API and worker verify the database certificate and hostname; a
+non-verifying mode is a downgrade, not a shortcut.
+
+```bash
+facility_secret_arn() {
+  terraform -chdir="$FACILITY_TF_DIR" output -json secret_arns | jq -r --arg n "$1" '.[$n]'
+}
+facility_put_secret() {
+  aws secretsmanager put-secret-value --region "$FACILITY_AWS_REGION" \
+    --secret-id "$(facility_secret_arn "$1")" --secret-string "$2" >/dev/null
+}
+```
+
+The RDS master password lives in its own managed secret:
+
+```bash
+aws secretsmanager get-secret-value \
+  --region "$FACILITY_AWS_REGION" \
+  --secret-id "$(terraform -chdir="$FACILITY_TF_DIR" output -raw rds_master_user_secret_arn)" \
+  --query SecretString --output text | jq -r .password
+```
+
+URL-encode it before putting it in `database_url`, and never print the values or
+commit `.env`, tfvars, or state.
+
+## 5. Migrate and seed, before any service starts
+
+The `migrate` task applies migrations **and** seeds the bundled roles, action
+types and default sandbox profile that the next step and `facility doctor`
+depend on. It is idempotent.
+
+```bash
+FACILITY_CLUSTER="$(terraform -chdir="$FACILITY_TF_DIR" output -raw ecs_cluster_name)"
+FACILITY_MIGRATE_DEF="$(terraform -chdir="$FACILITY_TF_DIR" output -raw migrate_task_definition_arn)"
+FACILITY_SUBNETS="$(terraform -chdir="$FACILITY_TF_DIR" output -json private_subnet_ids | jq -r 'join(",")')"
+FACILITY_SERVICE_SG="$(terraform -chdir="$FACILITY_TF_DIR" output -raw service_security_group_id)"
+FACILITY_NETWORK="awsvpcConfiguration={subnets=[${FACILITY_SUBNETS}],securityGroups=[${FACILITY_SERVICE_SG}],assignPublicIp=DISABLED}"
+
+FACILITY_TASK="$(aws ecs run-task --region "$FACILITY_AWS_REGION" \
+  --cluster "$FACILITY_CLUSTER" --launch-type FARGATE \
+  --task-definition "$FACILITY_MIGRATE_DEF" \
+  --network-configuration "$FACILITY_NETWORK" \
+  --query 'tasks[0].taskArn' --output text)"
+
+aws ecs wait tasks-stopped --region "$FACILITY_AWS_REGION" \
+  --cluster "$FACILITY_CLUSTER" --tasks "$FACILITY_TASK"
+
+aws ecs describe-tasks --region "$FACILITY_AWS_REGION" \
+  --cluster "$FACILITY_CLUSTER" --tasks "$FACILITY_TASK" \
+  --query 'tasks[0].containers[?name==`migrate`].exitCode | [0]' --output text
+```
+
+The exit code must be `0`. If it is not, read
+`/facility/<environment>/migrate` in CloudWatch before retrying, and do not
+start the API or worker.
+
+## 6. Bind the instance to your GitHub organization
+
+Every instance is dedicated to one Facility organization, one GitHub account and
+one App installation, and sign-in admits only explicitly provisioned members.
+Until that binding exists, every login fails with `not_invited` or
+`installation_access_required` — correctly, but confusingly.
+
+The database accepts connections only from the service security group, so the
+binding is created from inside the VPC. The API image carries the CLI for
+exactly this, and the `migrate` task definition already has `DATABASE_URL`:
+
+```bash
+gh api /user --jq .id                  # your GitHub user id
+gh api /orgs/<org> --jq .id            # the account id (/users/<login> for a personal account)
+# the installation id is the last path segment of
+# https://github.com/organizations/<org>/settings/installations/<id>
+
+aws ecs run-task --region "$FACILITY_AWS_REGION" \
+  --cluster "$FACILITY_CLUSTER" --launch-type FARGATE \
+  --task-definition "$FACILITY_MIGRATE_DEF" \
+  --network-configuration "$FACILITY_NETWORK" \
+  --overrides '{"containerOverrides":[{"name":"migrate","command":[
+    "node","cli/bin/facility.mjs","instance","bootstrap",
+    "--org-name","My Org","--org-slug","my-org",
+    "--owner-email","you@example.com","--owner-name","Your Name",
+    "--github-user-id","<user id>","--github-login","<login>",
+    "--github-account-id","<account id>","--github-account-login","<org login>",
+    "--github-installation-id","<installation id>",
+    "--github-account-type","organization","--json"]}]}'
+```
+
+Wait for the task and assert its exit code exactly as in step 5, then read the
+log stream: `{"ok":true,"created":true,...}` on the first run and
+`"created":false` on any later one. The command takes an advisory lock, is
+idempotent for the same binding, and refuses to modify a database already bound
+to a different instance.
+
+That refusal is also the one failure worth recognising in advance:
+`bootstrap_failed: Database already contains a different Facility instance`
+means something already created an organization — most often a seed run with
+demo data. The reference `migrate` task sets `FACILITY_SEED_DEMO=0` precisely so
+that this step owns the first organization; keep it that way.
+
+Unlike earlier revisions of this runbook, no operator API key is injected by
+hand. You sign in through the browser as the bound owner, and issue keys from
+there with `facility keys issue` or `POST /v1/keys` when you need headless
+access.
+
+## 7. Start the services
+
+Raise the desired counts in the same tfvars file, apply, and wait:
+
+```bash
+terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
+
+aws ecs wait services-stable --region "$FACILITY_AWS_REGION" \
+  --cluster "$FACILITY_PREFIX" --services api worker gateway web
+
+FACILITY_API_URL="$(terraform -chdir="$FACILITY_TF_DIR" output -raw api_url)"
+curl --fail --silent --show-error "$FACILITY_API_URL/health"
+```
+
+Then sign in at the `app_hostname` with GitHub, issue an API key, and let the
+doctor judge the deployment rather than judging it yourself:
+
+```bash
+facility doctor --url "$FACILITY_API_URL" --key fak_…
+```
+
+Do not send traffic until it reports no `FAIL`. It verifies migrations, object
+storage, seed essentials, the `sandbox_runner` profile, the production
+`auth_config`, and the audit hash chain.
+
+Add provider credentials through Facility rather than enabling the gateway's
+development fallback:
+
+```bash
+facility providers create --provider anthropic --name primary --secret "$ANTHROPIC_API_KEY"
+```
+
+## 8. Activate the webhook last
+
+Only once health and doctor pass. GitHub does not invent the webhook URL — it
+comes from the public API origin:
+
+```bash
+terraform -chdir="$FACILITY_TF_DIR" output -raw github_webhook_url
+```
+
+In the App's settings: replace the URL with that exact value, keep
+`GITHUB_APP_WEBHOOK_SECRET` identical on both sides, enable **Active**, and keep
+SSL verification on. Confirm the subscriptions — `check_run`,
+`deployment_status`, `issue_comment`, `issues`, `pull_request`,
+`pull_request_review`, `push`, `workflow_run` — then use **Advanced → Recent
+deliveries** to redeliver one event and require a `2xx` before invoking an
+agent.
+
+If you are replacing an old environment, its URL is gone. Never reactivate the
+App against it.
+
+## Repeated deployments and teardown
+
+For validation stacks, `target_deregistration_delay_seconds = 15` avoids waiting
+the production default of five minutes for every replaced API target. Keep the
+default `300` in production unless in-flight requests are safely bounded below
+the shorter drain window.
+
+A full apply provisions roughly 89 billed resources. Tear down with
+`terraform destroy`, having set `enable_deletion_protection = false` and
+`force_destroy_bucket = true` for anything ephemeral. Verify against the service
+APIs and an empty Terraform state rather than the Resource Groups Tagging API,
+which keeps listing deleted ARNs for a while and converges later. Secrets enter
+an asynchronous force-deletion queue, and the KMS key stays in
+`PendingDeletion` for its minimum window — neither is live, and neither blocks a
+fresh environment.

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -323,7 +323,7 @@ doctor judge the deployment rather than judging it yourself:
 
 ```bash
 node packages/cli/bin/facility.mjs login --url "$FACILITY_API_URL"
-node packages/cli/bin/facility.mjs doctor
+node packages/cli/bin/facility.mjs doctor --platform
 ```
 
 Do not send traffic until it reports no `FAIL`. It verifies migrations, object

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -28,9 +28,11 @@ CLI, `jq`, and OpenSSL. Fresh AWS credentials — an old `.env` may carry an
 expired session token, so confirm with `aws sts get-caller-identity` before
 applying anything.
 
-On GitHub: the App created and installed on the repositories you will automate,
-with its webhook **inactive**. The App is configured last, once the API is
-reachable, so its first delivery is not lost. See the
+On GitHub: the App configured for both human OAuth and repository automation,
+then installed on the repositories you will automate, with its webhook
+**inactive**. Installation gives you the id bootstrap needs; bootstrap records
+that binding directly, so the initial `installation` event is not required. The
+webhook is activated and tested only after the API is reachable. See the
 [GitHub App guide](github-app).
 
 Somewhere safe: Terraform state. Local state is acceptable only for a
@@ -45,7 +47,6 @@ corepack enable && pnpm install --frozen-lockfile
 
 export FACILITY_AWS_REGION=us-east-1
 export FACILITY_ENV="prod"
-export FACILITY_PREFIX="facility-${FACILITY_ENV}"
 export FACILITY_IMAGE_TAG="$(git rev-parse --short HEAD)"
 export FACILITY_TF_DIR=infra/terraform/aws
 ```
@@ -56,14 +57,21 @@ export FACILITY_TF_DIR=infra/terraform/aws
 cp $FACILITY_TF_DIR/terraform.tfvars.example $FACILITY_TF_DIR/${FACILITY_ENV}.tfvars
 ```
 
-Set the hostnames, `auth_identity_provider = "github"` for self-hosting, the
-image tags you are about to push, and — deliberately — no running services:
+Set `aws_region` and `environment` to the values exported above, set the
+hostnames, select `auth_identity_provider = "github"` for self-hosting, and use
+the image tag you are about to push. A tfvars filename does not set Terraform's
+`environment` variable, so do not leave the copied `playground` value behind.
+Start with — deliberately — no running services:
 
 ```hcl
+aws_region  = "us-east-1" # same value as FACILITY_AWS_REGION
+environment = "prod"      # same value as FACILITY_ENV
+
 api_desired_count     = 0
 worker_desired_count  = 0
 gateway_desired_count = 0
 web_desired_count     = 0
+mcp_desired_count     = 0
 ```
 
 The first apply creates repositories, the database, secret containers, the
@@ -71,10 +79,18 @@ network, task definitions and the load balancer **without** starting containers
 whose images and secrets do not exist yet. Starting them early produces a
 crash-loop that is slower to diagnose than it is to avoid.
 
-Without a public DNS zone, set `enable_cloudfront_api_endpoint = true` to get an
-AWS-managed HTTPS origin for the API and the webhook. For production, point
-`api_hostname` at the ALB with a valid certificate, and set `route53_zone_id` if
-Terraform should create the alias record.
+Without a public DNS zone, clear the example's fake certificate and hosted-zone
+values as well as enabling the AWS-managed HTTPS origin:
+
+```hcl
+acm_certificate_arn           = ""
+route53_zone_id               = ""
+enable_cloudfront_api_endpoint = true
+```
+
+For production, leave the CloudFront validation endpoint disabled, point
+`api_hostname` at the ALB with a real certificate, and set `route53_zone_id`
+only when Terraform should create the alias record.
 
 No secret values belong in tfvars. The file is gitignored; keep it that way.
 
@@ -91,15 +107,16 @@ The build script defaults to a playground prefix, so `ECR_PREFIX` is mandatory:
 
 ```bash
 AWS_REGION="$FACILITY_AWS_REGION" \
-ECR_PREFIX="$FACILITY_PREFIX" \
+ECR_PREFIX="$(terraform -chdir="$FACILITY_TF_DIR" output -raw ecs_cluster_name)" \
 IMAGE_TAG="$FACILITY_IMAGE_TAG" \
 CPU_ARCHITECTURE=X86_64 \
 ./infra/build-images.sh
 ```
 
 Never `latest`: the tag in tfvars must match `FACILITY_IMAGE_TAG` exactly, so
-that what is deployed is identifiable from a commit. Apply again once the images
-exist.
+that what is deployed is identifiable from a commit. Deriving `ECR_PREFIX` from
+Terraform keeps the pushed repositories aligned with the selected project and
+environment.
 
 ## 4. Populate the secret containers
 
@@ -124,23 +141,77 @@ non-verifying mode is a downgrade, not a shortcut.
 facility_secret_arn() {
   terraform -chdir="$FACILITY_TF_DIR" output -json secret_arns | jq -r --arg n "$1" '.[$n]'
 }
-facility_put_secret() {
+facility_put_secret_from_stdin() {
   aws secretsmanager put-secret-value --region "$FACILITY_AWS_REGION" \
-    --secret-id "$(facility_secret_arn "$1")" --secret-string "$2" >/dev/null
+    --secret-id "$(facility_secret_arn "$1")" \
+    --secret-string file:///dev/stdin >/dev/null
+}
+facility_prompt_secret() {
+  local facility_secret_name="$1" facility_secret_value
+  printf 'Value for %s: ' "$facility_secret_name" >&2
+  IFS= read -r -s facility_secret_value
+  printf '\n' >&2
+  printf '%s' "$facility_secret_value" | facility_put_secret_from_stdin "$facility_secret_name"
+  unset facility_secret_value
 }
 ```
 
-The RDS master password lives in its own managed secret:
+The helpers read secret material from standard input, keeping it out of the AWS
+CLI process arguments. Populate every required value; creating an empty secret
+container is not enough for an ECS task to start.
+
+The RDS master password lives in its own managed secret. Build and store the URL
+without printing the password:
 
 ```bash
-aws secretsmanager get-secret-value \
-  --region "$FACILITY_AWS_REGION" \
-  --secret-id "$(terraform -chdir="$FACILITY_TF_DIR" output -raw rds_master_user_secret_arn)" \
-  --query SecretString --output text | jq -r .password
+FACILITY_RDS_PASSWORD="$(
+  aws secretsmanager get-secret-value \
+    --region "$FACILITY_AWS_REGION" \
+    --secret-id "$(terraform -chdir="$FACILITY_TF_DIR" output -raw rds_master_user_secret_arn)" \
+    --query SecretString --output text | jq -r .password
+)"
+FACILITY_RDS_ENDPOINT="$(terraform -chdir="$FACILITY_TF_DIR" output -raw rds_endpoint)"
+FACILITY_DATABASE_URL="postgres://facility:$(printf '%s' "$FACILITY_RDS_PASSWORD" | jq -sRr @uri)@${FACILITY_RDS_ENDPOINT}:5432/facility?sslmode=verify-full"
+printf '%s' "$FACILITY_DATABASE_URL" | facility_put_secret_from_stdin database_url
+unset FACILITY_RDS_PASSWORD FACILITY_DATABASE_URL
 ```
 
-URL-encode it before putting it in `database_url`, and never print the values or
-commit `.env`, tfvars, or state.
+For a new instance, generate the encryption key and the private ES256 signing
+set directly into Secrets Manager:
+
+```bash
+openssl rand -base64 32 | tr -d '\n' | facility_put_secret_from_stdin secret_master_key
+
+node --input-type=module <<'NODE' | facility_put_secret_from_stdin facility_oauth_jwks
+import { randomUUID, webcrypto } from "node:crypto";
+const pair = await webcrypto.subtle.generateKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  true,
+  ["sign", "verify"],
+);
+const key = await webcrypto.subtle.exportKey("jwk", pair.privateKey);
+Object.assign(key, { alg: "ES256", kid: randomUUID(), use: "sig" });
+process.stdout.write(JSON.stringify({ keys: [key] }));
+NODE
+```
+
+Enter the remaining one-line values without echoing them, then load the App's
+multiline private key from its protected file:
+
+```bash
+for FACILITY_SECRET_NAME in \
+  github_oauth_client_id github_oauth_client_secret \
+  github_app_id github_app_slug github_app_webhook_secret; do
+  facility_prompt_secret "$FACILITY_SECRET_NAME"
+done
+unset FACILITY_SECRET_NAME
+
+facility_put_secret_from_stdin github_app_private_key < /secure/path/to/github-app.private-key.pem
+```
+
+On later deployments, reuse `secret_master_key` and `facility_oauth_jwks`;
+regenerating them breaks stored ciphertext and outstanding OAuth tokens. Never
+print secret values or commit `.env`, tfvars, state, or private-key files.
 
 ## 5. Migrate and seed, before any service starts
 
@@ -155,23 +226,31 @@ FACILITY_SUBNETS="$(terraform -chdir="$FACILITY_TF_DIR" output -json private_sub
 FACILITY_SERVICE_SG="$(terraform -chdir="$FACILITY_TF_DIR" output -raw service_security_group_id)"
 FACILITY_NETWORK="awsvpcConfiguration={subnets=[${FACILITY_SUBNETS}],securityGroups=[${FACILITY_SERVICE_SG}],assignPublicIp=DISABLED}"
 
+facility_wait_for_task() {
+  local facility_task_arn="$1" facility_exit_code
+  aws ecs wait tasks-stopped --region "$FACILITY_AWS_REGION" \
+    --cluster "$FACILITY_CLUSTER" --tasks "$facility_task_arn"
+  facility_exit_code="$(aws ecs describe-tasks --region "$FACILITY_AWS_REGION" \
+    --cluster "$FACILITY_CLUSTER" --tasks "$facility_task_arn" \
+    --query 'tasks[0].containers[?name==`migrate`].exitCode | [0]' --output text)"
+  if [ "$facility_exit_code" != "0" ]; then
+    printf 'ECS task failed with exit code %s; inspect /facility/%s/migrate in CloudWatch.\n' \
+      "$facility_exit_code" "$FACILITY_ENV" >&2
+    return 1
+  fi
+}
+
 FACILITY_TASK="$(aws ecs run-task --region "$FACILITY_AWS_REGION" \
   --cluster "$FACILITY_CLUSTER" --launch-type FARGATE \
   --task-definition "$FACILITY_MIGRATE_DEF" \
   --network-configuration "$FACILITY_NETWORK" \
   --query 'tasks[0].taskArn' --output text)"
 
-aws ecs wait tasks-stopped --region "$FACILITY_AWS_REGION" \
-  --cluster "$FACILITY_CLUSTER" --tasks "$FACILITY_TASK"
-
-aws ecs describe-tasks --region "$FACILITY_AWS_REGION" \
-  --cluster "$FACILITY_CLUSTER" --tasks "$FACILITY_TASK" \
-  --query 'tasks[0].containers[?name==`migrate`].exitCode | [0]' --output text
+facility_wait_for_task "$FACILITY_TASK"
 ```
 
-The exit code must be `0`. If it is not, read
-`/facility/<environment>/migrate` in CloudWatch before retrying, and do not
-start the API or worker.
+If the helper returns nonzero, do not continue. Read the named CloudWatch log
+group before retrying, and do not start any service.
 
 ## 6. Bind the instance to your GitHub organization
 
@@ -190,7 +269,7 @@ gh api /orgs/<org> --jq .id            # the account id (/users/<login> for a pe
 # the installation id is the last path segment of
 # https://github.com/organizations/<org>/settings/installations/<id>
 
-aws ecs run-task --region "$FACILITY_AWS_REGION" \
+FACILITY_TASK="$(aws ecs run-task --region "$FACILITY_AWS_REGION" \
   --cluster "$FACILITY_CLUSTER" --launch-type FARGATE \
   --task-definition "$FACILITY_MIGRATE_DEF" \
   --network-configuration "$FACILITY_NETWORK" \
@@ -201,14 +280,17 @@ aws ecs run-task --region "$FACILITY_AWS_REGION" \
     "--github-user-id","<user id>","--github-login","<login>",
     "--github-account-id","<account id>","--github-account-login","<org login>",
     "--github-installation-id","<installation id>",
-    "--github-account-type","organization","--json"]}]}'
+    "--github-account-type","organization","--json"]}]}' \
+  --query 'tasks[0].taskArn' --output text)"
+
+facility_wait_for_task "$FACILITY_TASK"
 ```
 
-Wait for the task and assert its exit code exactly as in step 5, then read the
-log stream: `{"ok":true,"created":true,...}` on the first run and
-`"created":false` on any later one. The command takes an advisory lock, is
-idempotent for the same binding, and refuses to modify a database already bound
-to a different instance.
+For a personal-account installation, use the `/users/<login>` lookup, the
+account login, and `--github-account-type user`. Then read the log stream:
+`{"ok":true,"created":true,...}` on the first run and `"created":false` on
+any later one. The command takes an advisory lock, is idempotent for the same
+binding, and refuses to modify a database already bound to a different instance.
 
 That refusal is also the one failure worth recognising in advance:
 `bootstrap_failed: Database already contains a different Facility instance`
@@ -217,41 +299,40 @@ demo data. The reference `migrate` task sets `FACILITY_SEED_DEMO=0` precisely so
 that this step owns the first organization; keep it that way.
 
 Unlike earlier revisions of this runbook, no operator API key is injected by
-hand. You sign in through the browser as the bound owner, and issue keys from
-there with `facility keys issue` or `POST /v1/keys` when you need headless
-access.
+hand. You sign in through the browser as the bound owner and issue the first key
+under **Settings → API keys**. The CLI and REST endpoint require an existing
+credential, so they cannot issue that first key.
 
 ## 7. Start the services
 
-Raise the desired counts in the same tfvars file, apply, and wait:
+Raise all five desired counts in the same tfvars file, apply, and wait:
 
 ```bash
 terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
 
 aws ecs wait services-stable --region "$FACILITY_AWS_REGION" \
-  --cluster "$FACILITY_PREFIX" --services api worker gateway web
+  --cluster "$FACILITY_CLUSTER" --services api worker gateway web mcp
 
 FACILITY_API_URL="$(terraform -chdir="$FACILITY_TF_DIR" output -raw api_url)"
 curl --fail --silent --show-error "$FACILITY_API_URL/health"
 ```
 
-Then sign in at the `app_hostname` with GitHub, issue an API key, and let the
+Then sign in at the `app_hostname` with GitHub, issue the first API key under
+**Settings → API keys**, and save it through the CLI's hidden prompt. Let the
 doctor judge the deployment rather than judging it yourself:
 
 ```bash
-facility doctor --url "$FACILITY_API_URL" --key fak_…
+node packages/cli/bin/facility.mjs login --url "$FACILITY_API_URL"
+node packages/cli/bin/facility.mjs doctor
 ```
 
 Do not send traffic until it reports no `FAIL`. It verifies migrations, object
 storage, seed essentials, the `sandbox_runner` profile, the production
 `auth_config`, and the audit hash chain.
 
-Add provider credentials through Facility rather than enabling the gateway's
-development fallback:
-
-```bash
-facility providers create --provider anthropic --name primary --secret "$ANTHROPIC_API_KEY"
-```
+Add provider credentials under **Settings → Providers** rather than enabling
+the gateway's development fallback or placing a provider secret in command-line
+arguments.
 
 ## 8. Activate the webhook last
 
@@ -267,8 +348,8 @@ In the App's settings: replace the URL with that exact value, keep
 SSL verification on. Confirm the subscriptions — `check_run`,
 `deployment_status`, `issue_comment`, `issues`, `pull_request`,
 `pull_request_review`, `push`, `workflow_run` — then use **Advanced → Recent
-deliveries** to redeliver one event and require a `2xx` before invoking an
-agent.
+deliveries** to create or redeliver a test event and require a `2xx` before
+invoking an agent.
 
 If you are replacing an old environment, its URL is gone. Never reactivate the
 App against it.
@@ -280,11 +361,29 @@ the production default of five minutes for every replaced API target. Keep the
 default `300` in production unless in-flight requests are safely bounded below
 the shorter drain window.
 
-A full apply provisions roughly 89 billed resources. Tear down with
-`terraform destroy`, having set `enable_deletion_protection = false` and
-`force_destroy_bucket = true` for anything ephemeral. Verify against the service
-APIs and an empty Terraform state rather than the Resource Groups Tagging API,
-which keeps listing deleted ARNs for a while and converges later. Secrets enter
-an asynchronous force-deletion queue, and the KMS key stays in
-`PendingDeletion` for its minimum window — neither is live, and neither blocks a
-fresh environment.
+A full apply provisions roughly 89 billed resources. For an ephemeral stack,
+set `enable_deletion_protection = false` and `force_destroy_bucket = true` in
+the same tfvars file, apply those settings, and destroy from the module with the
+same variables:
+
+```bash
+terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
+
+# Terraform protects non-empty ECR repositories. Remove all six repositories
+# and their images explicitly; destroy will reconcile them out of state.
+while IFS= read -r FACILITY_ECR_URL; do
+  FACILITY_ECR_REPOSITORY="${FACILITY_ECR_URL#*/}"
+  aws ecr delete-repository --region "$FACILITY_AWS_REGION" \
+    --repository-name "$FACILITY_ECR_REPOSITORY" --force >/dev/null
+done < <(terraform -chdir="$FACILITY_TF_DIR" output -json ecr_repository_urls | jq -r '.[]')
+unset FACILITY_ECR_URL FACILITY_ECR_REPOSITORY
+
+terraform -chdir="$FACILITY_TF_DIR" destroy -var-file="${FACILITY_ENV}.tfvars"
+```
+
+Keep the state until destroy completes. Verify against the service APIs and an
+empty Terraform state rather than the Resource Groups Tagging API, which keeps
+listing deleted ARNs for a while and converges later. Secrets enter an
+asynchronous force-deletion queue, and the KMS key stays in `PendingDeletion`
+for its minimum window — neither is live, and neither blocks a fresh
+environment.

--- a/apps/docs/docs/self-host/github-app.md
+++ b/apps/docs/docs/self-host/github-app.md
@@ -4,16 +4,17 @@ title: GitHub App
 
 # Configure the GitHub App
 
-Facility uses a GitHub App installation to discover repositories, clone private
-repositories, create governed branches and pull requests, collect delivery
-outcomes, and receive repository events. It does not use GitHub user OAuth, so
-the App does not need a callback URL, client secret, device flow, or user
-authorization during installation.
+Self-hosted Facility uses one GitHub App for two jobs: direct GitHub OAuth for
+human sign-in, and an App installation for repository automation. The OAuth
+side verifies a user's stable id and verified email; the installation side
+discovers repositories, creates governed branches and pull requests, collects
+delivery outcomes, and receives repository events.
 
-Configuration has two phases. Set the App's identity, permissions, and
-credentials first. After the public Facility API is reachable, activate the
-webhook, select its events, and install the App; otherwise the initial
-`installation` event has nowhere to go.
+Configuration has two phases. First set the App's OAuth identity, permissions,
+and credentials, then install it to obtain the installation id used by
+`facility instance bootstrap`. The webhook can remain inactive during initial
+deployment: bootstrap records the installation binding directly. After the
+public Facility API is reachable, activate and test the webhook.
 
 ## 1. Create or edit the App
 
@@ -26,10 +27,10 @@ Use these general settings:
 |---|---|
 | GitHub App name | a unique name, such as `facility-production` |
 | Homepage URL | the Facility web URL or project homepage |
-| Callback URL | empty |
+| Callback URL | `https://<web-host>/api/auth/callback`, exactly matching `AUTH_CALLBACK_URL` |
 | Setup URL | empty |
 | Device flow | disabled |
-| Request user authorization during installation | disabled |
+| Request user authorization (OAuth) during installation | enabled |
 | Where can this GitHub App be installed? | **Only on this account** for a private installation |
 
 Leave the webhook inactive until the API has a public HTTPS URL.
@@ -49,8 +50,10 @@ For an existing-repository lifecycle, set these **Repository permissions**:
 | Pull requests | Read and write | open and close PRs and collect review evidence |
 | Workflows | Read and write | install or update files under `.github/workflows` during kickstart |
 
-Set **Organization permissions → Members** to **Read-only**. Leave account and
-user permissions at **No access**.
+Set **Organization permissions → Members** and **Account permissions → Email
+addresses** to **Read-only**. The latter is required for direct GitHub sign-in;
+without it Facility cannot obtain a verified email and rejects the login. Leave
+all other account and user permissions at **No access**.
 
 `Administration: Read and write` is optional and high privilege. Enable it only
 when Facility must create repositories in the organization. It is not required
@@ -67,7 +70,7 @@ and [webhook event reference](https://docs.github.com/en/webhooks/webhook-events
 
 GitHub shows **Subscribe to events** only after the App's webhook is active and
 its URL has been saved. If the API is not reachable yet, complete sections 4
-and 5, save the active webhook, then return to **Permissions & events**.
+and 6, deploy and bootstrap Facility, then return here after section 5.
 
 On **Permissions & events**, scroll below the permission panels to **Subscribe
 to events** and select:
@@ -94,9 +97,11 @@ must approve the new permissions on the installation.
 
 ## 4. Create the credentials
 
-The Facility API needs four values:
+The Facility API needs six values in direct-GitHub mode:
 
 ```dotenv
+GITHUB_OAUTH_CLIENT_ID=<Client ID from the App's General page>
+GITHUB_OAUTH_CLIENT_SECRET=<generated client secret>
 GITHUB_APP_ID=<numeric App ID, not the Client ID>
 GITHUB_APP_SLUG=<the suffix from https://github.com/apps/<slug>>
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
@@ -104,6 +109,14 @@ GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
 -----END RSA PRIVATE KEY-----"
 GITHUB_APP_WEBHOOK_SECRET=<random secret shared with GitHub>
 ```
+
+### OAuth client credentials
+
+Copy the **Client ID** from the App's General page. Under **Client secrets**,
+select **Generate a new client secret** and store it immediately; GitHub shows
+the plaintext once. These values become `GITHUB_OAUTH_CLIENT_ID` and
+`GITHUB_OAUTH_CLIENT_SECRET`. They are distinct from the numeric App ID and the
+private key used for installation authentication.
 
 ### Private key
 
@@ -183,7 +196,8 @@ configure:
 | Webhook secret | the exact `GITHUB_APP_WEBHOOK_SECRET` value |
 | SSL verification | enabled |
 
-Save the changes before installing the App.
+Save the changes. An App installed while the webhook was inactive does not need
+to be reinstalled; bootstrap already recorded its installation binding.
 
 Return to **Permissions & events** and complete section 3. The event checkboxes
 will now appear below the permission panels.
@@ -194,10 +208,11 @@ Open **Install App**, choose the organization, and select **Only select
 repositories** for the least-privilege validation setup. Select the repositories
 Facility will govern and confirm the installation.
 
-Install only after the webhook is active so Facility receives the initial
-`installation` event. If the App was installed earlier, remove and re-add the
-repository to the installation, or reinstall the App, after the endpoint is
-ready.
+Install before running `facility instance bootstrap`, and note the installation
+id at the end of the installation-settings URL. It is safe to do this while the
+webhook is inactive: bootstrap creates the initial binding. Once the webhook is
+active, adding or removing a test repository generates an
+`installation_repositories` delivery if you need to verify that event family.
 
 ## 7. Verify the integration
 
@@ -210,15 +225,15 @@ attestations are available for the repository's visibility and organization
 plan; otherwise leave it unset so receipt collection remains green without an
 unsupported attestation call.
 
-1. In the GitHub App settings, open **Advanced → Recent deliveries**.
-2. Confirm the `installation` delivery received a `2xx` response.
-3. Create a test issue or comment in an installed repository.
-4. Submit a non-approving review on a disposable pull request.
-5. Confirm the corresponding `issues` or `issue_comment` and
+1. Create a test issue or comment in an installed repository.
+2. In the GitHub App settings, open **Advanced → Recent deliveries** and confirm
+   it received a `2xx` response.
+3. Submit a non-approving review on a disposable pull request.
+4. Confirm the corresponding `issues` or `issue_comment` and
    `pull_request_review` deliveries received a `2xx` response and appear in
    Facility's inbound event history. Without `pull_request_review`, the
    address-review agent cannot receive actionable feedback.
-6. Run the platform readiness check:
+5. Run the platform readiness check:
 
    ```bash
    node packages/cli/bin/facility.mjs doctor --url https://<api-host> --key fak_...
@@ -228,6 +243,9 @@ Common failures:
 
 | symptom | likely cause |
 |---|---|
+| `501 auth_unconfigured` on sign-in | OAuth client id/secret missing — configure both and restart the API |
+| GitHub reports a redirect URI mismatch | the App callback and `AUTH_CALLBACK_URL` differ; they must match exactly |
+| `auth_failed` after GitHub authorization | the App lacks **Email addresses: Read-only**, or the user has no verified email |
 | `404` delivery | wrong hostname or path; the path must be `/webhooks/github` |
 | `401` delivery | GitHub and Facility have different webhook secrets |
 | TLS delivery error | DNS or certificate is not valid for the API hostname |

--- a/apps/docs/docs/self-host/github-app.md
+++ b/apps/docs/docs/self-host/github-app.md
@@ -30,10 +30,13 @@ Use these general settings:
 | Callback URL | `https://<web-host>/api/auth/callback`, exactly matching `AUTH_CALLBACK_URL` |
 | Setup URL | empty |
 | Device flow | disabled |
-| Request user authorization (OAuth) during installation | enabled |
+| Request user authorization (OAuth) during installation | disabled |
 | Where can this GitHub App be installed? | **Only on this account** for a private installation |
 
-Leave the webhook inactive until the API has a public HTTPS URL.
+Keep automatic user authorization disabled when installing the App before
+Facility is deployed. This does not disable OAuth: signing in to Facility later
+starts GitHub authorization after the callback URL is reachable. Leave the
+webhook inactive until the API has a public HTTPS URL.
 
 ## 2. Grant permissions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,9 +15,9 @@ This command fails unless all of the following execute successfully:
 1. repository lint and typecheck;
 2. every declared build output removed, then every workspace rebuilt with the
    Turbo cache disabled;
-3. database, API, and gateway integration suites invoked directly (not through
-   Turbo), against `facility_test` and `facility_gw`; any reported skip is a
-   failure;
+3. database, CLI bootstrap, API, and gateway integration suites invoked
+   directly (not through Turbo), against `facility_test` and `facility_gw`; any
+   reported skip is a failure;
 4. the development-launcher tests and all remaining workspace tests with the
    Turbo cache disabled;
 5. deterministic repository guards; and

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -74,10 +74,16 @@ Record these outputs:
 
 ## 3. Build and push images
 
-From the repository root:
+From the module directory used above, build from the repository root and return
+afterward:
 
 ```bash
-AWS_REGION=us-east-1 IMAGE_TAG=$(git rev-parse --short HEAD) ./infra/build-images.sh
+cd ../../..
+AWS_REGION=us-east-1 \
+ECR_PREFIX="$(terraform -chdir=infra/terraform/aws output -raw ecs_cluster_name)" \
+IMAGE_TAG=$(git rev-parse --short HEAD) \
+./infra/build-images.sh
+cd infra/terraform/aws
 ```
 
 The script expects Dockerfiles for `api`, `worker`, `gateway`, `web`, `mcp`, and

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -126,7 +126,20 @@ Watch `/facility/<environment>/migrate` in CloudWatch Logs for
 `applied 0001_control_plane.sql` (or `already applied`) followed by the seed
 summary. `facility doctor` will flag `seed_essentials` if this task did not run.
 
-## 6. Verify service health
+## 6. Bind the instance
+
+`facility instance bootstrap` creates the organization, its owner, and the
+GitHub account/installation binding that sign-in checks. The database is
+reachable only from the service security group, so run it as a one-shot task
+using this module's `migrate` task definition — the API image carries the CLI —
+with a container override. The
+[AWS deployment runbook](https://github.com/theam/facility/blob/main/apps/docs/docs/self-host/aws.md#6-bind-the-instance-to-your-github-organization)
+has the exact invocation and the ids it needs.
+
+Until this runs, every sign-in fails with `not_invited` or
+`installation_access_required`.
+
+## 7. Verify service health
 
 ```bash
 curl -fsS "https://${api_hostname}/health"

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -24,6 +24,8 @@ cp terraform.tfvars.example playground.tfvars
 
 Edit `playground.tfvars`:
 
+- Set `aws_region` and change the copied `environment = "playground"` value if
+  this is not a playground deployment; a filename does not set the variable.
 - Set `app_hostname`, `api_hostname`, and `mcp_hostname`.
 - Set `acm_certificate_arn` for HTTPS, or leave it empty for HTTP-only testing.
 - Set `route53_zone_id` if Terraform should create alias records.
@@ -34,6 +36,21 @@ Edit `playground.tfvars`:
 - Select direct `github` authentication for self-hosting or `oidc` for a SaaS
   broker. MCP OAuth is always issued by the dedicated Facility instance.
 - Tune `envelope_retention_days` for your data-retention policy.
+
+For the first apply, set every service count to zero. The images and secret
+values do not exist yet, and `mcp_desired_count` otherwise defaults to `2`:
+
+```hcl
+api_desired_count     = 0
+worker_desired_count  = 0
+gateway_desired_count = 0
+web_desired_count     = 0
+mcp_desired_count     = 0
+```
+
+For the AWS-managed CloudFront validation endpoint, also clear the copied
+placeholder `acm_certificate_arn` and `route53_zone_id`; placeholder values are
+not disabled merely by setting `enable_cloudfront_api_endpoint = true`.
 
 No secret values belong in tfvars.
 
@@ -76,7 +93,10 @@ Apply again with matching `container_image_tags`.
 ## 4. Populate Secrets Manager
 
 Terraform creates encrypted secret containers but never writes secret values.
-Populate them with `aws secretsmanager put-secret-value`.
+Populate them with `aws secretsmanager put-secret-value`, loading plaintext from
+standard input or a protected file rather than a process argument. The
+[deployment runbook](https://github.com/theam/facility/blob/main/apps/docs/docs/self-host/aws.md#4-populate-the-secret-containers)
+has commands that populate every required value without printing it.
 
 Required runtime values:
 
@@ -98,14 +118,9 @@ The production service image loads Amazon's published global RDS CA bundle so
 `sslmode=verify-full` encrypts the connection and verifies the database
 hostname. Do not downgrade this to a non-verifying TLS mode.
 
-Fetch the RDS managed password:
-
-```bash
-aws secretsmanager get-secret-value \
-  --secret-id "$(terraform output -raw rds_master_user_secret_arn)" \
-  --query SecretString \
-  --output text
-```
+The RDS master password is in `rds_master_user_secret_arn`; use the runbook's
+captured pipeline to URL-encode it into `database_url` without writing the
+plaintext to the terminal.
 
 ## 5. Run the migrate + seed task once
 
@@ -139,7 +154,17 @@ has the exact invocation and the ids it needs.
 Until this runs, every sign-in fails with `not_invited` or
 `installation_access_required`.
 
-## 7. Verify service health
+## 7. Start and verify the services
+
+Raise all five desired counts in `playground.tfvars`, apply the same file, and
+wait for every service, including MCP:
+
+```bash
+terraform apply -var-file=playground.tfvars
+aws ecs wait services-stable \
+  --cluster "$(terraform output -raw ecs_cluster_name)" \
+  --services api worker gateway web mcp
+```
 
 ```bash
 curl -fsS "https://${api_hostname}/health"
@@ -167,6 +192,9 @@ The reference module has been checked with:
 
 A full `terraform apply` provisions ~89 billed resources (RDS, NAT gateway,
 ALB, ECS services) — run it when you want a live environment, then
-`build-images.sh` + the one-shot migrate task per the steps above. Tear down
-with `terraform destroy` (set `enable_deletion_protection=false` and
-`force_destroy_bucket=true` for an ephemeral playground).
+`build-images.sh` + the one-shot migrate task per the steps above. For an
+ephemeral playground, set `enable_deletion_protection=false` and
+`force_destroy_bucket=true`, apply `playground.tfvars`, remove the non-empty ECR
+repositories, then destroy with that same variable file. The published
+[deployment runbook](https://github.com/theam/facility/blob/main/apps/docs/docs/self-host/aws.md#repeated-deployments-and-teardown)
+contains the exact, state-safe teardown commands.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "pnpm test:dev && turbo run test",
     "test:dev": "node --test scripts/*.test.mjs",
     "test:critical": "node scripts/test-critical.mjs",
-    "test:uncached": "pnpm test:dev && turbo run test --force --filter='!@facility/db' --filter='!@facility/api' --filter='!@facility/gateway'",
+    "test:uncached": "pnpm test:dev && turbo run test --force --filter='!@facility/db' --filter='!@facility/api' --filter='!@facility/gateway' --filter='!@theagilemonkeys/facility'",
     "test:e2e-sandbox": "turbo run build --filter='@facility/api^...' && pnpm --filter @facility/api test:e2e-sandbox",
     "typecheck": "turbo run typecheck",
     "lint": "biome check .",

--- a/scripts/test-critical.mjs
+++ b/scripts/test-critical.mjs
@@ -32,7 +32,10 @@ function run(command, args, database) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 
   const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-  if (/\bskip(?:ped)?\b/i.test(output)) {
+  const reportedSkip =
+    /# SKIP\b/i.test(output) ||
+    /\b(?:[1-9]\d*\s+skipped|skipped\s+[1-9]\d*)\b/i.test(output);
+  if (reportedSkip) {
     console.error(
       `Critical integration suite for ${database} reported a skip. Critical tests must run, not degrade to green.`,
     );

--- a/scripts/test-critical.mjs
+++ b/scripts/test-critical.mjs
@@ -10,6 +10,7 @@ const apiTests = readdirSync(new URL("../services/api/test", import.meta.url))
 if (apiTests.length === 0) throw new Error("No API tests discovered");
 
 run("pnpm", ["--filter", "@facility/db", "test"], "facility_test");
+run("pnpm", ["--filter", "@theagilemonkeys/facility", "test"], "facility_test");
 run(
   "pnpm",
   ["--filter", "@facility/api", "exec", "vitest", "run", "--fileParallelism=false", ...apiTests],
@@ -31,7 +32,7 @@ function run(command, args, database) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 
   const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-  if (/\bskipped\b/i.test(output)) {
+  if (/\bskip(?:ped)?\b/i.test(output)) {
     console.error(
       `Critical integration suite for ${database} reported a skip. Critical tests must run, not degrade to green.`,
     );


### PR DESCRIPTION
Closes the gap between "the Terraform applies" and "you can sign in". Part of the work to deploy our own instance, and the first thing a self-hoster will follow.

## The gap

The AWS page described what the module provisions and left the sequence to a handoff document written before authentication changed. Following it produced a stack where **every sign-in failed** with `not_invited` or `installation_access_required`, because nothing created the organization, the owner, and the GitHub account/installation binding that sign-in checks.

The old handoff worked around that with a bounded shortcut: generate an API key locally and inject org, user, member and key rows as hand-written SQL through a one-shot ECS task. `facility instance bootstrap` is the supported replacement — but it needs the database, and in this module the database accepts connections only from the service security group. There was nowhere to run it from. That, not the prose, is why the runbook could not simply be updated.

## The change

The API image now carries the CLI (`/app/cli`). A few hundred kilobytes of plain ESM whose only dependency, `postgres`, is already in the image for `@facility/db`. Bootstrap then runs as a one-shot task through the **existing** `migrate` task definition with a container override — no new Terraform, no bastion, no port-forwarding — and every other operator command becomes available inside the VPC for free.

## Verified, not reasoned about

Against the built image and a real Postgres:

- `docker build --target api` → `node cli/bin/facility.mjs instance bootstrap --help` runs, and `postgres` resolves from the deployed tree;
- migrate + seed, then bootstrap → `{"ok":true,"created":true,...}`;
- the same bootstrap again → `"created":false`.

It also surfaced a failure worth documenting: seeding **with** demo data first makes bootstrap refuse the database as already bound to a different instance. The reference `migrate` task sets `FACILITY_SEED_DEMO=0` precisely so this step owns the first organization, and the runbook now says why.

## Kept from the handoff

The disciplines that were right and are easy to lose: zero desired counts on the first apply (so nothing crash-loops against images and secrets that do not exist yet), migrations before services, the exit-code assertion before continuing, provider credentials through Facility rather than the gateway fallback, the webhook activated **last** against a URL that only exists once the API is reachable, and a teardown verified against the service APIs rather than the tag index, which lags.

Also dropped: the hand-injected operator key. With GitHub login you sign in as the bound owner and issue keys normally.

`pnpm guards`, `pnpm lint`, the docs build, and the api image build all pass.