### PR TITLE
docs: correct the tag-ruleset step and split out the release runbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,40 +98,17 @@ Describe the user-visible behavior, the files or subsystems affected, and the
 verification commands you ran. Keep unrelated cleanup in a separate pull
 request so the change can be reviewed and reverted independently.
 
-## Releasing (maintainers)
+## Releasing
 
 **Merging to `main` is the release.** There is no version-bump commit, no
 release branch, and no tag to push by hand: `.github/workflows/ci.yml` decides
 from the commit subjects since the last release whether this merge publishes
 and as what version, then verifies, publishes, and writes the tag.
 
-The order matters, and it is the whole safety argument:
-
-1. **Decide** — `scripts/version.mjs` reads the full non-merge commit messages
-   since the last `v*` tag. Only `feat`, `fix`, `perf`, `revert`, and anything
-   marked breaking count. If nothing qualifies, the run ends here and nothing
-   is published.
-2. **Verify** — root verification, the self-host build, and the sandbox E2E, on
-   the merged commit.
-3. **Package** — the decided version is stamped into both `package.json` files
-   *inside the run*, the archive is built, installed the way `npx` would, and
-   its binary is executed. Nothing is committed; the checkout's version number
-   is not the source of truth.
-4. **Publish** — npm and, once the repository is public, the images, from that
-   exact archive and digest set.
-5. **Record** — only now is the annotated tag written and the GitHub release
-   published with the generated notes.
-
-A run that fails before both publishers finish leaves no tag. Retry the failed
-jobs in that same workflow run so they reuse the accepted artifacts and retain
-the successful publisher's result. Exact npm artifacts and image digests are
-idempotent on that retry; the publishers refuse the same version with different
-contents. Do not use another merge as the retry. If recording fails after the
-tag was pushed, rerunning that failed job verifies the tag still targets the
-released commit and creates the missing GitHub Release.
-
-Do not run `npm publish` locally or invoke the release workflow as a substitute
-for those gates; its manual entry point is a dry run.
+That puts one obligation on a contributor, and it is the section below. The
+maintainer's side — the ordering behind those gates, how to recover a failed
+release, and the setup steps that run once — is in
+[docs/releasing.md](docs/releasing.md).
 
 ### Commit subjects decide the version
 
@@ -139,69 +116,3 @@ Subjects follow [Conventional Commits](https://www.conventionalcommits.org/),
 and CI checks the pull request title, because a squash merge makes that title
 the subject on `main`. The rules — and the two ways a careless subject hurts a
 user — are in [AGENTS.md](AGENTS.md#commit-subjects-set-the-released-version).
-
-### First npm publish only
-
-npm cannot attach a trusted publisher until the package exists. Bootstrap
-`@theagilemonkeys/facility` once with a short-lived
-[granular access token](https://docs.npmjs.com/creating-and-viewing-access-tokens/):
-
-1. Give the token read/write access only to the `@theagilemonkeys` scope, no
-   organization-management access, the shortest practical expiry, and bypass
-   2FA for the CI publish.
-2. Create the GitHub environment named `npm`, restrict its deployment branches
-   to `main`, require maintainer approval, and store the token there as the
-   `NPM_BOOTSTRAP_TOKEN` environment secret.
-
-   Do **not** add a ruleset restricting `v*` tag creation while
-   `record-release` pushes that tag with `GITHUB_TOKEN` after a successful
-   publish. A ruleset's bypass list accepts roles, teams, GitHub Apps and
-   Dependabot; Actions' own token is none of those, so the push is rejected and
-   the release stays on npm and GHCR with no tag recording it. The next merge
-   then recomputes the same version and npm rejects it as a duplicate. The
-   environment approval is the gate; the tag is a record written afterwards.
-
-   The trade-off this accepts: anyone with write access can create a `v*` tag,
-   and `scripts/version.mjs` reads the highest one as the release baseline, so
-   a stray tag can skip a version or wedge a release after it has published.
-   Closing that means `record-release` authenticating as a GitHub App the
-   ruleset lists as a bypass actor — a change to the workflow, not a
-   setting to switch on.
-3. Before merging the release-on-merge workflow, establish the inert history
-   boundary it will read. For this repository, tag the existing version:
-
-   ```bash
-   git tag -a v0.3.0 -m "0.3.0 — release-on-merge baseline"
-   git push origin v0.3.0
-   ```
-
-   Tag pushes do not publish; this only prevents legacy history from entering
-   the first automated decision.
-4. Merge the first release-impacting pull request to `main`. The main-push
-   workflow accepts this credential only while the package is absent from npm;
-   it writes the release tag after npm and the images have both published.
-
-As soon as the first version exists, configure the package's
-[npm trusted publisher](https://docs.npmjs.com/trusted-publishers/) with these
-exact GitHub Actions values:
-
-- organization or user: `theam`
-- repository: `facility`
-- workflow filename: `ci.yml`
-- environment: `npm`
-- allowed action: `npm publish`
-
-Use `ci.yml`, not `release.yml`: npm validates the caller when a reusable
-workflow contains the publish command. Then delete the `NPM_BOOTSTRAP_TOKEN`
-GitHub secret, revoke the granular token on npm, and set the package's
-**Publishing access** to **Require two-factor authentication and disallow
-tokens**. Later release-impacting merges publish through short-lived OIDC
-credentials; their tags are written afterwards as records.
-
-### One-time GitHub Pages setup
-
-After the repository becomes public, a maintainer must select **GitHub
-Actions** under **Settings → Pages → Build and deployment → Source** once.
-After that, `.github/workflows/docs.yml` deploys pushes to `main` and manual
-runs selected from `main`. The workflow deliberately does not use an admin
-token or PAT to change the repository setting itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,13 +153,20 @@ npm cannot attach a trusted publisher until the package exists. Bootstrap
    to `main`, require maintainer approval, and store the token there as the
    `NPM_BOOTSTRAP_TOKEN` environment secret.
 
-   Do **not** add a ruleset restricting `v*` tag creation. `record-release`
-   writes that tag with `GITHUB_TOKEN` after a successful publish, and a
-   ruleset's bypass list accepts roles, teams, GitHub Apps and Dependabot —
-   not a workflow. Restricting tag creation would leave releases published to
-   npm and GHCR with no tag, so the next merge would recompute the same version
-   and npm would reject it as a duplicate. The environment approval is the gate;
-   the tag is a record written afterwards.
+   Do **not** add a ruleset restricting `v*` tag creation while
+   `record-release` pushes that tag with `GITHUB_TOKEN` after a successful
+   publish. A ruleset's bypass list accepts roles, teams, GitHub Apps and
+   Dependabot; Actions' own token is none of those, so the push is rejected and
+   the release stays on npm and GHCR with no tag recording it. The next merge
+   then recomputes the same version and npm rejects it as a duplicate. The
+   environment approval is the gate; the tag is a record written afterwards.
+
+   The trade-off this accepts: anyone with write access can create a `v*` tag,
+   and `scripts/version.mjs` reads the highest one as the release baseline, so
+   a stray tag can skip a version or wedge a release after it has published.
+   Closing that means `record-release` authenticating as a GitHub App the
+   ruleset lists as a bypass actor — a change to the workflow, not a
+   setting to switch on.
 3. Before merging the release-on-merge workflow, establish the inert history
    boundary it will read. For this repository, tag the existing version:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,17 @@ npm cannot attach a trusted publisher until the package exists. Bootstrap
 1. Give the token read/write access only to the `@theagilemonkeys` scope, no
    organization-management access, the shortest practical expiry, and bypass
    2FA for the CI publish.
-2. Protect `v*` tag creation with a repository ruleset. Create the GitHub
-   environment named `npm`, require maintainer approval for deployment, and
-   store the token there as the `NPM_BOOTSTRAP_TOKEN` environment secret.
+2. Create the GitHub environment named `npm`, restrict its deployment branches
+   to `main`, require maintainer approval, and store the token there as the
+   `NPM_BOOTSTRAP_TOKEN` environment secret.
+
+   Do **not** add a ruleset restricting `v*` tag creation. `record-release`
+   writes that tag with `GITHUB_TOKEN` after a successful publish, and a
+   ruleset's bypass list accepts roles, teams, GitHub Apps and Dependabot —
+   not a workflow. Restricting tag creation would leave releases published to
+   npm and GHCR with no tag, so the next merge would recompute the same version
+   and npm would reject it as a duplicate. The environment approval is the gate;
+   the tag is a record written afterwards.
 3. Before merging the release-on-merge workflow, establish the inert history
    boundary it will read. For this repository, tag the existing version:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # Documents about building Facility
 
 This directory holds the documents that only matter if you are working *on*
-Facility — today, what verification has to prove before a change is releasable.
+Facility — what verification has to prove before a change is releasable, and
+what happens when one is merged.
 
 Everything about *using* Facility — the method, the concepts, the guides, the
 reference, self-hosting — lives in [`apps/docs`](../apps/docs), which is the
@@ -10,3 +11,5 @@ it belongs there.
 
 - [`testing.md`](testing.md) — the two acceptance tiers and the sandbox E2E
   policy. A green fast test run is not release evidence.
+- [`releasing.md`](releasing.md) — how merging to `main` publishes, how to
+  recover a failed run, and the one-time bootstrap steps. Maintainers only.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,109 @@
+# Releasing Facility
+
+**Merging to `main` is the release.** There is no version-bump commit, no
+release branch, and no tag to push by hand: `.github/workflows/ci.yml` decides
+from the commit subjects since the last release whether this merge publishes
+and as what version, then verifies, publishes, and writes the tag.
+
+What that asks of a contributor — an honest commit subject — is in
+[CONTRIBUTING.md](../CONTRIBUTING.md#releasing). Everything below is the
+maintainer's side: the ordering that makes a release safe, how to recover a
+failed one, and the setup steps that run once and never again.
+
+## The release run
+
+The order matters, and it is the whole safety argument:
+
+1. **Decide** — `scripts/version.mjs` reads the full non-merge commit messages
+   since the last `v*` tag. Only `feat`, `fix`, `perf`, `revert`, and anything
+   marked breaking count. If nothing qualifies, the run ends here and nothing
+   is published.
+2. **Verify** — root verification, the self-host build, and the sandbox E2E, on
+   the merged commit.
+3. **Package** — the decided version is stamped into both `package.json` files
+   *inside the run*, the archive is built, installed the way `npx` would, and
+   its binary is executed. Nothing is committed; the checkout's version number
+   is not the source of truth.
+4. **Publish** — npm and, once the repository is public, the images, from that
+   exact archive and digest set.
+5. **Record** — only now is the annotated tag written and the GitHub release
+   published with the generated notes.
+
+## Recovering a failed run
+
+A run that fails before both publishers finish leaves no tag. Retry the failed
+jobs in that same workflow run so they reuse the accepted artifacts and retain
+the successful publisher's result. Exact npm artifacts and image digests are
+idempotent on that retry; the publishers refuse the same version with different
+contents. Do not use another merge as the retry. If recording fails after the
+tag was pushed, rerunning that failed job verifies the tag still targets the
+released commit and creates the missing GitHub Release.
+
+Do not run `npm publish` locally or invoke the release workflow as a substitute
+for those gates; its manual entry point is a dry run.
+
+## First npm publish only
+
+npm cannot attach a trusted publisher until the package exists. Bootstrap
+`@theagilemonkeys/facility` once with a short-lived
+[granular access token](https://docs.npmjs.com/creating-and-viewing-access-tokens/):
+
+1. Give the token read/write access only to the `@theagilemonkeys` scope, no
+   organization-management access, the shortest practical expiry, and bypass
+   2FA for the CI publish.
+2. Create the GitHub environment named `npm`, restrict its deployment branches
+   to `main`, require maintainer approval, and store the token there as the
+   `NPM_BOOTSTRAP_TOKEN` environment secret.
+
+   Do **not** add a ruleset restricting `v*` tag creation while
+   `record-release` pushes that tag with `GITHUB_TOKEN` after a successful
+   publish. A ruleset's bypass list accepts roles, teams, GitHub Apps and
+   Dependabot; Actions' own token is none of those, so the push is rejected and
+   the release stays on npm and GHCR with no tag recording it. The next merge
+   then recomputes the same version and npm rejects it as a duplicate. The
+   environment approval is the gate; the tag is a record written afterwards.
+
+   The trade-off this accepts: anyone with write access can create a `v*` tag,
+   and `scripts/version.mjs` reads the highest one as the release baseline, so
+   a stray tag can skip a version or wedge a release after it has published.
+   Closing that means `record-release` authenticating as a GitHub App the
+   ruleset lists as a bypass actor — a change to the workflow, not a
+   setting to switch on.
+3. Before merging the release-on-merge workflow, establish the inert history
+   boundary it will read. For this repository, tag the existing version:
+
+   ```bash
+   git tag -a v0.3.0 -m "0.3.0 — release-on-merge baseline"
+   git push origin v0.3.0
+   ```
+
+   Tag pushes do not publish; this only prevents legacy history from entering
+   the first automated decision.
+4. Merge the first release-impacting pull request to `main`. The main-push
+   workflow accepts this credential only while the package is absent from npm;
+   it writes the release tag after npm and the images have both published.
+
+As soon as the first version exists, configure the package's
+[npm trusted publisher](https://docs.npmjs.com/trusted-publishers/) with these
+exact GitHub Actions values:
+
+- organization or user: `theam`
+- repository: `facility`
+- workflow filename: `ci.yml`
+- environment: `npm`
+- allowed action: `npm publish`
+
+Use `ci.yml`, not `release.yml`: npm validates the caller when a reusable
+workflow contains the publish command. Then delete the `NPM_BOOTSTRAP_TOKEN`
+GitHub secret, revoke the granular token on npm, and set the package's
+**Publishing access** to **Require two-factor authentication and disallow
+tokens**. Later release-impacting merges publish through short-lived OIDC
+credentials; their tags are written afterwards as records.
+
+## One-time GitHub Pages setup
+
+After the repository becomes public, a maintainer must select **GitHub
+Actions** under **Settings → Pages → Build and deployment → Source** once.
+After that, `.github/workflows/docs.yml` deploys pushes to `main` and manual
+runs selected from `main`. The workflow deliberately does not use an admin
+token or PAT to change the repository setting itself.


### PR DESCRIPTION
While walking through the npm bootstrap, the instruction at `CONTRIBUTING.md:152` turned out to be a trap left over from the previous release model.

It says to protect `v*` tag creation with a repository ruleset. That was right when a human pushed the tag to *trigger* the release. It is now actively harmful: `record-release` writes that tag with `GITHUB_TOKEN` **after** npm and the images have accepted the release.

A ruleset cannot be made to allow that push as the workflow authenticates today. GitHub's eligible bypass actors are repository admins, organization owners, enterprise owners, the maintain/write role, teams, GitHub Apps and Dependabot — and Actions' own token is none of them.

So following the old step would produce the worst available state: a version published to npm and GHCR with no tag recording it, after which the next merge recomputes the same version and npm rejects it as a duplicate. The release would look successful and be unrepeatable.

The step now says what to do instead: restrict the `npm` environment to `main`, require approval there — that is the gate — and leave tag creation alone, because the tag is a record written afterwards rather than a request. After review it also states the trade-off that accepts: anyone with write access can create a `v*` tag, and `scripts/version.mjs` reads the highest one as the release baseline. Closing that would mean `record-release` authenticating as a GitHub App the ruleset lists as a bypass actor — a workflow change, deliberately not scheduled here.

### The maintainer runbook moves out of CONTRIBUTING.md

Half of `CONTRIBUTING.md` was a maintainer runbook: 107 of its 207 lines, 65 of them one-time bootstrap steps — npm token scopes, environment secret names, the baseline tag — that go stale the moment the first version publishes. A contributor read all of it before reaching the end of the file.

That side now lives in `docs/releasing.md`, which `docs/README.md` already defines as the home for documents that only matter when working *on* Facility. The prose moved verbatim. What a contributor actually needs stays behind: merging to `main` is the release, and the commit subject decides the version.

No code changes; 86 script tests and both guards still pass.