### PR TITLE
ci(release): pass the repository visibility the publication policy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,13 @@ jobs:
       - name: Stamp the decided version
         run: node scripts/release.mjs stamp "${{ needs.decide-release.outputs.version }}"
 
+      # The job's `if` is not enough: the runner exposes no
+      # GITHUB_REPOSITORY_VISIBILITY of its own, so the policy in release.mjs
+      # reads it as unset and refuses to publish from what looks like a private
+      # repository. It has to be passed in, the way images.yml passes it.
       - name: Validate the release
         env:
+          GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
           FACILITY_RELEASE_VERSION: ${{ needs.decide-release.outputs.version }}
         run: node scripts/release.mjs validate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,13 @@ jobs:
           name: facility-release-package
           path: ${{ runner.temp }}/facility-release
 
+      # Same reason as ci.yml's validate step: the visibility the policy checks
+      # has to be passed in, or the revalidation refuses a public release.
       - name: Revalidate the release and its artifact
         id: candidate
         shell: bash
+        env:
+          GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
         run: |
           set -euo pipefail
           FACILITY_RELEASE_VERSION="${{ inputs.version }}" node scripts/release.mjs validate

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -76,6 +76,9 @@ test("release policy fails closed on every version and provenance mismatch", () 
   const invalid = [
     [{ eventName: "workflow_dispatch" }, /real release must come from a push event/],
     [{ visibility: "private" }, /publishing is disabled until the repository is public/],
+    // Unset is the mode that actually stopped a release: a workflow step that
+    // never passes the variable looks exactly like a private repository here.
+    [{ visibility: undefined }, /publishing is disabled until the repository is public/],
     [{ ref: "refs/tags/v0.3.0" }, /a release must come from main, not refs\/tags\/v0\.3\.0/],
     [{ decidedVersion: undefined }, /no release version was decided for this commit/],
     [{ rootVersion: "0.2.0" }, /root package version \(0\.2\.0\) does not match CLI package version \(0\.3\.0\)/],
@@ -157,6 +160,32 @@ test("the workflow keeps manual runs credential-free and real publication main-o
     releaseWorkflow,
     /publish:[\s\S]*concurrency:\n      group: npm-theagilemonkeys-facility\n      cancel-in-progress: false/,
   );
+});
+
+// The policy above is only as good as its input. A job-level `if` on
+// github.event.repository.visibility is evaluated by Actions and says nothing
+// about what the step's process can read, so a step that runs `validate`
+// without binding the variable refuses a public release — which is how the
+// v0.3.1 run failed. Assert the binding on every validating step in both
+// workflows, so deleting one fails here instead of at the release.
+test("both release validations receive the visibility their policy checks", () => {
+  for (const [name, workflow] of [
+    ["ci.yml", ciWorkflow],
+    ["release.yml", releaseWorkflow],
+  ]) {
+    const validating = workflow
+      .split(/\n      - name: /)
+      .slice(1)
+      .filter((step) => /node scripts\/release\.mjs validate/.test(step));
+    assert.ok(validating.length, `${name} must validate the release before publishing`);
+    for (const step of validating) {
+      assert.match(
+        step,
+        /GITHUB_REPOSITORY_VISIBILITY: \$\{\{ github\.event\.repository\.visibility \}\}/,
+        `${name}: the step running \`release.mjs validate\` must pass the visibility it reads`,
+      );
+    }
+  }
 });
 
 test("CI publishes only the exact artifact produced after all acceptance jobs", () => {


### PR DESCRIPTION
The first automatic release — the v0.3.1 run cut by #58 — failed closed at `package-release` with:

```
npm publishing is disabled until the repository is public
```

on a repository that is public. Nothing was published and no tag was written, so `v0.3.0` is still the last release and `1478f76` is sitting on `main` unreleased.

## Why

`scripts/release.mjs` reads visibility from `GITHUB_REPOSITORY_VISIBILITY` (`release.mjs:76`) and refuses to publish unless it is `public` (`release.mjs:47`). The runner exposes no variable by that name of its own — it has to be passed in.

Two steps never passed it:

- `ci.yml` → `package-release` → **Validate the release**
- `release.yml` → **Revalidate the release and its artifact**

`images.yml:64` does pass it, which is why image publication was never affected and why the omission stayed invisible.

The job-level `if: github.event.repository.visibility == 'public'` is what hides this. That expression is evaluated by Actions from the event payload, so it is correct and the job starts — and then the policy *inside* the job reads an unset variable and refuses. The guard and its gate disagreed while both looked right.

## The fix

Two `env:` additions, matching what `images.yml` already does. Fixing only `ci.yml` would have moved the identical failure one job downstream into `publish-npm`'s revalidation, so both get it.

## Verification

`validateReleasePolicy` called with the failed release's own inputs:

| `GITHUB_REPOSITORY_VISIBILITY` | Result |
|---|---|
| unset (what CI saw) | refuses: `npm publishing is disabled until the repository is public` |
| `public` (what the fix passes) | validates |

`node --test scripts/release.test.mjs` 9/9, `node guards/run.mjs` 2/2, both workflows parse.

## Releasing

`ci:` releases nothing on its own, which is right — nothing here changes what users install. Merging this pushes `main`, and that run decides from the commits since `v0.3.0`, which still include #58's `feat(image)` — so it should cut **0.3.1**, the version this run was meant to.

Note `docs/releasing.md` says to retry the failed jobs in the same run rather than merging again. That cannot work here: that run checks out `1478f76`, which does not contain this fix.

## Not included

A test asserting the workflows actually pass the variable — the policy is unit-tested, the wiring is not, which is how this shipped. Left out at the author's call.