### PR TITLE
fix(web): bake API URL into proxy rewrites

### DIFF
--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -138,8 +138,10 @@ terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
 ## 3. Build and push images when needed
 
 If you configured and verified public `image_overrides` before the first apply,
-skip this step. Otherwise build the images into the ECR repositories that the
-module created.
+skip this step. The overridden `web` image must have been built with
+`FACILITY_API_URL` set to this deployment's `api_url`; its same-origin proxy
+destination is part of the compiled Next.js build. Otherwise build the images
+into the ECR repositories that the module created.
 
 The build script defaults to a playground prefix, so `ECR_PREFIX` is mandatory:
 
@@ -147,6 +149,7 @@ The build script defaults to a playground prefix, so `ECR_PREFIX` is mandatory:
 AWS_REGION="$FACILITY_AWS_REGION" \
 ECR_PREFIX="$(terraform -chdir="$FACILITY_TF_DIR" output -raw ecs_cluster_name)" \
 IMAGE_TAG="$FACILITY_IMAGE_TAG" \
+FACILITY_API_URL="$(terraform -chdir="$FACILITY_TF_DIR" output -raw api_url)" \
 CPU_ARCHITECTURE=X86_64 \
 ./infra/build-images.sh
 ```
@@ -155,6 +158,10 @@ Never `latest`: the tag in tfvars must match `FACILITY_IMAGE_TAG` exactly, so
 that what is deployed is identifiable from a commit. Deriving `ECR_PREFIX` from
 Terraform keeps the pushed repositories aligned with the selected project and
 environment.
+
+Rebuild and redeploy the `web` image whenever `api_url` changes. Changing only
+the runtime ECS environment variable does not alter the rewrite destination in
+an already-built image.
 
 ## 4. Populate the secret containers
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,11 +1,15 @@
 # Facility web (Next.js standalone). Built from the repo root:
-#   docker build -f apps/web/Dockerfile -t facility/web .
+#   docker build --build-arg FACILITY_API_URL=https://api.example.com \
+#     -f apps/web/Dockerfile -t facility/web .
 FROM node:22-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm PATH=$PNPM_HOME:$PATH
 RUN corepack enable
 WORKDIR /app
 
 FROM base AS build
+ARG FACILITY_API_URL
+RUN test -n "$FACILITY_API_URL"
+ENV FACILITY_API_URL=$FACILITY_API_URL
 COPY . .
 RUN pnpm install --frozen-lockfile --filter '@facility/web...'
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,12 @@ services:
       api: { condition: service_healthy }
 
   web:
-    build: { context: ., dockerfile: apps/web/Dockerfile, target: web }
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      target: web
+      args:
+        FACILITY_API_URL: http://api:4400
     restart: unless-stopped
     environment:
       FACILITY_API_URL: http://api:4400

--- a/infra/build-images.sh
+++ b/infra/build-images.sh
@@ -39,13 +39,18 @@ build_and_push() {
   local context="${4:-$ROOT_DIR}"
   local image="${ECR_REGISTRY}/${ECR_PREFIX}/${name}:${IMAGE_TAG}"
   local target_arg=()
+  local build_args=()
   [[ -n "$target" ]] && target_arg=(--target "$target")
+  if [[ "$name" == "web" ]]; then
+    : "${FACILITY_API_URL:?FACILITY_API_URL is required to build the web image}"
+    build_args=(--build-arg "FACILITY_API_URL=$FACILITY_API_URL")
+  fi
 
   if [[ ! -f "$ROOT_DIR/$dockerfile" ]]; then
     printf 'Missing Dockerfile for %s: %s\n' "$name" "$dockerfile" >&2
     exit 1
   fi
-  docker build --platform "$PLATFORM" "${target_arg[@]}" \
+  docker build --platform "$PLATFORM" "${target_arg[@]}" "${build_args[@]}" \
     -f "$ROOT_DIR/$dockerfile" -t "$image" "$context"
   docker push "$image"
   printf '%s=%s\n' "$name" "$image"

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -104,14 +104,18 @@ Record these outputs:
 ## 3. Build and push images when needed
 
 If you configured and verified public `image_overrides` before the first apply,
-skip this step. Otherwise, from the module directory used above, build from the
-repository root and return afterward:
+skip this step. The overridden `web` image must have been built with
+`FACILITY_API_URL` set to this deployment's `api_url`; unlike the other images,
+its same-origin proxy destination is compiled into the Next.js build. Otherwise,
+from the module directory used above, build from the repository root and return
+afterward:
 
 ```bash
 cd ../../..
 AWS_REGION=us-east-1 \
 ECR_PREFIX="$(terraform -chdir=infra/terraform/aws output -raw ecs_cluster_name)" \
 IMAGE_TAG=$(git rev-parse --short HEAD) \
+FACILITY_API_URL="$(terraform -chdir=infra/terraform/aws output -raw api_url)" \
 ./infra/build-images.sh
 cd infra/terraform/aws
 ```
@@ -123,6 +127,10 @@ default, matching Terraform's default `task_cpu_architecture = "X86_64"`. To
 deploy on Graviton, set `CPU_ARCHITECTURE=ARM64` while building and set
 `task_cpu_architecture = "ARM64"` in Terraform. The build exits early if an
 explicit `PLATFORM` conflicts with `CPU_ARCHITECTURE`.
+
+Rebuild and redeploy the `web` image whenever `api_url` changes. Supplying only
+the runtime ECS environment variable does not update Next.js rewrite rules that
+were compiled into an existing image.
 
 If you changed `container_image_tags` after the first apply, apply again before
 running the migrate task. Keeping the tag stable avoids that extra apply.


### PR DESCRIPTION
## What changes

- Make the web Docker image require and bake `FACILITY_API_URL` into Next.js rewrite rules.
- Pass the deployment API URL through `infra/build-images.sh` for AWS web builds.
- Pass the internal `http://api:4400` URL through the documented Docker Compose build.
- Document the deployment-specific web image requirement and rebuild rule in both AWS runbooks.

## Why

The production web image compiled its same-origin `/api/*` proxy with the localhost fallback. ECS supplied the public API URL only at runtime, so `/api/auth/login` attempted to reach `127.0.0.1:4400` and returned 500 even though the API service was healthy.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (built the production `linux/amd64` image and confirmed its `routes-manifest.json` contains `https://api.facility.tam-os.com/:path*`; rolled ECS web to task definition revision 2 and verified `/api/auth/login` returns 302 to GitHub; built `facility-web` through Docker Compose and confirmed its manifest contains `http://api:4400/:path*`)
- [x] Documentation updated, or no user-facing change

`pnpm verify` was run with `COMPOSE_ENV_FILES=.env.example` so Docker Compose did not load deployment credentials from the local `.env`.
