### PR TITLE
fix(gateway): wait for usage writes that outlive their response

### DIFF
--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -33,6 +33,18 @@ const allowedPaths = {
   openai: new Set(["/chat/completions", "/responses"]),
 } satisfies Record<Provider, Set<string>>;
 
+export function createMeteringDrain() {
+  const pending = new Set<Promise<unknown>>();
+  const track = <T>(work: Promise<T>): Promise<T> => {
+    pending.add(work);
+    return work.finally(() => pending.delete(work));
+  };
+  const settled = async () => {
+    while (pending.size > 0) await Promise.allSettled([...pending]);
+  };
+  return { track, settled };
+}
+
 export async function buildApp(
   config: GatewayConfig = readConfig(),
   deps: GatewayDeps = {},
@@ -60,19 +72,12 @@ export async function buildApp(
   }
   const envelopeStore = deps.envelopeStore ?? createEnvelopeStore(config);
   const now = deps.now ?? (() => new Date());
-  // A streamed response reaches the client when the pipeline finishes; its
-  // usage record is written afterwards. Track those writes so shutdown can wait
-  // for them — otherwise a redeploy drops the usage of every request that was
-  // still settling, and the spend it was about to account for.
-  const pendingMetering = new Set<Promise<unknown>>();
-  const meter = <T>(write: Promise<T>): Promise<T> => {
-    pendingMetering.add(write);
-    return write.finally(() => pendingMetering.delete(write));
-  };
-  const meteringSettled = async () => {
-    while (pendingMetering.size > 0) await Promise.allSettled([...pendingMetering]);
-  };
-  app.decorate("meteringSettled", meteringSettled);
+  // Register the whole provider handler before its raw response can finish.
+  // Registering only enqueueMetering in the handler's finally block is too late:
+  // Fastify may start onClose after the socket finishes but before that block
+  // resumes, observe an empty drain, and close Postgres ahead of the usage write.
+  const meteringDrain = createMeteringDrain();
+  app.decorate("meteringSettled", meteringDrain.settled);
 
   app.addHook("onRequest", async (request, reply) => {
     reply.header("x-request-id", request.id);
@@ -103,15 +108,17 @@ export async function buildApp(
   app.get("/readyz", readiness);
 
   app.post("/anthropic/v1/*", (request, reply) =>
-    handleProvider(request, reply, "anthropic", config, db, envelopeStore, now, meter),
+    meteringDrain.track(
+      handleProvider(request, reply, "anthropic", config, db, envelopeStore, now),
+    ),
   );
   app.post("/openai/v1/*", (request, reply) =>
-    handleProvider(request, reply, "openai", config, db, envelopeStore, now, meter),
+    meteringDrain.track(handleProvider(request, reply, "openai", config, db, envelopeStore, now)),
   );
 
   app.addHook("onClose", async () => {
     await revocationListener?.unlisten().catch(() => undefined);
-    await meteringSettled();
+    await meteringDrain.settled();
     await owned?.client.end();
   });
 
@@ -126,7 +133,6 @@ async function handleProvider(
   db: NonNullable<GatewayDeps["db"]>,
   envelopeStore: NonNullable<GatewayDeps["envelopeStore"]>,
   now: () => Date,
-  meter: <T>(write: Promise<T>) => Promise<T>,
 ) {
   const suffix = providerSuffix(request, provider);
   if (!allowedPaths[provider].has(suffix)) {
@@ -193,7 +199,7 @@ async function handleProvider(
       budgets,
       error: "model not priced",
     });
-    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
+    await enqueueMetering(db, envelopeStore, request.log, record, now());
     return reply.status(402).send(responseBody);
   }
 
@@ -224,7 +230,7 @@ async function handleProvider(
       budgets,
       error: `hard budget ${hardBlock.id} exceeded`,
     });
-    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
+    await enqueueMetering(db, envelopeStore, request.log, record, now());
     return reply.status(402).send(responseBody);
   }
 
@@ -248,7 +254,7 @@ async function handleProvider(
       budgets,
       error: "allowed_models violation",
     });
-    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
+    await enqueueMetering(db, envelopeStore, request.log, record, now());
     return reply.status(403).send(responseBody);
   }
 
@@ -293,7 +299,7 @@ async function handleProvider(
       budgets,
       error: `hard budget ${reservation.budget.id} exceeded`,
     });
-    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
+    await enqueueMetering(db, envelopeStore, request.log, record, now());
     return reply.status(402).send(responseBody);
   }
   const controller = new AbortController();
@@ -341,7 +347,7 @@ async function handleProvider(
       providerMayHaveCharged: false,
       error: "upstream fetch failed",
     });
-    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
+    await enqueueMetering(db, envelopeStore, request.log, record, now());
     throw new GatewayError(502, "provider_error", "Upstream provider request failed", provider);
   }
 
@@ -386,7 +392,7 @@ async function handleProvider(
       providerMayHaveCharged: true,
       error,
     });
-    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
+    await enqueueMetering(db, envelopeStore, request.log, record, now());
   }
 }
 

--- a/services/gateway/src/app.ts
+++ b/services/gateway/src/app.ts
@@ -19,6 +19,15 @@ import { enqueueMetering, reserveHardBudgetsAndRecordPending } from "./metering.
 import type { GatewayConfig, GatewayDeps, Provider, RequestRecord, Usage } from "./types.js";
 import { emptyUsage, UsageTee, usageFromJson } from "./usage.js";
 
+// `meteringSettled` lets a caller wait for usage writes that outlive the
+// response they belong to: the shutdown hook, and tests that clean up rows a
+// still-settling write would re-create.
+declare module "fastify" {
+  interface FastifyInstance {
+    meteringSettled: () => Promise<void>;
+  }
+}
+
 const allowedPaths = {
   anthropic: new Set(["/messages", "/messages/count_tokens"]),
   openai: new Set(["/chat/completions", "/responses"]),
@@ -51,6 +60,19 @@ export async function buildApp(
   }
   const envelopeStore = deps.envelopeStore ?? createEnvelopeStore(config);
   const now = deps.now ?? (() => new Date());
+  // A streamed response reaches the client when the pipeline finishes; its
+  // usage record is written afterwards. Track those writes so shutdown can wait
+  // for them — otherwise a redeploy drops the usage of every request that was
+  // still settling, and the spend it was about to account for.
+  const pendingMetering = new Set<Promise<unknown>>();
+  const meter = <T>(write: Promise<T>): Promise<T> => {
+    pendingMetering.add(write);
+    return write.finally(() => pendingMetering.delete(write));
+  };
+  const meteringSettled = async () => {
+    while (pendingMetering.size > 0) await Promise.allSettled([...pendingMetering]);
+  };
+  app.decorate("meteringSettled", meteringSettled);
 
   app.addHook("onRequest", async (request, reply) => {
     reply.header("x-request-id", request.id);
@@ -81,14 +103,15 @@ export async function buildApp(
   app.get("/readyz", readiness);
 
   app.post("/anthropic/v1/*", (request, reply) =>
-    handleProvider(request, reply, "anthropic", config, db, envelopeStore, now),
+    handleProvider(request, reply, "anthropic", config, db, envelopeStore, now, meter),
   );
   app.post("/openai/v1/*", (request, reply) =>
-    handleProvider(request, reply, "openai", config, db, envelopeStore, now),
+    handleProvider(request, reply, "openai", config, db, envelopeStore, now, meter),
   );
 
   app.addHook("onClose", async () => {
     await revocationListener?.unlisten().catch(() => undefined);
+    await meteringSettled();
     await owned?.client.end();
   });
 
@@ -103,6 +126,7 @@ async function handleProvider(
   db: NonNullable<GatewayDeps["db"]>,
   envelopeStore: NonNullable<GatewayDeps["envelopeStore"]>,
   now: () => Date,
+  meter: <T>(write: Promise<T>) => Promise<T>,
 ) {
   const suffix = providerSuffix(request, provider);
   if (!allowedPaths[provider].has(suffix)) {
@@ -169,7 +193,7 @@ async function handleProvider(
       budgets,
       error: "model not priced",
     });
-    await enqueueMetering(db, envelopeStore, request.log, record, now());
+    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
     return reply.status(402).send(responseBody);
   }
 
@@ -200,7 +224,7 @@ async function handleProvider(
       budgets,
       error: `hard budget ${hardBlock.id} exceeded`,
     });
-    await enqueueMetering(db, envelopeStore, request.log, record, now());
+    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
     return reply.status(402).send(responseBody);
   }
 
@@ -224,7 +248,7 @@ async function handleProvider(
       budgets,
       error: "allowed_models violation",
     });
-    await enqueueMetering(db, envelopeStore, request.log, record, now());
+    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
     return reply.status(403).send(responseBody);
   }
 
@@ -269,7 +293,7 @@ async function handleProvider(
       budgets,
       error: `hard budget ${reservation.budget.id} exceeded`,
     });
-    await enqueueMetering(db, envelopeStore, request.log, record, now());
+    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
     return reply.status(402).send(responseBody);
   }
   const controller = new AbortController();
@@ -317,7 +341,7 @@ async function handleProvider(
       providerMayHaveCharged: false,
       error: "upstream fetch failed",
     });
-    await enqueueMetering(db, envelopeStore, request.log, record, now());
+    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
     throw new GatewayError(502, "provider_error", "Upstream provider request failed", provider);
   }
 
@@ -362,7 +386,7 @@ async function handleProvider(
       providerMayHaveCharged: true,
       error,
     });
-    await enqueueMetering(db, envelopeStore, request.log, record, now());
+    await meter(enqueueMetering(db, envelopeStore, request.log, record, now()));
   }
 }
 

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -257,6 +257,102 @@ describe("gateway", async () => {
     expect(row?.outputTokens).toBe(1_000_000);
   });
 
+  it("2b. shutdown drains post-response metering before closing Postgres", async () => {
+    const setup = await setupVirtualKey({
+      provider: "anthropic",
+      baseUrl: `${stubOrigin}/anthropic/v1`,
+    });
+    const meteringStarted = deferred<void>();
+    const releaseMetering = deferred<void>();
+    const closeStarted = deferred<void>();
+    const drainingGateway = await buildApp(baseConfig, {
+      envelopeStore: {
+        putEnvelope: async () => {
+          meteringStarted.resolve();
+          await releaseMetering.promise;
+          return null;
+        },
+      },
+    });
+    let closePromise: Promise<void> | undefined;
+    let finishDrainPromise: Promise<void> | undefined;
+    let closeFinished = false;
+    let finishDrainFinished = false;
+    drainingGateway.server.on("request", (_request, response) => {
+      response.once("finish", () => {
+        // Observe the same drain boundary the production onClose hook uses at
+        // the exact instant the raw response becomes eligible for shutdown.
+        finishDrainPromise = drainingGateway.meteringSettled();
+        void finishDrainPromise.then(() => {
+          finishDrainFinished = true;
+        });
+        closePromise = drainingGateway.close();
+        void closePromise.then(
+          () => {
+            closeFinished = true;
+          },
+          () => {
+            closeFinished = true;
+          },
+        );
+        closeStarted.resolve();
+      });
+    });
+
+    try {
+      await drainingGateway.listen({ port: 0, host: "127.0.0.1" });
+      const origin = `http://127.0.0.1:${
+        (drainingGateway.server.address() as { port: number }).port
+      }`;
+      const response = await fetch(`${origin}/anthropic/v1/messages`, {
+        method: "POST",
+        headers: {
+          "x-api-key": setup.secret,
+          "content-type": "application/json",
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: "claude-sonnet-5",
+          stream: true,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(anthropicSseBody());
+      await closeStarted.promise;
+      await meteringStarted.promise;
+      await Promise.resolve();
+      // A provider handler must already be registered when its raw response
+      // finishes. Otherwise onClose can observe an empty drain before the
+      // trailing metering promise exists.
+      expect(finishDrainFinished).toBe(false);
+      expect(closeFinished).toBe(false);
+
+      releaseMetering.resolve();
+      if (!closePromise) throw new Error("gateway close did not start");
+      if (!finishDrainPromise) throw new Error("gateway finish drain did not start");
+      await finishDrainPromise;
+      await closePromise;
+      await drainingGateway.meteringSettled();
+
+      const row = (
+        await db.select().from(llmRequests).where(eq(llmRequests.virtualKeyId, setup.keyId))
+      )[0];
+      expect(row?.status).toBe("ok");
+      expect(row?.costCents).toBeGreaterThan(0);
+      const counter = (
+        await db.select().from(spendCounters).where(eq(spendCounters.budgetId, setup.budgetId))
+      )[0];
+      expect(counter?.spentCents).toBeCloseTo(row?.costCents ?? 0, 6);
+    } finally {
+      releaseMetering.resolve();
+      await finishDrainPromise?.catch(() => undefined);
+      await closePromise?.catch(() => undefined);
+      await drainingGateway.meteringSettled();
+      if (!closePromise) await drainingGateway.close().catch(() => undefined);
+    }
+  });
+
   it("3. OpenAI streaming injects include_usage but stores the original request", async () => {
     const setup = await setupVirtualKey({ provider: "openai", baseUrl: `${stubOrigin}/openai/v1` });
     const response = await postOpenAi(setup.secret, {
@@ -942,6 +1038,16 @@ async function waitFor(predicate: () => boolean | Promise<boolean>) {
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   throw new Error("timed out waiting for condition");
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 async function buildStub(state: StubState) {

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -190,11 +190,14 @@ describe("gateway", async () => {
     stubState.lastOpenAiRequest = null;
     stubState.abortObserved = false;
     envelopes.objects.clear();
+    // A streamed response is delivered before its usage record is written, so
+    // without this the previous test's write can land after the delete below
+    // and hold a foreign key on a virtual key this block then tries to remove.
+    await gateway.meteringSettled();
     await db.delete(llmRequests).where(eq(llmRequests.orgId, orgId));
     await db.delete(spendCounters).where(eq(spendCounters.orgId, orgId));
     await db.delete(platformIssues).where(eq(platformIssues.orgId, orgId));
     await db.delete(providerCredentials).where(eq(providerCredentials.orgId, orgId));
-    await db.delete(llmRequests).where(eq(llmRequests.orgId, orgId));
     await db.delete(virtualKeys).where(eq(virtualKeys.orgId, orgId));
     await db.delete(budgets).where(eq(budgets.orgId, orgId));
   });

--- a/services/gateway/test/metering-drain.test.ts
+++ b/services/gateway/test/metering-drain.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createMeteringDrain } from "../src/app.js";
+
+describe("metering drain", () => {
+  it("waits for work registered while a drain is already in progress", async () => {
+    const drain = createMeteringDrain();
+    const first = deferred<void>();
+    const second = deferred<void>();
+    const firstTracked = drain.track(first.promise);
+    let settled = false;
+    const settling = drain.settled().then(() => {
+      settled = true;
+    });
+
+    const secondTracked = drain.track(second.promise);
+    first.resolve();
+    await firstTracked;
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    second.resolve();
+    await Promise.all([secondTracked, settling]);
+    expect(settled).toBe(true);
+  });
+
+  it("settles rejected work without hiding the rejection from its caller", async () => {
+    const drain = createMeteringDrain();
+    const work = deferred<void>();
+    const failure = new Error("metering failed");
+    const tracked = drain.track(work.promise);
+    const trackedRejection = tracked.catch((error: unknown) => error);
+    const settling = drain.settled();
+
+    work.reject(failure);
+
+    await expect(settling).resolves.toBeUndefined();
+    expect(await trackedRejection).toBe(failure);
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}


### PR DESCRIPTION
`verify` failed on an unrelated branch with a foreign-key violation in the gateway suite, passed on a re-run, and turned out to be hiding a production bug rather than just an annoying test.

## What happens

A streamed response reaches the client when its pipeline finishes writing to the socket. The usage record is written *after* that, in the handler's `finally` block. Nothing waited for those writes.

- **In the suite**: the next test's cleanup deleted `llm_requests`, the previous test's write landed a moment later, and deleting `virtual_keys` then failed on `llm_requests_virtual_key_id_fkey`. A duplicated `delete(llmRequests)` had been added at some point to paper over this; it narrowed the window without closing it, which is why the failure still appears.
- **In production**: the `onClose` hook closed the database connection without draining them. A redeploy or a scale-in could drop the usage of every request still settling — and with it the spend that write was about to account for. This is the reason the fix belongs in the gateway rather than in the test.

## The change

`buildApp` tracks in-flight metering writes, drains them in `onClose` before the connection goes away, and exposes the same wait as `meteringSettled()` for tests. The duplicated delete is gone: the test now waits for the writes instead of racing them.

The tracker is a `Set` of promises that remove themselves on settle, and the drain loops while the set is non-empty, so a write started by another write in flight is also awaited.

## Verification

The gateway suite six times against an isolated database: six passes. The failure reproduced on CI rather than locally, so that is the evidence available — not a proof. What is provable, and is the point, is that shutdown no longer races the writes: the hook awaits them by construction.

Lint and typecheck pass.