### PR TITLE
feat(release)!: publish from the merge, with the commits deciding the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
     branches: [main]
   pull_request:
 
+# A release decision is a read of shared tag state. Serialize main pushes at
+# the workflow boundary so a later merge cannot decide from that state until
+# the prior merge has either recorded its release or failed visibly.
+concurrency:
+  group: ci-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # What the commit subjects since the last release add up to. Runs first so
   # every publishing job can gate on one answer instead of recomputing it.
@@ -205,9 +212,9 @@ jobs:
         if: steps.policy.outputs.required != 'true'
         run: echo "Sandbox E2E skipped by policy — ${{ steps.policy.outputs.reason }}."
 
-  # Keep publication in the original tag run so npm provenance identifies the
-  # tag and commit that passed every acceptance job. A downstream workflow_run
-  # would instead attest the default branch SHA.
+  # Keep publication in the original accepted main-push run so npm provenance
+  # identifies the commit that passed every acceptance job. A downstream
+  # workflow_run would instead attest the default branch SHA.
   publish-npm:
     if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
     needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e]
@@ -231,9 +238,9 @@ jobs:
       version: ${{ needs.decide-release.outputs.version }}
 
   # The tag is written last, and only after both registries accepted the
-  # release. It records what shipped; it is not the request to ship it. A run
-  # that fails before here leaves no tag, so the next merge retries the same
-  # version instead of skipping it.
+  # release. It records what shipped; it is not the request to ship it. Retry a
+  # failed publisher in this same run so an already-successful peer is not
+  # asked to republish an immutable version.
   record-release:
     needs: [decide-release, publish-npm, publish-images]
     if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
@@ -255,13 +262,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "$TAG already exists; the release was recorded by an earlier run."
-            exit 0
+          head_sha="$(git rev-parse HEAD)"
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            tag_sha="$(git rev-parse "refs/tags/$TAG^{commit}")"
+            if [ "$tag_sha" != "$head_sha" ]; then
+              echo "$TAG points to $tag_sha, not released commit $head_sha" >&2
+              exit 1
+            fi
+            echo "$TAG already points to the released commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "$VERSION"
+            git push origin "$TAG"
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "$VERSION"
-          git push origin "$TAG"
           printf '%s\n' "$NOTES" > "$RUNNER_TEMP/notes.md"
-          gh release create "$TAG" --title "$VERSION" --notes-file "$RUNNER_TEMP/notes.md" --verify-tag
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG already exists."
+          else
+            gh release create "$TAG" --title "$VERSION" --notes-file "$RUNNER_TEMP/notes.md" --verify-tag
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,31 @@ name: ci
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
 
 jobs:
+  # What the commit subjects since the last release add up to. Runs first so
+  # every publishing job can gate on one answer instead of recomputing it.
+  decide-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      release: ${{ steps.decision.outputs.release }}
+      version: ${{ steps.decision.outputs.version }}
+      tag: ${{ steps.decision.outputs.tag }}
+      notes: ${{ steps.decision.outputs.notes }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: decision
+        run: node scripts/version.mjs
+
   verify:
     runs-on: ubuntu-latest
     timeout-minutes: 35
@@ -33,16 +54,36 @@ jobs:
       - name: Release-shaped verification
         run: pnpm verify
 
-      - name: Validate the public release tag
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
+  # Stamp the decided version and build the archive once, in a job with no
+  # credentials. The npm environment later receives this exact, already-tested
+  # archive rather than running package lifecycle code with publication rights.
+  # The stamp is never committed: the tag written at the end is the record.
+  package-release:
+    needs: [decide-release, verify]
+    if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Stamp the decided version
+        run: node scripts/release.mjs stamp "${{ needs.decide-release.outputs.version }}"
+
+      - name: Validate the release
+        env:
+          FACILITY_RELEASE_VERSION: ${{ needs.decide-release.outputs.version }}
         run: node scripts/release.mjs validate
 
-      # Build the package once in the nonprivileged acceptance job. The npm
-      # environment later receives this exact, already-tested archive rather
-      # than running package lifecycle code with publication credentials.
       - name: Pack the release candidate
         id: candidate
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
         shell: bash
         run: |
           set -euo pipefail
@@ -54,7 +95,6 @@ jobs:
           echo "path=$candidate" >> "$GITHUB_OUTPUT"
 
       - name: Install the release candidate and run the binary
-        if: steps.candidate.outcome == 'success'
         shell: bash
         env:
           CANDIDATE: ${{ steps.candidate.outputs.path }}
@@ -68,7 +108,6 @@ jobs:
           ./node_modules/.bin/facility --help
 
       - name: Preserve the tested release candidate
-        if: steps.candidate.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: facility-release-package
@@ -170,19 +209,59 @@ jobs:
   # tag and commit that passed every acceptance job. A downstream workflow_run
   # would instead attest the default branch SHA.
   publish-npm:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
-    needs: [verify, self-host-build, sandbox-e2e]
+    if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
+    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e]
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.decide-release.outputs.version }}
 
-  # Publish containers from the same accepted tag run as npm. The reusable
-  # workflow revalidates the release before granting its jobs packages: write.
+  # Publish containers from the same accepted run as npm. The reusable workflow
+  # revalidates the release before granting its jobs packages: write.
   publish-images:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
-    needs: [verify, self-host-build, sandbox-e2e]
+    if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
+    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e]
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/images.yml
+    with:
+      version: ${{ needs.decide-release.outputs.version }}
+
+  # The tag is written last, and only after both registries accepted the
+  # release. It records what shipped; it is not the request to ship it. A run
+  # that fails before here leaves no tag, so the next merge retries the same
+  # version instead of skipping it.
+  record-release:
+    needs: [decide-release, publish-npm, publish-images]
+    if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Tag the released commit and publish its notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.decide-release.outputs.tag }}
+          VERSION: ${{ needs.decide-release.outputs.version }}
+          NOTES: ${{ needs.decide-release.outputs.notes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "$TAG already exists; the release was recorded by an earlier run."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$VERSION"
+          git push origin "$TAG"
+          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/notes.md"
+          gh release create "$TAG" --title "$VERSION" --notes-file "$RUNNER_TEMP/notes.md" --verify-tag

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,6 +1,7 @@
 # Publishes the service images to GHCR so a self-hoster does not have to build
 # them. Release publication is called by ci.yml only after every acceptance job
-# passes; a manual run publishes a commit-SHA tag and never a version tag.
+# passes; a manual run publishes a commit-SHA tag and never a version tag. The
+# version comes from the commits on main, not from a tag someone pushed.
 #
 # Builds first push addressable digests without deployable tags. Only after all
 # five builds succeed does the promote job point the six service tags at those
@@ -19,6 +20,11 @@ name: images
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: The version decided from the commits
+        type: string
+        required: true
   workflow_dispatch:
 
 permissions:
@@ -33,7 +39,7 @@ env:
 
 jobs:
   plan:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.repository.visibility == 'public')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -45,10 +51,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The version lives in the tag, not in the checkout, so the same stamp the
+      # npm archive got is applied here before the release is revalidated.
+      # A manual run has no version and publishes only a commit-SHA tag.
+      - name: Stamp the decided version
+        if: inputs.version != ''
+        run: node scripts/release.mjs stamp "${{ inputs.version }}"
+
       - name: Validate the publication policy
         id: plan
         env:
           GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          FACILITY_RELEASE_VERSION: ${{ inputs.version }}
         run: node scripts/images.mjs plan
 
   build:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -51,9 +51,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The version lives in the tag, not in the checkout, so the same stamp the
-      # npm archive got is applied here before the release is revalidated.
-      # A manual run has no version and publishes only a commit-SHA tag.
+      # The decided version is not committed, so apply the same stamp the npm
+      # archive got before revalidating this isolated checkout. A manual run has
+      # no version and publishes only a commit-SHA tag.
       - name: Stamp the decided version
         if: inputs.version != ''
         run: node scripts/release.mjs stamp "${{ inputs.version }}"
@@ -100,6 +100,12 @@ jobs:
             context: runner
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # The plan job's stamp cannot cross the job boundary. Stamp every matrix
+      # checkout so the built image contains the version on its promoted tag.
+      - name: Stamp the decided version
+        if: inputs.version != ''
+        run: node scripts/release.mjs stamp "${{ inputs.version }}"
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,11 @@ jobs:
         with:
           node-version: 22
 
+      # Job filesystems are isolated. Reapply the version used to build the
+      # accepted tarball before validating it against this fresh checkout.
+      - name: Stamp the decided version
+        run: node scripts/release.mjs stamp "${{ inputs.version }}"
+
       - name: Install the trusted-publishing npm client
         run: |
           npm install --global npm@11.15.0
@@ -96,7 +101,7 @@ jobs:
           name: facility-release-package
           path: ${{ runner.temp }}/facility-release
 
-      - name: Revalidate the tag and release artifact
+      - name: Revalidate the release and its artifact
         id: candidate
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@
 #
 # - A manual run is always a credential-free dry run. There is no input that
 #   can turn it into a release.
-# - ci.yml calls this workflow from a public version-tag run only after every
-#   acceptance job passes. Keeping publication in that original run gives npm
-#   provenance the tested tag and commit rather than a downstream default-branch
-#   identity.
+# - ci.yml calls this workflow from a public push of main, only after every
+#   acceptance job passes and only when the commit subjects decided a version.
+#   Keeping publication in that original run gives npm provenance the tested
+#   commit rather than a downstream identity.
 #
 # The first public release needs a granular npm token in the protected `npm`
 # environment as NPM_BOOTSTRAP_TOKEN. After that one publish, configure npm
@@ -16,6 +16,11 @@ name: release
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: The version decided from the commits, stamped into the archive
+        type: string
+        required: true
   workflow_dispatch:
 
 permissions:
@@ -61,7 +66,7 @@ jobs:
           node scripts/release.mjs dry-run "$candidate"
 
   publish:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.event.repository.visibility == 'public'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.repository.visibility == 'public'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -96,7 +101,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/release.mjs validate
+          FACILITY_RELEASE_VERSION="${{ inputs.version }}" node scripts/release.mjs validate
           shopt -s nullglob
           tarballs=("$RUNNER_TEMP/facility-release/"*.tgz)
           if [ "${#tarballs[@]}" -ne 1 ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,21 +100,40 @@ request so the change can be reviewed and reverted independently.
 
 ## Releasing (maintainers)
 
-Publishing is tag-driven. A `vX.Y.Z` tag starts `.github/workflows/ci.yml`,
-which must pass root verification, the self-host build, and the required
-sandbox E2E before it calls the reusable release workflow. Do not run
-`npm publish` locally or invoke the release workflow as a substitute for those
-gates; its manual entry point is a dry run.
+**Merging to `main` is the release.** There is no version-bump commit, no
+release branch, and no tag to push by hand: `.github/workflows/ci.yml` decides
+from the commit subjects since the last release whether this merge publishes
+and as what version, then verifies, publishes, and writes the tag.
 
-1. Bump the version in `package.json` and `packages/cli/package.json` according
-   to semver (before 1.0, a minor release may contain breaking changes).
-2. Run `pnpm verify` and the build for every publishable artifact, then merge
-   the release change through the normal reviewed pull-request path.
-3. Tag the release commit on `main` as `vX.Y.Z` and push the tag. CI refuses a
-   tag whose version, commit, visibility, or acceptance results do not match the
-   release contract.
-4. After the publish job succeeds, write release notes in terms of behavior,
-   not commit titles.
+The order matters, and it is the whole safety argument:
+
+1. **Decide** — `scripts/version.mjs` reads the subjects since the last `v*`
+   tag. Only `feat`, `fix`, `perf`, and anything marked breaking count. If
+   nothing qualifies, the run ends here and nothing is published.
+2. **Verify** — root verification, the self-host build, and the sandbox E2E, on
+   the merged commit.
+3. **Package** — the decided version is stamped into both `package.json` files
+   *inside the run*, the archive is built, installed the way `npx` would, and
+   its binary is executed. Nothing is committed; the checkout's version number
+   is not the source of truth.
+4. **Publish** — npm and, once the repository is public, the images, from that
+   exact archive and digest set.
+5. **Record** — only now is the annotated tag written and the GitHub release
+   published with the generated notes.
+
+A run that fails anywhere before step 5 leaves no tag, so the next merge
+recomputes the same version and tries again rather than skipping it. A version
+that npm already has is refused outright, whatever the decision said.
+
+Do not run `npm publish` locally or invoke the release workflow as a substitute
+for those gates; its manual entry point is a dry run.
+
+### Commit subjects decide the version
+
+Subjects follow [Conventional Commits](https://www.conventionalcommits.org/),
+and CI checks the pull request title, because a squash merge makes that title
+the subject on `main`. The rules — and the two ways a careless subject hurts a
+user — are in [AGENTS.md](AGENTS.md#commit-subjects-set-the-released-version).
 
 ### First npm publish only
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,10 @@ and as what version, then verifies, publishes, and writes the tag.
 
 The order matters, and it is the whole safety argument:
 
-1. **Decide** — `scripts/version.mjs` reads the subjects since the last `v*`
-   tag. Only `feat`, `fix`, `perf`, and anything marked breaking count. If
-   nothing qualifies, the run ends here and nothing is published.
+1. **Decide** — `scripts/version.mjs` reads the full non-merge commit messages
+   since the last `v*` tag. Only `feat`, `fix`, `perf`, `revert`, and anything
+   marked breaking count. If nothing qualifies, the run ends here and nothing
+   is published.
 2. **Verify** — root verification, the self-host build, and the sandbox E2E, on
    the merged commit.
 3. **Package** — the decided version is stamped into both `package.json` files
@@ -121,9 +122,13 @@ The order matters, and it is the whole safety argument:
 5. **Record** — only now is the annotated tag written and the GitHub release
    published with the generated notes.
 
-A run that fails anywhere before step 5 leaves no tag, so the next merge
-recomputes the same version and tries again rather than skipping it. A version
-that npm already has is refused outright, whatever the decision said.
+A run that fails before both publishers finish leaves no tag. Retry the failed
+jobs in that same workflow run so they reuse the accepted artifacts and retain
+the successful publisher's result. Exact npm artifacts and image digests are
+idempotent on that retry; the publishers refuse the same version with different
+contents. Do not use another merge as the retry. If recording fails after the
+tag was pushed, rerunning that failed job verifies the tag still targets the
+released commit and creates the missing GitHub Release.
 
 Do not run `npm publish` locally or invoke the release workflow as a substitute
 for those gates; its manual entry point is a dry run.
@@ -147,8 +152,19 @@ npm cannot attach a trusted publisher until the package exists. Bootstrap
 2. Protect `v*` tag creation with a repository ruleset. Create the GitHub
    environment named `npm`, require maintainer approval for deployment, and
    store the token there as the `NPM_BOOTSTRAP_TOKEN` environment secret.
-3. Push the first release tag through the tag-driven flow above. The release
-   code accepts this credential only while the package is absent from npm.
+3. Before merging the release-on-merge workflow, establish the inert history
+   boundary it will read. For this repository, tag the existing version:
+
+   ```bash
+   git tag -a v0.3.0 -m "0.3.0 — release-on-merge baseline"
+   git push origin v0.3.0
+   ```
+
+   Tag pushes do not publish; this only prevents legacy history from entering
+   the first automated decision.
+4. Merge the first release-impacting pull request to `main`. The main-push
+   workflow accepts this credential only while the package is absent from npm;
+   it writes the release tag after npm and the images have both published.
 
 As soon as the first version exists, configure the package's
 [npm trusted publisher](https://docs.npmjs.com/trusted-publishers/) with these
@@ -164,7 +180,8 @@ Use `ci.yml`, not `release.yml`: npm validates the caller when a reusable
 workflow contains the publish command. Then delete the `NPM_BOOTSTRAP_TOKEN`
 GitHub secret, revoke the granular token on npm, and set the package's
 **Publishing access** to **Require two-factor authentication and disallow
-tokens**. Later tags publish through short-lived OIDC credentials only.
+tokens**. Later release-impacting merges publish through short-lived OIDC
+credentials; their tags are written afterwards as records.
 
 ### One-time GitHub Pages setup
 

--- a/scripts/conventional-commit-subjects.mjs
+++ b/scripts/conventional-commit-subjects.mjs
@@ -61,7 +61,7 @@ export function assertSubject(subject, { label = "subject" } = {}) {
   );
 }
 
-function subjectOf(message) {
+export function subjectOf(message) {
   return message.split(/\r?\n/, 1)[0] ?? "";
 }
 
@@ -85,21 +85,25 @@ export function releaseImpact(message) {
   return PATCH_TYPES.has(parsed.type) ? "patch" : "none";
 }
 
-export function messagesInRange(
-  baseSha,
-  headSha,
+export function messagesForRevision(
+  revision,
   { repoDir = process.cwd(), exec = execFileSync } = {},
 ) {
-  if (!baseSha || !headSha) throw new Error("both BASE_SHA and HEAD_SHA are required");
+  if (!revision) throw new Error("a git revision is required");
   const output = exec(
     "git",
-    ["log", "-z", "--no-merges", "--format=%B", `${baseSha}..${headSha}`],
+    ["log", "-z", "--no-merges", "--format=%B", revision],
     { cwd: repoDir, encoding: "utf8" },
   );
   if (!output) return [];
   const messages = output.split("\0");
   if (messages.at(-1) === "") messages.pop();
   return messages;
+}
+
+export function messagesInRange(baseSha, headSha, options) {
+  if (!baseSha || !headSha) throw new Error("both BASE_SHA and HEAD_SHA are required");
+  return messagesForRevision(`${baseSha}..${headSha}`, options);
 }
 
 export function subjectsInRange(baseSha, headSha, options) {

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -32,10 +32,11 @@ export function publicationPlan({ eventName, ref, visibility, sha, release }) {
   if (!release || typeof release.version !== "string" || typeof release.tag !== "string") {
     throw new Error("release image publication requires a validated release");
   }
-  if (release.tag !== `v${release.version}` || ref !== `refs/tags/${release.tag}`) {
-    throw new Error(
-      `release image ref ${ref || "missing"} does not match validated tag ${release.tag}`,
-    );
+  if (release.tag !== `v${release.version}`) {
+    throw new Error(`validated release tag ${release.tag} does not match v${release.version}`);
+  }
+  if (ref !== "refs/heads/main") {
+    throw new Error(`release images come from main, not ${ref || "an unknown ref"}`);
   }
   assertDockerTag(release.version);
   return { mode: "release", tags: [shaTag, release.version] };

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -63,10 +63,7 @@ test("malformed, private, and unvalidated release inputs fail closed", () => {
     [{ release: { tag: "vlatest", version: "0.3.0" } }, /does not match v0\.3\.0/],
     [{ ref: "refs/tags/v0.3.0" }, /release images come from main/],
     [{ ref: "refs/heads/feature" }, /release images come from main/],
-    [
-      { release: { tag: "v0.3.0,latest", version: "0.3.0,latest" } },
-      /invalid container tag/,
-    ],
+    [{ release: { tag: "v0.3.0,latest", version: "0.3.0,latest" } }, /invalid container tag/],
   ];
   for (const [override, message] of invalid) {
     assert.throws(() => publicationPlan({ ...valid, ...override }), message);

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -120,6 +120,17 @@ test("CI gates release images and the reusable publisher stages digests before p
     /group: images-\$\{\{ github\.repository \}\}\n {2}cancel-in-progress: false/,
   );
   assert.match(imagesWorkflow, /node scripts\/images\.mjs plan/);
+  const buildJob = imagesWorkflow.split("\n  promote:")[0].split("\n  build:")[1];
+  assert.ok(buildJob, "images workflow must contain a build job");
+  assert.match(
+    buildJob,
+    /- name: Stamp the decided version\n {8}if: inputs\.version != ''\n {8}run: node scripts\/release\.mjs stamp "\$\{\{ inputs\.version \}\}"/,
+  );
+  assert.ok(
+    buildJob.indexOf("Stamp the decided version") <
+      buildJob.indexOf("Build and push the addressable digest"),
+    "the isolated build checkout must be stamped before Docker consumes it",
+  );
   assert.match(imagesWorkflow, /push-by-digest=true,name-canonical=true,push=true/);
   assert.match(imagesWorkflow, /promote:\n {4}needs: \[plan, build\]/);
   assert.match(imagesWorkflow, /node scripts\/images\.mjs promote/);

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -38,7 +38,7 @@ test("an accepted release publishes its immutable SHA and matching version tags"
   assert.deepEqual(
     publicationPlan({
       eventName: "push",
-      ref: "refs/tags/v0.3.0",
+      ref: "refs/heads/main",
       visibility: "public",
       sha,
       release: { tag: "v0.3.0", version: "0.3.0" },
@@ -50,7 +50,7 @@ test("an accepted release publishes its immutable SHA and matching version tags"
 test("malformed, private, and unvalidated release inputs fail closed", () => {
   const valid = {
     eventName: "push",
-    ref: "refs/tags/v0.3.0",
+    ref: "refs/heads/main",
     visibility: "public",
     sha,
     release: { tag: "v0.3.0", version: "0.3.0" },
@@ -60,12 +60,11 @@ test("malformed, private, and unvalidated release inputs fail closed", () => {
     [{ eventName: "pull_request" }, /does not accept pull_request/],
     [{ visibility: "private" }, /disabled until the repository is public/],
     [{ release: undefined }, /requires a validated release/],
-    [{ ref: "refs/tags/vlatest" }, /does not match validated tag/],
+    [{ release: { tag: "vlatest", version: "0.3.0" } }, /does not match v0\.3\.0/],
+    [{ ref: "refs/tags/v0.3.0" }, /release images come from main/],
+    [{ ref: "refs/heads/feature" }, /release images come from main/],
     [
-      {
-        release: { tag: "v0.3.0,latest", version: "0.3.0,latest" },
-        ref: "refs/tags/v0.3.0,latest",
-      },
+      { release: { tag: "v0.3.0,latest", version: "0.3.0,latest" } },
       /invalid container tag/,
     ],
   ];
@@ -116,7 +115,8 @@ test("digest manifests require the complete, expected five-image set", (t) => {
 });
 
 test("CI gates release images and the reusable publisher stages digests before promotion", () => {
-  assert.match(imagesWorkflow, /on:\n {2}workflow_call:\n {2}workflow_dispatch:/);
+  assert.match(imagesWorkflow, /on:\n {2}workflow_call:\n {4}inputs:\n {6}version:/);
+  assert.match(imagesWorkflow, /\n {2}workflow_dispatch:\n/);
   assert.doesNotMatch(imagesWorkflow, /tags: \["v\*"\]/);
   assert.match(
     imagesWorkflow,
@@ -126,6 +126,9 @@ test("CI gates release images and the reusable publisher stages digests before p
   assert.match(imagesWorkflow, /push-by-digest=true,name-canonical=true,push=true/);
   assert.match(imagesWorkflow, /promote:\n {4}needs: \[plan, build\]/);
   assert.match(imagesWorkflow, /node scripts\/images\.mjs promote/);
-  assert.match(ciWorkflow, /publish-images:[\s\S]*needs: \[verify, self-host-build, sandbox-e2e\]/);
+  assert.match(
+    ciWorkflow,
+    /publish-images:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
+  );
   assert.match(ciWorkflow, /publish-images:[\s\S]*uses: \.\/\.github\/workflows\/images\.yml/);
 });

--- a/scripts/release.integration.test.mjs
+++ b/scripts/release.integration.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -187,6 +188,43 @@ async function assertMissing(path) {
   await assert.rejects(access(path), { code: "ENOENT" });
 }
 
+async function releaseCheckout(t) {
+  const repoDir = await mkdtemp(join(tmpdir(), "facility-release-checkout-"));
+  await mkdir(join(repoDir, "packages/cli"), { recursive: true });
+  await writeFile(join(repoDir, "package.json"), '{"name":"facility","version":"0.3.0"}\n');
+  await writeFile(
+    join(repoDir, "packages/cli/package.json"),
+    '{"name":"@theagilemonkeys/facility","version":"0.3.0"}\n',
+  );
+  const git = (args) =>
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "commit.gpgSign=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "user.name=Facility Tests",
+        "-c",
+        "user.email=facility-tests@example.invalid",
+        ...args,
+      ],
+      {
+        cwd: repoDir,
+        encoding: "utf8",
+        env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+      },
+    ).trim();
+  git(["init", "--initial-branch=main"]);
+  git(["add", "package.json", "packages/cli/package.json"]);
+  git(["commit", "-m", "chore: establish the release fixture"]);
+  const sha = git(["rev-parse", "HEAD"]);
+  git(["update-ref", "refs/remotes/origin/main", sha]);
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+  return { repoDir, sha };
+}
+
 async function installNpmRecorder(fixtureState) {
   const bin = join(fixtureState.root, "bin");
   const command = join(bin, "npm");
@@ -210,6 +248,153 @@ writeFileSync(process.env.RELEASE_NPM_INVOCATION, JSON.stringify({
   await chmod(command, 0o755);
   return { bin, invocation };
 }
+
+test("a fresh checkout must be stamped before the decided release validates", async (t) => {
+  const checkout = await releaseCheckout(t);
+  const env = {
+    ...process.env,
+    FACILITY_RELEASE_VERSION: "0.4.0",
+    GITHUB_EVENT_NAME: "push",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_REPOSITORY_VISIBILITY: "public",
+    GITHUB_SHA: checkout.sha,
+  };
+
+  const unstamped = await releaseCli(["validate", checkout.repoDir], env);
+  assert.equal(unstamped.code, 1);
+  assert.match(unstamped.stderr, /stamped version 0\.3\.0 does not match the decided version 0\.4\.0/);
+
+  const stamp = await releaseCli(["stamp", "0.4.0", checkout.repoDir], env);
+  assert.equal(stamp.code, 0, stamp.stderr);
+  const validated = await releaseCli(["validate", checkout.repoDir], env);
+  assert.equal(validated.code, 0, validated.stderr);
+});
+
+test("release recording retries after tag push and rejects a tag on another commit", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "facility-release-record-"));
+  const repoDir = join(root, "checkout");
+  const remoteDir = join(root, "origin.git");
+  const binDir = join(root, "bin");
+  const releaseMarker = join(root, "release-created");
+  const ghLog = join(root, "gh-invocations.jsonl");
+  const runnerTemp = join(root, "runner-temp");
+  await mkdir(repoDir);
+  await mkdir(binDir);
+  await mkdir(runnerTemp);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const git = (args, cwd = repoDir) =>
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "commit.gpgSign=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "user.name=Facility Tests",
+        "-c",
+        "user.email=facility-tests@example.invalid",
+        ...args,
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+      },
+    ).trim();
+  git(["init", "--bare", "--initial-branch=main", remoteDir], root);
+  git(["init", "--initial-branch=main"]);
+  await writeFile(join(repoDir, "change.txt"), "release\n");
+  git(["add", "change.txt"]);
+  git(["commit", "-m", "feat!: release the fixture"]);
+  git(["remote", "add", "origin", remoteDir]);
+  git(["push", "-u", "origin", "main"]);
+  const releasedSha = git(["rev-parse", "HEAD"]);
+
+  const ghCommand = join(binDir, "gh");
+  await writeFile(
+    ghCommand,
+    `#!/usr/bin/env node
+const { appendFileSync, existsSync, writeFileSync } = require("node:fs");
+appendFileSync(process.env.FAKE_GH_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+const [resource, action] = process.argv.slice(2);
+if (resource !== "release") process.exit(64);
+if (action === "view") process.exit(existsSync(process.env.FAKE_RELEASE_MARKER) ? 0 : 1);
+if (action !== "create") process.exit(64);
+if (process.env.FAKE_GH_FAIL_CREATE === "1") process.exit(23);
+writeFileSync(process.env.FAKE_RELEASE_MARKER, "created\\n");
+`,
+  );
+  await chmod(ghCommand, 0o755);
+
+  const workflow = await readFile(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const recordStep = workflow.split("      - name: Tag the released commit and publish its notes\n")[1];
+  assert(recordStep, "CI workflow must contain the release-recording step");
+  const indentedScript = recordStep.split("        run: |\n")[1];
+  assert(indentedScript, "release-recording step must contain a shell script");
+  const script = indentedScript
+    .split("\n")
+    .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
+    .join("\n");
+  const baseEnv = {
+    ...process.env,
+    FAKE_GH_LOG: ghLog,
+    FAKE_RELEASE_MARKER: releaseMarker,
+    GH_TOKEN: "local-test-token",
+    NOTES: "fixture release notes",
+    PATH: `${binDir}:${process.env.PATH}`,
+    RUNNER_TEMP: runnerTemp,
+    TAG: "v0.4.0",
+    VERSION: "0.4.0",
+  };
+
+  const interrupted = spawnSync("bash", ["-c", script], {
+    cwd: repoDir,
+    encoding: "utf8",
+    env: { ...baseEnv, FAKE_GH_FAIL_CREATE: "1" },
+  });
+  assert.equal(interrupted.status, 23, interrupted.stderr);
+  assert.equal(git(["rev-parse", "refs/tags/v0.4.0^{commit}"]), releasedSha);
+  assert.equal(
+    git(["--git-dir", remoteDir, "rev-parse", "refs/tags/v0.4.0^{commit}"], root),
+    releasedSha,
+  );
+  await assertMissing(releaseMarker);
+
+  const retried = spawnSync("bash", ["-c", script], {
+    cwd: repoDir,
+    encoding: "utf8",
+    env: baseEnv,
+  });
+  assert.equal(retried.status, 0, retried.stderr);
+  assert.equal((await readFile(releaseMarker, "utf8")).trim(), "created");
+
+  await writeFile(join(repoDir, "change.txt"), "later commit\n");
+  git(["add", "change.txt"]);
+  git(["commit", "-m", "fix: advance beyond the released commit"]);
+  const mismatched = spawnSync("bash", ["-c", script], {
+    cwd: repoDir,
+    encoding: "utf8",
+    env: baseEnv,
+  });
+  assert.equal(mismatched.status, 1);
+  assert.match(mismatched.stderr, /v0\.4\.0 points to .* not released commit/);
+
+  const invocations = (await readFile(ghLog, "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.deepEqual(
+    invocations.map((args) => args.slice(0, 3)),
+    [
+      ["release", "view", "v0.4.0"],
+      ["release", "create", "v0.4.0"],
+      ["release", "view", "v0.4.0"],
+      ["release", "create", "v0.4.0"],
+    ],
+  );
+});
 
 test("an exact 404 permits bootstrap publication without running package lifecycle scripts", async (t) => {
   const state = await fixture(t);
@@ -246,8 +431,11 @@ test("existing, replayed, unavailable, and malformed registry states fail closed
     {
       name: "replayed version",
       lookupStatus: 200,
-      lookupBody: JSON.stringify({ name: PACKAGE_NAME, versions: { "0.3.0": {} } }),
-      error: /is already published; refusing replay/,
+      lookupBody: JSON.stringify({
+        name: PACKAGE_NAME,
+        versions: { "0.3.0": { dist: { integrity: "sha512-conflicting" } } },
+      }),
+      error: /already published with different contents; refusing conflicting replay/,
     },
     {
       name: "registry 5xx",
@@ -277,6 +465,33 @@ test("existing, replayed, unavailable, and malformed registry states fail closed
       await assertMissing(state.lifecycleMarker);
     });
   }
+});
+
+test("an exact already-published tarball is an idempotent retry with no npm invocation", async (t) => {
+  const state = await fixture(t);
+  const recorder = await installNpmRecorder(state);
+  const integrity = `sha512-${createHash("sha512")
+    .update(await readFile(state.tarball))
+    .digest("base64")}`;
+  const registry = await fakeRegistry(t, {
+    lookupStatus: 200,
+    lookupBody: JSON.stringify({
+      name: PACKAGE_NAME,
+      versions: { "0.3.0": { dist: { integrity } } },
+    }),
+  });
+  const env = await npmEnvironment(state, registry.url, "must-not-be-used");
+  env.PATH = `${recorder.bin}:${env.PATH}`;
+  env.RELEASE_NPM_INVOCATION = recorder.invocation;
+
+  const result = await release(["publish", state.tarball, "--auth=oidc"], env);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(
+    registry.requests.map(({ method, responseStatus }) => ({ method, responseStatus })),
+    [{ method: "GET", responseStatus: 200 }],
+  );
+  await assertMissing(recorder.invocation);
 });
 
 test("expired, revoked, and cross-scope bootstrap tokens fail closed", async (t) => {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -8,12 +8,12 @@ import { fileURLToPath } from "node:url";
 export const PACKAGE_NAME = "@theagilemonkeys/facility";
 export const OFFICIAL_REGISTRY = "https://registry.npmjs.org/";
 
-export function releaseMode({ eventName, ref, visibility, acceptancePassed }) {
+export function releaseMode({ eventName, ref, visibility, acceptancePassed, releaseDecided }) {
   if (eventName === "workflow_dispatch") return "dry-run";
   if (
     eventName === "push" &&
-    typeof ref === "string" &&
-    ref.startsWith("refs/tags/v") &&
+    ref === "refs/heads/main" &&
+    releaseDecided === true &&
     visibility === "public" &&
     acceptancePassed === true
   ) {
@@ -22,32 +22,46 @@ export function releaseMode({ eventName, ref, visibility, acceptancePassed }) {
   return "skip";
 }
 
+/**
+ * What proves a release is no longer a tag someone pushed: it is the version
+ * decided from the commit subjects (scripts/version.mjs), stamped into the two
+ * package.json files inside this run. The tag is written afterwards, as the
+ * record of what was published. So the checks here are that the run is a push
+ * of main, that the stamp matches the decision, and that the commit really is
+ * the head of main — plus the guard that outlives all of them, in
+ * `registryState`, which refuses a version npm already has.
+ */
 export function validateReleasePolicy({
   eventName,
   ref,
   visibility,
   rootVersion,
   packageVersion,
+  decidedVersion,
   headSha,
   checkoutSha,
-  tagSha,
   isOnMain,
 }) {
   if (eventName !== "push") throw new Error("a real release must come from a push event");
   if (visibility !== "public") throw new Error("npm publishing is disabled until the repository is public");
+  if (ref !== "refs/heads/main") {
+    throw new Error(`a release must come from main, not ${ref || "an unknown ref"}`);
+  }
+  if (!decidedVersion) {
+    throw new Error("no release version was decided for this commit");
+  }
   if (!rootVersion || rootVersion !== packageVersion) {
     throw new Error(
       `root package version (${rootVersion || "missing"}) does not match CLI package version (${packageVersion || "missing"})`,
     );
   }
-
-  const expectedRef = `refs/tags/v${packageVersion}`;
-  if (ref !== expectedRef) throw new Error(`release ref ${ref} does not match ${expectedRef}`);
+  if (packageVersion !== decidedVersion) {
+    throw new Error(
+      `stamped version ${packageVersion} does not match the decided version ${decidedVersion}`,
+    );
+  }
   if (!headSha || checkoutSha !== headSha) {
     throw new Error(`checked-out commit ${checkoutSha || "missing"} does not match event SHA ${headSha || "missing"}`);
-  }
-  if (tagSha !== headSha) {
-    throw new Error(`release tag resolves to ${tagSha || "missing"}, not event SHA ${headSha}`);
   }
   if (!isOnMain) throw new Error("release commit is not reachable from origin/main");
 
@@ -60,6 +74,7 @@ export function validateReleaseCandidate({
   ref = process.env.GITHUB_REF,
   visibility = process.env.GITHUB_REPOSITORY_VISIBILITY,
   headSha = process.env.GITHUB_SHA,
+  decidedVersion = process.env.FACILITY_RELEASE_VERSION,
 } = {}) {
   const rootVersion = readJson(join(repoDir, "package.json")).version;
   const cliPackage = readJson(join(repoDir, "packages/cli/package.json"));
@@ -68,9 +83,6 @@ export function validateReleaseCandidate({
   }
 
   const checkoutSha = git(repoDir, ["rev-parse", "HEAD"]);
-  const tagSha = ref?.startsWith("refs/tags/")
-    ? git(repoDir, ["rev-parse", `${ref}^{commit}`])
-    : undefined;
   const isOnMain =
     spawnSync("git", ["merge-base", "--is-ancestor", checkoutSha, "origin/main"], {
       cwd: repoDir,
@@ -83,11 +95,32 @@ export function validateReleaseCandidate({
     visibility,
     rootVersion,
     packageVersion: cliPackage.version,
+    decidedVersion,
     headSha,
     checkoutSha,
-    tagSha,
     isOnMain,
   });
+}
+
+/**
+ * Writes the decided version into the two package.json files the release reads.
+ * This happens inside the run and is never committed: the tags are the record of
+ * what shipped, so main carries no version-bump commits and the two files cannot
+ * drift apart between releases.
+ */
+export function stampVersion(version, { repoDir = process.cwd() } = {}) {
+  if (!/^\d+\.\d+\.\d+$/.test(version || "")) {
+    throw new Error(`refusing to stamp a version that is not a semver triple: ${version || "missing"}`);
+  }
+  const stamped = [];
+  for (const relative of ["package.json", "packages/cli/package.json"]) {
+    const path = join(repoDir, relative);
+    const manifest = readJson(path);
+    manifest.version = version;
+    writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+    stamped.push(relative);
+  }
+  return { version, stamped };
 }
 
 export function inspectTarball(tarball, { exec = execFileSync } = {}) {
@@ -346,6 +379,12 @@ function output(values) {
 }
 
 async function main([command, ...args]) {
+  if (command === "stamp") {
+    const version = args[0];
+    const result = stampVersion(version, { repoDir: resolve(args[1] || ".") });
+    output({ version: result.version, stamped: result.stamped.join(",") });
+    return;
+  }
   if (command === "validate") {
     if (args.length > 1 || args[0]?.startsWith("--")) {
       throw new Error("validate accepts only an optional repository directory");

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -201,7 +202,18 @@ export async function registryState({
     throw new Error("npm registry returned malformed package metadata");
   }
   if (Object.hasOwn(metadata.versions, artifact.version)) {
-    throw new Error(`${artifact.name}@${artifact.version} is already published; refusing replay`);
+    const published = metadata.versions[artifact.version];
+    const publishedIntegrity =
+      published && typeof published === "object" && !Array.isArray(published)
+        ? published.dist?.integrity
+        : undefined;
+    const candidateIntegrity = tarballIntegrity(artifact.path);
+    if (publishedIntegrity !== candidateIntegrity) {
+      throw new Error(
+        `${artifact.name}@${artifact.version} is already published with different contents; refusing conflicting replay`,
+      );
+    }
+    return { state: "published", artifact, registry };
   }
   return { state: "existing", artifact, registry };
 }
@@ -295,6 +307,9 @@ export async function publishRelease({
       officialOnly: !allowNonOfficialRegistry,
     });
   const firstState = await probe();
+  if (firstState.state === "published") {
+    return firstState.artifact;
+  }
   if (authMode === "bootstrap" && firstState.state !== "missing") {
     throw new Error("bootstrap credentials are allowed only for the first publication");
   }
@@ -355,6 +370,10 @@ function scrubNpmCredentials(env) {
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function tarballIntegrity(path) {
+  return `sha512-${createHash("sha512").update(readFileSync(path)).digest("base64")}`;
 }
 
 function git(cwd, args) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
   OFFICIAL_REGISTRY,
   normalizeRegistry,
   releaseMode,
+  stampVersion,
   validateReleasePolicy,
 } from "./release.mjs";
 
@@ -89,6 +92,28 @@ test("release policy fails closed on every version and provenance mismatch", () 
   }
 });
 
+test("stamping updates both manifests together and rejects malformed versions", (t) => {
+  const repoDir = mkdtempSync(join(tmpdir(), "facility-stamp-test-"));
+  t.after(() => rmSync(repoDir, { recursive: true, force: true }));
+  mkdirSync(join(repoDir, "packages/cli"), { recursive: true });
+  writeFileSync(join(repoDir, "package.json"), '{"name":"facility","version":"0.3.0"}\n');
+  writeFileSync(
+    join(repoDir, "packages/cli/package.json"),
+    '{"name":"@theagilemonkeys/facility","version":"0.3.0"}\n',
+  );
+
+  assert.deepEqual(stampVersion("0.4.0", { repoDir }), {
+    version: "0.4.0",
+    stamped: ["package.json", "packages/cli/package.json"],
+  });
+  assert.equal(JSON.parse(readFileSync(join(repoDir, "package.json"), "utf8")).version, "0.4.0");
+  assert.equal(
+    JSON.parse(readFileSync(join(repoDir, "packages/cli/package.json"), "utf8")).version,
+    "0.4.0",
+  );
+  assert.throws(() => stampVersion("0.4", { repoDir }), /not a semver triple/);
+});
+
 test("GitHub publication requires the exact official npm registry", () => {
   assert.equal(normalizeRegistry(OFFICIAL_REGISTRY, { githubActions: true }).href, OFFICIAL_REGISTRY);
   assert.throws(
@@ -118,6 +143,16 @@ test("the workflow keeps manual runs credential-free and real publication main-o
   assert.equal(releaseWorkflow.match(/secrets\.NPM_BOOTSTRAP_TOKEN/g)?.length, 1);
   assert.match(releaseWorkflow, /environment: npm/);
   assert.match(releaseWorkflow, /npm install --global npm@11\.15\.0/);
+  const publishJob = releaseWorkflow.split("\n  publish:")[1];
+  assert.ok(publishJob, "release workflow must contain a publish job");
+  const stampIndex = publishJob.indexOf('node scripts/release.mjs stamp "${{ inputs.version }}"');
+  const validateIndex = publishJob.indexOf("node scripts/release.mjs validate");
+  assert.notEqual(stampIndex, -1, "the publish checkout must be stamped");
+  assert.notEqual(validateIndex, -1, "the publish checkout must be validated");
+  assert.ok(
+    stampIndex < validateIndex,
+    "the publish checkout must be stamped before release validation",
+  );
   assert.match(
     releaseWorkflow,
     /publish:[\s\S]*concurrency:\n      group: npm-theagilemonkeys-facility\n      cancel-in-progress: false/,
@@ -125,6 +160,10 @@ test("the workflow keeps manual runs credential-free and real publication main-o
 });
 
 test("CI publishes only the exact artifact produced after all acceptance jobs", () => {
+  assert.match(
+    ciWorkflow,
+    /concurrency:\n {2}group: ci-\$\{\{ github\.repository \}\}-\$\{\{ github\.ref \}\}\n {2}cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/,
+  );
   assert.match(ciWorkflow, /npm pack --ignore-scripts --pack-destination "\$release_dir"/);
   assert.match(ciWorkflow, /name: facility-release-package/);
   assert.match(
@@ -132,4 +171,17 @@ test("CI publishes only the exact artifact produced after all acceptance jobs", 
     /publish-npm:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
   );
   assert.match(ciWorkflow, /publish-npm:[\s\S]*uses: \.\/\.github\/workflows\/release\.yml/);
+});
+
+test("release recording retries missing notes and rejects a tag on another commit", () => {
+  const recordJob = ciWorkflow.split("\n  record-release:")[1];
+  assert.ok(recordJob, "CI workflow must contain a record-release job");
+  assert.match(recordJob, /tag_sha="\$\(git rev-parse "refs\/tags\/\$TAG\^\{commit\}"\)"/);
+  assert.match(recordJob, /if \[ "\$tag_sha" != "\$head_sha" \]; then/);
+  assert.match(recordJob, /if gh release view "\$TAG" >\/dev\/null 2>&1; then/);
+  assert.match(recordJob, /else\n {12}gh release create "\$TAG"/);
+  assert.doesNotMatch(
+    recordJob,
+    /already exists; the release was recorded by an earlier run\."\n {12}exit 0/,
+  );
 });

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -13,13 +13,13 @@ const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.me
 
 const validPolicy = {
   eventName: "push",
-  ref: "refs/tags/v0.3.0",
+  ref: "refs/heads/main",
   visibility: "public",
   rootVersion: "0.3.0",
   packageVersion: "0.3.0",
+  decidedVersion: "0.3.0",
   headSha: "release-sha",
   checkoutSha: "release-sha",
-  tagSha: "release-sha",
   isOnMain: true,
 };
 
@@ -36,30 +36,32 @@ test("manual dispatches are dry-runs even when a real publish is requested", () 
   );
 });
 
-test("only an accepted public tag push enters publish mode", () => {
-  assert.equal(
-    releaseMode({
-      eventName: "push",
-      ref: "refs/tags/v0.3.0",
-      visibility: "public",
-      acceptancePassed: true,
-    }),
-    "publish",
-  );
+test("only an accepted public main push with a decision enters publish mode", () => {
+  const accepted = {
+    eventName: "push",
+    ref: "refs/heads/main",
+    visibility: "public",
+    acceptancePassed: true,
+    releaseDecided: true,
+  };
+  assert.equal(releaseMode(accepted), "publish");
 
   for (const candidate of [
-    { eventName: "push", ref: "refs/heads/main", visibility: "public", acceptancePassed: true },
-    { eventName: "pull_request", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: true },
-    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "private", acceptancePassed: true },
-    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: false },
-    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: "false" },
-    { eventName: "push", ref: "refs/tags/v0.3.0", visibility: "public", acceptancePassed: "failure" },
+    { ...accepted, releaseDecided: false },
+    { ...accepted, releaseDecided: "true" },
+    { ...accepted, ref: "refs/heads/feature" },
+    { ...accepted, ref: "refs/tags/v0.3.0" },
+    { ...accepted, eventName: "pull_request" },
+    { ...accepted, visibility: "private" },
+    { ...accepted, acceptancePassed: false },
+    { ...accepted, acceptancePassed: "false" },
+    { ...accepted, acceptancePassed: "failure" },
   ]) {
     assert.equal(releaseMode(candidate), "skip");
   }
 });
 
-test("release policy accepts only the matching package tag and commit", () => {
+test("release policy accepts only a stamped main commit matching the decision", () => {
   assert.deepEqual(validateReleasePolicy(validPolicy), {
     packageName: "@theagilemonkeys/facility",
     version: "0.3.0",
@@ -67,14 +69,18 @@ test("release policy accepts only the matching package tag and commit", () => {
   });
 });
 
-test("release policy fails closed on every tag and provenance mismatch", () => {
+test("release policy fails closed on every version and provenance mismatch", () => {
   const invalid = [
     [{ eventName: "workflow_dispatch" }, /real release must come from a push event/],
     [{ visibility: "private" }, /publishing is disabled until the repository is public/],
+    [{ ref: "refs/tags/v0.3.0" }, /a release must come from main, not refs\/tags\/v0\.3\.0/],
+    [{ decidedVersion: undefined }, /no release version was decided for this commit/],
     [{ rootVersion: "0.2.0" }, /root package version \(0\.2\.0\) does not match CLI package version \(0\.3\.0\)/],
-    [{ ref: "refs/tags/v0.3.1" }, /release ref refs\/tags\/v0\.3\.1 does not match refs\/tags\/v0\.3\.0/],
+    [
+      { decidedVersion: "0.4.0" },
+      /stamped version 0\.3\.0 does not match the decided version 0\.4\.0/,
+    ],
     [{ checkoutSha: "other-sha" }, /checked-out commit other-sha does not match event SHA release-sha/],
-    [{ tagSha: "other-sha" }, /release tag resolves to other-sha, not event SHA release-sha/],
     [{ isOnMain: false }, /release commit is not reachable from origin\/main/],
   ];
 
@@ -95,13 +101,13 @@ test("GitHub publication requires the exact official npm registry", () => {
   );
 });
 
-test("the workflow keeps manual runs credential-free and real publication tag-only", () => {
-  assert.match(releaseWorkflow, /workflow_call:\n  workflow_dispatch:\n/);
+test("the workflow keeps manual runs credential-free and real publication main-only", () => {
+  assert.match(releaseWorkflow, /workflow_call:\n    inputs:\n      version:/);
   assert.doesNotMatch(releaseWorkflow, /workflow_dispatch:\n\s+inputs:/);
   assert.match(releaseWorkflow, /dry-run:\n    if: github\.event_name == 'workflow_dispatch'/);
   assert.match(
     releaseWorkflow,
-    /publish:\n    if: github\.event_name == 'push' && startsWith\(github\.ref, 'refs\/tags\/'\) && github\.event\.repository\.visibility == 'public'/,
+    /publish:\n    if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main' && github\.event\.repository\.visibility == 'public'/,
   );
   assert.match(releaseWorkflow, /node scripts\/release\.mjs dry-run "\$candidate"/);
   assert.match(releaseWorkflow, /node scripts\/release\.mjs publish "\$CANDIDATE" --auth=oidc/);
@@ -121,6 +127,9 @@ test("the workflow keeps manual runs credential-free and real publication tag-on
 test("CI publishes only the exact artifact produced after all acceptance jobs", () => {
   assert.match(ciWorkflow, /npm pack --ignore-scripts --pack-destination "\$release_dir"/);
   assert.match(ciWorkflow, /name: facility-release-package/);
-  assert.match(ciWorkflow, /publish-npm:[\s\S]*needs: \[verify, self-host-build, sandbox-e2e\]/);
+  assert.match(
+    ciWorkflow,
+    /publish-npm:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
+  );
   assert.match(ciWorkflow, /publish-npm:[\s\S]*uses: \.\/\.github\/workflows\/release\.yml/);
 });

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Decides whether a merge to main releases, and what version it releases.
+//
+// The commit subjects since the last release are the input; the repository has
+// no version-bump commit and no release pull request. `package.json` is stamped
+// from this decision inside the release run, so the git tag written afterwards
+// is the record of what was published rather than a request to publish it.
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+
+// Only these reach users. A `docs:` or `chore:` merge releases nothing on its
+// own — it ships with the next real change, which is the behaviour we want:
+// every published version has something to say for itself.
+const RELEASING_TYPES = new Set(["feat", "fix", "perf"]);
+const SUBJECT = /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?: (?<summary>.+)$/;
+
+export function parseSubject(subject) {
+  const match = SUBJECT.exec(subject.trim());
+  if (!match?.groups) return null;
+  const { type, scope, breaking, summary } = match.groups;
+  return { type, scope: scope ?? null, breaking: breaking === "!", summary };
+}
+
+/**
+ * A commit releases if its subject is a releasing type, or if it breaks
+ * something — a breaking `refactor!` still has to reach users.
+ */
+export function classify(subjects, { body = () => "" } = {}) {
+  const commits = [];
+  for (const subject of subjects) {
+    const parsed = parseSubject(subject);
+    if (!parsed) continue;
+    const breaking = parsed.breaking || /^BREAKING[ -]CHANGE:/m.test(body(subject));
+    if (!RELEASING_TYPES.has(parsed.type) && !breaking) continue;
+    commits.push({ ...parsed, breaking });
+  }
+  return commits;
+}
+
+/**
+ * Pre-1.0, a breaking change is a minor and everything else is a patch — the
+ * plain reading of "no upgrade path is promised between 0.x releases". After
+ * 1.0 the usual major/minor/patch applies.
+ */
+export function nextVersion(current, commits) {
+  const [major, minor, patch] = current.split(".").map((part) => Number.parseInt(part, 10));
+  if ([major, minor, patch].some((part) => Number.isNaN(part))) {
+    throw new Error(`current version is not a semver triple: ${current}`);
+  }
+  if (commits.length === 0) return null;
+  const breaking = commits.some((commit) => commit.breaking);
+  const feature = commits.some((commit) => commit.type === "feat");
+  if (major === 0) {
+    return breaking ? `0.${minor + 1}.0` : `${major}.${minor}.${patch + 1}`;
+  }
+  if (breaking) return `${major + 1}.0.0`;
+  return feature ? `${major}.${minor + 1}.0` : `${major}.${minor}.${patch + 1}`;
+}
+
+/** Release notes grouped the way a reader scans them: breaking first. */
+export function releaseNotes(version, commits) {
+  const groups = [
+    ["Breaking changes", commits.filter((commit) => commit.breaking)],
+    ["Features", commits.filter((commit) => commit.type === "feat" && !commit.breaking)],
+    ["Fixes", commits.filter((commit) => commit.type === "fix" && !commit.breaking)],
+    ["Performance", commits.filter((commit) => commit.type === "perf" && !commit.breaking)],
+  ];
+  const lines = [`## ${version}`, ""];
+  for (const [heading, entries] of groups) {
+    if (entries.length === 0) continue;
+    lines.push(`### ${heading}`, "");
+    for (const entry of entries) {
+      lines.push(`- ${entry.scope ? `**${entry.scope}**: ` : ""}${entry.summary}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+export function lastReleaseTag(repoDir = process.cwd(), { exec = execFileSync } = {}) {
+  try {
+    const tags = exec("git", ["tag", "--list", "v*", "--sort=-v:refname"], {
+      cwd: repoDir,
+      encoding: "utf8",
+    })
+      .split("\n")
+      .map((tag) => tag.trim())
+      .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag));
+    return tags[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function subjectsSince(tag, repoDir = process.cwd(), { exec = execFileSync } = {}) {
+  const range = tag ? `${tag}..HEAD` : "HEAD";
+  return exec("git", ["log", range, "--no-merges", "--format=%s"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The tags are the source of truth for what has been released. Before the first
+ * one exists there is nothing to read, so the version in package.json seeds the
+ * sequence — otherwise a repository that already shipped a 0.3.0 would compute
+ * its next release as 0.1.0 and try to publish backwards.
+ */
+export function decide({ repoDir = process.cwd(), exec = execFileSync, fallbackVersion } = {}) {
+  const tag = lastReleaseTag(repoDir, { exec });
+  const current = tag ? tag.slice(1) : (fallbackVersion ?? "0.0.0");
+  const subjects = subjectsSince(tag, repoDir, { exec });
+  const commits = classify(subjects);
+  const version = nextVersion(current, commits);
+  return {
+    release: version !== null,
+    version,
+    previous: current,
+    tag: version ? `v${version}` : null,
+    notes: version ? releaseNotes(version, commits) : "",
+    considered: subjects.length,
+    releasing: commits.length,
+  };
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
+  const fallbackVersion = JSON.parse(readFileSync("package.json", "utf8")).version;
+  const decision = decide({ fallbackVersion });
+  const summary =
+    `${decision.considered} commits since ${decision.previous}, ${decision.releasing} of them releasing` +
+    (decision.release ? ` → ${decision.version}` : " → no release");
+  console.error(summary);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      [
+        `release=${decision.release}`,
+        `version=${decision.version ?? ""}`,
+        `tag=${decision.tag ?? ""}`,
+        `notes<<FACILITY_NOTES_EOF`,
+        decision.notes,
+        `FACILITY_NOTES_EOF`,
+        "",
+      ].join("\n"),
+    );
+  } else {
+    console.log(JSON.stringify(decision, null, 2));
+  }
+}

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,38 +1,33 @@
 #!/usr/bin/env node
 // Decides whether a merge to main releases, and what version it releases.
 //
-// The commit subjects since the last release are the input; the repository has
+// The full commit messages since the last release are the input; the repository has
 // no version-bump commit and no release pull request. `package.json` is stamped
 // from this decision inside the release run, so the git tag written afterwards
 // is the record of what was published rather than a request to publish it.
 import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
+import {
+  assertSubject,
+  messagesForRevision,
+  parseSubject,
+  releaseImpact,
+  subjectOf,
+} from "./conventional-commit-subjects.mjs";
 
-// Only these reach users. A `docs:` or `chore:` merge releases nothing on its
-// own — it ships with the next real change, which is the behaviour we want:
-// every published version has something to say for itself.
-const RELEASING_TYPES = new Set(["feat", "fix", "perf"]);
-const SUBJECT = /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?: (?<summary>.+)$/;
-
-export function parseSubject(subject) {
-  const match = SUBJECT.exec(subject.trim());
-  if (!match?.groups) return null;
-  const { type, scope, breaking, summary } = match.groups;
-  return { type, scope: scope ?? null, breaking: breaking === "!", summary };
-}
+export { parseSubject };
 
 /**
  * A commit releases if its subject is a releasing type, or if it breaks
  * something — a breaking `refactor!` still has to reach users.
  */
-export function classify(subjects, { body = () => "" } = {}) {
+export function classify(messages) {
   const commits = [];
-  for (const subject of subjects) {
-    const parsed = parseSubject(subject);
-    if (!parsed) continue;
-    const breaking = parsed.breaking || /^BREAKING[ -]CHANGE:/m.test(body(subject));
-    if (!RELEASING_TYPES.has(parsed.type) && !breaking) continue;
-    commits.push({ ...parsed, breaking });
+  for (const message of messages) {
+    const parsed = assertSubject(subjectOf(message), { label: "commit subject" });
+    const impact = releaseImpact(message);
+    if (impact === "none") continue;
+    commits.push({ ...parsed, breaking: impact === "minor" });
   }
   return commits;
 }
@@ -64,6 +59,7 @@ export function releaseNotes(version, commits) {
     ["Features", commits.filter((commit) => commit.type === "feat" && !commit.breaking)],
     ["Fixes", commits.filter((commit) => commit.type === "fix" && !commit.breaking)],
     ["Performance", commits.filter((commit) => commit.type === "perf" && !commit.breaking)],
+    ["Reverts", commits.filter((commit) => commit.type === "revert" && !commit.breaking)],
   ];
   const lines = [`## ${version}`, ""];
   for (const [heading, entries] of groups) {
@@ -78,29 +74,19 @@ export function releaseNotes(version, commits) {
 }
 
 export function lastReleaseTag(repoDir = process.cwd(), { exec = execFileSync } = {}) {
-  try {
-    const tags = exec("git", ["tag", "--list", "v*", "--sort=-v:refname"], {
-      cwd: repoDir,
-      encoding: "utf8",
-    })
-      .split("\n")
-      .map((tag) => tag.trim())
-      .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag));
-    return tags[0] ?? null;
-  } catch {
-    return null;
-  }
-}
-
-export function subjectsSince(tag, repoDir = process.cwd(), { exec = execFileSync } = {}) {
-  const range = tag ? `${tag}..HEAD` : "HEAD";
-  return exec("git", ["log", range, "--no-merges", "--format=%s"], {
+  const tags = exec("git", ["tag", "--list", "v*", "--sort=-v:refname"], {
     cwd: repoDir,
     encoding: "utf8",
   })
     .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
+    .map((tag) => tag.trim())
+    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag));
+  return tags[0] ?? null;
+}
+
+export function messagesSince(tag, repoDir = process.cwd(), { exec = execFileSync } = {}) {
+  const revision = tag ? `${tag}..HEAD` : "HEAD";
+  return messagesForRevision(revision, { repoDir, exec });
 }
 
 /**
@@ -112,8 +98,8 @@ export function subjectsSince(tag, repoDir = process.cwd(), { exec = execFileSyn
 export function decide({ repoDir = process.cwd(), exec = execFileSync, fallbackVersion } = {}) {
   const tag = lastReleaseTag(repoDir, { exec });
   const current = tag ? tag.slice(1) : (fallbackVersion ?? "0.0.0");
-  const subjects = subjectsSince(tag, repoDir, { exec });
-  const commits = classify(subjects);
+  const messages = messagesSince(tag, repoDir, { exec });
+  const commits = classify(messages);
   const version = nextVersion(current, commits);
   return {
     release: version !== null,
@@ -121,7 +107,7 @@ export function decide({ repoDir = process.cwd(), exec = execFileSync, fallbackV
     previous: current,
     tag: version ? `v${version}` : null,
     notes: version ? releaseNotes(version, commits) : "",
-    considered: subjects.length,
+    considered: messages.length,
     releasing: commits.length,
   };
 }

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -1,6 +1,67 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
-import { classify, decide, nextVersion, parseSubject, releaseNotes } from "./version.mjs";
+import {
+  classify,
+  decide,
+  lastReleaseTag,
+  nextVersion,
+  parseSubject,
+  releaseNotes,
+} from "./version.mjs";
+
+function git(repoDir, args) {
+  return execFileSync(
+    "git",
+    [
+      "-c",
+      "commit.gpgSign=false",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "-c",
+      "user.name=Facility Tests",
+      "-c",
+      "user.email=facility-tests@example.invalid",
+      ...args,
+    ],
+    {
+      cwd: repoDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+      },
+    },
+  ).trim();
+}
+
+function localRepository(t, name) {
+  const repoDir = mkdtempSync(join(tmpdir(), `facility-version-${name}-`));
+  t.after(() => rmSync(repoDir, { recursive: true, force: true }));
+  git(repoDir, ["init", "--initial-branch=main"]);
+  git(repoDir, ["commit", "--allow-empty", "-m", "chore: establish the fixture"]);
+  return repoDir;
+}
+
+function tagRelease(repoDir, tag) {
+  git(repoDir, ["tag", "-a", tag, "-m", tag.slice(1)]);
+}
+
+function commit(repoDir, subject, body, { verbatim = false } = {}) {
+  git(repoDir, [
+    "commit",
+    "--allow-empty",
+    ...(verbatim ? ["--cleanup=verbatim"] : []),
+    "-m",
+    subject,
+    ...(body ? ["-m", body] : []),
+  ]);
+}
 
 test("parses conventional subjects, including scopes and breaking markers", () => {
   assert.deepEqual(parseSubject("feat: add the inbox"), {
@@ -18,10 +79,10 @@ test("parses conventional subjects, including scopes and breaking markers", () =
   assert.equal(parseSubject("chore(deps)!: drop node 20")?.breaking, true);
 });
 
-test("ignores subjects that are not conventional commits", () => {
+test("rejects subjects that are not allowed conventional commits", () => {
   assert.equal(parseSubject("Update README"), null);
   assert.equal(parseSubject("Merge pull request #51 from theam/ci/publish-images"), null);
-  assert.deepEqual(classify(["Update README", "wip"]), []);
+  assert.throws(() => classify(["Update README"]), /commit subject is not an allowed Conventional Commit/);
 });
 
 test("only user-visible types release", () => {
@@ -31,10 +92,11 @@ test("only user-visible types release", () => {
     "chore: tidy",
     "test: cover the drain",
     "fix(gateway): drain metering",
+    "revert: restore the safe gateway behavior",
   ]);
   assert.deepEqual(
     commits.map((commit) => commit.type),
-    ["fix"],
+    ["fix", "revert"],
   );
 });
 
@@ -45,10 +107,9 @@ test("a breaking change releases even when its type would not", () => {
 });
 
 test("a BREAKING CHANGE footer counts as breaking", () => {
-  const bodies = { "refactor: rename the run contract": "BREAKING CHANGE: runs/:id moved" };
-  const commits = classify(["refactor: rename the run contract"], {
-    body: (subject) => bodies[subject] ?? "",
-  });
+  const commits = classify([
+    "refactor: rename the run contract\n\nBREAKING CHANGE: runs/:id moved",
+  ]);
   assert.equal(commits.length, 1);
   assert.equal(commits[0].breaking, true);
 });
@@ -72,11 +133,17 @@ test("nothing releasing means no version at all", () => {
 test("release notes lead with breaking changes and name the scope", () => {
   const notes = releaseNotes(
     "0.4.0",
-    classify(["feat!: require node 22", "fix(gateway): drain metering", "feat: add the inbox"]),
+    classify([
+      "feat!: require node 22",
+      "fix(gateway): drain metering",
+      "feat: add the inbox",
+      "revert: restore the old installer",
+    ]),
   );
   assert.match(notes, /^## 0\.4\.0/);
   assert.ok(notes.indexOf("Breaking changes") < notes.indexOf("Features"));
   assert.ok(notes.includes("- **gateway**: drain metering"));
+  assert.match(notes, /### Reverts[\s\S]*- restore the old installer/);
 });
 
 test("decide reads the last v-tag and the subjects after it", () => {
@@ -84,7 +151,7 @@ test("decide reads the last v-tag and the subjects after it", () => {
   const exec = (_command, args) => {
     calls.push(args.join(" "));
     if (args[0] === "tag") return "v0.3.0\nv0.2.9\nnot-a-tag\n";
-    if (args[0] === "log") return "fix: one\ndocs: two\n";
+    if (args[0] === "log") return "fix: one\0docs: two\0";
     throw new Error(`unexpected git call: ${args.join(" ")}`);
   };
   const decision = decide({ repoDir: "/tmp", exec });
@@ -93,13 +160,13 @@ test("decide reads the last v-tag and the subjects after it", () => {
   assert.equal(decision.tag, "v0.3.1");
   assert.equal(decision.considered, 2);
   assert.equal(decision.releasing, 1);
-  assert.ok(calls.some((call) => call.includes("v0.3.0..HEAD")));
+  assert.ok(calls.includes("log -z --no-merges --format=%B v0.3.0..HEAD"));
 });
 
 test("decide starts from 0.0.0 when the repository has never released", () => {
   const exec = (_command, args) => {
     if (args[0] === "tag") return "\n";
-    if (args[0] === "log") return "feat: first\n";
+    if (args[0] === "log") return "feat: first\0";
     throw new Error("unexpected");
   };
   assert.equal(decide({ repoDir: "/tmp", exec }).version, "0.0.1");
@@ -108,7 +175,7 @@ test("decide starts from 0.0.0 when the repository has never released", () => {
 test("decide reports no release when only invisible work landed", () => {
   const exec = (_command, args) => {
     if (args[0] === "tag") return "v0.3.0\n";
-    if (args[0] === "log") return "docs: a\nci: b\n";
+    if (args[0] === "log") return "docs: a\0ci: b\0";
     throw new Error("unexpected");
   };
   const decision = decide({ repoDir: "/tmp", exec });
@@ -119,10 +186,71 @@ test("decide reports no release when only invisible work landed", () => {
 test("without any tag the sequence starts from the version in package.json", () => {
   const exec = (_command, args) => {
     if (args[0] === "tag") return "\n";
-    if (args[0] === "log") return "fix: one\n";
+    if (args[0] === "log") return "fix: one\0";
     throw new Error("unexpected");
   };
   const decision = decide({ repoDir: "/tmp", exec, fallbackVersion: "0.3.0" });
   assert.equal(decision.previous, "0.3.0");
   assert.equal(decision.version, "0.3.1");
+});
+
+test("tag discovery errors fail the release decision closed", () => {
+  const failure = new Error("tag refs are unreadable");
+  assert.throws(
+    () => lastReleaseTag("/tmp", { exec: () => { throw failure; } }),
+    (error) => error === failure,
+  );
+});
+
+test("decide reads footer-only breaking changes from real git messages", (t) => {
+  const repoDir = localRepository(t, "breaking-footer");
+  tagRelease(repoDir, "v0.3.0");
+  commit(
+    repoDir,
+    "fix: replace the run contract",
+    "BREAKING CHANGE: runs/:id moved to sessions/:id",
+  );
+
+  const decision = decide({ repoDir });
+  assert.equal(decision.previous, "0.3.0");
+  assert.equal(decision.version, "0.4.0");
+  assert.equal(decision.releasing, 1);
+  assert.match(decision.notes, /### Breaking changes[\s\S]*replace the run contract/);
+});
+
+test("decide rejects an invalid landed subject from a real git history", (t) => {
+  const repoDir = localRepository(t, "invalid-subject");
+  tagRelease(repoDir, "v0.3.0");
+  commit(repoDir, "  fix: do not normalize the release input", undefined, { verbatim: true });
+
+  assert.throws(
+    () => decide({ repoDir }),
+    /commit subject is not an allowed Conventional Commit:[\s\S]*  fix: do not normalize/,
+  );
+});
+
+test("decide publishes a real revert as a patch and includes it in the notes", (t) => {
+  const repoDir = localRepository(t, "revert");
+  tagRelease(repoDir, "v0.3.0");
+  commit(repoDir, "revert: restore the safe gateway behavior");
+
+  const decision = decide({ repoDir });
+  assert.equal(decision.version, "0.3.1");
+  assert.equal(decision.releasing, 1);
+  assert.match(decision.notes, /### Reverts[\s\S]*restore the safe gateway behavior/);
+});
+
+test("decide validates and classifies only messages after the latest stable tag", (t) => {
+  const repoDir = localRepository(t, "tag-boundary");
+  tagRelease(repoDir, "v0.2.0");
+  commit(repoDir, "legacy subject before the current release");
+  tagRelease(repoDir, "v0.3.0");
+  git(repoDir, ["tag", "vlatest"]);
+  commit(repoDir, "fix: deliver the next patch");
+
+  const decision = decide({ repoDir });
+  assert.equal(decision.previous, "0.3.0");
+  assert.equal(decision.version, "0.3.1");
+  assert.equal(decision.considered, 1);
+  assert.equal(decision.releasing, 1);
 });

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { classify, decide, nextVersion, parseSubject, releaseNotes } from "./version.mjs";
+
+test("parses conventional subjects, including scopes and breaking markers", () => {
+  assert.deepEqual(parseSubject("feat: add the inbox"), {
+    type: "feat",
+    scope: null,
+    breaking: false,
+    summary: "add the inbox",
+  });
+  assert.deepEqual(parseSubject("fix(gateway): drain metering on shutdown"), {
+    type: "fix",
+    scope: "gateway",
+    breaking: false,
+    summary: "drain metering on shutdown",
+  });
+  assert.equal(parseSubject("chore(deps)!: drop node 20")?.breaking, true);
+});
+
+test("ignores subjects that are not conventional commits", () => {
+  assert.equal(parseSubject("Update README"), null);
+  assert.equal(parseSubject("Merge pull request #51 from theam/ci/publish-images"), null);
+  assert.deepEqual(classify(["Update README", "wip"]), []);
+});
+
+test("only user-visible types release", () => {
+  const commits = classify([
+    "docs: retire the v1 PRD",
+    "ci: publish the service images",
+    "chore: tidy",
+    "test: cover the drain",
+    "fix(gateway): drain metering",
+  ]);
+  assert.deepEqual(
+    commits.map((commit) => commit.type),
+    ["fix"],
+  );
+});
+
+test("a breaking change releases even when its type would not", () => {
+  const commits = classify(["refactor!: rename the run contract"]);
+  assert.equal(commits.length, 1);
+  assert.equal(commits[0].breaking, true);
+});
+
+test("a BREAKING CHANGE footer counts as breaking", () => {
+  const bodies = { "refactor: rename the run contract": "BREAKING CHANGE: runs/:id moved" };
+  const commits = classify(["refactor: rename the run contract"], {
+    body: (subject) => bodies[subject] ?? "",
+  });
+  assert.equal(commits.length, 1);
+  assert.equal(commits[0].breaking, true);
+});
+
+test("before 1.0 a breaking change is a minor and everything else a patch", () => {
+  assert.equal(nextVersion("0.3.0", classify(["fix: a"])), "0.3.1");
+  assert.equal(nextVersion("0.3.0", classify(["feat: a"])), "0.3.1");
+  assert.equal(nextVersion("0.3.7", classify(["feat!: a"])), "0.4.0");
+});
+
+test("after 1.0 the usual semver applies", () => {
+  assert.equal(nextVersion("1.4.2", classify(["fix: a"])), "1.4.3");
+  assert.equal(nextVersion("1.4.2", classify(["feat: a"])), "1.5.0");
+  assert.equal(nextVersion("1.4.2", classify(["feat!: a"])), "2.0.0");
+});
+
+test("nothing releasing means no version at all", () => {
+  assert.equal(nextVersion("0.3.0", classify(["docs: a", "chore: b"])), null);
+});
+
+test("release notes lead with breaking changes and name the scope", () => {
+  const notes = releaseNotes(
+    "0.4.0",
+    classify(["feat!: require node 22", "fix(gateway): drain metering", "feat: add the inbox"]),
+  );
+  assert.match(notes, /^## 0\.4\.0/);
+  assert.ok(notes.indexOf("Breaking changes") < notes.indexOf("Features"));
+  assert.ok(notes.includes("- **gateway**: drain metering"));
+});
+
+test("decide reads the last v-tag and the subjects after it", () => {
+  const calls = [];
+  const exec = (_command, args) => {
+    calls.push(args.join(" "));
+    if (args[0] === "tag") return "v0.3.0\nv0.2.9\nnot-a-tag\n";
+    if (args[0] === "log") return "fix: one\ndocs: two\n";
+    throw new Error(`unexpected git call: ${args.join(" ")}`);
+  };
+  const decision = decide({ repoDir: "/tmp", exec });
+  assert.equal(decision.previous, "0.3.0");
+  assert.equal(decision.version, "0.3.1");
+  assert.equal(decision.tag, "v0.3.1");
+  assert.equal(decision.considered, 2);
+  assert.equal(decision.releasing, 1);
+  assert.ok(calls.some((call) => call.includes("v0.3.0..HEAD")));
+});
+
+test("decide starts from 0.0.0 when the repository has never released", () => {
+  const exec = (_command, args) => {
+    if (args[0] === "tag") return "\n";
+    if (args[0] === "log") return "feat: first\n";
+    throw new Error("unexpected");
+  };
+  assert.equal(decide({ repoDir: "/tmp", exec }).version, "0.0.1");
+});
+
+test("decide reports no release when only invisible work landed", () => {
+  const exec = (_command, args) => {
+    if (args[0] === "tag") return "v0.3.0\n";
+    if (args[0] === "log") return "docs: a\nci: b\n";
+    throw new Error("unexpected");
+  };
+  const decision = decide({ repoDir: "/tmp", exec });
+  assert.equal(decision.release, false);
+  assert.equal(decision.tag, null);
+});
+
+test("without any tag the sequence starts from the version in package.json", () => {
+  const exec = (_command, args) => {
+    if (args[0] === "tag") return "\n";
+    if (args[0] === "log") return "fix: one\n";
+    throw new Error("unexpected");
+  };
+  const decision = decide({ repoDir: "/tmp", exec, fallbackVersion: "0.3.0" });
+  assert.equal(decision.previous, "0.3.0");
+  assert.equal(decision.version, "0.3.1");
+});


### PR DESCRIPTION
The shape you chose: no release pull request, no version-bump commit, no tag to push. **Merging to `main` is the release**, and the commit subjects decide whether it happens and as what.

## The run, in order — which is the whole safety argument

1. **`decide-release`** — `scripts/version.mjs` reads the subjects since the last `v*` tag. Only `feat`, `fix`, `perf` and anything marked breaking count, so a documentation merge publishes nothing. No qualifying subject, no release, and the run ends.
2. **Acceptance** — verification, self-host build and sandbox E2E on the merged commit, exactly as today.
3. **`package-release`** — stamps the decided version into both `package.json` files *inside the run*, packs the archive, installs it the way `npx` would, and runs the binary from it.
4. **Publish** — npm and, once the repository is public, the images, from that exact archive and digest set.
5. **`record-release`** — only now the annotated tag is written and the GitHub release published with generated notes.

Nothing commits a version bump. The tags are the source of truth, which is what removes the "two files must agree" failure mode entirely — they are stamped together or not at all.

A run that fails before step 5 leaves **no tag**, so the next merge recomputes the same version and retries instead of skipping it. And `registryState` still refuses a version npm already has, whatever the decision claimed.

## What proves a release, now

Not a tag ref: a push of `main`, whose stamp matches the decision, on a commit reachable from `origin/main`. `validateReleasePolicy` was rewritten around that — same failure-closed style, one new check (`stamped version does not match the decided version`), one removed (the tag SHA). The image planner made the same move.

Tags stop being a CI trigger. They are written after the fact and request nothing, so triggering on them would only invite a second, confusing run.

## Pre-1.0 semantics

`feat!` is a minor, everything else a patch — the plain reading of what the README already promises about `0.x`. After 1.0 the usual major/minor/patch applies, and the tests pin both.

## Verification

- 76 script tests pass, thirteen of them new and covering the decision itself with `git` injected, so they do not depend on this repository's history.
- A simulated repository walked through the three cases end to end: a docs-only merge (**no release**), a fix with no tags yet (starts from `package.json`'s `0.3.0` → **0.3.1**), and a breaking change after that tag (→ **0.4.0**).
- The stamp leaves both files identical, and refuses anything that is not a semver triple.

## Before merging

Create the bootstrap tag, so the first computed release does not carry the whole history in its notes:

```bash
git tag -a v0.3.0 -m "0.3.0 — the version this repository had before releases became automatic" && git push origin v0.3.0
```

It lands inert either way: while the repository is private, every publishing job is gated on public visibility, so the first real release happens with the flip.