### PR TITLE
fix(ci): make commit subjects reliable release inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,30 +11,6 @@ on:
   pull_request:
 
 jobs:
-  # Merge commits are synthetic and do not release. A squash commit is an
-  # ordinary commit, while merge/rebase paths retain the PR's own commits, so
-  # --no-merges selects the version inputs for every supported merge method.
-  commit-subjects:
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-
-      - name: Validate every version-input subject
-        env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: node scripts/conventional-commit-subjects.mjs range
-
   verify:
     runs-on: ubuntu-latest
     timeout-minutes: 35

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,35 @@ on:
   pull_request:
 
 jobs:
+  # The version is computed from commit subjects, and a squash merge makes this
+  # title the subject on main — so this is the last place to catch a subject
+  # that would release the wrong number, or nothing at all.
+  pull-request-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: The title is a conventional commit
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._-]+\))?!?: .+'
+          if ! printf '%s' "$TITLE" | grep -Eq "$pattern"; then
+            echo "Pull request title: $TITLE" >&2
+            echo "" >&2
+            echo "It must read as a conventional commit, because it becomes the commit" >&2
+            echo "subject on main and the subjects decide the released version:" >&2
+            echo "  <type>[(scope)][!]: <what changed>" >&2
+            echo "  types: feat fix docs style refactor perf test build ci chore revert" >&2
+            echo "  a trailing ! marks a breaking change" >&2
+            echo "" >&2
+            echo "See the commit-subject rules in AGENTS.md." >&2
+            exit 1
+          fi
+          echo "OK: $TITLE"
+
   verify:
     runs-on: ubuntu-latest
     timeout-minutes: 35

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,34 +11,29 @@ on:
   pull_request:
 
 jobs:
-  # The version is computed from commit subjects, and a squash merge makes this
-  # title the subject on main — so this is the last place to catch a subject
-  # that would release the wrong number, or nothing at all.
-  pull-request-title:
-    if: github.event_name == 'pull_request'
+  # Merge commits are synthetic and do not release. A squash commit is an
+  # ordinary commit, while merge/rebase paths retain the PR's own commits, so
+  # --no-merges selects the version inputs for every supported merge method.
+  commit-subjects:
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
     steps:
-      - name: The title is a conventional commit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Validate every version-input subject
         env:
-          TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._-]+\))?!?: .+'
-          if ! printf '%s' "$TITLE" | grep -Eq "$pattern"; then
-            echo "Pull request title: $TITLE" >&2
-            echo "" >&2
-            echo "It must read as a conventional commit, because it becomes the commit" >&2
-            echo "subject on main and the subjects decide the released version:" >&2
-            echo "  <type>[(scope)][!]: <what changed>" >&2
-            echo "  types: feat fix docs style refactor perf test build ci chore revert" >&2
-            echo "  a trailing ! marks a breaking change" >&2
-            echo "" >&2
-            echo "See the commit-subject rules in AGENTS.md." >&2
-            exit 1
-          fi
-          echo "OK: $TITLE"
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/conventional-commit-subjects.mjs range
 
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,0 +1,27 @@
+# Title edits do not trigger the default pull_request activity set. Keep this
+# check separate from ci.yml so correcting a title neither reruns the full
+# acceptance suite nor replaces an earlier failing acceptance check with skips.
+name: pull request title
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: The title is a conventional commit
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/conventional-commit-subjects.mjs title

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,9 +1,10 @@
-# Title edits do not trigger the default pull_request activity set. Keep this
-# check separate from ci.yml so correcting a title neither reruns the full
-# acceptance suite nor replaces an earlier failing acceptance check with skips.
-name: pull request title
+# Keep version-input checks separate from ci.yml so title or base-branch edits
+# revalidate the lightweight policy without rerunning the full acceptance suite.
+name: conventional commit subjects
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   pull-request-title:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,3 +27,24 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: node scripts/conventional-commit-subjects.mjs title
+
+  # Merge commits are synthetic and do not release. A squash commit is an
+  # ordinary commit, while merge/rebase paths retain the PR's own commits, so
+  # --no-merges selects the version inputs for every supported merge method.
+  commit-subjects:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Validate every version-input subject
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/conventional-commit-subjects.mjs range

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -28,9 +28,9 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: node scripts/conventional-commit-subjects.mjs title
 
-  # Merge commits are synthetic and do not release. A squash commit is an
-  # ordinary commit, while merge/rebase paths retain the PR's own commits, so
-  # --no-merges selects the version inputs for every supported merge method.
+  # Merge commits are synthetic and do not release. A multi-commit squash takes
+  # its subject from the PR title (a lone commit keeps its own), while merge and
+  # rebase retain branch commits. Equal impact keeps all methods equivalent.
   commit-subjects:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -43,8 +43,15 @@ jobs:
         with:
           node-version: 22
 
-      - name: Validate every version-input subject
+      - name: Validate version inputs and PR release impact
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          TITLE: ${{ github.event.pull_request.title || '' }}
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: node scripts/conventional-commit-subjects.mjs range
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            node scripts/conventional-commit-subjects.mjs pr
+          else
+            node scripts/conventional-commit-subjects.mjs range
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,35 @@
 Changes to security- or money-critical surfaces—including authentication, authorization/RBAC, tenant scoping, secrets and cryptography, billing or budget enforcement, webhook signature validation, and privileged external integrations—are incomplete without both unit tests and integration tests.
 
 Integration tests must use deterministic fakes or local servers for external systems. The default CI suite must not need live credentials or network access. Cover successful operation and relevant denial paths, including malformed, expired, revoked, replayed, and cross-tenant inputs. Add a regression test that would fail if the previous unsafe behavior returned.
+
+## Commit subjects set the released version
+
+Write every commit subject as a [Conventional Commit](https://www.conventionalcommits.org/):
+
+```text
+<type>[(scope)][!]: <what changed>
+```
+
+This is not a style preference. Merging to `main` releases, and the subjects
+merged since the last release are what decide the version — so a subject that
+lies about the kind of change ships the wrong version number to everyone who
+installed the package.
+
+| Subject | What it releases while the version is `0.x` |
+|---|---|
+| `fix: …`, `perf: …` | a patch |
+| `feat: …` | a patch |
+| `feat!: …`, or a `BREAKING CHANGE:` footer | a minor |
+| `docs: …`, `test: …`, `refactor: …`, `ci: …`, `chore: …`, `build: …`, `style: …` | nothing on its own |
+
+Two consequences worth internalising:
+
+- **A user-visible change hidden behind `chore:` never reaches users.** It sits
+  on `main` unreleased until something else triggers a release, and then ships
+  unannounced in someone else's release notes.
+- **A breaking change without `!` ships as a patch.** Mark it, in the subject or
+  in a `BREAKING CHANGE:` footer, and say in the body what a user has to change.
+
+The pull request title follows the same rule and is checked in CI, because a
+squash merge makes that title the subject on `main`.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,16 +14,20 @@ Write every commit subject as a [Conventional Commit](https://www.conventionalco
 <type>[(scope)][!]: <what changed>
 ```
 
-This is not a style preference. Merging to `main` releases, and the subjects
-merged since the last release are what decide the version — so a subject that
-lies about the kind of change ships the wrong version number to everyone who
-installed the package.
+Use one of these types: `feat`, `fix`, `perf`, `docs`, `style`, `refactor`,
+`test`, `build`, `ci`, `chore`, or `revert`.
+
+This is not a style preference. Release-on-merge derives the next version from
+the subjects merged since the last release. Subject validation lands before
+that workflow so the history it will consume is already trustworthy: a subject
+that lies about the kind of change ships the wrong version number to everyone
+who installed the package.
 
 | Subject | What it releases while the version is `0.x` |
 |---|---|
-| `fix: …`, `perf: …` | a patch |
+| `fix: …`, `perf: …`, `revert: …` | a patch |
 | `feat: …` | a patch |
-| `feat!: …`, or a `BREAKING CHANGE:` footer | a minor |
+| `<type>!: …`, or a `BREAKING CHANGE:` footer | a minor |
 | `docs: …`, `test: …`, `refactor: …`, `ci: …`, `chore: …`, `build: …`, `style: …` | nothing on its own |
 
 Two consequences worth internalising:
@@ -34,6 +38,7 @@ Two consequences worth internalising:
 - **A breaking change without `!` ships as a patch.** Mark it, in the subject or
   in a `BREAKING CHANGE:` footer, and say in the body what a user has to change.
 
-The pull request title follows the same rule and is checked in CI, because a
-squash merge makes that title the subject on `main`.
-
+The pull request title follows the same rule: it supplies the subject for a
+squash merge, while merge and rebase preserve the branch's commit subjects. CI
+checks the title, every non-merge commit in the pull request, and the actual
+subjects landed on `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,18 @@ Two consequences worth internalising:
 - **A breaking change without `!` ships as a patch.** Mark it, in the subject or
   in a `BREAKING CHANGE:` footer, and say in the body what a user has to change.
 
-The pull request title follows the same rule: it supplies the subject for a
-squash merge, while merge and rebase preserve the branch's commit subjects. CI
-checks the title, every non-merge commit in the pull request, and the actual
-subjects landed on `main`.
+The pull request title follows the same rule: it supplies a multi-commit squash
+subject (a one-commit squash keeps that commit's subject), while merge and
+rebase preserve the branch's commit subjects. CI checks the title, every
+non-merge commit in the pull request, and the actual subjects landed on `main`.
+It also requires the title's release impact to match the commit range, so
+squash, merge, and rebase choose the same version. If any commit has a
+`BREAKING CHANGE:` footer, mark the title with `!` too. This equality rule also
+applies to one-commit pull requests: their title remains a release declaration,
+and the rule stays safe if the repository's squash-title setting changes.
+
+Configure the pull-request checks as required and require an up-to-date branch
+or merge queue before merging. The release workflow must also validate and
+classify the full non-merge messages that actually landed since the last
+successful release in the same gated job that chooses the next version; a
+separate push check is useful feedback, not a release boundary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,4 @@ Follow all instructions in `AGENTS.md`.
 
 In particular, every change to authentication, authorization/RBAC, tenant isolation, secrets/cryptography, billing, webhooks, or privileged external integrations must include unit tests and deterministic integration tests that simulate external dependencies without live credentials or network access. Cover success, denial, malformed, expired, revoked, replay, and cross-tenant regression cases as applicable.
 
-Commit subjects and pull request titles must be Conventional Commits. `AGENTS.md` explains why: merging to `main` releases, and the subjects decide the version, so `feat:`, `fix:` and a `!` for a breaking change are load-bearing rather than cosmetic.
-
+Commit subjects and pull request titles must be Conventional Commits. `AGENTS.md` explains why: release-on-merge derives the next version from the subjects landed on `main`, so `feat:`, `fix:` and a `!` for a breaking change are load-bearing rather than cosmetic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,6 @@
 Follow all instructions in `AGENTS.md`.
 
 In particular, every change to authentication, authorization/RBAC, tenant isolation, secrets/cryptography, billing, webhooks, or privileged external integrations must include unit tests and deterministic integration tests that simulate external dependencies without live credentials or network access. Cover success, denial, malformed, expired, revoked, replay, and cross-tenant regression cases as applicable.
+
+Commit subjects and pull request titles must be Conventional Commits. `AGENTS.md` explains why: merging to `main` releases, and the subjects decide the version, so `feat:`, `fix:` and a `!` for a breaking change are load-bearing rather than cosmetic.
+

--- a/packages/cli/templates/delivery/verify.mjs
+++ b/packages/cli/templates/delivery/verify.mjs
@@ -54,9 +54,11 @@ function discover() {
 
   for (const commit of delivered) {
     const message = commit.commit?.message ?? "";
-    const subject = message.split("\n", 1)[0];
+    const subject = message.split("\n", 1)[0].trim();
     assert(
-      /^(feat|fix|chore|ci|docs|refactor|perf|test|build|revert)(\([^)]+\))?!?: .+/.test(subject),
+      /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^()]+\))?!?: \S.*$/.test(
+        subject,
+      ),
       `commit ${commit.sha} is not Conventional Commits: ${subject}`,
     );
     assert(

--- a/packages/cli/templates/delivery/verify.mjs
+++ b/packages/cli/templates/delivery/verify.mjs
@@ -9,6 +9,8 @@ const repo = required("GITHUB_REPOSITORY");
 const defaultBranch = required("DEFAULT_BRANCH");
 const receiptDir = join(required("RUNNER_TEMP"), "facility-delivery");
 const receiptPath = join(receiptDir, "receipt.json");
+const conventionalSubject =
+  /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((?=\S)[^()\r\n]*[^\s()\r\n]\))?!?: \S.*$/;
 
 if (mode === "discover") discover();
 else if (mode === "finalize") finalize();
@@ -54,11 +56,9 @@ function discover() {
 
   for (const commit of delivered) {
     const message = commit.commit?.message ?? "";
-    const subject = message.split("\n", 1)[0].trim();
+    const subject = message.split(/\r?\n/, 1)[0];
     assert(
-      /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^()]+\))?!?: \S.*$/.test(
-        subject,
-      ),
+      !hasForbiddenSubjectCharacters(subject) && conventionalSubject.test(subject),
       `commit ${commit.sha} is not Conventional Commits: ${subject}`,
     );
     assert(
@@ -132,6 +132,18 @@ function ghJson(args) {
 
 function output(name, value) {
   appendFileSync(required("GITHUB_OUTPUT"), `${name}=${value}\n`);
+}
+
+function hasForbiddenSubjectCharacters(subject) {
+  return [...subject].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
 }
 
 function required(name) {

--- a/packages/cli/test/delivery.test.mjs
+++ b/packages/cli/test/delivery.test.mjs
@@ -44,6 +44,31 @@ test("delivery verifier rejects agent-prefixed branches and false co-authorship"
   assert.match(trailer.stderr, /Co-authored-by trailer/);
 });
 
+test("delivery verifier accepts style commits and punctuation in scopes", (t) => {
+  for (const message of [
+    "style: normalize formatting",
+    "  fix(web+api): align shared routes  ",
+    "feat(api/auth)!: require scoped credentials",
+  ]) {
+    const fixture = makeFixture(t, { message });
+    const result = runVerifier(fixture, "discover");
+    assert.equal(result.status, 0, `${message}\n${result.stdout}${result.stderr}`);
+  }
+});
+
+test("delivery verifier rejects unknown types and malformed subjects", (t) => {
+  for (const message of [
+    "feature: add incident triage",
+    "fix(api(auth)): require scoped credentials",
+    "feat:  summary starts after an extra space",
+  ]) {
+    const fixture = makeFixture(t, { message });
+    const result = runVerifier(fixture, "discover");
+    assert.notEqual(result.status, 0, message);
+    assert.match(result.stderr, /not Conventional Commits/);
+  }
+});
+
 test("delivery verifier rejects a rewritten existing PR baseline", (t) => {
   const fixture = makeFixture(t, { omitBaseline: true });
   const result = runVerifier(fixture, "discover");

--- a/packages/cli/test/delivery.test.mjs
+++ b/packages/cli/test/delivery.test.mjs
@@ -47,7 +47,7 @@ test("delivery verifier rejects agent-prefixed branches and false co-authorship"
 test("delivery verifier accepts style commits and punctuation in scopes", (t) => {
   for (const message of [
     "style: normalize formatting",
-    "  fix(web+api): align shared routes  ",
+    "fix(web+api): align shared routes",
     "feat(api/auth)!: require scoped credentials",
   ]) {
     const fixture = makeFixture(t, { message });
@@ -59,7 +59,14 @@ test("delivery verifier accepts style commits and punctuation in scopes", (t) =>
 test("delivery verifier rejects unknown types and malformed subjects", (t) => {
   for (const message of [
     "feature: add incident triage",
+    "  fix: add incident triage",
     "fix(api(auth)): require scoped credentials",
+    "fix((): require scoped credentials",
+    "fix(api)): require scoped credentials",
+    "fix( ): require scoped credentials",
+    "fix(api\tauth): require scoped credentials",
+    "fix: render \u001b[31mred output",
+    "fix: render \u009b31mred output",
     "feat:  summary starts after an extra space",
   ]) {
     const fixture = makeFixture(t, { message });

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -1100,15 +1100,25 @@ async function assertRepairDeliveryReleaseImpact(
   if (messages.at(-1) === "") messages.pop();
   if (messages.length === 0) throw new Error("agent_delivery_pr_range_empty");
   const currentImpact = maximumDeliveryReleaseImpact(messages);
-  const title = typeof pullRequest.title === "string" ? pullRequest.title : "";
-  if (title && deliveryReleaseImpact(title) !== currentImpact) {
-    throw new Error("agent_delivery_existing_release_impact_mismatch");
-  }
   const transported = githubCommitMessage(commitMessage, "", runId);
   const addedImpact = deliveryReleaseImpact(`${transported.headline}\n\n${transported.body}`);
-  if (DELIVERY_IMPACT_RANK[addedImpact] > DELIVERY_IMPACT_RANK[currentImpact]) {
+  const finalImpact =
+    DELIVERY_IMPACT_RANK[addedImpact] > DELIVERY_IMPACT_RANK[currentImpact]
+      ? addedImpact
+      : currentImpact;
+  const title = typeof pullRequest.title === "string" ? pullRequest.title : "";
+  const titleImpact = title ? deliveryReleaseImpact(title) : null;
+  if (titleImpact && titleImpact !== finalImpact) {
     throw new Error(
-      `agent_delivery_release_impact_mismatch: repair commit ${addedImpact}, existing PR range ${currentImpact}`,
+      `agent_delivery_release_impact_mismatch: pull request title ${titleImpact}, final PR range ${finalImpact}`,
+    );
+  }
+  if (
+    titleImpact === null &&
+    DELIVERY_IMPACT_RANK[addedImpact] > DELIVERY_IMPACT_RANK[currentImpact]
+  ) {
+    throw new Error(
+      `agent_delivery_release_impact_mismatch: repair commit ${addedImpact}, existing PR range ${currentImpact}, title unavailable`,
     );
   }
 }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -977,6 +977,10 @@ const CONVENTIONAL_SUBJECT =
   /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^()]+\))?!?: \S.*$/;
 const GITHUB_CHANGE_BATCH = 100;
 
+function hasConventionalSubject(message: string) {
+  return CONVENTIONAL_SUBJECT.test(message.split("\n", 1)[0]?.trim() ?? "");
+}
+
 export function semanticDeliveryBranch(current: string, base: string) {
   if (current !== base && SEMANTIC_BRANCH.test(current)) return current;
   throw new Error("agent_delivery_branch_not_semantic");
@@ -1094,7 +1098,7 @@ export async function readAgentDeliveryMetadata(path: string): Promise<AgentDeli
   const title = typeof pullRequest.title === "string" ? pullRequest.title.trim() : "";
   const body = typeof pullRequest.body === "string" ? pullRequest.body.trim() : "";
   if (!SEMANTIC_BRANCH.test(branch)) throw new Error("agent_delivery_branch_not_semantic");
-  if (!CONVENTIONAL_SUBJECT.test(commitMessage) || /(^|\n)Co-authored-by:/i.test(commitMessage)) {
+  if (!hasConventionalSubject(commitMessage) || /(^|\n)Co-authored-by:/i.test(commitMessage)) {
     throw new Error("agent_delivery_commit_not_conventional");
   }
   if (!CONVENTIONAL_SUBJECT.test(title) || title.length > 256) {
@@ -1117,7 +1121,7 @@ export async function readAgentUpdateMetadata(
   const branch = typeof root.branch === "string" ? root.branch.trim() : "";
   const commitMessage = typeof root.commitMessage === "string" ? root.commitMessage.trim() : "";
   existingGithubBranch(branch);
-  if (!CONVENTIONAL_SUBJECT.test(commitMessage) || /(^|\n)Co-authored-by:/i.test(commitMessage)) {
+  if (!hasConventionalSubject(commitMessage) || /(^|\n)Co-authored-by:/i.test(commitMessage)) {
     throw new Error("agent_delivery_commit_not_conventional");
   }
   return { branch, commitMessage };

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -882,9 +882,17 @@ export function deliveryFailure(
   return null;
 }
 
-async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown> | undefined> {
+export type ShipGitOptions = {
+  root?: string;
+  githubFetch?: typeof fetch;
+};
+
+export async function shipGitChanges(
+  bundle: RunBundle,
+  options: ShipGitOptions = {},
+): Promise<Record<string, unknown> | undefined> {
   if (!bundle.repo.cloneUrl) return undefined;
-  const cwd = cwdFor(bundle);
+  const cwd = cwdFor(bundle, options.root ?? workRoot);
   const baseBranch = bundle.repo.branch ?? "main";
   try {
     // Stage the final workspace snapshot so this captures both agent commits and
@@ -923,7 +931,13 @@ async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown
       : semanticDeliveryBranch(delivery.branch, baseBranch);
     const baseSha = (await gitOutput(cwd, ["rev-parse", baseRef])).trim();
     const repo = githubRepositoryName(bundle.repo.cloneUrl);
-    const { token } = await api<{ token: string }>(`/internal/runs/${currentRunId()}/push-token`, {
+    const runId = currentRunId();
+    // Validate every signed-commit headline before asking the platform to mint
+    // a short-lived contents-write token. The publishers repeat this check at
+    // their public boundary, but the runner must fail locally before acquiring
+    // privileged credentials for an undeliverable message.
+    assertGithubCommitMessages(delivery.commitMessage, changes.length, runId);
+    const { token } = await api<{ token: string }>(`/internal/runs/${runId}/push-token`, {
       method: "POST",
     });
     secretsToRedact.add(token);
@@ -935,7 +949,8 @@ async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown
           expectedHeadSha: baseSha,
           commitMessage: delivery.commitMessage,
           changes,
-          runId: currentRunId(),
+          runId,
+          fetchImpl: options.githubFetch,
         })
       : await publishVerifiedGithubChanges({
           repo,
@@ -944,7 +959,8 @@ async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown
           baseSha,
           commitMessage: delivery.commitMessage,
           changes,
-          runId: currentRunId(),
+          runId,
+          fetchImpl: options.githubFetch,
         });
     const pullRequest = requiresDelivery(bundle.mode)
       ? (delivery as AgentDeliveryMetadata).pullRequest
@@ -961,7 +977,7 @@ async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown
         : {}),
     };
   } catch (error) {
-    const pushError = errorMessage(error);
+    const pushError = redactSecrets(errorMessage(error));
     await emit([{ type: "artifact_error", data: { kind: "git_push_failed", error: pushError } }]);
     return { changed: true, pushError };
   }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -937,6 +937,15 @@ export async function shipGitChanges(
     // their public boundary, but the runner must fail locally before acquiring
     // privileged credentials for an undeliverable message.
     assertGithubCommitMessages(delivery.commitMessage, changes.length, runId);
+    if (repairRepositoryMode(mode)) {
+      await assertRepairDeliveryReleaseImpact(
+        cwd,
+        bundle.scope,
+        baseRef,
+        delivery.commitMessage,
+        runId,
+      );
+    }
     const { token } = await api<{ token: string }>(`/internal/runs/${runId}/push-token`, {
       method: "POST",
     });
@@ -990,7 +999,9 @@ type GithubFileChange =
 const SEMANTIC_BRANCH =
   /^(feature|fix|chore|ci|docs|refactor|perf|test|build|revert)\/[a-z0-9][a-z0-9._/-]*$/;
 const CONVENTIONAL_SUBJECT =
-  /^(?<prefix>(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\((?=\S)[^()\r\n]*[^\s()\r\n]\))?!?: )(?<summary>\S.*)$/;
+  /^(?<prefix>(?<type>feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\((?=\S)[^()\r\n]*[^\s()\r\n]\))?(?<breaking>!)?: )(?<summary>\S.*)$/;
+const PATCH_COMMIT_TYPES = new Set(["feat", "fix", "perf", "revert"]);
+const DELIVERY_IMPACT_RANK = { none: 0, patch: 1, minor: 2 } as const;
 const GITHUB_CHANGE_BATCH = 100;
 const GITHUB_COMMIT_HEADLINE_LIMIT = 120;
 
@@ -1011,12 +1022,95 @@ function conventionalSubject(message: string) {
   if (hasForbiddenSubjectCharacters(subject)) return null;
   const match = CONVENTIONAL_SUBJECT.exec(subject);
   const prefix = match?.groups?.prefix;
+  const type = match?.groups?.type;
   const summary = match?.groups?.summary;
-  return prefix && summary ? { subject, prefix, summary } : null;
+  return prefix && type && summary
+    ? { subject, prefix, type, breaking: match?.groups?.breaking === "!", summary }
+    : null;
 }
 
 function hasConventionalSubject(message: string) {
   return conventionalSubject(message) !== null;
+}
+
+function hasBreakingFooter(message: string) {
+  const blocks = message
+    .replace(/\r\n/g, "\n")
+    .trimEnd()
+    .split(/\n[ \t]*\n+/);
+  if (blocks.length < 2) return false;
+  const lines = (blocks.at(-1) ?? "").split("\n");
+  const trailer = /^(?:(?:[A-Za-z0-9-]+|BREAKING CHANGE): +\S|[A-Za-z0-9-]+ #\S)/;
+  const breakingTrailer = /^BREAKING(?: |-)CHANGE: +\S/;
+  if (!trailer.test(lines[0] ?? "")) return false;
+  return lines.some((line) => breakingTrailer.test(line));
+}
+
+type DeliveryReleaseImpact = keyof typeof DELIVERY_IMPACT_RANK;
+
+export function deliveryReleaseImpact(message: string): DeliveryReleaseImpact {
+  const parsed = conventionalSubject(message);
+  if (!parsed) throw new Error("agent_delivery_commit_not_conventional");
+  if (parsed.breaking || hasBreakingFooter(message)) return "minor";
+  return PATCH_COMMIT_TYPES.has(parsed.type) ? "patch" : "none";
+}
+
+function maximumDeliveryReleaseImpact(messages: string[]) {
+  return messages.reduce<DeliveryReleaseImpact>((highest, message) => {
+    const impact = deliveryReleaseImpact(message);
+    return DELIVERY_IMPACT_RANK[impact] > DELIVERY_IMPACT_RANK[highest] ? impact : highest;
+  }, "none");
+}
+
+function assertDeliveryReleaseImpact(commitMessage: string, pullRequestTitle: string) {
+  // GitHub stores headline and body as one commit message separated by a
+  // blank line. Classify that exact transported message, including Facility's
+  // provenance paragraph, rather than the raw manifest text.
+  const transported = githubCommitMessage(commitMessage, "", "release-impact-check");
+  const commitImpact = deliveryReleaseImpact(`${transported.headline}\n\n${transported.body}`);
+  const titleImpact = deliveryReleaseImpact(pullRequestTitle);
+  if (commitImpact !== titleImpact) {
+    throw new Error(
+      `agent_delivery_release_impact_mismatch: commit ${commitImpact}, pull request title ${titleImpact}`,
+    );
+  }
+}
+
+async function assertRepairDeliveryReleaseImpact(
+  cwd: string,
+  scope: Record<string, unknown>,
+  headRef: string,
+  commitMessage: string,
+  runId: string,
+) {
+  const pullRequest = objectValue(scope.pullRequest);
+  const baseBranch = typeof pullRequest.base === "string" ? pullRequest.base.trim() : "";
+  if (!baseBranch) throw new Error("agent_delivery_pr_base_missing");
+  existingGithubBranch(baseBranch);
+  const baseRef = `origin/${baseBranch}`;
+  const output = await gitOutput(cwd, [
+    "log",
+    "-z",
+    "--no-merges",
+    "--format=%B",
+    `${baseRef}..${headRef}`,
+    "--",
+  ]);
+  const messages = output ? output.split("\0") : [];
+  if (messages.at(-1) === "") messages.pop();
+  if (messages.length === 0) throw new Error("agent_delivery_pr_range_empty");
+  const currentImpact = maximumDeliveryReleaseImpact(messages);
+  const title = typeof pullRequest.title === "string" ? pullRequest.title : "";
+  if (title && deliveryReleaseImpact(title) !== currentImpact) {
+    throw new Error("agent_delivery_existing_release_impact_mismatch");
+  }
+  const transported = githubCommitMessage(commitMessage, "", runId);
+  const addedImpact = deliveryReleaseImpact(`${transported.headline}\n\n${transported.body}`);
+  if (DELIVERY_IMPACT_RANK[addedImpact] > DELIVERY_IMPACT_RANK[currentImpact]) {
+    throw new Error(
+      `agent_delivery_release_impact_mismatch: repair commit ${addedImpact}, existing PR range ${currentImpact}`,
+    );
+  }
 }
 
 function githubCommitMessage(commitMessage: string, multipart: string, runId: string) {
@@ -1033,7 +1127,12 @@ function githubCommitMessage(commitMessage: string, multipart: string, runId: st
     throw new Error("github_signed_delivery_commit_subject_too_long");
   }
   const [, ...bodyLines] = commitMessage.split(/\r?\n/);
-  const suppliedBody = bodyLines.join("\n").trim();
+  if (bodyLines.length > 0 && !/^[ \t]*$/.test(bodyLines[0] ?? "")) {
+    throw new Error("github_signed_delivery_commit_body_separator_invalid");
+  }
+  // Remove only the required structural separator. Preserve leading
+  // indentation because stripping it can turn a code example into a trailer.
+  const suppliedBody = bodyLines.slice(1).join("\n").trimEnd();
   return {
     headline,
     body: [`Delivered by Facility run ${runId}.`, suppliedBody].filter(Boolean).join("\n\n"),
@@ -1175,6 +1274,7 @@ export async function readAgentDeliveryMetadata(path: string): Promise<AgentDeli
   ) {
     throw new Error("agent_delivery_pr_title_not_conventional");
   }
+  assertDeliveryReleaseImpact(commitMessage, title);
   if (!body || body.length > 60_000) throw new Error("agent_delivery_pr_body_invalid");
   return { branch, commitMessage, pullRequest: { title, body } };
 }
@@ -1558,10 +1658,10 @@ export function composedPrompt(bundle: RunBundle) {
         .join("\n")}`
     : "";
   const deliveryNote = requiresDelivery(bundle.mode)
-    ? `\n\n## Agent-owned delivery\nFacility will create the signed commit, push, and non-draft pull request with the GitHub App after your engine exits. You own all delivery metadata. Before finishing, create \`.agent-sdlc/delivery.json\` with exactly this shape:\n\n\`\`\`json\n{\n  "branch": "feature/task-slug",\n  "commitMessage": "feat: describe the change",\n  "pullRequest": {\n    "title": "feat: describe the change",\n    "body": "## Summary\\n- ...\\n\\n## Context\\n- ...\\n\\n## Verification\\n- ...\\n\\n## Linked issues\\n- Closes #123"\n  }\n}\n\`\`\`\n\nThe branch must be semantic; the commit and PR title must use Conventional Commits; the PR body must be your complete team-lead-ready description. Do not commit this managed file. Do not require \`gh\`, a writable clone token, or a local signing key: Facility transports your exact metadata and fails closed if it is absent or invalid.`
+    ? `\n\n## Agent-owned delivery\nFacility will create the signed commit, push, and non-draft pull request with the GitHub App after your engine exits. You own all delivery metadata. Before finishing, create \`.agent-sdlc/delivery.json\` with exactly this shape:\n\n\`\`\`json\n{\n  "branch": "feature/task-slug",\n  "commitMessage": "feat: describe the change",\n  "pullRequest": {\n    "title": "feat: describe the change",\n    "body": "## Summary\\n- ...\\n\\n## Context\\n- ...\\n\\n## Verification\\n- ...\\n\\n## Linked issues\\n- Closes #123"\n  }\n}\n\`\`\`\n\nThe branch must be semantic; the commit and PR title must use Conventional Commits and have the same release impact. If the commit has a \`BREAKING CHANGE:\` footer, mark the PR title with \`!\` too. The PR body must be your complete team-lead-ready description. Do not commit this managed file. Do not require \`gh\`, a writable clone token, or a local signing key: Facility transports your exact metadata and fails closed if it is absent or invalid.`
     : "";
   const repairDeliveryNote = repairRepositoryMode(normalizedMode(bundle.mode))
-    ? `\n\n## Agent-owned PR update\nIf and only if you make verified repository changes, create \`.agent-sdlc/delivery.json\` before finishing with exactly \`{"branch":"<the existing PR branch>","commitMessage":"fix: describe the correction"}\`. Facility will add a signed commit to that same branch through the GitHub App. The branch must exactly match the checked-out PR branch and the message must use Conventional Commits. Do not run \`git push\`, create another branch or pull request, force-push, or depend on \`gh\`. If no code change is needed, do not create the manifest.`
+    ? `\n\n## Agent-owned PR update\nIf and only if you make verified repository changes, create \`.agent-sdlc/delivery.json\` before finishing with exactly \`{"branch":"<the existing PR branch>","commitMessage":"<matching Conventional Commit type>: describe the correction"}\`. Facility will add a signed commit to that same branch through the GitHub App. The branch must exactly match the checked-out PR branch. Choose a truthful Conventional Commit type whose release impact is no greater than the existing pull request range; do not add \`!\` or a \`BREAKING CHANGE:\` footer unless that range is already breaking. If a truthful message would raise the impact, leave the manifest absent and report that the PR title must be updated first. Do not run \`git push\`, create another branch or pull request, force-push, or depend on \`gh\`. If no code change is needed, do not create the manifest.`
     : "";
   return `${bundle.contract}\n\nScope:\n${JSON.stringify(bundle.scope, null, 2)}${harnessNote}${steeringNote}${conversationNote}${progressNote}${repositoryOutputNote}${githubEventNote}${projectSkillsNote}${deliveryNote}${repairDeliveryNote}`;
 }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -974,7 +974,7 @@ type GithubFileChange =
 const SEMANTIC_BRANCH =
   /^(feature|fix|chore|ci|docs|refactor|perf|test|build|revert)\/[a-z0-9][a-z0-9._/-]*$/;
 const CONVENTIONAL_SUBJECT =
-  /^(feat|fix|chore|ci|docs|refactor|perf|test|build|revert)(\([^)]+\))?!?: .+/;
+  /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^()]+\))?!?: \S.*$/;
 const GITHUB_CHANGE_BATCH = 100;
 
 export function semanticDeliveryBranch(current: string, base: string) {

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -933,7 +933,7 @@ async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown
           token,
           branch: requestedBranch,
           expectedHeadSha: baseSha,
-          headline: delivery.commitMessage,
+          commitMessage: delivery.commitMessage,
           changes,
           runId: currentRunId(),
         })
@@ -942,7 +942,7 @@ async function shipGitChanges(bundle: RunBundle): Promise<Record<string, unknown
           token,
           requestedBranch,
           baseSha,
-          headline: delivery.commitMessage,
+          commitMessage: delivery.commitMessage,
           changes,
           runId: currentRunId(),
         });
@@ -974,11 +974,62 @@ type GithubFileChange =
 const SEMANTIC_BRANCH =
   /^(feature|fix|chore|ci|docs|refactor|perf|test|build|revert)\/[a-z0-9][a-z0-9._/-]*$/;
 const CONVENTIONAL_SUBJECT =
-  /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^()]+\))?!?: \S.*$/;
+  /^(?<prefix>(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\((?=\S)[^()\r\n]*[^\s()\r\n]\))?!?: )(?<summary>\S.*)$/;
 const GITHUB_CHANGE_BATCH = 100;
+const GITHUB_COMMIT_HEADLINE_LIMIT = 120;
+
+function hasForbiddenSubjectCharacters(subject: string) {
+  return [...subject].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+}
+
+function conventionalSubject(message: string) {
+  const subject = message.split(/\r?\n/, 1)[0] ?? "";
+  if (hasForbiddenSubjectCharacters(subject)) return null;
+  const match = CONVENTIONAL_SUBJECT.exec(subject);
+  const prefix = match?.groups?.prefix;
+  const summary = match?.groups?.summary;
+  return prefix && summary ? { subject, prefix, summary } : null;
+}
 
 function hasConventionalSubject(message: string) {
-  return CONVENTIONAL_SUBJECT.test(message.split("\n", 1)[0]?.trim() ?? "");
+  return conventionalSubject(message) !== null;
+}
+
+function githubCommitMessage(commitMessage: string, multipart: string, runId: string) {
+  const parsed = conventionalSubject(commitMessage);
+  if (!parsed) throw new Error("github_signed_delivery_commit_not_conventional");
+  const availableSummaryCharacters =
+    GITHUB_COMMIT_HEADLINE_LIMIT - [...parsed.prefix].length - [...multipart].length;
+  if (availableSummaryCharacters < 1) {
+    throw new Error("github_signed_delivery_commit_subject_too_long");
+  }
+  const summary = [...parsed.summary].slice(0, availableSummaryCharacters).join("").trimEnd();
+  const headline = `${parsed.prefix}${summary}${multipart}`;
+  if (!hasConventionalSubject(headline)) {
+    throw new Error("github_signed_delivery_commit_subject_too_long");
+  }
+  const [, ...bodyLines] = commitMessage.split(/\r?\n/);
+  const suppliedBody = bodyLines.join("\n").trim();
+  return {
+    headline,
+    body: [`Delivered by Facility run ${runId}.`, suppliedBody].filter(Boolean).join("\n\n"),
+  };
+}
+
+function assertGithubCommitMessages(commitMessage: string, changeCount: number, runId: string) {
+  const batchCount = Math.ceil(changeCount / GITHUB_CHANGE_BATCH);
+  for (let index = 0; index < batchCount; index += 1) {
+    const multipart = batchCount > 1 ? ` (part ${index + 1}/${batchCount})` : "";
+    githubCommitMessage(commitMessage, multipart, runId);
+  }
 }
 
 export function semanticDeliveryBranch(current: string, base: string) {
@@ -1094,14 +1145,18 @@ export async function readAgentDeliveryMetadata(path: string): Promise<AgentDeli
   const root = objectValue(parsed);
   const pullRequest = objectValue(root.pullRequest);
   const branch = typeof root.branch === "string" ? root.branch.trim() : "";
-  const commitMessage = typeof root.commitMessage === "string" ? root.commitMessage.trim() : "";
-  const title = typeof pullRequest.title === "string" ? pullRequest.title.trim() : "";
+  const commitMessage = typeof root.commitMessage === "string" ? root.commitMessage : "";
+  const title = typeof pullRequest.title === "string" ? pullRequest.title : "";
   const body = typeof pullRequest.body === "string" ? pullRequest.body.trim() : "";
   if (!SEMANTIC_BRANCH.test(branch)) throw new Error("agent_delivery_branch_not_semantic");
   if (!hasConventionalSubject(commitMessage) || /(^|\n)Co-authored-by:/i.test(commitMessage)) {
     throw new Error("agent_delivery_commit_not_conventional");
   }
-  if (!CONVENTIONAL_SUBJECT.test(title) || title.length > 256) {
+  if (
+    hasForbiddenSubjectCharacters(title) ||
+    !hasConventionalSubject(title) ||
+    title.length > 256
+  ) {
     throw new Error("agent_delivery_pr_title_not_conventional");
   }
   if (!body || body.length > 60_000) throw new Error("agent_delivery_pr_body_invalid");
@@ -1119,7 +1174,7 @@ export async function readAgentUpdateMetadata(
   }
   const root = objectValue(parsed);
   const branch = typeof root.branch === "string" ? root.branch.trim() : "";
-  const commitMessage = typeof root.commitMessage === "string" ? root.commitMessage.trim() : "";
+  const commitMessage = typeof root.commitMessage === "string" ? root.commitMessage : "";
   existingGithubBranch(branch);
   if (!hasConventionalSubject(commitMessage) || /(^|\n)Co-authored-by:/i.test(commitMessage)) {
     throw new Error("agent_delivery_commit_not_conventional");
@@ -1138,11 +1193,12 @@ export async function publishVerifiedGithubChanges(input: {
   token: string;
   requestedBranch: string;
   baseSha: string;
-  headline: string;
+  commitMessage: string;
   changes: GithubFileChange[];
   runId: string;
   fetchImpl?: typeof fetch;
 }) {
+  assertGithubCommitMessages(input.commitMessage, input.changes.length, input.runId);
   const request = input.fetchImpl ?? fetch;
   const branch = await availableGithubBranch(
     request,
@@ -1169,12 +1225,13 @@ export async function publishVerifiedGithubBranchUpdate(input: {
   token: string;
   branch: string;
   expectedHeadSha: string;
-  headline: string;
+  commitMessage: string;
   changes: GithubFileChange[];
   runId: string;
   fetchImpl?: typeof fetch;
 }) {
   existingGithubBranch(input.branch);
+  assertGithubCommitMessages(input.commitMessage, input.changes.length, input.runId);
   const request = input.fetchImpl ?? fetch;
   const headSha = await commitVerifiedGithubChanges({ ...input, request });
   return { branch: input.branch, headSha };
@@ -1185,7 +1242,7 @@ async function commitVerifiedGithubChanges(input: {
   token: string;
   branch: string;
   expectedHeadSha: string;
-  headline: string;
+  commitMessage: string;
   changes: GithubFileChange[];
   runId: string;
   request: typeof fetch;
@@ -1206,6 +1263,7 @@ async function commitVerifiedGithubChanges(input: {
       )
       .map(({ path }) => ({ path }));
     const multipart = batches.length > 1 ? ` (part ${index + 1}/${batches.length})` : "";
+    const message = githubCommitMessage(input.commitMessage, multipart, input.runId);
     const data = await githubRequest<{
       data?: { createCommitOnBranch?: { commit?: { oid?: string } } };
       errors?: Array<{ message?: string }>;
@@ -1218,10 +1276,7 @@ async function commitVerifiedGithubChanges(input: {
           input: {
             branch: { repositoryNameWithOwner: input.repo, branchName: input.branch },
             expectedHeadOid,
-            message: {
-              headline: `${input.headline}${multipart}`.slice(0, 120),
-              body: `Delivered by Facility run ${input.runId}.`,
-            },
+            message,
             fileChanges: {
               ...(additions.length > 0 ? { additions } : {}),
               ...(deletions.length > 0 ? { deletions } : {}),

--- a/runner/test/github-delivery.integration.test.ts
+++ b/runner/test/github-delivery.integration.test.ts
@@ -1,0 +1,545 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deliveryFailure, prepareWorkspace, shipGitChanges } from "../src/index.js";
+import type { RunBundle } from "../src/types.js";
+
+type RecordedRequest = {
+  method: string;
+  path: string;
+  headers: IncomingHttpHeaders;
+  body: string;
+};
+
+type JsonReply = { status?: number; body?: unknown };
+
+const ENV_KEYS = [
+  "FACILITY_API_URL",
+  "RUN_ID",
+  "RUNNER_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "OPENAI_BASE_URL",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "FACILITY_PROJECT_ID",
+  "FACILITY_PLATFORM_KEY",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+] as const;
+
+let cleanups: Array<() => Promise<void>> = [];
+let handlerFailures: unknown[] = [];
+let previousEnv: Record<(typeof ENV_KEYS)[number], string | undefined>;
+let previousFetch: typeof fetch;
+
+beforeEach(() => {
+  cleanups = [];
+  handlerFailures = [];
+  previousEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+    (typeof ENV_KEYS)[number],
+    string | undefined
+  >;
+  previousFetch = globalThis.fetch;
+});
+
+afterEach(async () => {
+  const failures: unknown[] = [];
+  try {
+    for (const cleanup of cleanups.reverse()) {
+      try {
+        await cleanup();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+  } finally {
+    for (const key of ENV_KEYS) restoreEnv(key, previousEnv[key]);
+    globalThis.fetch = previousFetch;
+  }
+  failures.push(...handlerFailures);
+  if (failures.length > 0) throw new AggregateError(failures, "integration fixture cleanup failed");
+});
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+async function startJsonServer(
+  respond: (request: RecordedRequest) => JsonReply | Promise<JsonReply>,
+) {
+  const requests: RecordedRequest[] = [];
+  const handlerErrors: unknown[] = [];
+  const server = createServer(async (request, response) => {
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const recorded = {
+        method: request.method ?? "GET",
+        path: request.url ?? "/",
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString("utf8"),
+      };
+      requests.push(recorded);
+      const reply = await respond(recorded);
+      response.writeHead(reply.status ?? 200, { "content-type": "application/json" });
+      response.end(JSON.stringify(reply.body ?? {}));
+    } catch (error) {
+      handlerErrors.push(error);
+      handlerFailures.push(error);
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ message: String(error) }));
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  cleanups.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    requests,
+    handlerErrors,
+  };
+}
+
+async function startFacilityServer(token: string) {
+  return startJsonServer((request) => {
+    if (request.method === "POST" && request.path === "/internal/runs/run_integration/push-token") {
+      if (request.headers.authorization !== "Bearer runner-integration-token") {
+        return { status: 401, body: { message: "invalid runner token" } };
+      }
+      return { body: { token } };
+    }
+    if (request.method === "POST" && request.path === "/internal/runs/run_integration/events") {
+      if (request.headers.authorization !== "Bearer runner-integration-token") {
+        return { status: 401, body: { message: "invalid runner token" } };
+      }
+      return { body: {} };
+    }
+    return { status: 404, body: { message: `unexpected Facility route ${request.path}` } };
+  });
+}
+
+type GithubScenario =
+  | "success"
+  | "expired"
+  | "revoked"
+  | "cross-repository"
+  | "stale-head"
+  | "missing-oid";
+
+async function startGithubServer(input: {
+  scenario: GithubScenario;
+  token: string;
+  baseSha: string;
+}) {
+  const refs = new Map<string, string>([["main", input.baseSha]]);
+  const allowedRepo = "acme/widget";
+  let committed = false;
+  const local = await startJsonServer((request) => {
+    if (request.headers.authorization !== `Bearer ${input.token}`) {
+      return { status: 401, body: { message: "unexpected GitHub token" } };
+    }
+    if (input.scenario === "expired") {
+      return { status: 401, body: { message: `expired token ${input.token}` } };
+    }
+    if (input.scenario === "revoked") {
+      return { status: 403, body: { message: `revoked token ${input.token}` } };
+    }
+    const restRepo = /^\/repos\/([^/]+\/[^/]+)\//.exec(request.path)?.[1];
+    if (restRepo && restRepo !== allowedRepo) {
+      return {
+        status: 403,
+        body: { message: `token ${input.token} is scoped to another repository` },
+      };
+    }
+
+    const refPrefix = "/repos/acme/widget/git/ref/heads/";
+    if (request.method === "GET" && request.path.startsWith(refPrefix)) {
+      const branch = request.path.slice(refPrefix.length);
+      const sha = refs.get(branch);
+      return sha ? { body: { object: { sha } } } : { status: 404, body: { message: "Not Found" } };
+    }
+    if (request.method === "POST" && request.path === "/repos/acme/widget/git/refs") {
+      const payload = JSON.parse(request.body) as { ref: string; sha: string };
+      const branch = payload.ref.replace(/^refs\/heads\//, "");
+      if (payload.sha !== input.baseSha || refs.has(branch)) {
+        return { status: 422, body: { message: "invalid ref creation" } };
+      }
+      refs.set(branch, input.scenario === "stale-head" ? "concurrent_sha" : payload.sha);
+      return { status: 201, body: { ref: payload.ref, object: { sha: payload.sha } } };
+    }
+    if (request.method === "POST" && request.path === "/graphql") {
+      const payload = JSON.parse(request.body) as {
+        variables: {
+          input: {
+            branch: { repositoryNameWithOwner: string; branchName: string };
+            expectedHeadOid: string;
+          };
+        };
+      };
+      const mutation = payload.variables.input;
+      if (mutation.branch.repositoryNameWithOwner !== allowedRepo) {
+        return { status: 403, body: { message: "repository scope mismatch" } };
+      }
+      const current = refs.get(mutation.branch.branchName);
+      if (mutation.expectedHeadOid !== current) {
+        return { body: { errors: [{ message: "expectedHeadOid is stale or replayed" }] } };
+      }
+      if (input.scenario === "missing-oid") {
+        return { body: { data: { createCommitOnBranch: { commit: {} } } } };
+      }
+      committed = true;
+      refs.set(mutation.branch.branchName, "signed_sha");
+      return {
+        body: { data: { createCommitOnBranch: { commit: { oid: "signed_sha" } } } },
+      };
+    }
+    return { status: 404, body: { message: `unexpected GitHub route ${request.path}` } };
+  });
+
+  const originalUrls: string[] = [];
+  const githubFetch: typeof fetch = async (request, init) => {
+    const url = new URL(
+      typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
+    );
+    if (url.origin !== "https://api.github.com") {
+      throw new Error(`unexpected external GitHub origin ${url.origin}`);
+    }
+    originalUrls.push(url.href);
+    return previousFetch(new URL(`${url.pathname}${url.search}`, local.origin), init);
+  };
+  return {
+    ...local,
+    refs,
+    originalUrls,
+    githubFetch,
+    committed: () => committed,
+  };
+}
+
+function runBundle(cloneUrl: string): RunBundle {
+  return {
+    runId: "run_integration",
+    mode: "builder",
+    engine: "codex",
+    contract: "Deliver the integration fixture.",
+    skills: [],
+    engineConfig: {},
+    repo: { cloneUrl, branch: "main", installationTokenRef: null },
+    harness: null,
+    provisionCmd: null,
+    checkCmds: [],
+    gatewayUrls: { anthropic: "https://anthropic.test", openai: "https://openai.test" },
+    scope: {},
+    timeoutMin: 5,
+  };
+}
+
+async function deliveryFixture(commitMessage: string) {
+  const fixtureRoot = await mkdtemp(join(tmpdir(), "facility-github-delivery-"));
+  cleanups.push(() => rm(fixtureRoot, { recursive: true, force: true }));
+  const origin = join(fixtureRoot, "origin");
+  const workspace = join(fixtureRoot, "workspace");
+  process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+  process.env.GIT_CONFIG_NOSYSTEM = "1";
+  await mkdir(origin);
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: origin });
+  execFileSync("git", ["config", "user.email", "facility@example.invalid"], { cwd: origin });
+  execFileSync("git", ["config", "user.name", "Facility Integration"], { cwd: origin });
+  await writeFile(join(origin, "README.md"), "# Signed delivery fixture\n");
+  execFileSync("git", ["add", "README.md"], { cwd: origin });
+  execFileSync("git", ["commit", "-m", "test: seed signed delivery fixture"], { cwd: origin });
+
+  const bundle = runBundle(origin);
+  await prepareWorkspace(
+    bundle,
+    "virtual-integration-key",
+    {
+      platformKey: null,
+      platformApiUrl: "https://platform.test",
+      projectId: "project_integration",
+      repoToken: null,
+    },
+    workspace,
+  );
+  bundle.repo.cloneUrl = "https://github.com/acme/widget.git";
+  const repo = join(workspace, "repo");
+  await mkdir(join(repo, "src"), { recursive: true });
+  await writeFile(join(repo, "src", "task.ts"), "export const delivered = true;\n");
+  await mkdir(join(repo, ".agent-sdlc"), { recursive: true });
+  await writeFile(
+    join(repo, ".agent-sdlc", "delivery.json"),
+    JSON.stringify({
+      branch: "feature/task",
+      commitMessage,
+      pullRequest: {
+        title: "fix: deliver signed task",
+        body: "## Summary\n\n- Deliver the signed task.",
+      },
+    }),
+  );
+  const baseSha = execFileSync("git", ["rev-parse", "origin/main"], {
+    cwd: repo,
+    encoding: "utf8",
+  }).trim();
+  return { bundle, workspace, repo, baseSha };
+}
+
+function configureRunner(facilityOrigin: string, githubOrigin: string) {
+  process.env.FACILITY_API_URL = facilityOrigin;
+  process.env.RUN_ID = "run_integration";
+  process.env.RUNNER_TOKEN = "runner-integration-token";
+  const allowedOrigins = new Set([facilityOrigin, githubOrigin]);
+  globalThis.fetch = async (request, init) => {
+    const url = new URL(
+      typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
+    );
+    if (!allowedOrigins.has(url.origin)) {
+      throw new Error(`integration test blocked external request to ${url.origin}`);
+    }
+    return previousFetch(request, init);
+  };
+}
+
+function facilityRequests(requests: RecordedRequest[], suffix: string) {
+  return requests.filter((request) => request.path.endsWith(suffix));
+}
+
+function failureEvent(requests: RecordedRequest[]) {
+  const events = facilityRequests(requests, "/events");
+  expect(events).toHaveLength(1);
+  const body = JSON.parse(events[0]?.body ?? "null") as Array<{
+    type: string;
+    data: { kind: string; error: string };
+  }>;
+  expect(body).toHaveLength(1);
+  expect(body[0]).toMatchObject({ type: "artifact_error", data: { kind: "git_push_failed" } });
+  return body[0]?.data.error ?? "";
+}
+
+describe.sequential("signed GitHub delivery integration", () => {
+  it("publishes the real workspace diff with exact Conventional Commit metadata", async () => {
+    const fixture = await deliveryFixture(
+      "fix: deliver signed task\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
+    );
+    const token = "installation-token-success";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "success",
+      token,
+      baseSha: fixture.baseSha,
+    });
+    configureRunner(facility.origin, github.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toEqual({
+      branch: "feature/task",
+      headSha: "signed_sha",
+      changed: true,
+      pullRequestTitle: "fix: deliver signed task",
+      pullRequestBody: "## Summary\n\n- Deliver the signed task.",
+    });
+    expect(deliveryFailure(fixture.bundle, result)).toBeNull();
+    expect(
+      execFileSync("git", ["rev-parse", "HEAD"], { cwd: fixture.repo, encoding: "utf8" }).trim(),
+    ).toBe(fixture.baseSha);
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(1);
+    expect(facilityRequests(facility.requests, "/events")).toHaveLength(0);
+    expect(github.originalUrls).toEqual([
+      "https://api.github.com/repos/acme/widget/git/ref/heads/feature/task",
+      "https://api.github.com/repos/acme/widget/git/refs",
+      "https://api.github.com/graphql",
+    ]);
+    expect(github.requests.map((request) => request.headers.authorization)).toEqual([
+      `Bearer ${token}`,
+      `Bearer ${token}`,
+      `Bearer ${token}`,
+    ]);
+    const ref = JSON.parse(github.requests[1]?.body ?? "null");
+    expect(ref).toEqual({ ref: "refs/heads/feature/task", sha: fixture.baseSha });
+    const mutation = JSON.parse(github.requests[2]?.body ?? "null");
+    expect(mutation.variables.input).toMatchObject({
+      branch: { repositoryNameWithOwner: "acme/widget", branchName: "feature/task" },
+      expectedHeadOid: fixture.baseSha,
+      message: {
+        headline: "fix: deliver signed task",
+        body: "Delivered by Facility run run_integration.\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
+      },
+      fileChanges: {
+        additions: [
+          {
+            path: "src/task.ts",
+            contents: Buffer.from("export const delivered = true;\n").toString("base64"),
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(mutation.variables.input.fileChanges)).not.toContain("delivery.json");
+    expect(github.refs.get("feature/task")).toBe("signed_sha");
+    expect(github.committed()).toBe(true);
+    expect(facility.handlerErrors).toEqual([]);
+    expect(github.handlerErrors).toEqual([]);
+  });
+
+  it.each([
+    ["control character", "fix: render \u001b[31mred output", "commit_not_conventional"],
+    [
+      "co-author footer",
+      "fix: deliver task\n\nCo-authored-by: Intruder <intruder@example.test>",
+      "commit_not_conventional",
+    ],
+    [
+      "oversized prefix",
+      `feat(${"a".repeat(112)}): x`,
+      "github_signed_delivery_commit_subject_too_long",
+    ],
+  ])("rejects a malformed %s before acquiring a push token", async (_name, message, error) => {
+    const fixture = await deliveryFixture(message);
+    const token = `installation-token-malformed-${_name}`;
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "success",
+      token,
+      baseSha: fixture.baseSha,
+    });
+    configureRunner(facility.origin, github.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toMatchObject({ changed: true, pushError: expect.stringContaining(error) });
+    expect(result).not.toHaveProperty("headSha");
+    expect(deliveryFailure(fixture.bundle, result)).toBe("delivery_push_failed");
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(0);
+    expect(github.originalUrls).toEqual([]);
+    expect(failureEvent(facility.requests)).toContain(error);
+    expect(github.committed()).toBe(false);
+  });
+
+  it.each([
+    ["expired", "expired"],
+    ["revoked", "revoked"],
+    ["cross-repository", "another repository"],
+  ] as const)("fails closed when the installation token is %s", async (scenario, error) => {
+    const fixture = await deliveryFixture("fix: deliver signed task");
+    if (scenario === "cross-repository") {
+      fixture.bundle.repo.cloneUrl = "https://github.com/other/widget.git";
+    }
+    const token = `installation-token-${scenario}`;
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({ scenario, token, baseSha: fixture.baseSha });
+    configureRunner(facility.origin, github.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toMatchObject({ changed: true, pushError: expect.stringContaining(error) });
+    expect(result).not.toHaveProperty("headSha");
+    expect(deliveryFailure(fixture.bundle, result)).toBe("delivery_push_failed");
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(1);
+    expect(github.originalUrls).toEqual([
+      `https://api.github.com/repos/${scenario === "cross-repository" ? "other/widget" : "acme/widget"}/git/ref/heads/feature/task`,
+    ]);
+    expect(github.refs.has("feature/task")).toBe(false);
+    expect(github.committed()).toBe(false);
+    const eventError = failureEvent(facility.requests);
+    expect(JSON.stringify(result)).not.toContain(token);
+    expect(eventError).not.toContain(token);
+    expect(eventError).not.toContain("runner-integration-token");
+    expect(eventError).toContain("«redacted»");
+  });
+
+  it("rejects a stale or replayed expected head without reporting a commit", async () => {
+    const fixture = await deliveryFixture("fix: deliver signed task");
+    const token = "installation-token-stale-head";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "stale-head",
+      token,
+      baseSha: fixture.baseSha,
+    });
+    configureRunner(facility.origin, github.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toMatchObject({
+      changed: true,
+      pushError: expect.stringContaining("expectedHeadOid is stale or replayed"),
+    });
+    expect(result).not.toHaveProperty("headSha");
+    expect(deliveryFailure(fixture.bundle, result)).toBe("delivery_push_failed");
+    expect(github.originalUrls).toHaveLength(3);
+    expect(github.refs.get("feature/task")).toBe("concurrent_sha");
+    expect(github.committed()).toBe(false);
+    expect(failureEvent(facility.requests)).toContain("stale or replayed");
+  });
+
+  it("rejects a malformed success response with no signed commit OID", async () => {
+    const fixture = await deliveryFixture("fix: deliver signed task");
+    const token = "installation-token-missing-oid";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "missing-oid",
+      token,
+      baseSha: fixture.baseSha,
+    });
+    configureRunner(facility.origin, github.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toMatchObject({
+      changed: true,
+      pushError: expect.stringContaining("github_signed_delivery_missing_commit_oid"),
+    });
+    expect(result).not.toHaveProperty("headSha");
+    expect(deliveryFailure(fixture.bundle, result)).toBe("delivery_push_failed");
+    expect(github.refs.get("feature/task")).toBe(fixture.baseSha);
+    expect(github.committed()).toBe(false);
+    expect(failureEvent(facility.requests)).toContain("missing_commit_oid");
+    expect(facility.handlerErrors).toEqual([]);
+    expect(github.handlerErrors).toEqual([]);
+  });
+
+  it("keeps the delivery manifest excluded from the repository diff", async () => {
+    const fixture = await deliveryFixture("fix: deliver signed task");
+    const exclude = await readFile(join(fixture.repo, ".git", "info", "exclude"), "utf8");
+    expect(exclude).toContain(".agent-sdlc/delivery.json");
+    expect(
+      execFileSync("git", ["status", "--short", "--ignored"], {
+        cwd: fixture.repo,
+        encoding: "utf8",
+      }),
+    ).toContain("!! .agent-sdlc/");
+  });
+});

--- a/runner/test/github-delivery.integration.test.ts
+++ b/runner/test/github-delivery.integration.test.ts
@@ -44,6 +44,15 @@ beforeEach(() => {
     string | undefined
   >;
   previousFetch = globalThis.fetch;
+  globalThis.fetch = async (request, init) => {
+    const url = new URL(
+      typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
+    );
+    if (url.protocol !== "http:" || url.hostname !== "127.0.0.1") {
+      throw new Error(`integration test blocked external request to ${url.origin}`);
+    }
+    return previousFetch(request, init);
+  };
 });
 
 afterEach(async () => {
@@ -148,8 +157,9 @@ async function startGithubServer(input: {
   scenario: GithubScenario;
   token: string;
   baseSha: string;
+  branch?: string;
 }) {
-  const refs = new Map<string, string>([["main", input.baseSha]]);
+  const refs = new Map<string, string>([[input.branch ?? "main", input.baseSha]]);
   const allowedRepo = "acme/widget";
   let committed = false;
   const local = await startJsonServer((request) => {
@@ -223,7 +233,7 @@ async function startGithubServer(input: {
       throw new Error(`unexpected external GitHub origin ${url.origin}`);
     }
     originalUrls.push(url.href);
-    return previousFetch(new URL(`${url.pathname}${url.search}`, local.origin), init);
+    return globalThis.fetch(new URL(`${url.pathname}${url.search}`, local.origin), init);
   };
   return {
     ...local,
@@ -234,7 +244,7 @@ async function startGithubServer(input: {
   };
 }
 
-function runBundle(cloneUrl: string): RunBundle {
+function runBundle(cloneUrl: string, overrides: Partial<RunBundle> = {}): RunBundle {
   return {
     runId: "run_integration",
     mode: "builder",
@@ -249,10 +259,18 @@ function runBundle(cloneUrl: string): RunBundle {
     gatewayUrls: { anthropic: "https://anthropic.test", openai: "https://openai.test" },
     scope: {},
     timeoutMin: 5,
+    ...overrides,
   };
 }
 
-async function deliveryFixture(commitMessage: string) {
+async function deliveryFixture(
+  commitMessage: string,
+  pullRequestTitle = "fix: deliver signed task",
+  {
+    repair = false,
+    repairCodeChange = false,
+  }: { repair?: boolean; repairCodeChange?: boolean } = {},
+) {
   const fixtureRoot = await mkdtemp(join(tmpdir(), "facility-github-delivery-"));
   cleanups.push(() => rm(fixtureRoot, { recursive: true, force: true }));
   const origin = join(fixtureRoot, "origin");
@@ -266,8 +284,30 @@ async function deliveryFixture(commitMessage: string) {
   await writeFile(join(origin, "README.md"), "# Signed delivery fixture\n");
   execFileSync("git", ["add", "README.md"], { cwd: origin });
   execFileSync("git", ["commit", "-m", "test: seed signed delivery fixture"], { cwd: origin });
+  if (repair) {
+    execFileSync("git", ["checkout", "-b", "feature/task"], { cwd: origin });
+    await writeFile(join(origin, "existing.md"), "Existing pull request change.\n");
+    execFileSync("git", ["add", "existing.md"], { cwd: origin });
+    execFileSync("git", ["commit", "-m", "docs: document the existing behavior"], {
+      cwd: origin,
+    });
+  }
 
-  const bundle = runBundle(origin);
+  const bundle = runBundle(
+    origin,
+    repair
+      ? {
+          mode: "address_review",
+          repo: { cloneUrl: origin, branch: "feature/task", installationTokenRef: null },
+          scope: {
+            pullRequest: {
+              base: "main",
+              title: pullRequestTitle,
+            },
+          },
+        }
+      : {},
+  );
   await prepareWorkspace(
     bundle,
     "virtual-integration-key",
@@ -281,41 +321,42 @@ async function deliveryFixture(commitMessage: string) {
   );
   bundle.repo.cloneUrl = "https://github.com/acme/widget.git";
   const repo = join(workspace, "repo");
-  await mkdir(join(repo, "src"), { recursive: true });
-  await writeFile(join(repo, "src", "task.ts"), "export const delivered = true;\n");
+  if (repair && !repairCodeChange) {
+    await writeFile(
+      join(repo, "README.md"),
+      "# Signed delivery fixture\n\nClarify the existing behavior.\n",
+    );
+  } else {
+    await mkdir(join(repo, "src"), { recursive: true });
+    await writeFile(join(repo, "src", "task.ts"), "export const delivered = true;\n");
+  }
   await mkdir(join(repo, ".agent-sdlc"), { recursive: true });
   await writeFile(
     join(repo, ".agent-sdlc", "delivery.json"),
-    JSON.stringify({
-      branch: "feature/task",
-      commitMessage,
-      pullRequest: {
-        title: "fix: deliver signed task",
-        body: "## Summary\n\n- Deliver the signed task.",
-      },
-    }),
+    JSON.stringify(
+      repair
+        ? { branch: "feature/task", commitMessage }
+        : {
+            branch: "feature/task",
+            commitMessage,
+            pullRequest: {
+              title: pullRequestTitle,
+              body: "## Summary\n\n- Deliver the signed task.",
+            },
+          },
+    ),
   );
-  const baseSha = execFileSync("git", ["rev-parse", "origin/main"], {
+  const baseSha = execFileSync("git", ["rev-parse", `origin/${repair ? "feature/task" : "main"}`], {
     cwd: repo,
     encoding: "utf8",
   }).trim();
   return { bundle, workspace, repo, baseSha };
 }
 
-function configureRunner(facilityOrigin: string, githubOrigin: string) {
+function configureRunner(facilityOrigin: string) {
   process.env.FACILITY_API_URL = facilityOrigin;
   process.env.RUN_ID = "run_integration";
   process.env.RUNNER_TOKEN = "runner-integration-token";
-  const allowedOrigins = new Set([facilityOrigin, githubOrigin]);
-  globalThis.fetch = async (request, init) => {
-    const url = new URL(
-      typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
-    );
-    if (!allowedOrigins.has(url.origin)) {
-      throw new Error(`integration test blocked external request to ${url.origin}`);
-    }
-    return previousFetch(request, init);
-  };
 }
 
 function facilityRequests(requests: RecordedRequest[], suffix: string) {
@@ -338,6 +379,7 @@ describe.sequential("signed GitHub delivery integration", () => {
   it("publishes the real workspace diff with exact Conventional Commit metadata", async () => {
     const fixture = await deliveryFixture(
       "fix: deliver signed task\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
+      "fix!: deliver signed task",
     );
     const token = "installation-token-success";
     const facility = await startFacilityServer(token);
@@ -346,7 +388,7 @@ describe.sequential("signed GitHub delivery integration", () => {
       token,
       baseSha: fixture.baseSha,
     });
-    configureRunner(facility.origin, github.origin);
+    configureRunner(facility.origin);
 
     const result = await shipGitChanges(fixture.bundle, {
       root: fixture.workspace,
@@ -357,7 +399,7 @@ describe.sequential("signed GitHub delivery integration", () => {
       branch: "feature/task",
       headSha: "signed_sha",
       changed: true,
-      pullRequestTitle: "fix: deliver signed task",
+      pullRequestTitle: "fix!: deliver signed task",
       pullRequestBody: "## Summary\n\n- Deliver the signed task.",
     });
     expect(deliveryFailure(fixture.bundle, result)).toBeNull();
@@ -410,6 +452,11 @@ describe.sequential("signed GitHub delivery integration", () => {
       "commit_not_conventional",
     ],
     [
+      "missing body separator",
+      "fix: replace the contract\nBREAKING CHANGE: migrate the client",
+      "commit_body_separator_invalid",
+    ],
+    [
       "oversized prefix",
       `feat(${"a".repeat(112)}): x`,
       "github_signed_delivery_commit_subject_too_long",
@@ -423,7 +470,7 @@ describe.sequential("signed GitHub delivery integration", () => {
       token,
       baseSha: fixture.baseSha,
     });
-    configureRunner(facility.origin, github.origin);
+    configureRunner(facility.origin);
 
     const result = await shipGitChanges(fixture.bundle, {
       root: fixture.workspace,
@@ -439,6 +486,94 @@ describe.sequential("signed GitHub delivery integration", () => {
     expect(github.committed()).toBe(false);
   });
 
+  it("rejects mismatched commit and PR-title impact before acquiring a push token", async () => {
+    const fixture = await deliveryFixture(
+      "fix: replace the public contract\n\nBREAKING CHANGE: migrate the client",
+    );
+    const token = "installation-token-impact-mismatch";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "success",
+      token,
+      baseSha: fixture.baseSha,
+    });
+    configureRunner(facility.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toMatchObject({
+      changed: true,
+      pushError: expect.stringContaining("agent_delivery_release_impact_mismatch"),
+    });
+    expect(result).not.toHaveProperty("headSha");
+    expect(deliveryFailure(fixture.bundle, result)).toBe("delivery_push_failed");
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(0);
+    expect(github.originalUrls).toEqual([]);
+    expect(failureEvent(facility.requests)).toContain("release_impact_mismatch");
+    expect(github.committed()).toBe(false);
+  });
+
+  it("publishes a repair that does not raise the existing PR range impact", async () => {
+    const fixture = await deliveryFixture(
+      "docs: clarify the existing behavior",
+      "docs: document the existing behavior",
+      { repair: true },
+    );
+    const token = "installation-token-repair-success";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "success",
+      token,
+      baseSha: fixture.baseSha,
+      branch: "feature/task",
+    });
+    configureRunner(facility.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toEqual({ branch: "feature/task", headSha: "signed_sha", changed: true });
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(1);
+    expect(github.originalUrls).toEqual(["https://api.github.com/graphql"]);
+    expect(github.committed()).toBe(true);
+  });
+
+  it("rejects a repair that raises PR impact before acquiring a push token", async () => {
+    const fixture = await deliveryFixture(
+      "fix: correct the task behavior",
+      "docs: document the existing behavior",
+      { repair: true, repairCodeChange: true },
+    );
+    const token = "installation-token-repair-impact-mismatch";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "success",
+      token,
+      baseSha: fixture.baseSha,
+      branch: "feature/task",
+    });
+    configureRunner(facility.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toMatchObject({
+      changed: true,
+      pushError: expect.stringContaining("agent_delivery_release_impact_mismatch"),
+    });
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(0);
+    expect(github.originalUrls).toEqual([]);
+    expect(failureEvent(facility.requests)).toContain("release_impact_mismatch");
+    expect(github.committed()).toBe(false);
+  });
+
   it.each([
     ["expired", "expired"],
     ["revoked", "revoked"],
@@ -451,7 +586,7 @@ describe.sequential("signed GitHub delivery integration", () => {
     const token = `installation-token-${scenario}`;
     const facility = await startFacilityServer(token);
     const github = await startGithubServer({ scenario, token, baseSha: fixture.baseSha });
-    configureRunner(facility.origin, github.origin);
+    configureRunner(facility.origin);
 
     const result = await shipGitChanges(fixture.bundle, {
       root: fixture.workspace,
@@ -483,7 +618,7 @@ describe.sequential("signed GitHub delivery integration", () => {
       token,
       baseSha: fixture.baseSha,
     });
-    configureRunner(facility.origin, github.origin);
+    configureRunner(facility.origin);
 
     const result = await shipGitChanges(fixture.bundle, {
       root: fixture.workspace,
@@ -511,7 +646,7 @@ describe.sequential("signed GitHub delivery integration", () => {
       token,
       baseSha: fixture.baseSha,
     });
-    configureRunner(facility.origin, github.origin);
+    configureRunner(facility.origin);
 
     const result = await shipGitChanges(fixture.bundle, {
       root: fixture.workspace,

--- a/runner/test/github-delivery.integration.test.ts
+++ b/runner/test/github-delivery.integration.test.ts
@@ -269,7 +269,8 @@ async function deliveryFixture(
   {
     repair = false,
     repairCodeChange = false,
-  }: { repair?: boolean; repairCodeChange?: boolean } = {},
+    repairTitleAvailable = true,
+  }: { repair?: boolean; repairCodeChange?: boolean; repairTitleAvailable?: boolean } = {},
 ) {
   const fixtureRoot = await mkdtemp(join(tmpdir(), "facility-github-delivery-"));
   cleanups.push(() => rm(fixtureRoot, { recursive: true, force: true }));
@@ -302,7 +303,7 @@ async function deliveryFixture(
           scope: {
             pullRequest: {
               base: "main",
-              title: pullRequestTitle,
+              ...(repairTitleAvailable ? { title: pullRequestTitle } : {}),
             },
           },
         }
@@ -543,13 +544,43 @@ describe.sequential("signed GitHub delivery integration", () => {
     expect(github.committed()).toBe(true);
   });
 
-  it("rejects a repair that raises PR impact before acquiring a push token", async () => {
+  it("publishes an impact-raising repair after the PR is truthfully retitled", async () => {
+    const fixture = await deliveryFixture(
+      "fix: correct the task behavior",
+      "fix: correct the task behavior",
+      { repair: true, repairCodeChange: true },
+    );
+    const token = "installation-token-retitled-repair-success";
+    const facility = await startFacilityServer(token);
+    const github = await startGithubServer({
+      scenario: "success",
+      token,
+      baseSha: fixture.baseSha,
+      branch: "feature/task",
+    });
+    configureRunner(facility.origin);
+
+    const result = await shipGitChanges(fixture.bundle, {
+      root: fixture.workspace,
+      githubFetch: github.githubFetch,
+    });
+
+    expect(result).toEqual({ branch: "feature/task", headSha: "signed_sha", changed: true });
+    expect(facilityRequests(facility.requests, "/push-token")).toHaveLength(1);
+    expect(github.originalUrls).toEqual(["https://api.github.com/graphql"]);
+    expect(github.committed()).toBe(true);
+  });
+
+  it.each([
+    ["has an incompatible docs title", true],
+    ["has no authoritative title", false],
+  ] as const)("rejects an impact-raising repair that %s before acquiring a push token", async (_case, repairTitleAvailable) => {
     const fixture = await deliveryFixture(
       "fix: correct the task behavior",
       "docs: document the existing behavior",
-      { repair: true, repairCodeChange: true },
+      { repair: true, repairCodeChange: true, repairTitleAvailable },
     );
-    const token = "installation-token-repair-impact-mismatch";
+    const token = `installation-token-repair-impact-mismatch-${repairTitleAvailable}`;
     const facility = await startFacilityServer(token);
     const github = await startGithubServer({
       scenario: "success",

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -7,6 +7,7 @@ import {
   buildClaudeCodeArgs,
   buildCodexArgs,
   composedPrompt,
+  deliveryReleaseImpact,
   exitCode,
   handleControlMessage,
   parseGitNameStatus,
@@ -43,6 +44,38 @@ function bundle(overrides: Partial<RunBundle> = {}): RunBundle {
 }
 
 describe("workspace preparation", () => {
+  it("keeps runner release classification aligned with the root policy", async () => {
+    const rootPolicy = (await import(
+      new URL("../../scripts/conventional-commit-subjects.mjs", import.meta.url).href
+    )) as { releaseImpact(message: string): string };
+    const messages = [
+      ...[
+        "feat",
+        "fix",
+        "perf",
+        "revert",
+        "docs",
+        "style",
+        "refactor",
+        "test",
+        "build",
+        "ci",
+        "chore",
+      ].map((type) => `${type}: describe the change`),
+      "docs!: replace the contract",
+      "docs: replace the contract\n\nBREAKING CHANGE: migrate the client",
+      "docs: replace the contract\n\nRefs: #42\ncontext for the reference\nBREAKING-CHANGE: migrate the client\nCloses #123",
+      "docs: quote output\n\nThe tool printed:\nBREAKING CHANGE: example text",
+      "docs: show a fence\n\n```text\nBREAKING CHANGE: example text\n```",
+      "docs: missing separator\nBREAKING CHANGE: example text",
+      "docs: malformed trailer\n\nBREAKING CHANGE:\texample text",
+    ];
+
+    for (const message of messages) {
+      expect(deliveryReleaseImpact(message), message).toBe(rootPolicy.releaseImpact(message));
+    }
+  });
+
   it("accepts only a bounded structured security findings artifact", async () => {
     const root = await mkdtemp(join(tmpdir(), "facility-runner-"));
     const path = join(root, "security-findings.json");
@@ -128,6 +161,17 @@ describe("workspace preparation", () => {
     expect(composedPrompt(bundle())).toContain(".agent-sdlc/progress.md");
     expect(composedPrompt(bundle({ mode: "custom" }))).not.toContain(".agent-sdlc/progress.md");
     expect(composedPrompt(bundle())).toContain(".agent-sdlc/delivery.json");
+    expect(composedPrompt(bundle())).toContain("same release impact");
+    expect(composedPrompt(bundle())).toContain("BREAKING CHANGE:");
+    expect(composedPrompt(bundle({ mode: "address_review" }))).toContain(
+      "release impact is no greater than the existing pull request range",
+    );
+    expect(composedPrompt(bundle({ mode: "ci_doctor" }))).toContain(
+      "do not add `!` or a `BREAKING CHANGE:` footer unless that range is already breaking",
+    );
+    expect(composedPrompt(bundle({ mode: "address_review" }))).toContain(
+      "PR title must be updated first",
+    );
     expect(composedPrompt(bundle({ mode: "architect" }))).not.toContain(
       ".agent-sdlc/delivery.json",
     );
@@ -268,6 +312,66 @@ describe("workspace preparation", () => {
       }),
     );
     await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("pr_title_not_conventional");
+  });
+
+  it("requires matching commit and PR-title impact using only an actual breaking footer", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-runner-"));
+    const path = join(root, "delivery.json");
+    const writeDelivery = (commitMessage: string, title: string) =>
+      writeFile(
+        path,
+        JSON.stringify({
+          branch: "feature/release-impact",
+          commitMessage,
+          pullRequest: { title, body: "## Summary\n- Preserve release semantics." },
+        }),
+      );
+
+    await writeDelivery(
+      "fix: document the migration phrase\n\nBREAKING CHANGE: appears in an example\n\nThe behavior remains compatible.",
+      "fix: document the migration phrase",
+    );
+    await expect(readAgentDeliveryMetadata(path)).resolves.toMatchObject({
+      pullRequest: { title: "fix: document the migration phrase" },
+    });
+
+    await writeDelivery(
+      "fix: document malformed input\nBREAKING CHANGE: missing footer separator",
+      "fix: document malformed input",
+    );
+    await expect(readAgentDeliveryMetadata(path)).rejects.toThrow(
+      "github_signed_delivery_commit_body_separator_invalid",
+    );
+
+    for (const nonFooter of [
+      "fix: quote output\n\nThe tool printed:\nBREAKING CHANGE: example text",
+      "fix: show a fence\n\n```text\nBREAKING CHANGE: example text\n```",
+      "fix: show indented code\n\n    BREAKING CHANGE: example text",
+      "fix: use a tab separator\n\nBREAKING CHANGE:\tmigrate the client",
+    ]) {
+      await writeDelivery(nonFooter, "fix: preserve compatible behavior");
+      await expect(readAgentDeliveryMetadata(path)).resolves.toMatchObject({
+        pullRequest: { title: "fix: preserve compatible behavior" },
+      });
+    }
+
+    const breakingCommit =
+      "fix: replace the public contract\n\nExplain the migration.\n\nBREAKING CHANGE: migrate the client\ncontinue with the second step\nCloses #123";
+    await writeDelivery(breakingCommit, "fix: replace the public contract");
+    await expect(readAgentDeliveryMetadata(path)).rejects.toThrow(
+      "agent_delivery_release_impact_mismatch",
+    );
+
+    await writeDelivery(breakingCommit, "fix!: replace the public contract");
+    await expect(readAgentDeliveryMetadata(path)).resolves.toMatchObject({
+      commitMessage: breakingCommit,
+      pullRequest: { title: "fix!: replace the public contract" },
+    });
+
+    await writeDelivery("docs: explain the public contract", "fix: explain the public contract");
+    await expect(readAgentDeliveryMetadata(path)).rejects.toThrow(
+      "agent_delivery_release_impact_mismatch",
+    );
   });
 
   it("publishes agent-owned metadata through GitHub's signed commit mutation", async () => {

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -220,6 +220,29 @@ describe("workspace preparation", () => {
     );
     await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("commit_not_conventional");
 
+    for (const commitMessage of [
+      "  fix: normalize formatting",
+      "fix((): normalize formatting",
+      "fix(api)): normalize formatting",
+      "fix( ): normalize formatting",
+      "fix(api\tauth): normalize formatting",
+      "fix: render \u001b[31mred output",
+      "fix: render \u009b31mred output",
+    ]) {
+      await writeFile(
+        path,
+        JSON.stringify({
+          branch: "feature/format-auth-api",
+          commitMessage,
+          pullRequest: {
+            title: "fix(api/auth): require scoped credentials",
+            body: "Summary",
+          },
+        }),
+      );
+      await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("commit_not_conventional");
+    }
+
     await writeFile(
       path,
       JSON.stringify({
@@ -227,6 +250,19 @@ describe("workspace preparation", () => {
         commitMessage: "style(web+api): normalize formatting",
         pullRequest: {
           title: "fix(api(auth)): require scoped credentials",
+          body: "Summary",
+        },
+      }),
+    );
+    await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("pr_title_not_conventional");
+
+    await writeFile(
+      path,
+      JSON.stringify({
+        branch: "feature/format-auth-api",
+        commitMessage: "fix: normalize formatting",
+        pullRequest: {
+          title: "  fix: require scoped credentials",
           body: "Summary",
         },
       }),
@@ -257,14 +293,18 @@ describe("workspace preparation", () => {
         token: "installation-token",
         requestedBranch: "feature/task",
         baseSha: "base_sha",
-        headline: "feat: deliver task",
+        commitMessage:
+          "feat!: deliver task\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
         changes: [{ kind: "addition", path: "src/task.js", contents: "Y29udGVudA==" }],
         runId: "run_12345678",
         fetchImpl,
       }),
     ).resolves.toEqual({ branch: "feature/task", headSha: "signed_sha" });
     const mutation = JSON.parse(String(requests[2]?.init?.body));
-    expect(mutation.variables.input.message.headline).toBe("feat: deliver task");
+    expect(mutation.variables.input.message).toEqual({
+      headline: "feat!: deliver task",
+      body: "Delivered by Facility run run_12345678.\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
+    });
     expect(mutation.variables.input.fileChanges.additions[0]).toEqual({
       path: "src/task.js",
       contents: "Y29udGVudA==",
@@ -272,6 +312,78 @@ describe("workspace preparation", () => {
     expect(requests[1]?.init?.headers).toMatchObject({
       authorization: "Bearer installation-token",
     });
+  });
+
+  it("fails before publishing when a Conventional Commit prefix cannot fit GitHub", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify({ message: "unexpected request" }), { status: 500 });
+    };
+
+    await expect(
+      publishVerifiedGithubChanges({
+        repo: "acme/widget",
+        token: "installation-token",
+        requestedBranch: "feature/task",
+        baseSha: "base_sha",
+        commitMessage: `feat(${"a".repeat(112)}): x`,
+        changes: [{ kind: "addition", path: "src/task.js", contents: "Y29udGVudA==" }],
+        runId: "run_12345678",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("commit_subject_too_long");
+    expect(requests).toHaveLength(0);
+  });
+
+  it("keeps multipart signed commit headlines conventional at the Unicode limit", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      requests.push({ url: String(input), init });
+      return new Response(
+        JSON.stringify({
+          data: {
+            createCommitOnBranch: { commit: { oid: `updated_${requests.length}` } },
+          },
+        }),
+        { status: 200 },
+      );
+    };
+    const changes = Array.from({ length: 101 }, (_, index) => ({
+      kind: "addition" as const,
+      path: `src/task-${index}.js`,
+      contents: "Y29udGVudA==",
+    }));
+
+    await expect(
+      publishVerifiedGithubBranchUpdate({
+        repo: "acme/widget",
+        token: "installation-token",
+        branch: "automation/dependency-refresh",
+        expectedHeadSha: "current_sha",
+        commitMessage: `feat(web+api)!: ${"x".repeat(92)}😀tail\n\nBREAKING CHANGE: use the new task API`,
+        changes,
+        runId: "run_12345678",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      branch: "automation/dependency-refresh",
+      headSha: "updated_2",
+    });
+
+    expect(requests).toHaveLength(2);
+    for (const [index, request] of requests.entries()) {
+      const mutation = JSON.parse(String(request.init?.body));
+      const message = mutation.variables.input.message;
+      expect([...message.headline]).toHaveLength(120);
+      expect(message.headline).toMatch(
+        /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^()]+\))?!?: \S.*$/,
+      );
+      expect(message.headline.endsWith(`😀 (part ${index + 1}/2)`)).toBe(true);
+      expect(message.body).toBe(
+        "Delivered by Facility run run_12345678.\n\nBREAKING CHANGE: use the new task API",
+      );
+    }
   });
 
   it("updates the existing PR branch without creating a generic branch", async () => {
@@ -289,7 +401,7 @@ describe("workspace preparation", () => {
         token: "installation-token",
         branch: "automation/dependency-refresh",
         expectedHeadSha: "current_sha",
-        headline: "fix: address review",
+        commitMessage: "fix: address review\n\nKeep the explanation in the commit body.",
         changes: [{ kind: "addition", path: "src/task.js", contents: "Y29udGVudA==" }],
         runId: "run_12345678",
         fetchImpl,
@@ -300,6 +412,10 @@ describe("workspace preparation", () => {
     const mutation = JSON.parse(String(requests[0]?.init?.body));
     expect(mutation.variables.input.branch.branchName).toBe("automation/dependency-refresh");
     expect(mutation.variables.input.expectedHeadOid).toBe("current_sha");
+    expect(mutation.variables.input.message).toEqual({
+      headline: "fix: address review",
+      body: "Delivered by Facility run run_12345678.\n\nKeep the explanation in the commit body.",
+    });
   });
 
   it("parses null-delimited git changes and preserves semantic branches", () => {
@@ -325,6 +441,14 @@ describe("workspace preparation", () => {
       branch: "automation/dependency-refresh",
       commitMessage: "fix: address review\n\nKeep the explanation in the commit body.",
     });
+    await writeFile(
+      path,
+      JSON.stringify({
+        branch: "automation/dependency-refresh",
+        commitMessage: "  fix: address review",
+      }),
+    );
+    await expect(readAgentUpdateMetadata(path)).rejects.toThrow("commit_not_conventional");
     await writeFile(
       path,
       JSON.stringify({ branch: "bad..branch", commitMessage: "fix: address review" }),

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -192,7 +192,8 @@ describe("workspace preparation", () => {
       path,
       JSON.stringify({
         branch: "feature/format-auth-api",
-        commitMessage: "  style(web+api): normalize formatting  ",
+        commitMessage:
+          "style(web+api): normalize formatting\n\nBREAKING CHANGE: generated output changed",
         pullRequest: {
           title: "fix(api/auth)!: require scoped credentials",
           body: "## Summary\n- Normalize formatting and scope credentials.",
@@ -201,7 +202,8 @@ describe("workspace preparation", () => {
     );
 
     await expect(readAgentDeliveryMetadata(path)).resolves.toMatchObject({
-      commitMessage: "style(web+api): normalize formatting",
+      commitMessage:
+        "style(web+api): normalize formatting\n\nBREAKING CHANGE: generated output changed",
       pullRequest: { title: "fix(api/auth)!: require scoped credentials" },
     });
 
@@ -316,12 +318,12 @@ describe("workspace preparation", () => {
       path,
       JSON.stringify({
         branch: "automation/dependency-refresh",
-        commitMessage: "fix: address review",
+        commitMessage: "fix: address review\n\nKeep the explanation in the commit body.",
       }),
     );
     await expect(readAgentUpdateMetadata(path)).resolves.toEqual({
       branch: "automation/dependency-refresh",
-      commitMessage: "fix: address review",
+      commitMessage: "fix: address review\n\nKeep the explanation in the commit body.",
     });
     await writeFile(
       path,

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -185,6 +185,53 @@ describe("workspace preparation", () => {
     await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("branch_not_semantic");
   });
 
+  it("accepts style and punctuation scopes and rejects malformed conventional subjects", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-runner-"));
+    const path = join(root, "delivery.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        branch: "feature/format-auth-api",
+        commitMessage: "  style(web+api): normalize formatting  ",
+        pullRequest: {
+          title: "fix(api/auth)!: require scoped credentials",
+          body: "## Summary\n- Normalize formatting and scope credentials.",
+        },
+      }),
+    );
+
+    await expect(readAgentDeliveryMetadata(path)).resolves.toMatchObject({
+      commitMessage: "style(web+api): normalize formatting",
+      pullRequest: { title: "fix(api/auth)!: require scoped credentials" },
+    });
+
+    await writeFile(
+      path,
+      JSON.stringify({
+        branch: "feature/format-auth-api",
+        commitMessage: "feature(web+api): normalize formatting",
+        pullRequest: {
+          title: "fix(api/auth): require scoped credentials",
+          body: "Summary",
+        },
+      }),
+    );
+    await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("commit_not_conventional");
+
+    await writeFile(
+      path,
+      JSON.stringify({
+        branch: "feature/format-auth-api",
+        commitMessage: "style(web+api): normalize formatting",
+        pullRequest: {
+          title: "fix(api(auth)): require scoped credentials",
+          body: "Summary",
+        },
+      }),
+    );
+    await expect(readAgentDeliveryMetadata(path)).rejects.toThrow("pr_title_not_conventional");
+  });
+
   it("publishes agent-owned metadata through GitHub's signed commit mutation", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const fetchImpl: typeof fetch = async (input, init) => {

--- a/scripts/conventional-commit-subjects.mjs
+++ b/scripts/conventional-commit-subjects.mjs
@@ -23,6 +23,8 @@ export const ALLOWED_TYPES = Object.freeze([
 const SUBJECT = new RegExp(
   `^(?<type>${ALLOWED_TYPES.join("|")})(?:\\((?<scope>(?=\\S)[^()\\r\\n]*[^\\s()\\r\\n])\\))?(?<breaking>!)?: (?<summary>\\S.*)$`,
 );
+const PATCH_TYPES = new Set(["feat", "fix", "perf", "revert"]);
+const IMPACT_RANK = Object.freeze({ none: 0, patch: 1, minor: 2 });
 
 function hasForbiddenSubjectCharacters(subject) {
   return [...subject].some((character) => {
@@ -59,7 +61,31 @@ export function assertSubject(subject, { label = "subject" } = {}) {
   );
 }
 
-export function subjectsInRange(
+function subjectOf(message) {
+  return message.split(/\r?\n/, 1)[0] ?? "";
+}
+
+function hasBreakingFooter(message) {
+  const blocks = message.replace(/\r\n/g, "\n").trimEnd().split(/\n[ \t]*\n+/);
+  if (blocks.length < 2) return false;
+  const lines = (blocks.at(-1) ?? "").split("\n");
+  const trailer = /^(?:(?:[A-Za-z0-9-]+|BREAKING CHANGE): +\S|[A-Za-z0-9-]+ #\S)/;
+  const breakingTrailer = /^BREAKING(?: |-)CHANGE: +\S/;
+
+  // A footer is the final, blank-line-separated trailer block. Once that block
+  // begins with a trailer, non-token lines are multiline value continuation;
+  // a later BREAKING CHANGE token starts another footer.
+  if (!trailer.test(lines[0] ?? "")) return false;
+  return lines.some((line) => breakingTrailer.test(line));
+}
+
+export function releaseImpact(message) {
+  const parsed = assertSubject(subjectOf(message));
+  if (parsed.breaking || hasBreakingFooter(message)) return "minor";
+  return PATCH_TYPES.has(parsed.type) ? "patch" : "none";
+}
+
+export function messagesInRange(
   baseSha,
   headSha,
   { repoDir = process.cwd(), exec = execFileSync } = {},
@@ -71,13 +97,17 @@ export function subjectsInRange(
     { cwd: repoDir, encoding: "utf8" },
   );
   if (!output) return [];
-  const subjects = output.split("\0");
-  if (subjects.at(-1) === "") subjects.pop();
-  return subjects.map((message) => message.split(/\r?\n/, 1)[0] ?? "");
+  const messages = output.split("\0");
+  if (messages.at(-1) === "") messages.pop();
+  return messages;
 }
 
-export function assertRange(baseSha, headSha, options) {
-  const subjects = subjectsInRange(baseSha, headSha, options);
+export function subjectsInRange(baseSha, headSha, options) {
+  return messagesInRange(baseSha, headSha, options).map(subjectOf);
+}
+
+function assertMessages(messages) {
+  const subjects = messages.map(subjectOf);
   const invalid = subjects.filter((subject) => !parseSubject(subject));
   if (invalid.length > 0) {
     throw new Error(
@@ -90,6 +120,101 @@ export function assertRange(baseSha, headSha, options) {
     );
   }
   return subjects;
+}
+
+export function assertRange(baseSha, headSha, options) {
+  return assertMessages(messagesInRange(baseSha, headSha, options));
+}
+
+function maximumImpact(messages) {
+  return messages.reduce(
+    (highest, message) => {
+      const impact = releaseImpact(message);
+      return IMPACT_RANK[impact] > IMPACT_RANK[highest] ? impact : highest;
+    },
+    "none",
+  );
+}
+
+function commitHashesInRange(
+  baseSha,
+  headSha,
+  { repoDir = process.cwd(), exec = execFileSync } = {},
+) {
+  const output = exec(
+    "git",
+    ["rev-list", "--no-merges", `${baseSha}..${headSha}`],
+    { cwd: repoDir, encoding: "utf8" },
+  );
+  return output.trim() ? output.trim().split(/\r?\n/) : [];
+}
+
+function gitCommitIsEmpty(
+  hash,
+  { repoDir = process.cwd(), exec = execFileSync, isEmptyCommit } = {},
+) {
+  if (isEmptyCommit) return Boolean(isEmptyCommit(hash));
+  try {
+    exec(
+      "git",
+      ["diff-tree", "--quiet", "--exit-code", "--root", hash],
+      { cwd: repoDir, stdio: "ignore" },
+    );
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && error.status === 1) return false;
+    throw error;
+  }
+}
+
+function assertNoReleaseImpactingEmptyCommits(baseSha, headSha, messages, options) {
+  const hashes = commitHashesInRange(baseSha, headSha, options);
+  if (hashes.length !== messages.length) {
+    throw new Error(
+      `could not pair ${messages.length} commit message${messages.length === 1 ? "" : "s"} with ${hashes.length} commit hash${hashes.length === 1 ? "" : "es"}`,
+    );
+  }
+  const empty = hashes.flatMap((hash, index) => {
+    if (releaseImpact(messages[index]) === "none" || !gitCommitIsEmpty(hash, options)) return [];
+    return [{ hash, subject: subjectOf(messages[index]) }];
+  });
+  if (empty.length === 0) return;
+  throw new Error(
+    [
+      `${empty.length} release-impacting empty commit${empty.length === 1 ? " is" : "s are"} not allowed:`,
+      ...empty.map(({ hash, subject }) => `  ${hash} ${JSON.stringify(subject)}`),
+      "Rebase merges can omit empty commits, which would choose a different next version from squash or merge.",
+    ].join("\n"),
+  );
+}
+
+export function rangeImpact(baseSha, headSha, options) {
+  const messages = messagesInRange(baseSha, headSha, options);
+  return { subjects: assertMessages(messages), impact: maximumImpact(messages) };
+}
+
+export function assertPullRequest(title, baseSha, headSha, options) {
+  assertSubject(title, { label: "pull request title" });
+  const messages = messagesInRange(baseSha, headSha, options);
+  const range = { subjects: assertMessages(messages), impact: maximumImpact(messages) };
+  if (range.subjects.length === 0) {
+    throw new Error("pull request has no non-merge commits to classify");
+  }
+  assertNoReleaseImpactingEmptyCommits(baseSha, headSha, messages, options);
+  const titleImpact = releaseImpact(title);
+  const commitImpact = range.impact;
+  if (titleImpact !== commitImpact) {
+    throw new Error(
+      [
+        `pull request title release impact (${titleImpact}) does not match its commit range (${commitImpact})`,
+        `Title: ${JSON.stringify(title)}`,
+        "Commit subjects:",
+        ...range.subjects.map((subject) => `  ${JSON.stringify(subject)}`),
+        "Make them match so PR metadata and every supported merge configuration declare the same next version.",
+      ].join("\n"),
+    );
+  }
+  return range;
 }
 
 function required(name) {
@@ -111,7 +236,18 @@ function main() {
     console.log(`OK: ${subjects.length} non-merge commit subject${subjects.length === 1 ? "" : "s"}`);
     return;
   }
-  throw new Error("Usage: conventional-commit-subjects.mjs title|range");
+  if (command === "pr") {
+    const result = assertPullRequest(
+      required("TITLE"),
+      required("BASE_SHA"),
+      required("HEAD_SHA"),
+    );
+    console.log(
+      `OK: ${result.subjects.length} non-merge commit subject${result.subjects.length === 1 ? "" : "s"}; release impact ${result.impact}`,
+    );
+    return;
+  }
+  throw new Error("Usage: conventional-commit-subjects.mjs title|range|pr");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/scripts/conventional-commit-subjects.mjs
+++ b/scripts/conventional-commit-subjects.mjs
@@ -21,12 +21,25 @@ export const ALLOWED_TYPES = Object.freeze([
 ]);
 
 const SUBJECT = new RegExp(
-  `^(?<type>${ALLOWED_TYPES.join("|")})(?:\\((?<scope>[^()]+)\\))?(?<breaking>!)?: (?<summary>\\S.*)$`,
+  `^(?<type>${ALLOWED_TYPES.join("|")})(?:\\((?<scope>(?=\\S)[^()\\r\\n]*[^\\s()\\r\\n])\\))?(?<breaking>!)?: (?<summary>\\S.*)$`,
 );
+
+function hasForbiddenSubjectCharacters(subject) {
+  return [...subject].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+}
 
 export function parseSubject(subject) {
   if (typeof subject !== "string") return null;
-  const match = SUBJECT.exec(subject.trim());
+  if (hasForbiddenSubjectCharacters(subject)) return null;
+  const match = SUBJECT.exec(subject);
   if (!match?.groups) return null;
   return {
     type: match.groups.type,
@@ -54,13 +67,13 @@ export function subjectsInRange(
   if (!baseSha || !headSha) throw new Error("both BASE_SHA and HEAD_SHA are required");
   const output = exec(
     "git",
-    ["log", "-z", "--no-merges", "--format=%s", `${baseSha}..${headSha}`],
+    ["log", "-z", "--no-merges", "--format=%B", `${baseSha}..${headSha}`],
     { cwd: repoDir, encoding: "utf8" },
   );
   if (!output) return [];
   const subjects = output.split("\0");
   if (subjects.at(-1) === "") subjects.pop();
-  return subjects.map((subject) => subject.trim());
+  return subjects.map((message) => message.split(/\r?\n/, 1)[0] ?? "");
 }
 
 export function assertRange(baseSha, headSha, options) {

--- a/scripts/conventional-commit-subjects.mjs
+++ b/scripts/conventional-commit-subjects.mjs
@@ -52,14 +52,15 @@ export function subjectsInRange(
   { repoDir = process.cwd(), exec = execFileSync } = {},
 ) {
   if (!baseSha || !headSha) throw new Error("both BASE_SHA and HEAD_SHA are required");
-  return exec(
+  const output = exec(
     "git",
-    ["log", "--no-merges", "--format=%s", `${baseSha}..${headSha}`],
+    ["log", "-z", "--no-merges", "--format=%s", `${baseSha}..${headSha}`],
     { cwd: repoDir, encoding: "utf8" },
-  )
-    .split("\n")
-    .map((subject) => subject.trim())
-    .filter(Boolean);
+  );
+  if (!output) return [];
+  const subjects = output.split("\0");
+  if (subjects.at(-1) === "") subjects.pop();
+  return subjects.map((subject) => subject.trim());
 }
 
 export function assertRange(baseSha, headSha, options) {
@@ -69,7 +70,7 @@ export function assertRange(baseSha, headSha, options) {
     throw new Error(
       [
         `${invalid.length} commit subject${invalid.length === 1 ? " is" : "s are"} not allowed:`,
-        ...invalid.map((subject) => `  ${subject}`),
+        ...invalid.map((subject) => `  ${JSON.stringify(subject)}`),
         "Expected: <type>[(scope)][!]: <what changed>",
         `Allowed types: ${ALLOWED_TYPES.join(" ")}`,
       ].join("\n"),

--- a/scripts/conventional-commit-subjects.mjs
+++ b/scripts/conventional-commit-subjects.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// The subjects that land on main decide the released version. Keep the policy
+// here so PR-title checks, PR commit checks, and landed-history checks cannot
+// drift into accepting different commit grammars.
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const ALLOWED_TYPES = Object.freeze([
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+]);
+
+const SUBJECT = new RegExp(
+  `^(?<type>${ALLOWED_TYPES.join("|")})(?:\\((?<scope>[^()]+)\\))?(?<breaking>!)?: (?<summary>\\S.*)$`,
+);
+
+export function parseSubject(subject) {
+  if (typeof subject !== "string") return null;
+  const match = SUBJECT.exec(subject.trim());
+  if (!match?.groups) return null;
+  return {
+    type: match.groups.type,
+    scope: match.groups.scope ?? null,
+    breaking: match.groups.breaking === "!",
+    summary: match.groups.summary,
+  };
+}
+
+export function assertSubject(subject, { label = "subject" } = {}) {
+  const parsed = parseSubject(subject);
+  if (parsed) return parsed;
+  throw new Error(
+    `${label} is not an allowed Conventional Commit: ${JSON.stringify(subject)}\n` +
+      "Expected: <type>[(scope)][!]: <what changed>\n" +
+      `Allowed types: ${ALLOWED_TYPES.join(" ")}`,
+  );
+}
+
+export function subjectsInRange(
+  baseSha,
+  headSha,
+  { repoDir = process.cwd(), exec = execFileSync } = {},
+) {
+  if (!baseSha || !headSha) throw new Error("both BASE_SHA and HEAD_SHA are required");
+  return exec(
+    "git",
+    ["log", "--no-merges", "--format=%s", `${baseSha}..${headSha}`],
+    { cwd: repoDir, encoding: "utf8" },
+  )
+    .split("\n")
+    .map((subject) => subject.trim())
+    .filter(Boolean);
+}
+
+export function assertRange(baseSha, headSha, options) {
+  const subjects = subjectsInRange(baseSha, headSha, options);
+  const invalid = subjects.filter((subject) => !parseSubject(subject));
+  if (invalid.length > 0) {
+    throw new Error(
+      [
+        `${invalid.length} commit subject${invalid.length === 1 ? " is" : "s are"} not allowed:`,
+        ...invalid.map((subject) => `  ${subject}`),
+        "Expected: <type>[(scope)][!]: <what changed>",
+        `Allowed types: ${ALLOWED_TYPES.join(" ")}`,
+      ].join("\n"),
+    );
+  }
+  return subjects;
+}
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function main() {
+  const command = process.argv[2];
+  if (command === "title") {
+    const title = required("TITLE");
+    assertSubject(title, { label: "pull request title" });
+    console.log(`OK: ${title}`);
+    return;
+  }
+  if (command === "range") {
+    const subjects = assertRange(required("BASE_SHA"), required("HEAD_SHA"));
+    console.log(`OK: ${subjects.length} non-merge commit subject${subjects.length === 1 ? "" : "s"}`);
+    return;
+  }
+  throw new Error("Usage: conventional-commit-subjects.mjs title|range");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/conventional-commit-subjects.test.mjs
+++ b/scripts/conventional-commit-subjects.test.mjs
@@ -7,9 +7,12 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   ALLOWED_TYPES,
+  assertPullRequest,
   assertRange,
   assertSubject,
   parseSubject,
+  rangeImpact,
+  releaseImpact,
   subjectsInRange,
 } from "./conventional-commit-subjects.mjs";
 
@@ -63,10 +66,24 @@ function localRepository(t, name) {
   return repoDir;
 }
 
-function commitChange(repoDir, content, subject) {
+function commitChange(repoDir, content, subject, body) {
   writeFileSync(join(repoDir, "change.txt"), `${content}\n`);
   git(repoDir, ["add", "change.txt"]);
-  git(repoDir, ["commit", "-m", subject]);
+  git(repoDir, ["commit", "-m", subject, ...(body ? ["-m", body] : [])]);
+}
+
+function fakeRange(...messages) {
+  const hashes = messages.map((_, index) => `commit-${index + 1}`);
+  return {
+    exec(_command, args) {
+      if (args[0] === "log") return messages.length > 0 ? `${messages.join("\0")}\0` : "";
+      if (args[0] === "rev-list") return hashes.length > 0 ? `${hashes.join("\n")}\n` : "";
+      throw new Error(`unexpected git command: ${args.join(" ")}`);
+    },
+    isEmptyCommit() {
+      return false;
+    },
+  };
 }
 
 test("the repository's allowed Conventional Commit types are accepted", () => {
@@ -114,6 +131,49 @@ test("breaking markers and established punctuation in scopes are accepted", () =
   assert.equal(assertSubject("perf!: remove the legacy path").breaking, true);
 });
 
+test("release impact follows the repository's 0.x version policy and full commit messages", () => {
+  for (const type of ["feat", "fix", "perf", "revert"]) {
+    assert.equal(releaseImpact(`${type}: describe the change`), "patch", type);
+  }
+  for (const type of ["docs", "style", "refactor", "test", "build", "ci", "chore"]) {
+    assert.equal(releaseImpact(`${type}: describe the change`), "none", type);
+  }
+  assert.equal(releaseImpact("docs!: replace the public contract"), "minor");
+  assert.equal(
+    releaseImpact("fix: preserve the old subject\n\nBREAKING CHANGE: migrate the client"),
+    "minor",
+  );
+  assert.equal(
+    releaseImpact("fix: preserve the old subject\r\n\r\nBREAKING-CHANGE: migrate the client"),
+    "minor",
+  );
+  assert.equal(
+    releaseImpact(
+      "docs: replace the contract\n\nRefs: #42\nBREAKING CHANGE: migrate the client\ncontinue with the second step\nCloses #123",
+    ),
+    "minor",
+  );
+  assert.equal(
+    releaseImpact(
+      "docs: explain the phrase\n\nBREAKING CHANGE: appears in an example\n\nThis is still documentation.",
+    ),
+    "none",
+  );
+  assert.equal(
+    releaseImpact("docs: explain malformed input\nBREAKING CHANGE: missing footer separator"),
+    "none",
+  );
+  for (const example of [
+    "docs: quote output\n\nThe tool printed:\nBREAKING CHANGE: example text",
+    "docs: show a fence\n\n```text\nBREAKING CHANGE: example text\n```",
+    "docs: show indented code\n\n    BREAKING CHANGE: example text",
+    "docs: omit the description\n\nBREAKING CHANGE: ",
+    "docs: use a tab separator\n\nBREAKING CHANGE:\tmigrate the client",
+  ]) {
+    assert.equal(releaseImpact(example), "none", example);
+  }
+});
+
 test("unknown types and malformed subjects are rejected", () => {
   for (const subject of [
     "unknown: describe the change",
@@ -157,12 +217,86 @@ test("commit ranges are read as non-merge subjects from base-exclusive history",
   assert.equal(calls[0].options.encoding, "utf8");
 });
 
-test("commit ranges follow the subjects that survive squash, no-ff, and rebase merges", (t) => {
+test("pull request titles have the same release impact as their full commit range", () => {
+  const patchRange = fakeRange("docs: explain the change\n", "fix: deliver the change\n");
+  assert.deepEqual(rangeImpact("base", "head", patchRange), {
+    subjects: ["docs: explain the change", "fix: deliver the change"],
+    impact: "patch",
+  });
+  assert.deepEqual(assertPullRequest("feat: deliver the change", "base", "head", patchRange), {
+    subjects: ["docs: explain the change", "fix: deliver the change"],
+    impact: "patch",
+  });
+  assert.throws(
+    () => assertPullRequest("ci: validate the change", "base", "head", patchRange),
+    /title release impact \(none\) does not match its commit range \(patch\)/,
+  );
+
+  const breakingRange = fakeRange(
+    "fix: replace the contract\n\nBREAKING CHANGE: migrate the client\n",
+  );
+  assert.deepEqual(
+    assertPullRequest("fix!: replace the contract", "base", "head", breakingRange),
+    { subjects: ["fix: replace the contract"], impact: "minor" },
+  );
+  assert.throws(
+    () => assertPullRequest("fix: replace the contract", "base", "head", breakingRange),
+    /title release impact \(patch\) does not match its commit range \(minor\)/,
+  );
+
+  const noReleaseRange = fakeRange("docs: explain the existing behavior\n");
+  assert.throws(
+    () => assertPullRequest("fix: explain the existing behavior", "base", "head", noReleaseRange),
+    /title release impact \(patch\) does not match its commit range \(none\)/,
+  );
+});
+
+test("pull request classification fails closed for an empty non-merge range", () => {
+  assert.throws(
+    () => assertPullRequest("docs: explain the change", "base", "head", fakeRange()),
+    /no non-merge commits to classify/,
+  );
+});
+
+test("release-impacting commits must not be empty before a possible rebase", (t) => {
+  const repoDir = localRepository(t, "release-impacting-empty");
+  const baseSha = git(repoDir, ["rev-parse", "HEAD"]);
+  git(repoDir, ["commit", "--allow-empty", "-m", "fix: claim a delivered fix"]);
+  const headSha = git(repoDir, ["rev-parse", "HEAD"]);
+
+  assert.throws(
+    () => assertPullRequest("fix: claim a delivered fix", baseSha, headSha, { repoDir }),
+    /release-impacting empty commit is not allowed[\s\S]*fix: claim a delivered fix[\s\S]*Rebase merges can omit empty commits/,
+  );
+});
+
+test("squash, no-ff, and rebase land the same footer-only breaking impact", (t) => {
   const squashRepo = localRepository(t, "squash");
   const squashBase = git(squashRepo, ["rev-parse", "HEAD"]);
   git(squashRepo, ["checkout", "-b", "squash-feature"]);
   commitChange(squashRepo, "squash step one", "fix(web+api): prepare the squash");
-  commitChange(squashRepo, "squash step two", "feat(api/auth): finish the squash");
+  commitChange(
+    squashRepo,
+    "squash step two",
+    "docs(api/auth): describe the breaking squash",
+    "BREAKING CHANGE: migrate the squash client",
+  );
+  const squashFeatureHead = git(squashRepo, ["rev-parse", "HEAD"]);
+  assert.deepEqual(
+    assertPullRequest(
+      "feat(registry,sandbox)!: land one squash subject",
+      squashBase,
+      squashFeatureHead,
+      { repoDir: squashRepo },
+    ),
+    {
+      subjects: [
+        "docs(api/auth): describe the breaking squash",
+        "fix(web+api): prepare the squash",
+      ],
+      impact: "minor",
+    },
+  );
   git(squashRepo, ["checkout", "main"]);
   git(squashRepo, ["merge", "--squash", "squash-feature"]);
   git(squashRepo, ["commit", "-m", "feat(registry,sandbox)!: land one squash subject"]);
@@ -171,25 +305,37 @@ test("commit ranges follow the subjects that survive squash, no-ff, and rebase m
   assert.deepEqual(subjectsInRange(squashBase, squashHead, { repoDir: squashRepo }), [
     "feat(registry,sandbox)!: land one squash subject",
   ]);
+  const squashImpact = rangeImpact(squashBase, squashHead, { repoDir: squashRepo });
 
   const mergeRepo = localRepository(t, "merge");
   const mergeBase = git(mergeRepo, ["rev-parse", "HEAD"]);
   git(mergeRepo, ["checkout", "-b", "merge-feature"]);
   commitChange(mergeRepo, "merge step one", "feat(api/auth): add the first commit");
-  commitChange(mergeRepo, "merge step two", "fix(registry,sandbox): add the second commit");
+  commitChange(
+    mergeRepo,
+    "merge step two",
+    "docs(registry,sandbox): describe the breaking merge",
+    "BREAKING CHANGE: migrate the merge client",
+  );
   git(mergeRepo, ["checkout", "main"]);
   git(mergeRepo, ["merge", "--no-ff", "merge-feature", "-m", "Merge branch 'merge-feature'"]);
   const mergeHead = git(mergeRepo, ["rev-parse", "HEAD"]);
 
   assert.deepEqual(subjectsInRange(mergeBase, mergeHead, { repoDir: mergeRepo }), [
-    "fix(registry,sandbox): add the second commit",
+    "docs(registry,sandbox): describe the breaking merge",
     "feat(api/auth): add the first commit",
   ]);
+  const mergeImpact = rangeImpact(mergeBase, mergeHead, { repoDir: mergeRepo });
 
   const rebaseRepo = localRepository(t, "rebase");
   git(rebaseRepo, ["checkout", "-b", "rebase-feature"]);
   commitChange(rebaseRepo, "rebase step one", "feat(api/auth): add the rebased feature");
-  commitChange(rebaseRepo, "rebase step two", "fix(web+api): finish the rebased feature");
+  commitChange(
+    rebaseRepo,
+    "rebase step two",
+    "docs(web+api): describe the breaking rebase",
+    "BREAKING CHANGE: migrate the rebased client",
+  );
   git(rebaseRepo, ["checkout", "main"]);
   writeFileSync(join(rebaseRepo, "main.txt"), "advance main\n");
   git(rebaseRepo, ["add", "main.txt"]);
@@ -202,9 +348,14 @@ test("commit ranges follow the subjects that survive squash, no-ff, and rebase m
   const rebaseHead = git(rebaseRepo, ["rev-parse", "HEAD"]);
 
   assert.deepEqual(subjectsInRange(rebaseBase, rebaseHead, { repoDir: rebaseRepo }), [
-    "fix(web+api): finish the rebased feature",
+    "docs(web+api): describe the breaking rebase",
     "feat(api/auth): add the rebased feature",
   ]);
+  const rebaseImpact = rangeImpact(rebaseBase, rebaseHead, { repoDir: rebaseRepo });
+
+  assert.equal(squashImpact.impact, "minor");
+  assert.equal(mergeImpact.impact, squashImpact.impact);
+  assert.equal(rebaseImpact.impact, squashImpact.impact);
 });
 
 test("an empty commit subject is retained and rejected", (t) => {
@@ -270,7 +421,46 @@ test("the title CLI accepts valid input and denies invalid input", () => {
   assert.match(denied.stderr, /unknown: hide a release change/);
 });
 
-test("workflows validate edited titles, retargeted ranges, and landed main commits", () => {
+test("the pull request CLI rejects squash impact that differs from the commit range", (t) => {
+  const repoDir = localRepository(t, "pull-request-impact");
+  const baseSha = git(repoDir, ["rev-parse", "HEAD"]);
+  writeFileSync(join(repoDir, "change.txt"), "breaking change\n");
+  git(repoDir, ["add", "change.txt"]);
+  git(repoDir, [
+    "commit",
+    "-m",
+    "fix: replace the public contract",
+    "-m",
+    "BREAKING CHANGE: migrate the client",
+  ]);
+  const headSha = git(repoDir, ["rev-parse", "HEAD"]);
+
+  const accepted = subjectCli(
+    "pr",
+    {
+      TITLE: "fix!: replace the public contract",
+      BASE_SHA: baseSha,
+      HEAD_SHA: headSha,
+    },
+    repoDir,
+  );
+  assert.equal(accepted.status, 0, accepted.stderr);
+  assert.match(accepted.stdout, /release impact minor/);
+
+  const denied = subjectCli(
+    "pr",
+    {
+      TITLE: "fix: replace the public contract",
+      BASE_SHA: baseSha,
+      HEAD_SHA: headSha,
+    },
+    repoDir,
+  );
+  assert.notEqual(denied.status, 0, denied.stdout);
+  assert.match(denied.stderr, /title release impact \(patch\).*commit range \(minor\)/s);
+});
+
+test("workflows validate edited titles, matching PR impact, and landed main commits", () => {
   const subjectWorkflow = readFileSync(
     new URL("../.github/workflows/pull-request-title.yml", import.meta.url),
     "utf8",
@@ -298,6 +488,9 @@ test("workflows validate edited titles, retargeted ranges, and landed main commi
   const rangeJob = rangeJobs[0];
   assert.doesNotMatch(rangeJob.split(/^\s+steps:/m)[0], /^\s+if:/m);
   assert.match(rangeJob, /fetch-depth:\s*0/);
+  assert.match(rangeJob, /EVENT_NAME: \$\{\{ github\.event_name \}\}/);
+  assert.match(rangeJob, /TITLE: \$\{\{ github\.event\.pull_request\.title \|\| '' \}\}/);
+  assert.match(rangeJob, /node scripts\/conventional-commit-subjects\.mjs pr\b/);
   assert.match(
     rangeJob,
     /BASE_SHA: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/,

--- a/scripts/conventional-commit-subjects.test.mjs
+++ b/scripts/conventional-commit-subjects.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   ALLOWED_TYPES,
+  assertRange,
   assertSubject,
   parseSubject,
   subjectsInRange,
@@ -131,7 +132,7 @@ test("commit ranges are read as non-merge subjects from base-exclusive history",
     repoDir: "/fixture/repository",
     exec(command, args, options) {
       calls.push({ command, args, options });
-      return "feat: add the capability\nfix(api/auth)!: close the gap\n";
+      return "feat: add the capability\0fix(api/auth)!: close the gap\0";
     },
   });
 
@@ -140,6 +141,7 @@ test("commit ranges are read as non-merge subjects from base-exclusive history",
   assert.equal(calls[0].command, "git");
   assert.deepEqual(calls[0].args, [
     "log",
+    "-z",
     "--no-merges",
     "--format=%s",
     "base-sha..head-sha",
@@ -148,7 +150,7 @@ test("commit ranges are read as non-merge subjects from base-exclusive history",
   assert.equal(calls[0].options.encoding, "utf8");
 });
 
-test("commit ranges follow the subjects that survive squash and no-ff merges", (t) => {
+test("commit ranges follow the subjects that survive squash, no-ff, and rebase merges", (t) => {
   const squashRepo = localRepository(t, "squash");
   const squashBase = git(squashRepo, ["rev-parse", "HEAD"]);
   git(squashRepo, ["checkout", "-b", "squash-feature"]);
@@ -176,6 +178,39 @@ test("commit ranges follow the subjects that survive squash and no-ff merges", (
     "fix(registry,sandbox): add the second commit",
     "feat(api/auth): add the first commit",
   ]);
+
+  const rebaseRepo = localRepository(t, "rebase");
+  git(rebaseRepo, ["checkout", "-b", "rebase-feature"]);
+  commitChange(rebaseRepo, "rebase step one", "feat(api/auth): add the rebased feature");
+  commitChange(rebaseRepo, "rebase step two", "fix(web+api): finish the rebased feature");
+  git(rebaseRepo, ["checkout", "main"]);
+  writeFileSync(join(rebaseRepo, "main.txt"), "advance main\n");
+  git(rebaseRepo, ["add", "main.txt"]);
+  git(rebaseRepo, ["commit", "-m", "chore: advance the target branch"]);
+  const rebaseBase = git(rebaseRepo, ["rev-parse", "HEAD"]);
+  git(rebaseRepo, ["checkout", "rebase-feature"]);
+  git(rebaseRepo, ["rebase", "main"]);
+  git(rebaseRepo, ["checkout", "main"]);
+  git(rebaseRepo, ["merge", "--ff-only", "rebase-feature"]);
+  const rebaseHead = git(rebaseRepo, ["rev-parse", "HEAD"]);
+
+  assert.deepEqual(subjectsInRange(rebaseBase, rebaseHead, { repoDir: rebaseRepo }), [
+    "fix(web+api): finish the rebased feature",
+    "feat(api/auth): add the rebased feature",
+  ]);
+});
+
+test("an empty commit subject is retained and rejected", (t) => {
+  const repoDir = localRepository(t, "empty-subject");
+  const baseSha = git(repoDir, ["rev-parse", "HEAD"]);
+  git(repoDir, ["commit", "--allow-empty", "--allow-empty-message", "-m", ""]);
+  const headSha = git(repoDir, ["rev-parse", "HEAD"]);
+
+  assert.deepEqual(subjectsInRange(baseSha, headSha, { repoDir }), [""]);
+  assert.throws(
+    () => assertRange(baseSha, headSha, { repoDir }),
+    /commit subject is not allowed:[\s\S]*""/,
+  );
 });
 
 test("the title CLI accepts valid input and denies invalid input", () => {

--- a/scripts/conventional-commit-subjects.test.mjs
+++ b/scripts/conventional-commit-subjects.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  ALLOWED_TYPES,
+  assertSubject,
+  parseSubject,
+  subjectsInRange,
+} from "./conventional-commit-subjects.mjs";
+
+const subjectScript = fileURLToPath(
+  new URL("./conventional-commit-subjects.mjs", import.meta.url),
+);
+const repoRoot = dirname(dirname(subjectScript));
+
+function subjectCli(command, environment) {
+  return spawnSync(process.execPath, [subjectScript, command], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...environment },
+  });
+}
+
+function git(repoDir, args) {
+  return execFileSync(
+    "git",
+    [
+      "-c",
+      "commit.gpgSign=false",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "-c",
+      "user.name=Facility Tests",
+      "-c",
+      "user.email=facility-tests@example.invalid",
+      ...args,
+    ],
+    {
+      cwd: repoDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+      },
+    },
+  ).trim();
+}
+
+function localRepository(t, name) {
+  const repoDir = mkdtempSync(join(tmpdir(), `facility-subjects-${name}-`));
+  t.after(() => rmSync(repoDir, { recursive: true, force: true }));
+  git(repoDir, ["init", "--initial-branch=main"]);
+  writeFileSync(join(repoDir, "change.txt"), "base\n");
+  git(repoDir, ["add", "change.txt"]);
+  git(repoDir, ["commit", "-m", "chore: establish the fixture"]);
+  return repoDir;
+}
+
+function commitChange(repoDir, content, subject) {
+  writeFileSync(join(repoDir, "change.txt"), `${content}\n`);
+  git(repoDir, ["add", "change.txt"]);
+  git(repoDir, ["commit", "-m", subject]);
+}
+
+test("the repository's allowed Conventional Commit types are accepted", () => {
+  const expected = [
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "perf",
+    "test",
+    "build",
+    "ci",
+    "chore",
+    "revert",
+  ];
+
+  assert.deepEqual(ALLOWED_TYPES, expected);
+  for (const type of expected) {
+    assert.deepEqual(parseSubject(`${type}: describe the change`), {
+      type,
+      scope: null,
+      breaking: false,
+      summary: "describe the change",
+    });
+  }
+});
+
+test("breaking markers and established punctuation in scopes are accepted", () => {
+  assert.deepEqual(parseSubject("feat(web+api)!: replace the public contract"), {
+    type: "feat",
+    scope: "web+api",
+    breaking: true,
+    summary: "replace the public contract",
+  });
+
+  for (const scope of ["web+api", "api/auth", "registry,sandbox"]) {
+    assert.deepEqual(assertSubject(`fix(${scope}): keep the existing scope`), {
+      type: "fix",
+      scope,
+      breaking: false,
+      summary: "keep the existing scope",
+    });
+  }
+  assert.equal(assertSubject("perf!: remove the legacy path").breaking, true);
+});
+
+test("unknown types and malformed subjects are rejected", () => {
+  for (const subject of [
+    "unknown: describe the change",
+    "fix(): describe the change",
+    "fix(api(auth)): describe the change",
+    "fix(api):",
+    "fix(api):   ",
+  ]) {
+    assert.throws(() => assertSubject(subject), undefined, subject);
+  }
+});
+
+test("commit ranges are read as non-merge subjects from base-exclusive history", () => {
+  const calls = [];
+  const subjects = subjectsInRange("base-sha", "head-sha", {
+    repoDir: "/fixture/repository",
+    exec(command, args, options) {
+      calls.push({ command, args, options });
+      return "feat: add the capability\nfix(api/auth)!: close the gap\n";
+    },
+  });
+
+  assert.deepEqual(subjects, ["feat: add the capability", "fix(api/auth)!: close the gap"]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "git");
+  assert.deepEqual(calls[0].args, [
+    "log",
+    "--no-merges",
+    "--format=%s",
+    "base-sha..head-sha",
+  ]);
+  assert.equal(calls[0].options.cwd, "/fixture/repository");
+  assert.equal(calls[0].options.encoding, "utf8");
+});
+
+test("commit ranges follow the subjects that survive squash and no-ff merges", (t) => {
+  const squashRepo = localRepository(t, "squash");
+  const squashBase = git(squashRepo, ["rev-parse", "HEAD"]);
+  git(squashRepo, ["checkout", "-b", "squash-feature"]);
+  commitChange(squashRepo, "squash step one", "fix(web+api): prepare the squash");
+  commitChange(squashRepo, "squash step two", "feat(api/auth): finish the squash");
+  git(squashRepo, ["checkout", "main"]);
+  git(squashRepo, ["merge", "--squash", "squash-feature"]);
+  git(squashRepo, ["commit", "-m", "feat(registry,sandbox)!: land one squash subject"]);
+  const squashHead = git(squashRepo, ["rev-parse", "HEAD"]);
+
+  assert.deepEqual(subjectsInRange(squashBase, squashHead, { repoDir: squashRepo }), [
+    "feat(registry,sandbox)!: land one squash subject",
+  ]);
+
+  const mergeRepo = localRepository(t, "merge");
+  const mergeBase = git(mergeRepo, ["rev-parse", "HEAD"]);
+  git(mergeRepo, ["checkout", "-b", "merge-feature"]);
+  commitChange(mergeRepo, "merge step one", "feat(api/auth): add the first commit");
+  commitChange(mergeRepo, "merge step two", "fix(registry,sandbox): add the second commit");
+  git(mergeRepo, ["checkout", "main"]);
+  git(mergeRepo, ["merge", "--no-ff", "merge-feature", "-m", "Merge branch 'merge-feature'"]);
+  const mergeHead = git(mergeRepo, ["rev-parse", "HEAD"]);
+
+  assert.deepEqual(subjectsInRange(mergeBase, mergeHead, { repoDir: mergeRepo }), [
+    "fix(registry,sandbox): add the second commit",
+    "feat(api/auth): add the first commit",
+  ]);
+});
+
+test("the title CLI accepts valid input and denies invalid input", () => {
+  const accepted = subjectCli("title", {
+    TITLE: "feat(web+api)!: replace the public contract",
+  });
+  assert.equal(accepted.status, 0, accepted.stderr);
+
+  const denied = subjectCli("title", { TITLE: "unknown: hide a release change" });
+  assert.notEqual(denied.status, 0, denied.stdout);
+  assert.match(denied.stderr, /unknown: hide a release change/);
+});
+
+test("workflows validate edited titles, pull request commits, and landed main commits", () => {
+  const titleWorkflow = readFileSync(
+    new URL("../.github/workflows/pull-request-title.yml", import.meta.url),
+    "utf8",
+  );
+  const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+  const titleTriggers = titleWorkflow.split(/^jobs:/m)[0];
+  assert.match(titleTriggers, /pull_request:\s*\n\s+types:/);
+  for (const activity of ["opened", "synchronize", "reopened", "edited"]) {
+    assert.match(titleTriggers, new RegExp(`\\b${activity}\\b`));
+  }
+  assert.match(titleWorkflow, /node scripts\/conventional-commit-subjects\.mjs title\b/);
+
+  const rangeJobs = ciWorkflow
+    .split(/(?=^  [a-zA-Z0-9_-]+:\s*$)/m)
+    .filter((job) => /node scripts\/conventional-commit-subjects\.mjs range\b/.test(job));
+  assert(rangeJobs.length > 0, "ci.yml must invoke the commit-range validator");
+  assert(
+    rangeJobs.some((job) => /github\.event_name == 'pull_request'/.test(job)),
+    "ci.yml must validate pull request commits",
+  );
+  assert(
+    rangeJobs.some((job) => /github\.ref == 'refs\/heads\/main'/.test(job)),
+    "ci.yml must revalidate commits landed on main",
+  );
+});

--- a/scripts/conventional-commit-subjects.test.mjs
+++ b/scripts/conventional-commit-subjects.test.mjs
@@ -18,9 +18,9 @@ const subjectScript = fileURLToPath(
 );
 const repoRoot = dirname(dirname(subjectScript));
 
-function subjectCli(command, environment) {
+function subjectCli(command, environment, cwd = repoRoot) {
   return spawnSync(process.execPath, [subjectScript, command], {
-    cwd: repoRoot,
+    cwd,
     encoding: "utf8",
     env: { ...process.env, ...environment },
   });
@@ -117,8 +117,15 @@ test("breaking markers and established punctuation in scopes are accepted", () =
 test("unknown types and malformed subjects are rejected", () => {
   for (const subject of [
     "unknown: describe the change",
+    "  fix: describe the change",
     "fix(): describe the change",
     "fix(api(auth)): describe the change",
+    "fix((): describe the change",
+    "fix(api)): describe the change",
+    "fix( ): describe the change",
+    "fix(api\nauth): describe the change",
+    "fix(api): describe\u001b[31m the change",
+    "fix: render \u009b31mred output",
     "fix(api):",
     "fix(api):   ",
   ]) {
@@ -132,7 +139,7 @@ test("commit ranges are read as non-merge subjects from base-exclusive history",
     repoDir: "/fixture/repository",
     exec(command, args, options) {
       calls.push({ command, args, options });
-      return "feat: add the capability\0fix(api/auth)!: close the gap\0";
+      return "feat: add the capability\n\nExplain the change.\0fix(api/auth)!: close the gap\n\0";
     },
   });
 
@@ -143,7 +150,7 @@ test("commit ranges are read as non-merge subjects from base-exclusive history",
     "log",
     "-z",
     "--no-merges",
-    "--format=%s",
+    "--format=%B",
     "base-sha..head-sha",
   ]);
   assert.equal(calls[0].options.cwd, "/fixture/repository");
@@ -213,6 +220,45 @@ test("an empty commit subject is retained and rejected", (t) => {
   );
 });
 
+test("the exact first commit-message line is validated by the range CLI", (t) => {
+  const repoDir = localRepository(t, "multiline-header");
+  const baseSha = git(repoDir, ["rev-parse", "HEAD"]);
+  git(repoDir, [
+    "commit",
+    "--allow-empty",
+    "--cleanup=verbatim",
+    "-m",
+    "fix:\nsummary continued on a second line",
+  ]);
+  const headSha = git(repoDir, ["rev-parse", "HEAD"]);
+
+  assert.deepEqual(subjectsInRange(baseSha, headSha, { repoDir }), ["fix:"]);
+  const denied = subjectCli("range", { BASE_SHA: baseSha, HEAD_SHA: headSha }, repoDir);
+  assert.notEqual(denied.status, 0, denied.stdout);
+  assert.match(denied.stderr, /commit subject is not allowed:[\s\S]*"fix:"/);
+});
+
+test("leading whitespace in a landed subject is retained and rejected", (t) => {
+  const repoDir = localRepository(t, "leading-whitespace");
+  const baseSha = git(repoDir, ["rev-parse", "HEAD"]);
+  git(repoDir, [
+    "commit",
+    "--allow-empty",
+    "--cleanup=verbatim",
+    "-m",
+    "  fix: do not normalize the version input",
+  ]);
+  const headSha = git(repoDir, ["rev-parse", "HEAD"]);
+
+  assert.deepEqual(subjectsInRange(baseSha, headSha, { repoDir }), [
+    "  fix: do not normalize the version input",
+  ]);
+  assert.throws(
+    () => assertRange(baseSha, headSha, { repoDir }),
+    /commit subject is not allowed:[\s\S]*  fix: do not normalize/,
+  );
+});
+
 test("the title CLI accepts valid input and denies invalid input", () => {
   const accepted = subjectCli("title", {
     TITLE: "feat(web+api)!: replace the public contract",
@@ -224,30 +270,45 @@ test("the title CLI accepts valid input and denies invalid input", () => {
   assert.match(denied.stderr, /unknown: hide a release change/);
 });
 
-test("workflows validate edited titles, pull request commits, and landed main commits", () => {
-  const titleWorkflow = readFileSync(
+test("workflows validate edited titles, retargeted ranges, and landed main commits", () => {
+  const subjectWorkflow = readFileSync(
     new URL("../.github/workflows/pull-request-title.yml", import.meta.url),
     "utf8",
   );
   const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
 
-  const titleTriggers = titleWorkflow.split(/^jobs:/m)[0];
-  assert.match(titleTriggers, /pull_request:\s*\n\s+types:/);
+  const subjectTriggers = subjectWorkflow.split(/^jobs:/m)[0];
+  assert.match(subjectTriggers, /push:\s*\n\s+branches:\s*\[main\]/);
+  assert.match(subjectTriggers, /pull_request:\s*\n\s+types:/);
   for (const activity of ["opened", "synchronize", "reopened", "edited"]) {
-    assert.match(titleTriggers, new RegExp(`\\b${activity}\\b`));
+    assert.match(subjectTriggers, new RegExp(`\\b${activity}\\b`));
   }
-  assert.match(titleWorkflow, /node scripts\/conventional-commit-subjects\.mjs title\b/);
+  assert.match(subjectWorkflow, /node scripts\/conventional-commit-subjects\.mjs title\b/);
 
-  const rangeJobs = ciWorkflow
-    .split(/(?=^  [a-zA-Z0-9_-]+:\s*$)/m)
-    .filter((job) => /node scripts\/conventional-commit-subjects\.mjs range\b/.test(job));
-  assert(rangeJobs.length > 0, "ci.yml must invoke the commit-range validator");
-  assert(
-    rangeJobs.some((job) => /github\.event_name == 'pull_request'/.test(job)),
-    "ci.yml must validate pull request commits",
+  const jobs = subjectWorkflow.split(/(?=^  [a-zA-Z0-9_-]+:\s*$)/m);
+  const titleJobs = jobs.filter((job) =>
+    /node scripts\/conventional-commit-subjects\.mjs title\b/.test(job),
   );
-  assert(
-    rangeJobs.some((job) => /github\.ref == 'refs\/heads\/main'/.test(job)),
-    "ci.yml must revalidate commits landed on main",
+  assert.equal(titleJobs.length, 1);
+  assert.match(titleJobs[0], /if: github\.event_name == 'pull_request'/);
+
+  const rangeJobs = jobs
+    .filter((job) => /node scripts\/conventional-commit-subjects\.mjs range\b/.test(job));
+  assert.equal(rangeJobs.length, 1, "the lightweight workflow must validate commit ranges");
+  const rangeJob = rangeJobs[0];
+  assert.doesNotMatch(rangeJob.split(/^\s+steps:/m)[0], /^\s+if:/m);
+  assert.match(rangeJob, /fetch-depth:\s*0/);
+  assert.match(
+    rangeJob,
+    /BASE_SHA: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/,
+  );
+  assert.match(
+    rangeJob,
+    /HEAD_SHA: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/,
+  );
+  assert.doesNotMatch(
+    ciWorkflow,
+    /node scripts\/conventional-commit-subjects\.mjs range\b/,
+    "title or base edits must not rerun the full acceptance workflow",
   );
 });


### PR DESCRIPTION
Groundwork for releasing on every merge to `main`: before a version can be computed from commit subjects, the subjects have to be trustworthy — and whoever writes them, human or agent, has to know they are load-bearing.

## The rule, where it is actually read

`AGENTS.md` defines the subject-to-version table and the two important failure modes:

- **a user-visible change hidden behind `chore:` does not trigger a release** — it can sit on `main` until another change triggers one, then ship unannounced in someone else's notes;
- **a breaking change without `!` ships at the wrong version level.**

`CLAUDE.md` points at the same rule, matching how that file already delegates to `AGENTS.md`.

## The checks

The validation follows the commits that each GitHub merge method actually leaves on `main`:

- **Squash merge:** the squash commit is the surviving, version-bearing commit. Its subject comes from the Conventional Commit PR title (or, for GitHub's single-commit case, from the already-validated commit subject).
- **Merge commit:** the synthetic `Merge ...` commit is ignored; every non-merge commit brought in by the PR remains version-bearing and is validated.
- **Rebase merge:** the rewritten non-merge commits survive and each subject is validated.

A dedicated lightweight workflow reruns the title and commit-range checks on `opened`, `synchronize`, `reopened`, and `edited` (including a base-branch retarget). On pull requests it also classifies the full non-merge commit messages — including `BREAKING CHANGE:` footers — and requires their maximum `0.x` release impact to exactly match the title. That prevents the same PR from becoming no-release under squash but patch/minor under merge or rebase. The equality rule intentionally applies to one-commit PRs too: the title remains a truthful release declaration and the invariant survives a future squash-title setting change. The same workflow validates the actual landed range again on pushes to `main` as a post-landing guard.

Repository rules must make the pull-request jobs required and require an up-to-date branch or merge queue; otherwise those checks are advisory. The future release workflow must invoke this same classifier inside its own gated job before deriving a version, rather than relying on a separate workflow run.

The shared validator accepts the repository's established scopes such as `web+api`, `api/auth`, and `registry,sandbox`, and the runner and CLI delivery checks use the same grammar. Tests exercise malformed and control-character inputs, empty and whitespace-prefixed subjects, exact raw commit-message headers, release-impact mismatches, preserved breaking-change footers, safe GitHub headline limits, and real local Git histories for squash, merge-commit, and rebase flows.

The signed GitHub App delivery path now classifies the exact commit message GitHub will store, preserves body indentation, and rejects malformed subject/body separation before requesting a write token. Builder metadata must match the PR title's impact; repair runs may not raise the existing PR range's impact. Deterministic integration coverage traverses the real workspace clone/diff, Facility push-token and event HTTP calls, and a stateful loopback GitHub fake. It covers builder and repair success plus impact mismatches, malformed metadata, expired and revoked tokens, cross-repository scope denial, stale/replayed heads, missing commit OIDs, and credential redaction without live credentials or network access.

## What comes next, separately

The release-on-merge workflow itself: read the full non-merge messages that actually landed since the last successful release tag, decide the next version with this same classifier, run the full acceptance suite, publish, and then write the tag as the record of what was published. That lands in its own pull request because it rewrites the release contract in `scripts/release.mjs` and deserves its own review.

Salvaged from #53, which is closed.
