### PR TITLE
feat(image): put facility on the PATH in the api image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,10 +87,12 @@ COPY --from=build-api /app/packages/cli /app/cli
 # without a shell to resolve it.
 RUN printf '#!/bin/sh\nexec node /app/cli/bin/facility.mjs "$@"\n' > /usr/local/bin/facility \
   && chmod +x /usr/local/bin/facility
-# Regression guard for the deployed operator path: reaching the bootstrap
-# command through the wrapper proves the PATH entry, and importing it proves
-# that its production `postgres` dependency resolves.
-RUN facility instance bootstrap --help >/dev/null
+# Regression guard for the deployed operator path. Exec form on purpose: it
+# resolves `facility` the way the container runtime does for an ECS command
+# override, with no shell in between, so the guard exercises the same lookup the
+# runbook depends on. Reaching the command proves the PATH entry, and importing
+# it proves that its production `postgres` dependency resolves.
+RUN ["facility", "instance", "bootstrap", "--help"]
 EXPOSE 4400
 CMD ["node", "dist/start.js"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,16 @@ COPY --from=build-api /prod/api /app
 # hundred kilobytes of plain ESM whose only dependency, `postgres`, is already
 # here for @facility/db.
 COPY --from=build-api /app/packages/cli /app/cli
-# Regression guard for the deployed operator path: importing the bootstrap
-# command also proves that its production `postgres` dependency resolves.
-RUN node cli/bin/facility.mjs instance bootstrap --help >/dev/null
+# Operator commands read as `facility …` inside the image, the way they read
+# everywhere else, instead of as a path into it. A wrapper rather than a symlink
+# because the checked-in bin is not executable, and an ECS command override runs
+# without a shell to resolve it.
+RUN printf '#!/bin/sh\nexec node /app/cli/bin/facility.mjs "$@"\n' > /usr/local/bin/facility \
+  && chmod +x /usr/local/bin/facility
+# Regression guard for the deployed operator path: reaching the bootstrap
+# command through the wrapper proves the PATH entry, and importing it proves
+# that its production `postgres` dependency resolves.
+RUN facility instance bootstrap --help >/dev/null
 EXPOSE 4400
 CMD ["node", "dist/start.js"]
 

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -307,7 +307,7 @@ FACILITY_TASK="$(aws ecs run-task --region "$FACILITY_AWS_REGION" \
   --task-definition "$FACILITY_MIGRATE_DEF" \
   --network-configuration "$FACILITY_NETWORK" \
   --overrides '{"containerOverrides":[{"name":"migrate","command":[
-    "node","cli/bin/facility.mjs","instance","bootstrap",
+    "facility","instance","bootstrap",
     "--org-name","My Org","--org-slug","my-org",
     "--owner-email","you@example.com","--owner-name","Your Name",
     "--github-user-id","<user id>","--github-login","<login>",

--- a/apps/docs/test/aws-deployment-runbook.test.mjs
+++ b/apps/docs/test/aws-deployment-runbook.test.mjs
@@ -16,6 +16,23 @@ const guides = new Map([
   ],
 ]);
 
+const dockerfile = readFileSync(resolve(repoRoot, "Dockerfile"), "utf8");
+
+function apiStage(image) {
+  const start = image.indexOf("FROM base AS api\n");
+  assert.notEqual(start, -1, "the root Dockerfile must still build an api stage");
+  const end = image.indexOf("\nFROM ", start + 1);
+  return image.slice(start, end === -1 ? undefined : end);
+}
+
+function bootstrapOverrideCommand(markdown) {
+  const override = markdown.match(
+    /"containerOverrides":\[\{"name":"migrate","command":\[([\s\S]*?)\]\}\]\}/,
+  );
+  assert.ok(override, "the runbook must bootstrap the instance through a migrate task override");
+  return [...override[1].matchAll(/"([^"]*)"/g)].map(([, token]) => token);
+}
+
 function imageOverrideBlock(markdown, guideName) {
   const match = markdown.match(/```hcl\n(image_overrides = \{[\s\S]*?\n\})\n```/);
   assert.ok(match, `${guideName} must include the release image_overrides block`);
@@ -58,6 +75,33 @@ test("AWS guides select verified public release images before the first apply", 
       `${guideName} must not assume the packages are already public`,
     );
   }
+});
+
+// The bootstrap step binds the first organization, owner, and installation, so a
+// command the image cannot resolve fails it — and every later sign-in with
+// `not_invited`. Nothing else fails when the two halves drift apart: the runbook is
+// prose to CI, and the image builds happily without the name the runbook spells.
+test("the runbook bootstraps by the name the api image puts on the PATH", () => {
+  const [[, runbook]] = guides;
+  const stage = apiStage(dockerfile);
+
+  assert.deepEqual(
+    bootstrapOverrideCommand(runbook).slice(0, 3),
+    ["facility", "instance", "bootstrap"],
+    "the runbook must invoke the CLI by name, not as a path into the image",
+  );
+  assert.match(
+    stage,
+    /chmod \+x \/usr\/local\/bin\/facility/,
+    "the api stage must install an executable `facility` on the PATH",
+  );
+  // Exec form, so the guard resolves the name without a shell — the way the
+  // container runtime does for an ECS command override, and unlike `RUN cmd`.
+  assert.match(
+    stage,
+    /RUN\s*\[\s*"facility",\s*"instance",\s*"bootstrap"/,
+    "the api stage must fail the build when that name stops resolving without a shell",
+  );
 });
 
 test("AWS guides keep the release override and build-fallback paths synchronized", () => {


### PR DESCRIPTION
A small, real improvement — and deliberately the one that cuts the **first automatic release**, so we watch the whole pipeline run once with both of us looking at it.

## The change

The api image already carries the CLI, because `facility instance bootstrap` needs the database and in the reference deployment the database accepts connections only from the service security group — a one-shot ECS task is the only place it can run. But it could only be reached as a path into the image, so the runbook spells:

```
"node","cli/bin/facility.mjs","instance","bootstrap", …
```

in the middle of a JSON container override, at the step where getting it wrong means every sign-in fails with `not_invited`. Now it is `"facility","instance","bootstrap", …`.

A wrapper in `/usr/local/bin` rather than a symlink, for two reasons that are easy to trip over: the checked-in bin is not executable, and an ECS command override runs **without a shell** to resolve it. The build-time guard now goes through the wrapper, so the PATH entry cannot rot silently — if it breaks, the image build fails rather than the deployment.

## Verified against the built image

- `docker run … facility instance bootstrap --help` — the command resolves with no path;
- `docker run --entrypoint facility …` — how ECS invokes it, no shell involved;
- the runbook's exact bootstrap against a real Postgres: `{"ok":true,"created":true,…}`, then `"created":false` on a second run.

Guards, lint and the 86 script tests pass.

## What merging this does

`decide-release` reads `feat(image): …` since `v0.3.0` and computes **0.3.1** — a patch, since pre-1.0 only a breaking change is a minor. Then: acceptance, stamp and pack, publish to npm with the bootstrap token, publish the six images, and finally write the `v0.3.1` tag with its release notes.

Which leaves one thing for a maintainer right after: the six GHCR packages are created private, and making each public is a one-time manual step.