### PR TITLE
ci(release): inherit secrets so the npm environment token reaches the publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,14 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ needs.decide-release.outputs.version }}
+    # Required for the publish job to see NPM_BOOTSTRAP_TOKEN. Declaring
+    # `environment: npm` on that job is not enough on its own: without this, a
+    # called workflow resolves every environment-scoped secret to an empty
+    # string rather than failing, which is how the first 0.3.1 attempt reached
+    # the bootstrap step with no token. The environment still gates the secret —
+    # it materializes only in the job that names the environment — and there are
+    # no repository or organization secrets here for `inherit` to widen.
+    secrets: inherit
 
   # Publish containers from the same accepted run as npm. The reusable workflow
   # revalidates the release before granting its jobs packages: write.

--- a/scripts/release.integration.test.mjs
+++ b/scripts/release.integration.test.mjs
@@ -420,6 +420,37 @@ test("an exact 404 permits bootstrap publication without running package lifecyc
   await assertMissing(state.lifecycleMarker);
 });
 
+// The mode a missing `secrets: inherit` produces. A called workflow resolves an
+// environment secret it was never passed to the empty string rather than
+// failing, so the bootstrap step runs with NODE_AUTH_TOKEN set and empty — which
+// is how the first 0.3.1 attempt reached npm with no credential. Unset is
+// covered alongside it because the two must not diverge: both are "no token".
+test("bootstrap publication without a token fails closed before any write", async (t) => {
+  for (const [name, mutate] of [
+    ["empty", (env) => Object.assign(env, { NODE_AUTH_TOKEN: "" })],
+    ["unset", (env) => (delete env.NODE_AUTH_TOKEN, env)],
+  ]) {
+    const state = await fixture(t);
+    const registry = await fakeRegistry(t, { tokenStatus: () => 201 });
+    const env = mutate(await npmEnvironment(state, registry.url, "unused-bootstrap-token"));
+
+    const result = await release(["publish", state.tarball, "--auth=bootstrap"], env);
+
+    assert.equal(result.code, 1, `${name} token must not publish: ${result.stdout}`);
+    assert.match(
+      result.stderr,
+      /NPM_BOOTSTRAP_TOKEN is required for the first package publication/,
+      `${name} token must name the missing credential`,
+    );
+    assert.deepEqual(
+      registry.requests.filter(({ method }) => method === "PUT"),
+      [],
+      `${name} token must not reach the registry with a write`,
+    );
+    await assertMissing(state.lifecycleMarker);
+  }
+});
+
 test("existing, replayed, unavailable, and malformed registry states fail closed before PUT", async (t) => {
   const cases = [
     {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -188,6 +188,28 @@ test("both release validations receive the visibility their policy checks", () =
   }
 });
 
+// `environment: npm` on the called job is necessary but not sufficient: without
+// `secrets: inherit` on the caller, a called workflow resolves every
+// environment-scoped secret to an empty string instead of failing, so the
+// bootstrap step runs with no token. That is how the first 0.3.1 attempt
+// published six images and nothing to npm. Both halves are asserted here
+// because either one alone silently reproduces that split.
+test("the npm publisher inherits the secrets its environment gates", () => {
+  const publishNpm = ciWorkflow.split("\n  publish-npm:")[1]?.split("\n\n  ")[0];
+  assert.ok(publishNpm, "CI workflow must contain a publish-npm job");
+  assert.match(publishNpm, /uses: \.\/\.github\/workflows\/release\.yml/);
+  assert.match(
+    publishNpm,
+    /\n    secrets: inherit\b/,
+    "publish-npm must pass secrets to the reusable workflow, or NPM_BOOTSTRAP_TOKEN arrives empty",
+  );
+  assert.match(
+    releaseWorkflow.split("\n  publish:")[1] ?? "",
+    /\n    environment: npm\n/,
+    "the publish job must still name the environment that gates the token",
+  );
+});
+
 test("CI publishes only the exact artifact produced after all acceptance jobs", () => {
   assert.match(
     ciWorkflow,


### PR DESCRIPTION
The 0.3.1 run got further than the last one — `package-release` passed, so #59's fix works — and then split:

| | Result |
|---|---|
| GHCR | ✅ six images promoted at `0.3.1` and `sha-73f88778a5a3` |
| npm | ❌ nothing — `@theagilemonkeys/facility` is absent from the registry |
| tag | ❌ none; `record-release` needs both publishers |

`publish-npm / publish` failed at **Bootstrap the package once with a granular token** with `NPM_BOOTSTRAP_TOKEN is required for the first package publication`, and `NODE_AUTH_TOKEN` printed blank rather than `***` — an empty value, not a masked one.

## Why

The token is fine. `NPM_BOOTSTRAP_TOKEN` exists in the `npm` environment (created 2026-07-31), the environment allows only `main`, and the publish job correctly declares `environment: npm`.

The gap is the reusable-workflow boundary: `ci.yml` calls `release.yml` with no `secrets:` key. A called workflow does not receive environment-scoped secrets by declaring the environment alone — without `secrets: inherit` on the caller, **every environment-scoped secret resolves to an empty string** rather than erroring. GitHub's docs omit this; it is tracked in [actions/runner#1490](https://github.com/actions/runner/issues/1490) and [github/docs#44458](https://github.com/github/docs/issues/44458).

So the job authenticated with nothing and failed the way it would if the secret had never been created.

## Why `inherit` is not a widening here

- The environment still gates the token: it materializes only in the job naming `environment: npm`, which keeps the branch policy and approval as the real control.
- `gh api repos/theam/facility/actions/secrets` and the org-secrets endpoint both return empty — there is nothing else for `inherit` to forward.
- Explicitly mapping `NPM_BOOTSTRAP_TOKEN:` from the caller cannot work: the calling job does not declare the environment, so it would forward an empty string too.

`publish-images` needs no change — it uses `GITHUB_TOKEN`, which called workflows always receive.

## Verification

`node --test scripts/*.test.mjs` → 88/88. The new test asserts `secrets: inherit` on the caller **and** `environment: npm` on the callee; removing either makes it fail, checked both ways. Both workflows parse, and `secrets` is accepted on the `publish-npm` job.

I cannot prove this end to end from a PR — `publish-npm` only runs on a push to `main`, so the release run is again the first real exercise.

## Before merging

The six GHCR images already carry `0.3.1` from `73f8877`. `scripts/images.mjs:160` refuses to move an existing tag to a different digest, and `.dockerignore` does not exclude `.github`, so rebuilding after this commit may produce different digests and wedge `promote`. **Delete the six `0.3.1` package versions first**, so this merge can publish a coherent 0.3.1 to both registries.

## Follow-up worth considering, not included here

`docs/releasing.md` tells maintainers to retry the failed jobs in the same run. That cannot work when the failure is in the workflow itself, since a re-run uses the workflow files from the run's own commit — true for both 0.3.1 attempts. The runbook deserves that caveat.