### PR TITLE
feat(aws): run platform lanes in CodeBuild

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,13 @@ FACILITY_INSECURE_DEV=1
 
 # --- Sandboxes ---
 # Driver the seeded default sandbox profile uses; must match the deployment.
-# "docker" for local/self-host, "aws" for the Fargate stack. `facility doctor`
+# "docker" for local/self-host, "aws" for the CodeBuild stack. `facility doctor`
 # fails if no profile matches this driver.
 FACILITY_SANDBOX_DRIVER=docker
 # Image the seeded default sandbox profile uses to run platform-lane agents
 # (Claude Code, Codex) on the docker driver. Its entrypoint must be the Facility
 # runner — build it with `docker build -t facility-runner:dev runner/`. In the
-# cloud the AWS runner task definition provides the runner instead.
+# cloud the same image is selected per CodeBuild sandbox.
 FACILITY_RUNNER_IMAGE=facility-runner:dev
 # URLs as resolved from inside a sandbox, not necessarily browser-facing URLs.
 SANDBOX_API_URL=http://host.docker.internal:4400

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,14 @@ jobs:
         if: steps.policy.outputs.required == 'true'
         run: docker build --pull -t facility-runner:dev runner
 
+      - name: Exercise the privileged CodeBuild boundary
+        if: steps.policy.outputs.required == 'true'
+        run: |
+          timeout 10m docker run --rm --privileged --user root \
+            --entrypoint /app/codebuild-runner.sh \
+            --env FACILITY_CODEBUILD_SMOKE=1 \
+            facility-runner:dev
+
       - name: Run the Docker-backed sandbox loop
         if: steps.policy.outputs.required == 'true'
         env:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ itself when the team wants agents running in its own CI.
 | Turn team rules into enforcement | Repository-specific invariants live in zero-dependency guards. Repeated review feedback can graduate from prose into a deterministic check. | Installer or platform |
 | Keep repositories on a known system version | The platform fingerprints managed files, reports drift, and delivers template upgrades as reviewable pull requests. | Platform |
 | Control model access and spend | The gateway issues project-scoped virtual keys, enforces budgets, attributes usage by project/agent/task, and can store request/response envelopes in your object store. | Platform |
-| Run and supervise agents outside CI | The platform launches Claude Code, Codex, or bring-your-own agents in disposable Docker or AWS Fargate sandboxes, streams sessions, and records human steering. | Platform |
+| Run and supervise agents outside CI | The platform launches Claude Code, Codex, or bring-your-own agents in disposable Docker or AWS CodeBuild sandboxes, streams sessions, and records human steering. | Platform |
 | Reuse operational knowledge | The harness versions skills, rules, agent contracts, guards, and templates. Project knowledge and learning proposals remain human-validated. | Platform |
 | See whether the process works | Receipts, outcomes, health checks, analytics, issues, and a synthetic canary show cost, reliability, acceptance, and recurring failures. | Installer or platform |
 | Operate from different clients | The same permission model is exposed through the web app, REST API, CLI, and MCP server. | Platform |

--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -24,12 +24,14 @@ A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
   runner. Build it with `docker build -t facility-runner:dev runner/` and set
   `FACILITY_RUNNER_IMAGE` (default `facility-runner:dev`). A bare base image like
   `node:22-bookworm` only supports **BYO-command** runs.
-- **aws** (CodeBuild) — each run starts a private CodeBuild job using the
-  profile's runner image. Privileged mode lets provisioning launch nested Docker
-  services such as local Supabase. Nested Docker is rootless and reachable by
-  agent commands only through a restricted API proxy; the runner credential and
-  raw daemon socket use separate UIDs. Set `FACILITY_SANDBOX_DRIVER=aws` so the
-  seeded default profile uses that driver.
+- **aws** (CodeBuild) — each run starts a private CodeBuild job using the runner
+  image fixed in the deployed CodeBuild project. Profile image overrides are
+  deliberately ignored: an editable image cannot inherit the project's AWS
+  service role before the sandbox boundary exists. Privileged mode lets
+  provisioning launch nested Docker services such as local Supabase. Nested
+  Docker is rootless and reachable by agent commands only through a restricted
+  API proxy; the runner credential and raw daemon socket use separate UIDs. Set
+  `FACILITY_SANDBOX_DRIVER=aws` so the seeded default profile uses that driver.
 
 `facility doctor` **fails** its `sandbox_runner` check when no profile matches
 the deployment's driver (a docker profile can't launch on an aws stack, or vice

--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -24,8 +24,10 @@ A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
   runner. Build it with `docker build -t facility-runner:dev runner/` and set
   `FACILITY_RUNNER_IMAGE` (default `facility-runner:dev`). A bare base image like
   `node:22-bookworm` only supports **BYO-command** runs.
-- **aws** (Fargate) — the runner comes from the AWS runner task definition; set
-  `FACILITY_SANDBOX_DRIVER=aws` so the seeded default profile uses that driver.
+- **aws** (CodeBuild) — each run starts a private CodeBuild job using the
+  profile's runner image. Privileged mode lets provisioning launch nested Docker
+  services such as local Supabase. Set `FACILITY_SANDBOX_DRIVER=aws` so the
+  seeded default profile uses that driver.
 
 `facility doctor` **fails** its `sandbox_runner` check when no profile matches
 the deployment's driver (a docker profile can't launch on an aws stack, or vice
@@ -41,8 +43,13 @@ exactly as the object-store check is.
 ## Drivers
 
 Execution is driver-based: local Docker for development and self-hosting,
-AWS Fargate for cloud, with the driver interface open for Kubernetes jobs.
+AWS CodeBuild for cloud, with the driver interface open for Kubernetes jobs.
 The control plane sees one contract: launch, status, stop, destroy.
+
+AWS preview environments are the deliberate exception to the execution backend:
+they need a private inbound service endpoint, which CodeBuild does not expose.
+The AWS module therefore registers an immutable, unprivileged ECS Fargate task
+definition for each preview image while agent runs remain on privileged CodeBuild.
 
 ## What's inside (and what isn't)
 

--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -26,7 +26,9 @@ A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
   `node:22-bookworm` only supports **BYO-command** runs.
 - **aws** (CodeBuild) — each run starts a private CodeBuild job using the
   profile's runner image. Privileged mode lets provisioning launch nested Docker
-  services such as local Supabase. Set `FACILITY_SANDBOX_DRIVER=aws` so the
+  services such as local Supabase. Nested Docker is rootless and reachable by
+  agent commands only through a restricted API proxy; the runner credential and
+  raw daemon socket use separate UIDs. Set `FACILITY_SANDBOX_DRIVER=aws` so the
   seeded default profile uses that driver.
 
 `facility doctor` **fails** its `sandbox_runner` check when no profile matches

--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -33,6 +33,12 @@ A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
   API proxy; the runner credential and raw daemon socket use separate UIDs. Set
   `FACILITY_SANDBOX_DRIVER=aws` so the seeded default profile uses that driver.
 
+  An AWS profile's optional `setup.cmd` replaces Facility's lifecycle runner.
+  It runs as the unprivileged sandbox UID and keeps the run-scoped lifecycle
+  token so it can report events and its final result. Treat `sandboxes:*` as a
+  trusted lifecycle-administration permission; repository/model children do not
+  receive that token.
+
 `facility doctor` **fails** its `sandbox_runner` check when no profile matches
 the deployment's driver (a docker profile can't launch on an aws stack, or vice
 versa), so a false-ready deployment surfaces before the first run. For the docker

--- a/apps/docs/docs/guides/existing-repo.md
+++ b/apps/docs/docs/guides/existing-repo.md
@@ -33,6 +33,16 @@ weekly security sweep to a platform sandbox, run the new Project Owner agent
 platform-side. Each flip is reversible; the vendored workflows remain the
 fallback.
 
+Declare those choices in `.facility.json` under `executionLane`. A push to the
+default branch synchronizes the reviewed manifest into the control plane. An
+unset agent remains on the `repo` lane, so adoption fails closed and does not
+start duplicate automation.
+
+Platform sandboxes clone the repository before starting the agent. Checked-in
+`AGENTS.md`, `CLAUDE.md`, hooks, commands, guards, and skills therefore remain
+available. If a repository skill and a Facility catalog skill have the same
+name, the checked-in repository skill wins.
+
 ## Step 5 — upgrades
 
 From now on, method updates arrive as upgrade PRs from the platform instead

--- a/apps/docs/docs/reference/architecture.md
+++ b/apps/docs/docs/reference/architecture.md
@@ -75,7 +75,7 @@ infra/              # docker-compose (self-host), terraform/aws (reference deplo
 | 9 | GitHub identity for humans; hashed API keys for machines; **per-instance MCP OAuth** | Self-hosted instances use direct GitHub OAuth; SaaS instances consume the commercial broker over OIDC. Each instance publishes its own OAuth authorization server and audience-bound MCP tokens so upstream GitHub credentials are never accepted as Facility credentials. |
 | 10 | RBAC = permission-string catalog; bundled roles + custom roles | `resource:action` grants at org/project scope; custom roles are named permission sets — no policy-engine dependency (OPA rejected for v1: complexity without a customer). |
 | 11 | Audit = append-only `audit_events`, hash-chained per org | tamper-evident without external infra; gateway keeps full request/response envelopes (bodies in object storage). "Store everything by default." |
-| 12 | Sandbox drivers: `docker` (dev/self-host) + `aws` (Fargate) behind one interface | any-cloud via driver seam (k8s Job driver is a documented extension point); Fargate provides the reference cloud path. |
+| 12 | Sandbox drivers: `docker` (dev/self-host) + `aws` (CodeBuild) behind one interface | any-cloud via driver seam (k8s Job driver is a documented extension point); CodeBuild provides the reference cloud path and supports nested Docker services. |
 | 13 | Dual-lane execution: repository lane (compatibility) + control-plane lane (sandboxed) | existing repositories keep their vendored workflows on day one; the control-plane lane runs Project Owner/learning/crew sessions in governed sandboxes. Cutover is per trigger and human-gated. |
 | 14 | HITL uses action types, resolvers, and an append-only ledger | typed actions support different approval workflows while the ledger preserves every human decision. |
 | 15 | KB native storage in Postgres (entries + typed frontmatter + link graph) with git export | write-time validation and graph queries need a DB; git remains the interchange and audit format. |
@@ -137,7 +137,7 @@ corroborates its success.
 ## 7. Deployment
 
 - **Self-host quickstart**: `docker compose up` → postgres, minio, api, worker, gateway, web, and MCP. An administrator binds the dedicated org, owner, GitHub account, and installation with `facility instance bootstrap`; login never auto-creates tenancy.
-- **AWS reference deployment**: Terraform — VPC, RDS Postgres, S3, ECS Fargate services (api/worker/gateway/web/MCP), ALB, ECR, Fargate runner tasks, KMS for master key, CloudWatch logs.
+- **AWS reference deployment**: Terraform — VPC, RDS Postgres, S3, ECS Fargate services (api/worker/gateway/web/MCP), unprivileged Fargate preview tasks, ALB, ECR, privileged CodeBuild runner jobs, KMS for master key, CloudWatch logs.
 - **Any-cloud claim**: everything is containers + PG + S3-API; drivers isolate compute specifics; helm chart is a documented follow-up with the k8s Job driver.
 
 ## 8. What stays deliberately simple (v1)

--- a/apps/docs/docs/reference/cli.md
+++ b/apps/docs/docs/reference/cli.md
@@ -53,9 +53,11 @@ Actions in the repository lane and by Facility in the platform lane.
 ```json
 {
   "defaultBranch": "main",
-  "provision": "pnpm install --frozen-lockfile",
+  "packageInstall": "pnpm install --frozen-lockfile",
+  "provision": "pnpm run local:setup",
   "checks": ["pnpm lint", "pnpm typecheck", "pnpm test"],
   "board": { "org": "acme", "project": 12 },
+  "executionLane": { "architect": "platform", "builder": "platform" },
   "preview": {
     "enabled": true,
     "image": "ghcr.io/acme/app:sha-…",

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -20,11 +20,20 @@ subnets with the sandbox security group. Its service role can pull the runner
 image, write its own logs, and manage its VPC network interface; it cannot read
 Facility's Secrets Manager values.
 
+Privileged mode belongs to the outer CodeBuild host, not to repository code.
+The runner starts Docker rootless under a dedicated UID and exposes only a
+policy proxy to agent commands. The proxy denies privileged/host-namespace
+containers, devices, added capabilities, daemon administration, and host binds
+outside `/work` (plus its own restricted socket). The lifecycle runner keeps its
+run token under a different UID, and link-local metadata egress is blocked.
+
 Preview services stay on Fargate because the authenticated Facility proxy needs
 to reach their private port. They use a dedicated task role with no permissions
 and a narrowly scoped execution role for image pull and CloudWatch logs. The API
 registers only the requested immutable preview definition and destroys it with
-the task; this path is separate from the privileged agent runner.
+the task. Failed/lost previews retain their reference until reconciliation has
+also deregistered that definition; this path is separate from the privileged
+agent runner.
 
 Nothing in the services is AWS-specific — this module is a reference, not a
 requirement. The sandbox driver seam (`docker` | `aws`) is where compute

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -9,9 +9,22 @@ title: AWS (Terraform)
 - VPC (2 AZ), private subnets for services and RDS
 - RDS Postgres 16, S3 bucket (envelopes/transcripts), ECR repositories
 - ECS Fargate services: `api`, `worker`, `gateway`, `web`, `mcp` behind an ALB
-- Fargate runner tasks for the `aws` sandbox driver
+- ephemeral, privileged CodeBuild jobs for the `aws` sandbox driver
+- unprivileged, per-image ECS Fargate tasks for private preview services
 - KMS-backed secrets into task environments
 - CloudWatch log groups per service
+
+CodeBuild privileged mode is required because repository provisioning may start
+Docker containers (for example, local Supabase). Each build runs in the private
+subnets with the sandbox security group. Its service role can pull the runner
+image, write its own logs, and manage its VPC network interface; it cannot read
+Facility's Secrets Manager values.
+
+Preview services stay on Fargate because the authenticated Facility proxy needs
+to reach their private port. They use a dedicated task role with no permissions
+and a narrowly scoped execution role for image pull and CloudWatch logs. The API
+registers only the requested immutable preview definition and destroys it with
+the task; this path is separate from the privileged agent runner.
 
 Nothing in the services is AWS-specific — this module is a reference, not a
 requirement. The sandbox driver seam (`docker` | `aws`) is where compute
@@ -174,9 +187,18 @@ Terraform creates encrypted containers and never writes values into them.
 | `github_oauth_client_id`, `github_oauth_client_secret` | the App's OAuth credentials (`oidc_client_id` / `oidc_client_secret` in broker mode) |
 | `facility_oauth_jwks` | a persistent private ES256 JWK set |
 | `github_app_id`, `github_app_slug`, `github_app_private_key`, `github_app_webhook_secret` | from the App |
+| `package_registry_token` | optional classic PAT with only `read:packages`, for private GitHub npm packages |
 
 `dev_anthropic_api_key` and `dev_openai_api_key` are a local fallback only —
 add provider credentials through Facility after boot instead.
+
+The trusted API releases `package_registry_token` through the runner's one-shot
+authenticated handshake only when a run declares `.facility.json`'s
+`packageInstall` phase. The CodeBuild role cannot read the secret from AWS. The
+runner writes a temporary user-level npm config for that install child, deletes
+it afterward, and does not pass the token to provisioning scripts, acceptance
+checks, Claude, or Codex. Set `enable_package_registry_token = true` only after
+populating the secret; leave it false for repositories that use public packages.
 
 Keep `sslmode=verify-full`. The production image carries Amazon's global RDS CA
 bundle so the API and worker verify the database certificate and hostname; a

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -15,7 +15,9 @@ Topology:
   Cloud Map at the `gateway_internal_url` output.
 - Postgres accepts `5432` only from the ECS service security group.
 - CodeBuild sandboxes run in private subnets and can reach the internal gateway.
-  Their least-privilege service role has no Secrets Manager access.
+  Their least-privilege service role has no Secrets Manager access. Runs always
+  use the runner image fixed on the CodeBuild project; database-backed sandbox
+  profiles cannot override that AWS-trusted image.
 - Private preview services use per-image Fargate task definitions, a no-permission
   task role, and a dedicated execution role. Only Facility services can reach
   their private ports through the sandbox security group.

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -169,6 +169,12 @@ Required runtime values:
   it, and the runner deletes its temporary npm config before provisioning. Set
   `enable_package_registry_token = true` only after populating it.
 
+The privileged CodeBuild host does not give repository commands an unrestricted
+Docker socket. The runner uses a separate root lifecycle process, a rootless
+daemon UID, and an allowlisted socket proxy; its production smoke test rejects
+privileged containers, host PID mode, `/proc` mounts, raw-socket access, and
+runner-environment reads before the project is considered ready.
+
 The `dev_anthropic_api_key` and `dev_openai_api_key` secrets exist only for
 local/bootstrap fallback compatibility. Prefer provider credentials stored
 through the Facility API after boot.

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -2,8 +2,9 @@
 
 This module provisions the AWS reference deployment from the platform architecture:
 VPC, two private AZs, public ALB, RDS Postgres 16, S3 object storage, ECR,
-ECS Fargate services for `api`, `worker`, `gateway`, `web`, and `mcp`, a runner task
-definition for the AWS sandbox driver, KMS, Secrets Manager, and CloudWatch logs.
+ECS Fargate services for `api`, `worker`, `gateway`, `web`, and `mcp`, privileged
+CodeBuild jobs for agent runs, unprivileged Fargate preview tasks, KMS, Secrets
+Manager, and CloudWatch logs.
 
 Topology:
 
@@ -13,6 +14,11 @@ Topology:
 - `gateway` has no public ALB route. It is reachable only inside the VPC through
   Cloud Map at the `gateway_internal_url` output.
 - Postgres accepts `5432` only from the ECS service security group.
+- CodeBuild sandboxes run in private subnets and can reach the internal gateway.
+  Their least-privilege service role has no Secrets Manager access.
+- Private preview services use per-image Fargate task definitions, a no-permission
+  task role, and a dedicated execution role. Only Facility services can reach
+  their private ports through the sandbox security group.
 - Migrations are a one-shot ECS task definition. Terraform does not run them.
 
 ## 1. Prepare variables
@@ -38,6 +44,8 @@ Edit `playground.tfvars`:
 - Set `github_oauth_allowed_organization` to a GitHub organization login when
   direct login must require active membership; leave it empty for no additional
   organization restriction.
+- Set `enable_package_registry_token = true` only after populating the optional
+  private package token; leave it false for public-package repositories.
 - Tune `envelope_retention_days` for your data-retention policy.
 
 Release tags publish images as `:<version>` (for example, `v0.3.0` publishes
@@ -97,6 +105,7 @@ Record these outputs:
 - `rds_endpoint`
 - `rds_master_user_secret_arn`
 - `ecs_cluster_name`
+- `codebuild_runner_project_name`
 - `migrate_task_definition_arn`
 - `private_subnet_ids`
 - `service_security_group_id`
@@ -154,6 +163,11 @@ Required runtime values:
 - `github_app_private_key`
 - `github_app_webhook_secret`
 - `github_app_slug`
+- `package_registry_token`: optional classic PAT restricted to `read:packages`;
+  the API releases it through the authenticated runner handshake only for the
+  dedicated dependency-install phase; the CodeBuild role has no IAM access to
+  it, and the runner deletes its temporary npm config before provisioning. Set
+  `enable_package_registry_token = true` only after populating it.
 
 The `dev_anthropic_api_key` and `dev_openai_api_key` secrets exist only for
 local/bootstrap fallback compatibility. Prefer provider credentials stored

--- a/infra/terraform/aws/codebuild.tf
+++ b/infra/terraform/aws/codebuild.tf
@@ -13,6 +13,7 @@ resource "aws_codebuild_project" "runner" {
     type      = "NO_SOURCE"
     buildspec = <<-YAML
       version: 0.2
+      run-as: root
       phases:
         build:
           commands:

--- a/infra/terraform/aws/codebuild.tf
+++ b/infra/terraform/aws/codebuild.tf
@@ -1,0 +1,47 @@
+resource "aws_codebuild_project" "runner" {
+  name           = "${local.name_prefix}-runner"
+  description    = "Ephemeral privileged Facility sandboxes"
+  service_role   = aws_iam_role.codebuild_runner.arn
+  build_timeout  = 180
+  queued_timeout = 60
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  source {
+    type      = "NO_SOURCE"
+    buildspec = <<-YAML
+      version: 0.2
+      phases:
+        build:
+          commands:
+            - /app/codebuild-runner.sh
+    YAML
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_LARGE"
+    image                       = local.images.runner
+    type                        = var.task_cpu_architecture == "ARM64" ? "ARM_CONTAINER" : "LINUX_CONTAINER"
+    image_pull_credentials_type = "SERVICE_ROLE"
+    privileged_mode             = true
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.service["runner"].name
+      stream_name = "runner"
+    }
+  }
+
+  vpc_config {
+    vpc_id             = aws_vpc.facility.id
+    subnets            = [for subnet in aws_subnet.private : subnet.id]
+    security_group_ids = [aws_security_group.sandbox.id]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-runner"
+  }
+}

--- a/infra/terraform/aws/ecs.tf
+++ b/infra/terraform/aws/ecs.tf
@@ -85,43 +85,6 @@ resource "aws_ecs_task_definition" "service" {
   ])
 }
 
-resource "aws_ecs_task_definition" "runner" {
-  family                   = "${local.name_prefix}-runner"
-  requires_compatibilities = ["FARGATE"]
-  network_mode             = "awsvpc"
-
-  runtime_platform {
-    cpu_architecture        = var.task_cpu_architecture
-    operating_system_family = "LINUX"
-  }
-  cpu                = tostring(var.task_cpu.runner)
-  memory             = tostring(var.task_memory.runner)
-  execution_role_arn = aws_iam_role.ecs_execution.arn
-  task_role_arn      = aws_iam_role.runner_task.arn
-
-  container_definitions = jsonencode([
-    {
-      name      = "runner"
-      image     = local.images.runner
-      essential = true
-      environment = concat(local.common_environment, [
-        { name = "FACILITY_API_URL", value = local.public_urls.api },
-        { name = "GATEWAY_URL", value = "http://${aws_service_discovery_service.gateway.name}.${aws_service_discovery_private_dns_namespace.facility.name}:${local.ports.gateway}" },
-        { name = "SANDBOX_GATEWAY_URL", value = "http://${aws_service_discovery_service.gateway.name}.${aws_service_discovery_private_dns_namespace.facility.name}:${local.ports.gateway}" },
-      ])
-      secrets = []
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = aws_cloudwatch_log_group.service["runner"].name
-          awslogs-region        = var.aws_region
-          awslogs-stream-prefix = "runner"
-        }
-      }
-    }
-  ])
-}
-
 resource "aws_ecs_task_definition" "migrate" {
   family                   = "${local.name_prefix}-migrate"
   requires_compatibilities = ["FARGATE"]

--- a/infra/terraform/aws/iam.tf
+++ b/infra/terraform/aws/iam.tf
@@ -28,8 +28,8 @@ resource "aws_iam_role" "task" {
   })
 }
 
-resource "aws_iam_role" "runner_task" {
-  name = "${local.name_prefix}-runner-task"
+resource "aws_iam_role" "preview_execution" {
+  name = "${local.name_prefix}-preview-execution"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -39,6 +39,41 @@ resource "aws_iam_role" "runner_task" {
         Service = "ecs-tasks.amazonaws.com"
       }
       Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role" "preview_task" {
+  name = "${local.name_prefix}-preview-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role" "codebuild_runner" {
+  name = "${local.name_prefix}-codebuild-runner"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "codebuild.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
     }]
   })
 }
@@ -97,6 +132,42 @@ resource "aws_iam_role_policy" "ecs_execution" {
   })
 }
 
+resource "aws_iam_role_policy" "preview_execution" {
+  name = "${local.name_prefix}-preview-execution"
+  role = aws_iam_role.preview_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EcrAuthToken"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "PullFacilityImages"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer"
+        ]
+        Resource = [for repo in aws_ecr_repository.service : repo.arn]
+      },
+      {
+        Sid    = "WritePreviewLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "${aws_cloudwatch_log_group.service["preview"].arn}:*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "task" {
   name = "${local.name_prefix}-task"
   role = aws_iam_role.task.id
@@ -139,42 +210,21 @@ resource "aws_iam_role_policy" "task" {
         Resource = aws_kms_key.facility.arn
       },
       {
-        Sid    = "LaunchRunnerTasks"
+        Sid    = "LaunchRunnerBuilds"
         Effect = "Allow"
         Action = [
-          "ecs:RunTask"
+          "codebuild:StartBuild"
         ]
-        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${local.name_prefix}-runner:*"
-        Condition = {
-          ArnEquals = {
-            "ecs:cluster" = aws_ecs_cluster.facility.arn
-          }
-        }
+        Resource = aws_codebuild_project.runner.arn
       },
       {
-        Sid    = "ManageRunnerTasks"
+        Sid    = "ManageRunnerBuilds"
         Effect = "Allow"
         Action = [
-          "ecs:DescribeTasks",
-          "ecs:StopTask"
+          "codebuild:BatchGetBuilds",
+          "codebuild:StopBuild"
         ]
-        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task/${aws_ecs_cluster.facility.name}/*"
-      },
-      {
-        Sid    = "PassRunnerRoles"
-        Effect = "Allow"
-        Action = [
-          "iam:PassRole"
-        ]
-        Resource = [
-          aws_iam_role.ecs_execution.arn,
-          aws_iam_role.runner_task.arn
-        ]
-        Condition = {
-          StringEquals = {
-            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
-          }
-        }
+        Resource = aws_codebuild_project.runner.arn
       },
       {
         Sid    = "ReadRunnerLogs"
@@ -183,26 +233,122 @@ resource "aws_iam_role_policy" "task" {
           "logs:GetLogEvents"
         ]
         Resource = "${aws_cloudwatch_log_group.service["runner"].arn}:*"
+      },
+      {
+        Sid      = "RegisterPreviewTaskDefinitions"
+        Effect   = "Allow"
+        Action   = "ecs:RegisterTaskDefinition"
+        Resource = "*"
+      },
+      {
+        Sid      = "DeregisterPreviewTaskDefinitions"
+        Effect   = "Allow"
+        Action   = "ecs:DeregisterTaskDefinition"
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${local.name_prefix}-preview:*"
+      },
+      {
+        Sid      = "LaunchPreviewTasks"
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${local.name_prefix}-preview:*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = aws_ecs_cluster.facility.arn
+          }
+        }
+      },
+      {
+        Sid    = "ManagePreviewTasks"
+        Effect = "Allow"
+        Action = [
+          "ecs:DescribeTasks",
+          "ecs:StopTask"
+        ]
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task/${aws_ecs_cluster.facility.name}/*"
+      },
+      {
+        Sid    = "PassPreviewRoles"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          aws_iam_role.preview_execution.arn,
+          aws_iam_role.preview_task.arn
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid      = "ReadPreviewLogs"
+        Effect   = "Allow"
+        Action   = "logs:GetLogEvents"
+        Resource = "${aws_cloudwatch_log_group.service["preview"].arn}:*"
       }
     ]
   })
 }
 
-resource "aws_iam_role_policy" "runner_task" {
-  name = "${local.name_prefix}-runner-task"
-  role = aws_iam_role.runner_task.id
+resource "aws_iam_role_policy" "codebuild_runner" {
+  name = "${local.name_prefix}-codebuild-runner"
+  role = aws_iam_role.codebuild_runner.id
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "WriteOwnLogs"
+        Sid    = "WriteRunnerLogs"
         Effect = "Allow"
         Action = [
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
         Resource = "${aws_cloudwatch_log_group.service["runner"].arn}:*"
+      },
+      {
+        Sid      = "EcrAuthToken"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "PullRunnerImage"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer"
+        ]
+        Resource = aws_ecr_repository.service["runner"].arn
+      },
+      {
+        Sid    = "ManageVpcNetworkInterfaces"
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeDhcpOptions",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "AuthorizeCodeBuildNetworkInterfaces"
+        Effect   = "Allow"
+        Action   = "ec2:CreateNetworkInterfacePermission"
+        Resource = "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+        Condition = {
+          StringEquals = {
+            "ec2:AuthorizedService" = "codebuild.amazonaws.com"
+          }
+          ArnEquals = {
+            "ec2:Subnet" = [for subnet in aws_subnet.private : subnet.arn]
+          }
+        }
       }
     ]
   })

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -44,18 +44,24 @@ locals {
     { name = "LOG_LEVEL", value = "info" },
     { name = "S3_BUCKET", value = aws_s3_bucket.objects.bucket },
     { name = "AWS_REGION", value = var.aws_region },
-    # The Fargate stack runs sandboxes via the AWS driver, so the seeded default
+    # The AWS stack runs sandboxes via CodeBuild, so the seeded default
     # sandbox profile (created by the migrate+seed task) must use it too.
     { name = "FACILITY_SANDBOX_DRIVER", value = "aws" },
+    { name = "FACILITY_RUNNER_IMAGE", value = local.images.runner },
   ]
 
   aws_sandbox_environment = [
+    { name = "FACILITY_AWS_CODEBUILD_PROJECT", value = aws_codebuild_project.runner.name },
+    # Agent runs use CodeBuild; preview services still need an inbound endpoint,
+    # so they run as unprivileged, dynamically registered Fargate tasks.
     { name = "FACILITY_AWS_ECS_CLUSTER", value = aws_ecs_cluster.facility.name },
-    { name = "FACILITY_AWS_RUNNER_TASK_DEF", value = aws_ecs_task_definition.runner.arn },
     { name = "FACILITY_AWS_SUBNETS", value = join(",", [for subnet in aws_subnet.private : subnet.id]) },
-    { name = "FACILITY_AWS_SECURITY_GROUPS", value = aws_security_group.sandbox.id },
-    { name = "FACILITY_AWS_RUNNER_CONTAINER", value = "runner" },
-    { name = "FACILITY_AWS_RUNNER_LOG_GROUP", value = aws_cloudwatch_log_group.service["runner"].name },
+    { name = "FACILITY_AWS_PREVIEW_SECURITY_GROUPS", value = aws_security_group.sandbox.id },
+    { name = "FACILITY_AWS_PREVIEW_TASK_FAMILY", value = "${local.name_prefix}-preview" },
+    { name = "FACILITY_AWS_PREVIEW_EXECUTION_ROLE_ARN", value = aws_iam_role.preview_execution.arn },
+    { name = "FACILITY_AWS_PREVIEW_TASK_ROLE_ARN", value = aws_iam_role.preview_task.arn },
+    { name = "FACILITY_AWS_PREVIEW_LOG_GROUP", value = aws_cloudwatch_log_group.service["preview"].name },
+    { name = "FACILITY_AWS_TASK_CPU_ARCHITECTURE", value = var.task_cpu_architecture },
   ]
 
   api_environment = concat(local.common_environment, local.aws_sandbox_environment, [
@@ -113,6 +119,7 @@ locals {
     "github_app_private_key",
     "github_app_webhook_secret",
     "github_app_slug",
+    "package_registry_token",
     "dev_anthropic_api_key",
     "dev_openai_api_key",
   ])
@@ -135,9 +142,16 @@ locals {
   ]
 
   common_secrets = local.core_secrets
-  api_secrets = concat(local.core_secrets, local.identity_secrets, [
-    { name = "FACILITY_OAUTH_JWKS", valueFrom = aws_secretsmanager_secret.app["facility_oauth_jwks"].arn },
-  ])
+  package_registry_secrets = [
+    { name = "PACKAGE_REGISTRY_TOKEN", valueFrom = aws_secretsmanager_secret.app["package_registry_token"].arn },
+  ]
+
+  api_secrets = concat(
+    local.core_secrets,
+    local.identity_secrets,
+    [{ name = "FACILITY_OAUTH_JWKS", valueFrom = aws_secretsmanager_secret.app["facility_oauth_jwks"].arn }],
+    var.enable_package_registry_token ? local.package_registry_secrets : []
+  )
 
   dev_provider_secrets = [
     { name = "DEV_ANTHROPIC_API_KEY", valueFrom = aws_secretsmanager_secret.app["dev_anthropic_api_key"].arn },
@@ -146,7 +160,7 @@ locals {
 
   gateway_secrets = concat(local.common_secrets, var.enable_dev_provider_fallback ? local.dev_provider_secrets : [])
 
-  log_groups = toset(["api", "worker", "gateway", "web", "mcp", "runner", "migrate"])
+  log_groups = toset(["api", "worker", "gateway", "web", "mcp", "runner", "preview", "migrate"])
 
   ecs_services = {
     api = {

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -53,6 +53,11 @@ output "ecs_cluster_name" {
   value       = aws_ecs_cluster.facility.name
 }
 
+output "codebuild_runner_project_name" {
+  description = "CodeBuild project used for ephemeral privileged Facility sandboxes."
+  value       = aws_codebuild_project.runner.name
+}
+
 output "migrate_task_definition_arn" {
   description = "One-shot migration task definition. Run manually; Terraform does not auto-run migrations."
   value       = aws_ecs_task_definition.migrate.arn

--- a/infra/terraform/aws/security.tf
+++ b/infra/terraform/aws/security.tf
@@ -23,6 +23,15 @@ resource "aws_security_group" "sandbox" {
   description = "Facility ephemeral CodeBuild sandbox environments"
   vpc_id      = aws_vpc.facility.id
 
+  # AWS makes security-group descriptions immutable. Existing ECS-based
+  # installations already have this group wired into cross-group rules and
+  # ENIs, so replacing it only to rename the description creates a dependency
+  # cycle during the CodeBuild migration. New stacks still receive the current
+  # description; existing stacks safely retain the cosmetic legacy value.
+  lifecycle {
+    ignore_changes = [description]
+  }
+
   tags = {
     Name = "${local.name_prefix}-sandbox"
   }

--- a/infra/terraform/aws/security.tf
+++ b/infra/terraform/aws/security.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "service" {
 
 resource "aws_security_group" "sandbox" {
   name        = "${local.name_prefix}-sandbox"
-  description = "Facility ephemeral sandbox runner tasks"
+  description = "Facility ephemeral CodeBuild sandbox environments"
   vpc_id      = aws_vpc.facility.id
 
   tags = {
@@ -161,6 +161,24 @@ resource "aws_vpc_security_group_egress_rule" "service_to_gateway" {
   from_port                    = local.ports.gateway
   ip_protocol                  = "tcp"
   to_port                      = local.ports.gateway
+}
+
+resource "aws_vpc_security_group_egress_rule" "service_to_previews" {
+  security_group_id            = aws_security_group.service.id
+  referenced_security_group_id = aws_security_group.sandbox.id
+  from_port                    = 1
+  ip_protocol                  = "tcp"
+  to_port                      = 65535
+  description                  = "Facility API proxy to private preview services"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "preview_from_services" {
+  security_group_id            = aws_security_group.sandbox.id
+  referenced_security_group_id = aws_security_group.service.id
+  from_port                    = 1
+  ip_protocol                  = "tcp"
+  to_port                      = 65535
+  description                  = "Private preview traffic from Facility services"
 }
 
 resource "aws_vpc_security_group_egress_rule" "service_https_ipv4" {

--- a/infra/terraform/aws/terraform.tfvars.example
+++ b/infra/terraform/aws/terraform.tfvars.example
@@ -26,6 +26,7 @@ facility_instance_id    = ""
 # Local/bootstrap provider fallback only. Production gateways should load
 # provider credentials through the Facility API instead.
 enable_dev_provider_fallback = false
+enable_package_registry_token = false
 
 # Restrict this for non-public test deployments.
 allowed_http_cidr_blocks = ["0.0.0.0/0"]

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -99,6 +99,12 @@ variable "enable_dev_provider_fallback" {
   default     = false
 }
 
+variable "enable_package_registry_token" {
+  description = "Inject the optional private package registry token into the trusted API for scoped runner handoff. Populate the secret before enabling."
+  type        = bool
+  default     = false
+}
+
 variable "database_name" {
   description = "Initial RDS database name."
   type        = string

--- a/packages/cli/src/init.mjs
+++ b/packages/cli/src/init.mjs
@@ -403,6 +403,8 @@ export async function init(flags, pkgRoot, version) {
     CODEX_VERSION: "0.144.6",
     ARCHITECT_REPO_LANE: "true",
     BUILDER_REPO_LANE: "true",
+    CODEX_ARCHITECT_REPO_LANE: "true",
+    CODEX_BUILDER_REPO_LANE: "true",
     PROVISION_CMD: provisionCmd,
     CHECKS_INLINE: checksInline,
     CHECKS_RUN: checksRun(checks),
@@ -527,12 +529,14 @@ export async function init(flags, pkgRoot, version) {
       codex: { provider: "openai", mode: "api-key" },
     },
     defaultBranch,
+    packageInstall: null,
     provision: provision || null,
     checks,
     models,
     preview,
     canaryBot,
     board: project ? { org, project: Number(project) } : null,
+    executionLane: { architect: "repo", builder: "repo" },
     modules: [],
   };
   writeFileSync(join(dir, ".facility.json"), formatManifest(manifest));

--- a/packages/cli/templates/workflows/facility-codex.yml
+++ b/packages/cli/templates/workflows/facility-codex.yml
@@ -23,9 +23,9 @@ jobs:
     if: |
       github.event.sender.type != 'Bot' &&
       (
-        (github.event_name == 'issue_comment' && (({{BUILDER_REPO_LANE}} && contains(github.event.comment.body, '/codex-builder')) || ({{ARCHITECT_REPO_LANE}} && contains(github.event.comment.body, '/codex-architect')))) ||
-        (github.event_name == 'pull_request_review_comment' && (({{BUILDER_REPO_LANE}} && contains(github.event.comment.body, '/codex-builder')) || ({{ARCHITECT_REPO_LANE}} && contains(github.event.comment.body, '/codex-architect')))) ||
-        (github.event_name == 'issues' && (({{BUILDER_REPO_LANE}} && (contains(github.event.issue.body || '', '/codex-builder') || contains(github.event.issue.title || '', '/codex-builder'))) || ({{ARCHITECT_REPO_LANE}} && (contains(github.event.issue.body || '', '/codex-architect') || contains(github.event.issue.title || '', '/codex-architect')))))
+        (github.event_name == 'issue_comment' && (({{CODEX_BUILDER_REPO_LANE}} && contains(github.event.comment.body, '/codex-builder')) || ({{CODEX_ARCHITECT_REPO_LANE}} && contains(github.event.comment.body, '/codex-architect')))) ||
+        (github.event_name == 'pull_request_review_comment' && (({{CODEX_BUILDER_REPO_LANE}} && contains(github.event.comment.body, '/codex-builder')) || ({{CODEX_ARCHITECT_REPO_LANE}} && contains(github.event.comment.body, '/codex-architect')))) ||
+        (github.event_name == 'issues' && (({{CODEX_BUILDER_REPO_LANE}} && (contains(github.event.issue.body || '', '/codex-builder') || contains(github.event.issue.title || '', '/codex-builder'))) || ({{CODEX_ARCHITECT_REPO_LANE}} && (contains(github.event.issue.body || '', '/codex-architect') || contains(github.event.issue.title || '', '/codex-architect')))))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 180

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -21,6 +21,7 @@ export type RenderedFile = {
 
 export type RenderAnswers = {
   defaultBranch: string;
+  packageInstallCmd?: string;
   provisionCmd?: string;
   checkCmds?: string[];
   modules?: string[];
@@ -441,6 +442,16 @@ export async function renderFacilityInit(
       answers.execution_lane?.["/builder"] === "platform"
         ? "false"
         : "true",
+    CODEX_ARCHITECT_REPO_LANE:
+      answers.execution_lane?.["codex-architect"] === "platform" ||
+      answers.execution_lane?.["/codex-architect"] === "platform"
+        ? "false"
+        : "true",
+    CODEX_BUILDER_REPO_LANE:
+      answers.execution_lane?.["codex-builder"] === "platform" ||
+      answers.execution_lane?.["/codex-builder"] === "platform"
+        ? "false"
+        : "true",
     PROVISION_CMD: provision,
     CHECKS_INLINE: checks.length ? checks.join(" ; ") : "the checks configured in STANDARD.md",
     CHECKS_LIST: checksList(checks),
@@ -614,6 +625,7 @@ export async function renderFacilityInit(
       codex: { provider: "openai", mode: "api-key" },
     },
     defaultBranch: answers.defaultBranch,
+    packageInstall: answers.packageInstallCmd || null,
     provision: answers.provisionCmd || null,
     checks,
     models,
@@ -622,6 +634,7 @@ export async function renderFacilityInit(
     board: answers.board?.project
       ? { org: answers.board.org, project: Number(answers.board.project) }
       : null,
+    executionLane: answers.execution_lane ?? { architect: "repo", builder: "repo" },
     modules: [],
   };
   addOrReplace(files, {

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -274,8 +274,8 @@ describe("render", () => {
 
     expect(crew).toContain("false && contains(github.event.comment.body, '/builder')");
     expect(crew).toContain("false && contains(github.event.comment.body, '/architect')");
-    expect(codex).toContain("false && contains(github.event.comment.body, '/codex-builder')");
-    expect(codex).toContain("false && contains(github.event.comment.body, '/codex-architect')");
+    expect(codex).toContain("true && contains(github.event.comment.body, '/codex-builder')");
+    expect(codex).toContain("true && contains(github.event.comment.body, '/codex-architect')");
   });
 });
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -60,10 +60,18 @@ function defaultRunnerImage(): string {
 }
 
 // Driver the default sandbox profile uses; must match the deployment ("docker"
-// for local/self-host, "aws" for the Fargate stack). Keep in sync with
+// for local/self-host, "aws" for the CodeBuild stack). Keep in sync with
 // config.sandboxDriver.
 function defaultSandboxDriver(): string {
   return process.env.FACILITY_SANDBOX_DRIVER === "aws" ? "aws" : "docker";
+}
+
+function defaultSandboxResources(): string {
+  return JSON.stringify(
+    defaultSandboxDriver() === "aws"
+      ? { cpu: 8, memory_mb: 15_360, timeout_min: 180 }
+      : { cpu: 2, memory_mb: 4_096, timeout_min: 60 },
+  );
 }
 
 function actionTypeExecutor(name: string) {
@@ -293,7 +301,7 @@ async function seedOrgEssentialsSql(sql: postgres.Sql, orgId: string): Promise<v
       ${defaultSandboxDriver()},
       ${defaultRunnerImage()},
       '{"deps":[]}'::jsonb,
-      '{"cpu":2,"memory_mb":4096,"timeout_min":60}'::jsonb,
+      ${defaultSandboxResources()}::jsonb,
       '{"egress":"restricted"}'::jsonb
     )
     ON CONFLICT (id) DO UPDATE SET
@@ -353,7 +361,7 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
       ${defaultSandboxDriver()},
       ${defaultRunnerImage()},
       '{"deps":[]}'::jsonb,
-      '{"cpu":2,"memory_mb":4096,"timeout_min":60}'::jsonb,
+      ${defaultSandboxResources()}::jsonb,
       '{"egress":"restricted"}'::jsonb
     FROM inputs
     ON CONFLICT (id) DO UPDATE SET
@@ -417,7 +425,7 @@ async function seedOrgEssentialsDb(db: RegistryDb, orgId: string): Promise<void>
       ${defaultSandboxDriver()},
       ${defaultRunnerImage()},
       '{"deps":[]}'::jsonb,
-      '{"cpu":2,"memory_mb":4096,"timeout_min":60}'::jsonb,
+      ${defaultSandboxResources()}::jsonb,
       '{"egress":"restricted"}'::jsonb
     )
     ON CONFLICT (id) DO UPDATE SET

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -35,12 +35,10 @@ export function serveHttp(options: HttpServerOptions) {
     response.setHeader("x-content-type-options", "nosniff");
     response.setHeader("cache-control", "no-store");
 
-    if (!validRequestAuthority(request, allowedHosts)) {
-      response.writeHead(421, { "content-type": "application/json" });
-      response.end(JSON.stringify({ error: "untrusted request authority" }));
-      return;
-    }
-
+    // Load balancers address targets by private IP and therefore cannot send
+    // the public authority allowlisted for MCP traffic. These read-only probes
+    // expose no credentials or tenant data; keep every functional endpoint
+    // behind the authority check below.
     if (request.method === "GET" && ["/health", "/healthz"].includes(path)) {
       response.writeHead(200, { "content-type": "application/json", "cache-control": "no-store" });
       response.end(JSON.stringify({ ok: true, version: "0.3.0", transport: "streamable-http" }));
@@ -68,6 +66,12 @@ export function serveHttp(options: HttpServerOptions) {
         });
         response.end(JSON.stringify({ ok: false, api: "down" }));
       }
+      return;
+    }
+
+    if (!validRequestAuthority(request, allowedHosts)) {
+      response.writeHead(421, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "untrusted request authority" }));
       return;
     }
 

--- a/packages/mcp/test/mcp.test.ts
+++ b/packages/mcp/test/mcp.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { once } from "node:events";
+import { request as httpRequest } from "node:http";
 import type { AddressInfo } from "node:net";
 import { FacilityApiError } from "@facility/sdk";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -46,6 +47,39 @@ function textPayload(result: unknown) {
   if (!Array.isArray(content)) return "{}";
   const first = content[0] as { type?: string; text?: string } | undefined;
   return first?.type === "text" ? (first.text ?? "{}") : "{}";
+}
+
+function requestWithAuthority(options: {
+  port: number;
+  path: string;
+  authority: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}) {
+  return new Promise<{ status: number; body: string }>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: "127.0.0.1",
+        port: options.port,
+        path: options.path,
+        method: options.method ?? "GET",
+        headers: { ...options.headers, host: options.authority },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () =>
+          resolve({
+            status: response.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    request.on("error", reject);
+    request.end(options.body);
+  });
 }
 
 async function connect(stub: {
@@ -525,6 +559,61 @@ describe("@facility/mcp", () => {
     const readiness = await fetch(`http://127.0.0.1:${port}/readyz`);
     expect(readiness.status).toBe(503);
     expect(await readiness.json()).toEqual({ ok: false, api: "down" });
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test("load-balancer probes accept a private authority without exposing MCP traffic", async () => {
+    const server = serveHttp({
+      apiUrl: "http://facility.test",
+      port: 0,
+      allowedHosts: ["mcp.facility.test"],
+      fetch: async () => new Response("ok"),
+    });
+    await once(server, "listening");
+    const port = (server.address() as AddressInfo).port;
+    const privateAuthority = "10.0.1.42:4420";
+
+    for (const path of ["/health", "/healthz"]) {
+      const health = await requestWithAuthority({
+        port,
+        path,
+        authority: privateAuthority,
+      });
+      expect(health.status).toBe(200);
+      expect(JSON.parse(health.body)).toEqual({
+        ok: true,
+        version: "0.3.0",
+        transport: "streamable-http",
+      });
+    }
+
+    const readiness = await requestWithAuthority({
+      port,
+      path: "/readyz",
+      authority: privateAuthority,
+    });
+    expect(readiness.status).toBe(200);
+    expect(JSON.parse(readiness.body)).toEqual({ ok: true, api: "up" });
+
+    const protectedResponse = await requestWithAuthority({
+      port,
+      path: "/mcp",
+      authority: privateAuthority,
+      method: "POST",
+      headers: {
+        authorization: "Bearer fak_test",
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(protectedResponse.status).toBe(421);
+
+    const oauthDiscovery = await requestWithAuthority({
+      port,
+      path: "/.well-known/oauth-protected-resource",
+      authority: privateAuthority,
+    });
+    expect(oauthDiscovery.status).toBe(421);
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -28332,6 +28332,9 @@
                       "defaultBranch": {
                         "type": "string"
                       },
+                      "packageInstallCmd": {
+                        "type": "string"
+                      },
                       "provisionCmd": {
                         "type": "string"
                       },

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -18236,6 +18236,7 @@ export interface operations {
                     repoId: string;
                     answers: {
                         defaultBranch?: string;
+                        packageInstallCmd?: string;
                         provisionCmd?: string;
                         checkCmds?: string[];
                         modules?: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,20 +6,22 @@ settings:
 
 overrides:
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  postcss@<8.5.18: 8.5.18
+  postcss@<8.5.23: 8.5.23
   serialize-javascript@<=7.0.2: 7.0.7
   uuid@<11.1.1: 11.1.1
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
+  brace-expansion@<1.1.18: 1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
+  brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   '@fastify/static@<10.1.2': 10.1.2
-  fast-uri@>=3.0.0 <3.1.4: 3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
   find-my-way@<9.6.1: 9.7.0
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
   sharp@<0.35.0: 0.35.0
   svgo@>=3.0.0 <3.3.4: 3.3.4
   body-parser@<1.20.6: 1.20.6
   '@hono/node-server@<2.0.10': 2.0.10
+  hono@<4.12.34: 4.12.34
+  ip-address@<10.3.1: 10.3.1
   protobufjs@>=7.5.0 <7.6.5: 7.6.5
   webpack-dev-server@<=5.2.5: 5.2.6
 
@@ -41,10 +43,10 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.9.2
-        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: ^3.9.2
-        version: 3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
       '@fontsource/ibm-plex-mono':
         specifier: ^5.0.0
         version: 5.2.7
@@ -66,13 +68,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.9.2
-        version: 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/tsconfig':
         specifier: ^3.9.2
         version: 3.10.1
       '@docusaurus/types':
         specifier: ^3.9.2
-        version: 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -158,7 +160,7 @@ importers:
         version: 24.13.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.22.5
@@ -189,7 +191,7 @@ importers:
         version: 24.13.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.22.5
@@ -208,7 +210,7 @@ importers:
         version: 24.13.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -239,7 +241,7 @@ importers:
         version: 24.13.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -254,7 +256,7 @@ importers:
         version: 7.13.0(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -289,7 +291,7 @@ importers:
         version: 24.13.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.22.5
@@ -306,6 +308,9 @@ importers:
         specifier: ^0.112.5
         version: 0.112.5(zod@4.4.3)
       '@aws-sdk/client-cloudwatch-logs':
+        specifier: 3.1079.0
+        version: 3.1079.0
+      '@aws-sdk/client-codebuild':
         specifier: 3.1079.0
         version: 3.1079.0
       '@aws-sdk/client-ecs':
@@ -384,8 +389,8 @@ importers:
         specifier: ^3.4.7
         version: 3.4.9
       undici:
-        specifier: ^7.28.0
-        version: 7.28.0
+        specifier: ^7.29.0
+        version: 7.29.0
       uuidv7:
         specifier: ^1.0.2
         version: 1.2.1
@@ -404,7 +409,7 @@ importers:
         version: 7.13.0(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.22.5
@@ -447,7 +452,7 @@ importers:
         version: 24.13.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.21.0
         version: 4.22.5
@@ -559,6 +564,10 @@ packages:
 
   '@aws-sdk/client-cloudwatch-logs@3.1079.0':
     resolution: {integrity: sha512-mn+j4nDWi599W90MGljDBKExo6bGH8d6JzNFGPNM0udsWJGWQWNp1teCINEXUKY3uTEslqyPgcxhb62EkdciRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-codebuild@3.1079.0':
+    resolution: {integrity: sha512-VPn4vVeibj1CArj91QKL1MXqPTs1SoE4ZT4sV+M6Q68MVk4Xcw29iNZpKqsc9SNmXCdQj80kbWwdoG9UT0nfTQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-ecs@3.1079.0':
@@ -1400,241 +1409,241 @@ packages:
     resolution: {integrity: sha512-isfLLwksH3yHkFXfCI2Gcaqg7wGGHZZwunoJzEZk0yKYIokgre6hYVFibKL3SYAoR1kBXova8LB+JoO5vZzi9w==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-cascade-layers@5.0.2':
     resolution: {integrity: sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-color-function-display-p3-linear@1.0.1':
     resolution: {integrity: sha512-E5qusdzhlmO1TztYzDIi8XPdPoYOjoTY6HBYBCYSj+Gn4gQRBlvjgPQXzfzuPQqt8EhkC/SzPKObg4Mbn8/xMg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-color-function@4.0.12':
     resolution: {integrity: sha512-yx3cljQKRaSBc2hfh8rMZFZzChaFgwmO2JfFgFr1vMcF3C/uyy5I4RFIBOIWGq1D+XbKCG789CGkG6zzkLpagA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-color-mix-function@3.0.12':
     resolution: {integrity: sha512-4STERZfCP5Jcs13P1U5pTvI9SkgLgfMUMhdXW8IlJWkzOOOqhZIjcNhWtNJZes2nkBDsIKJ0CJtFtuaZ00moag==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-color-mix-variadic-function-arguments@1.0.2':
     resolution: {integrity: sha512-rM67Gp9lRAkTo+X31DUqMEq+iK+EFqsidfecmhrteErxJZb6tUoJBVQca1Vn1GpDql1s1rD1pKcuYzMsg7Z1KQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-content-alt-text@2.0.8':
     resolution: {integrity: sha512-9SfEW9QCxEpTlNMnpSqFaHyzsiRpZ5J5+KqCu1u5/eEJAWsMhzT40qf0FIbeeglEvrGRMdDzAxMIz3wqoGSb+Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-contrast-color-function@2.0.12':
     resolution: {integrity: sha512-YbwWckjK3qwKjeYz/CijgcS7WDUCtKTd8ShLztm3/i5dhh4NaqzsbYnhm4bjrpFpnLZ31jVcbK8YL77z3GBPzA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-exponential-functions@2.0.9':
     resolution: {integrity: sha512-abg2W/PI3HXwS/CZshSa79kNWNZHdJPMBXeZNyPQFbbj8sKO3jXxOt/wF7juJVjyDTc6JrvaUZYFcSBZBhaxjw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-font-format-keywords@4.0.0':
     resolution: {integrity: sha512-usBzw9aCRDvchpok6C+4TXC57btc4bJtmKQWOHQxOVKen1ZfVqBUuCZ/wuqdX5GHsD0NRSr9XTP+5ID1ZZQBXw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-gamut-mapping@2.0.11':
     resolution: {integrity: sha512-fCpCUgZNE2piVJKC76zFsgVW1apF6dpYsqGyH8SIeCcM4pTEsRTWTLCaJIMKFEundsCKwY1rwfhtrio04RJ4Dw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-gradients-interpolation-method@5.0.12':
     resolution: {integrity: sha512-jugzjwkUY0wtNrZlFeyXzimUL3hN4xMvoPnIXxoZqxDvjZRiSh+itgHcVUWzJ2VwD/VAMEgCLvtaJHX+4Vj3Ow==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-hwb-function@4.0.12':
     resolution: {integrity: sha512-mL/+88Z53KrE4JdePYFJAQWFrcADEqsLprExCM04GDNgHIztwFzj0Mbhd/yxMBngq0NIlz58VVxjt5abNs1VhA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-ic-unit@4.0.4':
     resolution: {integrity: sha512-yQ4VmossuOAql65sCPppVO1yfb7hDscf4GseF0VCA/DTDaBc0Wtf8MTqVPfjGYlT5+2buokG0Gp7y0atYZpwjg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-initial@2.0.1':
     resolution: {integrity: sha512-L1wLVMSAZ4wovznquK0xmC7QSctzO4D0Is590bxpGqhqjboLXYA16dWZpfwImkdOgACdQ9PqXsuRroW6qPlEsg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-is-pseudo-class@5.0.3':
     resolution: {integrity: sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-light-dark-function@2.0.11':
     resolution: {integrity: sha512-fNJcKXJdPM3Lyrbmgw2OBbaioU7yuKZtiXClf4sGdQttitijYlZMD5K7HrC/eF83VRWRrYq6OZ0Lx92leV2LFA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-logical-float-and-clear@3.0.0':
     resolution: {integrity: sha512-SEmaHMszwakI2rqKRJgE+8rpotFfne1ZS6bZqBoQIicFyV+xT1UF42eORPxJkVJVrH9C0ctUgwMSn3BLOIZldQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-logical-overflow@2.0.0':
     resolution: {integrity: sha512-spzR1MInxPuXKEX2csMamshR4LRaSZ3UXVaRGjeQxl70ySxOhMpP2252RAFsg8QyyBXBzuVOOdx1+bVO5bPIzA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-logical-overscroll-behavior@2.0.0':
     resolution: {integrity: sha512-e/webMjoGOSYfqLunyzByZj5KKe5oyVg/YSbie99VEaSDE2kimFm0q1f6t/6Jo+VVCQ/jbe2Xy+uX+C4xzWs4w==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-logical-resize@3.0.0':
     resolution: {integrity: sha512-DFbHQOFW/+I+MY4Ycd/QN6Dg4Hcbb50elIJCfnwkRTCX05G11SwViI5BbBlg9iHRl4ytB7pmY5ieAFk3ws7yyg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-logical-viewport-units@3.0.4':
     resolution: {integrity: sha512-q+eHV1haXA4w9xBwZLKjVKAWn3W2CMqmpNpZUk5kRprvSiBEGMgrNH3/sJZ8UA3JgyHaOt3jwT9uFa4wLX4EqQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-media-minmax@2.0.9':
     resolution: {integrity: sha512-af9Qw3uS3JhYLnCbqtZ9crTvvkR+0Se+bBqSr7ykAnl9yKhk6895z9rf+2F4dClIDJWxgn0iZZ1PSdkhrbs2ig==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5':
     resolution: {integrity: sha512-zhAe31xaaXOY2Px8IYfoVTB3wglbJUVigGphFLj6exb7cjZRH9A6adyE22XfFK3P2PzwRk0VDeTJmaxpluyrDg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-nested-calc@4.0.0':
     resolution: {integrity: sha512-jMYDdqrQQxE7k9+KjstC3NbsmC063n1FTPLCgCRS2/qHUbHM0mNy9pIn4QIiQGs9I/Bg98vMqw7mJXBxa0N88A==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-normalize-display-values@4.0.1':
     resolution: {integrity: sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-oklab-function@4.0.12':
     resolution: {integrity: sha512-HhlSmnE1NKBhXsTnNGjxvhryKtO7tJd1w42DKOGFD6jSHtYOrsJTQDKPMwvOfrzUAk8t7GcpIfRyM7ssqHpFjg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-position-area-property@1.0.0':
     resolution: {integrity: sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-progressive-custom-properties@4.2.1':
     resolution: {integrity: sha512-uPiiXf7IEKtUQXsxu6uWtOlRMXd2QWWy5fhxHDnPdXKCQckPP3E34ZgDoZ62r2iT+UOgWsSbM4NvHE5m3mAEdw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-property-rule-prelude-list@1.0.0':
     resolution: {integrity: sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-random-function@2.0.1':
     resolution: {integrity: sha512-q+FQaNiRBhnoSNo+GzqGOIBKoHQ43lYz0ICrV+UudfWnEF6ksS6DsBIJSISKQT2Bvu3g4k6r7t0zYrk5pDlo8w==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-relative-color-syntax@3.0.12':
     resolution: {integrity: sha512-0RLIeONxu/mtxRtf3o41Lq2ghLimw0w9ByLWnnEVuy89exmEEq8bynveBxNW3nyHqLAFEeNtVEmC1QK9MZ8Huw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-scope-pseudo-class@4.0.1':
     resolution: {integrity: sha512-IMi9FwtH6LMNuLea1bjVMQAsUhFxJnyLSgOp/cpv5hrzWmrUYU5fm0EguNDIIOHUqzXode8F/1qkC/tEo/qN8Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-sign-functions@1.1.4':
     resolution: {integrity: sha512-P97h1XqRPcfcJndFdG95Gv/6ZzxUBBISem0IDqPZ7WMvc/wlO+yU0c5D/OCpZ5TJoTt63Ok3knGk64N+o6L2Pg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-stepped-value-functions@4.0.9':
     resolution: {integrity: sha512-h9btycWrsex4dNLeQfyU3y3w40LMQooJWFMm/SK9lrKguHDcFl4VMkncKKoXi2z5rM9YGWbUQABI8BT2UydIcA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-syntax-descriptor-syntax-production@1.0.1':
     resolution: {integrity: sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-system-ui-font-family@1.0.0':
     resolution: {integrity: sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-text-decoration-shorthand@4.0.3':
     resolution: {integrity: sha512-KSkGgZfx0kQjRIYnpsD7X2Om9BUXX/Kii77VBifQW9Ih929hK0KNjVngHDH0bFB9GmfWcR9vJYJJRvw/NQjkrA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-trigonometric-functions@4.0.9':
     resolution: {integrity: sha512-Hnh5zJUdpNrJqK9v1/E3BbrQhaDTj5YiX7P61TOvUhoDHnUmsNNxcDAgkQ32RrcWx9GVUvfUNPcUkn8R3vIX6A==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/postcss-unset-value@4.0.0':
     resolution: {integrity: sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/selector-resolve-nested@3.1.0':
     resolution: {integrity: sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==}
@@ -1652,7 +1661,7 @@ packages:
     resolution: {integrity: sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -2121,7 +2130,7 @@ packages:
     resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3837,7 +3846,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
@@ -3934,14 +3943,14 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -4297,6 +4306,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -4315,19 +4325,19 @@ packages:
     resolution: {integrity: sha512-jf+twWGDf6LDoXDUode+nc7ZlrqfaNphrBIBrcmeP3D8yw1uPaix1gCC8LUQUGQ6CycuK2opkbFFWFuq/a94ag==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   css-declaration-sorter@7.4.0:
     resolution: {integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   css-has-pseudo@7.0.3:
     resolution: {integrity: sha512-oG+vKuGyqe/xvEMoxAQrhi7uY16deJR3i7wwhBerVrGQKSqUC5GiOVxTpM9F9B9hw0J+eKeOWLH7E9gZ1Dr5rA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   css-loader@6.11.0:
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
@@ -4370,7 +4380,7 @@ packages:
     resolution: {integrity: sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -4402,25 +4412,25 @@ packages:
     resolution: {integrity: sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   cssnano-preset-default@6.1.2:
     resolution: {integrity: sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   cssnano-utils@4.0.2:
     resolution: {integrity: sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   cssnano@6.1.2:
     resolution: {integrity: sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
@@ -4921,8 +4931,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -5196,8 +5206,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hpack.js@2.1.6:
@@ -5303,7 +5313,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -5357,8 +5367,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -6531,151 +6541,151 @@ packages:
     resolution: {integrity: sha512-Uai+SupNSqzlschRyNx3kbCTWgY/2hcwtHEI/ej2LJWc9JJ77qKgGptd8DHwY1mXtZ7Aoh4z4yxfwMBue9eNgw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-calc@9.0.1:
     resolution: {integrity: sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-clamp@4.1.0:
     resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
     engines: {node: '>=7.6.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-color-functional-notation@7.0.12:
     resolution: {integrity: sha512-TLCW9fN5kvO/u38/uesdpbx3e8AkTYhMvDZYa9JpmImWuTE99bDQ7GU7hdOADIZsiI9/zuxfAJxny/khknp1Zw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-color-hex-alpha@10.0.0:
     resolution: {integrity: sha512-1kervM2cnlgPs2a8Vt/Qbe5cQ++N7rkYo/2rz2BkqJZIHQwaVuJgQH38REHrAi4uM0b1fqxMkWYmese94iMp3w==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-color-rebeccapurple@10.0.0:
     resolution: {integrity: sha512-JFta737jSP+hdAIEhk1Vs0q0YF5P8fFcj+09pweS8ktuGuZ8pPlykHsk6mPxZ8awDl4TrcxUqJo9l1IhVr/OjQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-colormin@6.1.0:
     resolution: {integrity: sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-convert-values@6.1.0:
     resolution: {integrity: sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-custom-media@11.0.6:
     resolution: {integrity: sha512-C4lD4b7mUIw+RZhtY7qUbf4eADmb7Ey8BFA2px9jUbwg7pjTZDl4KY4bvlUV+/vXQvzQRfiGEVJyAbtOsCMInw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-custom-properties@14.0.6:
     resolution: {integrity: sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-custom-selectors@8.0.5:
     resolution: {integrity: sha512-9PGmckHQswiB2usSO6XMSswO2yFWVoCAuih1yl9FVcwkscLjRKjwsjM3t+NIWpSU2Jx3eOiK2+t4vVTQaoCHHg==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-dir-pseudo-class@9.0.1:
     resolution: {integrity: sha512-tRBEK0MHYvcMUrAuYMEOa0zg9APqirBcgzi6P21OhxtJyJADo/SWBwY1CAwEohQ/6HDaa9jCjLRG7K3PVQYHEA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-comments@6.0.2:
     resolution: {integrity: sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-duplicates@6.0.3:
     resolution: {integrity: sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-empty@6.0.3:
     resolution: {integrity: sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-overridden@6.0.2:
     resolution: {integrity: sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-unused@6.0.5:
     resolution: {integrity: sha512-wHalBlRHkaNnNwfC8z+ppX57VhvS+HWgjW508esjdaEYr3Mx7Gnn2xA4R/CKf5+Z9S5qsqC+Uzh4ueENWwCVUA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-double-position-gradients@6.0.4:
     resolution: {integrity: sha512-m6IKmxo7FxSP5nF2l63QbCC3r+bWpFUWmZXZf096WxG0m7Vl1Q1+ruFOhpdDRmKrRS+S3Jtk+TVk/7z0+BVK6g==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-focus-visible@10.0.1:
     resolution: {integrity: sha512-U58wyjS/I1GZgjRok33aE8juW9qQgQUNwTSdxQGuShHzwuYdcklnvK/+qOWX1Q9kr7ysbraQ6ht6r+udansalA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-focus-within@9.0.1:
     resolution: {integrity: sha512-fzNUyS1yOYa7mOjpci/bR+u+ESvdar6hk8XNK/TRR0fiGTp2QT5N+ducP0n3rfH/m9I7H/EQU6lsa2BrgxkEjw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-font-variant@5.0.0:
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-gap-properties@6.0.0:
     resolution: {integrity: sha512-Om0WPjEwiM9Ru+VhfEDPZJAKWUd0mV1HmNXqp2C29z80aQ2uP9UVhLc7e3aYMIor/S5cVhoPgYQ7RtfeZpYTRw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-image-set-function@7.0.0:
     resolution: {integrity: sha512-QL7W7QNlZuzOwBTeXEmbVckNt1FSmhQtbMRvGGqqU4Nf4xk6KUEQhAoWuMzwbSv5jxiRiSZ5Tv7eiDB9U87znA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-lab-function@7.0.12:
     resolution: {integrity: sha512-tUcyRk1ZTPec3OuKFsqtRzW2Go5lehW29XA21lZ65XmzQkz43VY2tyWEC202F7W3mILOjw0voOiuxRGTsN+J9w==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: 8.5.18
+      postcss: 8.5.23
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -6692,210 +6702,210 @@ packages:
     resolution: {integrity: sha512-iW5WTTBSC5BfsBJ9daFMPVrLT36MrNiC6fqOZTTaHjBNX6Pfd5p+hSBqe/fEeNd7pc13QiAyGt7VdGMw4eRC4A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       webpack: ^5.0.0
 
   postcss-logical@8.1.0:
     resolution: {integrity: sha512-pL1hXFQ2fEXNKiNiAgtfA005T9FBxky5zkX6s4GZM2D8RkVgRqz3f4g1JUoq925zXv495qk8UNldDwh8uGEDoA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-merge-idents@6.0.3:
     resolution: {integrity: sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-merge-longhand@6.0.5:
     resolution: {integrity: sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-merge-rules@6.1.1:
     resolution: {integrity: sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-font-values@6.1.0:
     resolution: {integrity: sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-gradients@6.0.3:
     resolution: {integrity: sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-params@6.1.0:
     resolution: {integrity: sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-selectors@6.0.4:
     resolution: {integrity: sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-modules-extract-imports@3.1.0:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-modules-local-by-default@4.2.0:
     resolution: {integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-modules-scope@3.2.1:
     resolution: {integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-modules-values@4.0.0:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-nesting@13.0.2:
     resolution: {integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-charset@6.0.2:
     resolution: {integrity: sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-display-values@6.0.2:
     resolution: {integrity: sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-positions@6.0.2:
     resolution: {integrity: sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-repeat-style@6.0.2:
     resolution: {integrity: sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-string@6.0.2:
     resolution: {integrity: sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-timing-functions@6.0.2:
     resolution: {integrity: sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-unicode@6.1.0:
     resolution: {integrity: sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-url@6.0.2:
     resolution: {integrity: sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-whitespace@6.0.2:
     resolution: {integrity: sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-opacity-percentage@3.0.0:
     resolution: {integrity: sha512-K6HGVzyxUxd/VgZdX04DCtdwWJ4NGLG212US4/LA1TLAbHgmAsTWVR86o+gGIbFtnTkfOpb9sCRBx8K7HO66qQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-ordered-values@6.0.2:
     resolution: {integrity: sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-overflow-shorthand@6.0.0:
     resolution: {integrity: sha512-BdDl/AbVkDjoTofzDQnwDdm/Ym6oS9KgmO7Gr+LHYjNWJ6ExORe4+3pcLQsLA9gIROMkiGVjjwZNoL/mpXHd5Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-page-break@3.0.4:
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-place@10.0.0:
     resolution: {integrity: sha512-5EBrMzat2pPAxQNWYavwAfoKfYcTADJ8AXGVPcUZ2UkNloUTWzJQExgrzrDkh3EKzmAx1evfTAzF9I8NGcc+qw==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-preset-env@10.6.1:
     resolution: {integrity: sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-pseudo-class-any-link@10.0.1:
     resolution: {integrity: sha512-3el9rXlBOqTFaMFkWDOkHUTQekFIYnaQY55Rsp8As8QQkpiSgIYEcF/6Ond93oHiDsGb4kad8zjt+NPlOC1H0Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-reduce-idents@6.0.3:
     resolution: {integrity: sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-reduce-initial@6.1.0:
     resolution: {integrity: sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-reduce-transforms@6.0.2:
     resolution: {integrity: sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-replace-overflow-wrap@4.0.0:
     resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-selector-not@8.0.1:
     resolution: {integrity: sha512-kmVy/5PYVb2UOhy0+LqUYAhKj7DUGDpSWa5LZqlkWJaaAV+dxxsOG3+St0yNLu6vsKD7Dmqx+nWQt0iil89+WA==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-selector-parser@6.1.4:
     resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
@@ -6909,19 +6919,19 @@ packages:
     resolution: {integrity: sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-svgo@6.0.3:
     resolution: {integrity: sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==}
     engines: {node: ^14 || ^16 || >= 18}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-unique-selectors@6.0.4:
     resolution: {integrity: sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -6930,14 +6940,10 @@ packages:
     resolution: {integrity: sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.21:
-    resolution: {integrity: sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -7700,7 +7706,7 @@ packages:
     resolution: {integrity: sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -7896,7 +7902,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: 8.5.18
+      postcss: 8.5.23
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -7965,8 +7971,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8520,6 +8526,17 @@ snapshots:
       zod: 4.4.3
 
   '@aws-sdk/client-cloudwatch-logs@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-node': 3.972.62
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-codebuild@3.1079.0':
     dependencies:
       '@aws-sdk/core': 3.974.27
       '@aws-sdk/credential-provider-node': 3.972.62
@@ -9761,272 +9778,272 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/postcss-alpha-function@1.0.1(postcss@8.5.18)':
+  '@csstools/postcss-alpha-function@1.0.1(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.18)':
+  '@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.23)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  '@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.18)':
+  '@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-color-function@4.0.12(postcss@8.5.18)':
+  '@csstools/postcss-color-function@4.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.18)':
+  '@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.18)':
+  '@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.18)':
+  '@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.18)':
+  '@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.18)':
+  '@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.18)':
+  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.23)':
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.18)':
+  '@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.18)':
+  '@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-hwb-function@4.0.12(postcss@8.5.18)':
+  '@csstools/postcss-hwb-function@4.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-ic-unit@4.0.4(postcss@8.5.18)':
+  '@csstools/postcss-ic-unit@4.0.4(postcss@8.5.23)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-initial@2.0.1(postcss@8.5.18)':
+  '@csstools/postcss-initial@2.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.18)':
+  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.23)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  '@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.18)':
+  '@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.18)':
+  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.18)':
+  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.18)':
+  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-logical-resize@3.0.0(postcss@8.5.18)':
+  '@csstools/postcss-logical-resize@3.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.18)':
+  '@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.23)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-media-minmax@2.0.9(postcss@8.5.18)':
+  '@csstools/postcss-media-minmax@2.0.9(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.18)':
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.18)':
+  '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.23)':
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.18)':
+  '@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-oklab-function@4.0.12(postcss@8.5.18)':
+  '@csstools/postcss-oklab-function@4.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-position-area-property@1.0.0(postcss@8.5.18)':
+  '@csstools/postcss-position-area-property@1.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.18)':
+  '@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.18)':
+  '@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-random-function@2.0.1(postcss@8.5.18)':
+  '@csstools/postcss-random-function@2.0.1(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.18)':
+  '@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.23)':
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.18)':
+  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  '@csstools/postcss-sign-functions@1.1.4(postcss@8.5.18)':
+  '@csstools/postcss-sign-functions@1.1.4(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.18)':
+  '@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.18)':
+  '@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.23)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.18)':
+  '@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.23)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.18)':
+  '@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.23)':
     dependencies:
       '@csstools/color-helpers': 5.1.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.18)':
+  '@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.23)':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  '@csstools/postcss-unset-value@4.0.0(postcss@8.5.18)':
+  '@csstools/postcss-unset-value@4.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.4)':
     dependencies:
@@ -10036,9 +10053,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.4
 
-  '@csstools/utilities@2.0.0(postcss@8.5.18)':
+  '@csstools/utilities@2.0.0(postcss@8.5.23)':
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -10064,7 +10081,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/babel@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -10076,7 +10093,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.7
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.6
       tslib: 2.8.1
@@ -10101,29 +10118,29 @@ snapshots:
   '@docusaurus/bundler@3.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.7
-      '@docusaurus/babel': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/babel': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/cssnano-preset': 3.10.1
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.3(postcss@8.5.18))
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.3(postcss@8.5.23))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.108.3(postcss@8.5.18))
-      css-loader: 6.11.0(webpack@5.108.3(postcss@8.5.18))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.3(postcss@8.5.18))
-      cssnano: 6.1.2(postcss@8.5.18)
-      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.18))
+      copy-webpack-plugin: 11.0.0(webpack@5.108.3(postcss@8.5.23))
+      css-loader: 6.11.0(webpack@5.108.3(postcss@8.5.23))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.3(postcss@8.5.23))
+      cssnano: 6.1.2(postcss@8.5.23)
+      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.23))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.3(postcss@8.5.18))
-      null-loader: 4.0.1(webpack@5.108.3(postcss@8.5.18))
-      postcss: 8.5.18
-      postcss-loader: 7.3.4(postcss@8.5.18)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.18))
-      postcss-preset-env: 10.6.1(postcss@8.5.18)
-      terser-webpack-plugin: 5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.3(postcss@8.5.18))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.3(postcss@8.5.23))
+      null-loader: 4.0.1(webpack@5.108.3(postcss@8.5.23))
+      postcss: 8.5.23
+      postcss-loader: 7.3.4(postcss@8.5.23)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.23))
+      postcss-preset-env: 10.6.1(postcss@8.5.23)
+      terser-webpack-plugin: 5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.108.3(postcss@8.5.23))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.18)))(webpack@5.108.3(postcss@8.5.18))
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
-      webpackbar: 7.0.0(webpack@5.108.3(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.23)))(webpack@5.108.3(postcss@8.5.23))
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
+      webpackbar: 7.0.0(webpack@5.108.3(postcss@8.5.23))
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@parcel/css'
@@ -10141,15 +10158,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/babel': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/bundler': 3.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@18.3.1)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10165,7 +10182,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.6
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.7(webpack@5.108.3(postcss@8.5.18))
+      html-webpack-plugin: 5.6.7(webpack@5.108.3(postcss@8.5.23))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -10175,7 +10192,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.108.3(postcss@8.5.18))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.108.3(postcss@8.5.23))
       react-router: 5.3.4(react@18.3.1)
       react-router-config: 5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
@@ -10184,9 +10201,9 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.18))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.23))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10212,9 +10229,9 @@ snapshots:
 
   '@docusaurus/cssnano-preset@3.10.1':
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.5.18)
-      postcss: 8.5.18
-      postcss-sort-media-queries: 5.2.0(postcss@8.5.18)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.23)
       tslib: 2.8.1
 
   '@docusaurus/logger@3.10.1':
@@ -10222,16 +10239,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/mdx-loader@3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.23))
       fs-extra: 11.3.6
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -10247,9 +10264,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.18)))(webpack@5.108.3(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.23)))(webpack@5.108.3(postcss@8.5.23))
       vfile: 6.0.3
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -10266,9 +10283,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/module-type-aliases@3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 19.2.17
       '@types/react-router-config': 5.0.11
@@ -10293,17 +10310,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -10316,7 +10333,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10341,17 +10358,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/module-type-aliases': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/module-type-aliases': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.6
@@ -10362,7 +10379,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10387,18 +10404,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-pages@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10423,12 +10440,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -10456,11 +10473,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-debug@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -10490,11 +10507,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-analytics@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -10522,11 +10539,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-gtag@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/gtag.js': 0.0.20
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -10555,11 +10572,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -10587,14 +10604,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-sitemap@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -10624,18 +10641,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-svgr@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10660,23 +10677,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-debug': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-google-analytics': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-google-gtag': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-sitemap': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-svgr': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-debug': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-google-analytics': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-google-gtag': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-sitemap': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-svgr': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/theme-classic': 3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -10713,26 +10730,26 @@ snapshots:
 
   '@docusaurus/theme-classic@3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/module-type-aliases': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/module-type-aliases': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
       infima: 0.2.0-alpha.45
       lodash: 4.18.1
       nprogress: 0.2.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
       react: 18.3.1
@@ -10764,13 +10781,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/module-type-aliases': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/mdx-loader': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/module-type-aliases': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 19.2.17
       '@types/react-router-config': 5.0.11
@@ -10797,17 +10814,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.55.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(@types/react@19.2.17)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.9(@algolia/client-search@5.55.1)(algoliasearch@5.55.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.3(@algolia/client-search@5.55.1)(@types/react@19.2.17)(algoliasearch@5.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@18.3.1))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algoliasearch: 5.55.1
       algoliasearch-helper: 3.29.1(algoliasearch@5.55.1)
       clsx: 2.1.1
@@ -10852,7 +10869,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.1': {}
 
-  '@docusaurus/types@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/types@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -10864,7 +10881,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       utility-types: 3.11.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10882,9 +10899,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/utils-common@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10904,11 +10921,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.1(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/utils-validation@3.10.1(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.6
       joi: 17.13.4
       js-yaml: 4.3.0
@@ -10932,14 +10949,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/utils@3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.23))
       fs-extra: 11.3.6
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -10952,9 +10969,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.18)))(webpack@5.108.3(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.23)))(webpack@5.108.3(postcss@8.5.23))
       utility-types: 3.11.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -11075,7 +11092,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/cookie@11.0.2':
     dependencies:
@@ -11199,9 +11216,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/node-server@2.0.10(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.12.34
 
   '@img/colour@1.1.0':
     optional: true
@@ -11926,7 +11943,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -11936,7 +11953,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12654,7 +12671,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.18
+      postcss: 8.5.23
       tailwindcss: 4.3.2
 
   '@turbo/darwin-64@2.10.2':
@@ -12946,7 +12963,7 @@ snapshots:
       '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.21
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -13120,7 +13137,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13208,13 +13225,13 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.5.2(postcss@8.5.18):
+  autoprefixer@10.5.2(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
       caniuse-lite: 1.0.30001800
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   avvio@9.2.0:
@@ -13222,12 +13239,12 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.3(postcss@8.5.18)):
+  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -13355,16 +13372,16 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13662,7 +13679,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.108.3(postcss@8.5.18)):
+  copy-webpack-plugin@11.0.0(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -13670,7 +13687,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.7
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -13721,50 +13738,50 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-blank-pseudo@7.0.1(postcss@8.5.18):
+  css-blank-pseudo@7.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  css-declaration-sorter@7.4.0(postcss@8.5.18):
+  css-declaration-sorter@7.4.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  css-has-pseudo@7.0.3(postcss@8.5.18):
+  css-has-pseudo@7.0.3(postcss@8.5.23):
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.108.3(postcss@8.5.18)):
+  css-loader@6.11.0(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.18)
-      postcss: 8.5.18
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.18)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.18)
-      postcss-modules-scope: 3.2.1(postcss@8.5.18)
-      postcss-modules-values: 4.0.0(postcss@8.5.18)
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.23)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.23)
+      postcss-modules-scope: 3.2.1(postcss@8.5.23)
+      postcss-modules-values: 4.0.0(postcss@8.5.23)
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.3(postcss@8.5.18)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 6.1.2(postcss@8.5.18)
+      cssnano: 6.1.2(postcss@8.5.23)
       jest-worker: 29.7.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       schema-utils: 4.3.3
       serialize-javascript: 7.0.7
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     optionalDependencies:
       clean-css: 5.3.3
 
-  css-prefers-color-scheme@10.0.0(postcss@8.5.18):
+  css-prefers-color-scheme@10.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   css-select@4.3.0:
     dependencies:
@@ -13798,60 +13815,60 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-advanced@6.1.2(postcss@8.5.18):
+  cssnano-preset-advanced@6.1.2(postcss@8.5.23):
     dependencies:
-      autoprefixer: 10.5.2(postcss@8.5.18)
+      autoprefixer: 10.5.2(postcss@8.5.23)
       browserslist: 4.28.4
-      cssnano-preset-default: 6.1.2(postcss@8.5.18)
-      postcss: 8.5.18
-      postcss-discard-unused: 6.0.5(postcss@8.5.18)
-      postcss-merge-idents: 6.0.3(postcss@8.5.18)
-      postcss-reduce-idents: 6.0.3(postcss@8.5.18)
-      postcss-zindex: 6.0.2(postcss@8.5.18)
+      cssnano-preset-default: 6.1.2(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-discard-unused: 6.0.5(postcss@8.5.23)
+      postcss-merge-idents: 6.0.3(postcss@8.5.23)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.23)
+      postcss-zindex: 6.0.2(postcss@8.5.23)
 
-  cssnano-preset-default@6.1.2(postcss@8.5.18):
+  cssnano-preset-default@6.1.2(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
-      css-declaration-sorter: 7.4.0(postcss@8.5.18)
-      cssnano-utils: 4.0.2(postcss@8.5.18)
-      postcss: 8.5.18
-      postcss-calc: 9.0.1(postcss@8.5.18)
-      postcss-colormin: 6.1.0(postcss@8.5.18)
-      postcss-convert-values: 6.1.0(postcss@8.5.18)
-      postcss-discard-comments: 6.0.2(postcss@8.5.18)
-      postcss-discard-duplicates: 6.0.3(postcss@8.5.18)
-      postcss-discard-empty: 6.0.3(postcss@8.5.18)
-      postcss-discard-overridden: 6.0.2(postcss@8.5.18)
-      postcss-merge-longhand: 6.0.5(postcss@8.5.18)
-      postcss-merge-rules: 6.1.1(postcss@8.5.18)
-      postcss-minify-font-values: 6.1.0(postcss@8.5.18)
-      postcss-minify-gradients: 6.0.3(postcss@8.5.18)
-      postcss-minify-params: 6.1.0(postcss@8.5.18)
-      postcss-minify-selectors: 6.0.4(postcss@8.5.18)
-      postcss-normalize-charset: 6.0.2(postcss@8.5.18)
-      postcss-normalize-display-values: 6.0.2(postcss@8.5.18)
-      postcss-normalize-positions: 6.0.2(postcss@8.5.18)
-      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.18)
-      postcss-normalize-string: 6.0.2(postcss@8.5.18)
-      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.18)
-      postcss-normalize-unicode: 6.1.0(postcss@8.5.18)
-      postcss-normalize-url: 6.0.2(postcss@8.5.18)
-      postcss-normalize-whitespace: 6.0.2(postcss@8.5.18)
-      postcss-ordered-values: 6.0.2(postcss@8.5.18)
-      postcss-reduce-initial: 6.1.0(postcss@8.5.18)
-      postcss-reduce-transforms: 6.0.2(postcss@8.5.18)
-      postcss-svgo: 6.0.3(postcss@8.5.18)
-      postcss-unique-selectors: 6.0.4(postcss@8.5.18)
+      css-declaration-sorter: 7.4.0(postcss@8.5.23)
+      cssnano-utils: 4.0.2(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-calc: 9.0.1(postcss@8.5.23)
+      postcss-colormin: 6.1.0(postcss@8.5.23)
+      postcss-convert-values: 6.1.0(postcss@8.5.23)
+      postcss-discard-comments: 6.0.2(postcss@8.5.23)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.23)
+      postcss-discard-empty: 6.0.3(postcss@8.5.23)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.23)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.23)
+      postcss-merge-rules: 6.1.1(postcss@8.5.23)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.23)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.23)
+      postcss-minify-params: 6.1.0(postcss@8.5.23)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.23)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.23)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.23)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.23)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.23)
+      postcss-normalize-string: 6.0.2(postcss@8.5.23)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.23)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.23)
+      postcss-normalize-url: 6.0.2(postcss@8.5.23)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.23)
+      postcss-ordered-values: 6.0.2(postcss@8.5.23)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.23)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.23)
+      postcss-svgo: 6.0.3(postcss@8.5.23)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.23)
 
-  cssnano-utils@4.0.2(postcss@8.5.18):
+  cssnano-utils@4.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  cssnano@6.1.2(postcss@8.5.18):
+  cssnano@6.1.2(postcss@8.5.23):
     dependencies:
-      cssnano-preset-default: 6.1.2(postcss@8.5.18)
+      cssnano-preset-default: 6.1.2(postcss@8.5.23)
       lilconfig: 3.1.3
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   csso@5.0.5:
     dependencies:
@@ -14230,7 +14247,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.3.1
 
   express@4.22.2:
     dependencies:
@@ -14326,7 +14343,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -14336,7 +14353,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -14388,11 +14405,11 @@ snapshots:
     dependencies:
       xml-js: 1.6.11
 
-  file-loader@6.2.0(webpack@5.108.3(postcss@8.5.18)):
+  file-loader@6.2.0(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   fill-range@7.1.1:
     dependencies:
@@ -14704,7 +14721,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.27: {}
+  hono@4.12.34: {}
 
   hpack.js@2.1.6:
     dependencies:
@@ -14739,7 +14756,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(webpack@5.108.3(postcss@8.5.18)):
+  html-webpack-plugin@5.6.7(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14747,7 +14764,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -14834,9 +14851,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.18):
+  icss-utils@5.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   ieee754@1.2.1: {}
 
@@ -14871,7 +14888,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -15035,7 +15052,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -15817,40 +15834,40 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.3(postcss@8.5.18)):
+  mini-css-extract-plugin@2.10.2(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.3(postcss@8.5.18)):
+  minimizer-webpack-plugin@5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     optionalDependencies:
       clean-css: 5.3.3
-      cssnano: 6.1.2(postcss@8.5.18)
+      cssnano: 6.1.2(postcss@8.5.23)
       html-minifier-terser: 7.2.0
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   minipass@7.1.3: {}
 
@@ -15909,7 +15926,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001800
-      postcss: 8.5.18
+      postcss: 8.5.23
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
@@ -15959,11 +15976,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.108.3(postcss@8.5.18)):
+  null-loader@4.0.1(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   object-assign@4.1.1: {}
 
@@ -16253,416 +16270,416 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.18):
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-calc@9.0.1(postcss@8.5.18):
+  postcss-calc@9.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.5.18):
+  postcss-clamp@4.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@7.0.12(postcss@8.5.18):
+  postcss-color-functional-notation@7.0.12(postcss@8.5.23):
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  postcss-color-hex-alpha@10.0.0(postcss@8.5.18):
+  postcss-color-hex-alpha@10.0.0(postcss@8.5.23):
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@10.0.0(postcss@8.5.18):
+  postcss-color-rebeccapurple@10.0.0(postcss@8.5.23):
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@6.1.0(postcss@8.5.18):
+  postcss-colormin@6.1.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@6.1.0(postcss@8.5.18):
+  postcss-convert-values@6.1.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@11.0.6(postcss@8.5.18):
+  postcss-custom-media@11.0.6(postcss@8.5.23):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-custom-properties@14.0.6(postcss@8.5.18):
+  postcss-custom-properties@14.0.6(postcss@8.5.23):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@8.0.5(postcss@8.5.18):
+  postcss-custom-selectors@8.0.5(postcss@8.5.23):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-dir-pseudo-class@9.0.1(postcss@8.5.18):
+  postcss-dir-pseudo-class@9.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-discard-comments@6.0.2(postcss@8.5.18):
+  postcss-discard-comments@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-discard-duplicates@6.0.3(postcss@8.5.18):
+  postcss-discard-duplicates@6.0.3(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-discard-empty@6.0.3(postcss@8.5.18):
+  postcss-discard-empty@6.0.3(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-discard-overridden@6.0.2(postcss@8.5.18):
+  postcss-discard-overridden@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-discard-unused@6.0.5(postcss@8.5.18):
+  postcss-discard-unused@6.0.5(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-double-position-gradients@6.0.4(postcss@8.5.18):
+  postcss-double-position-gradients@6.0.4(postcss@8.5.23):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-focus-visible@10.0.1(postcss@8.5.18):
+  postcss-focus-visible@10.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-focus-within@9.0.1(postcss@8.5.18):
+  postcss-focus-within@9.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-font-variant@5.0.0(postcss@8.5.18):
+  postcss-font-variant@5.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-gap-properties@6.0.0(postcss@8.5.18):
+  postcss-gap-properties@6.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-image-set-function@7.0.0(postcss@8.5.18):
+  postcss-image-set-function@7.0.0(postcss@8.5.23):
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-lab-function@7.0.12(postcss@8.5.18):
+  postcss-lab-function@7.0.12(postcss@8.5.23):
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/utilities': 2.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/utilities': 2.0.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       tsx: 4.22.5
       yaml: 2.9.0
 
-  postcss-loader@7.3.4(postcss@8.5.18)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.18)):
+  postcss-loader@7.3.4(postcss@8.5.23)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.9.3)
       jiti: 1.21.7
-      postcss: 8.5.18
+      postcss: 8.5.23
       semver: 7.8.5
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - typescript
 
-  postcss-logical@8.1.0(postcss@8.5.18):
+  postcss-logical@8.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-merge-idents@6.0.3(postcss@8.5.18):
+  postcss-merge-idents@6.0.3(postcss@8.5.23):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 4.0.2(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-merge-longhand@6.0.5(postcss@8.5.18):
+  postcss-merge-longhand@6.0.5(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
-      stylehacks: 6.1.1(postcss@8.5.18)
+      stylehacks: 6.1.1(postcss@8.5.23)
 
-  postcss-merge-rules@6.1.1(postcss@8.5.18):
+  postcss-merge-rules@6.1.1(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
       caniuse-api: 3.0.0
-      cssnano-utils: 4.0.2(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 4.0.2(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-minify-font-values@6.1.0(postcss@8.5.18):
+  postcss-minify-font-values@6.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@6.0.3(postcss@8.5.18):
+  postcss-minify-gradients@6.0.3(postcss@8.5.23):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 4.0.2(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 4.0.2(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@6.1.0(postcss@8.5.18):
+  postcss-minify-params@6.1.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
-      cssnano-utils: 4.0.2(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 4.0.2(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@6.0.4(postcss@8.5.18):
+  postcss-minify-selectors@6.0.4(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.18):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.18):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.23):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.18)
-      postcss: 8.5.18
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.18):
+  postcss-modules-scope@3.2.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-modules-values@4.0.0(postcss@8.5.18):
+  postcss-modules-values@4.0.0(postcss@8.5.23):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.18)
-      postcss: 8.5.18
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
 
-  postcss-nesting@13.0.2(postcss@8.5.18):
+  postcss-nesting@13.0.2(postcss@8.5.23):
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.4)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-normalize-charset@6.0.2(postcss@8.5.18):
+  postcss-normalize-charset@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-normalize-display-values@6.0.2(postcss@8.5.18):
+  postcss-normalize-display-values@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@6.0.2(postcss@8.5.18):
+  postcss-normalize-positions@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@6.0.2(postcss@8.5.18):
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@6.0.2(postcss@8.5.18):
+  postcss-normalize-string@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@6.0.2(postcss@8.5.18):
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@6.1.0(postcss@8.5.18):
+  postcss-normalize-unicode@6.1.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@6.0.2(postcss@8.5.18):
+  postcss-normalize-url@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@6.0.2(postcss@8.5.18):
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@3.0.0(postcss@8.5.18):
+  postcss-opacity-percentage@3.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-ordered-values@6.0.2(postcss@8.5.18):
+  postcss-ordered-values@6.0.2(postcss@8.5.23):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 4.0.2(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@6.0.0(postcss@8.5.18):
+  postcss-overflow-shorthand@6.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.18):
+  postcss-page-break@3.0.4(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-place@10.0.0(postcss@8.5.18):
+  postcss-place@10.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@10.6.1(postcss@8.5.18):
+  postcss-preset-env@10.6.1(postcss@8.5.23):
     dependencies:
-      '@csstools/postcss-alpha-function': 1.0.1(postcss@8.5.18)
-      '@csstools/postcss-cascade-layers': 5.0.2(postcss@8.5.18)
-      '@csstools/postcss-color-function': 4.0.12(postcss@8.5.18)
-      '@csstools/postcss-color-function-display-p3-linear': 1.0.1(postcss@8.5.18)
-      '@csstools/postcss-color-mix-function': 3.0.12(postcss@8.5.18)
-      '@csstools/postcss-color-mix-variadic-function-arguments': 1.0.2(postcss@8.5.18)
-      '@csstools/postcss-content-alt-text': 2.0.8(postcss@8.5.18)
-      '@csstools/postcss-contrast-color-function': 2.0.12(postcss@8.5.18)
-      '@csstools/postcss-exponential-functions': 2.0.9(postcss@8.5.18)
-      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.5.18)
-      '@csstools/postcss-gamut-mapping': 2.0.11(postcss@8.5.18)
-      '@csstools/postcss-gradients-interpolation-method': 5.0.12(postcss@8.5.18)
-      '@csstools/postcss-hwb-function': 4.0.12(postcss@8.5.18)
-      '@csstools/postcss-ic-unit': 4.0.4(postcss@8.5.18)
-      '@csstools/postcss-initial': 2.0.1(postcss@8.5.18)
-      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.18)
-      '@csstools/postcss-light-dark-function': 2.0.11(postcss@8.5.18)
-      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.5.18)
-      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.5.18)
-      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.5.18)
-      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.5.18)
-      '@csstools/postcss-logical-viewport-units': 3.0.4(postcss@8.5.18)
-      '@csstools/postcss-media-minmax': 2.0.9(postcss@8.5.18)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.5(postcss@8.5.18)
-      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.5.18)
-      '@csstools/postcss-normalize-display-values': 4.0.1(postcss@8.5.18)
-      '@csstools/postcss-oklab-function': 4.0.12(postcss@8.5.18)
-      '@csstools/postcss-position-area-property': 1.0.0(postcss@8.5.18)
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.18)
-      '@csstools/postcss-property-rule-prelude-list': 1.0.0(postcss@8.5.18)
-      '@csstools/postcss-random-function': 2.0.1(postcss@8.5.18)
-      '@csstools/postcss-relative-color-syntax': 3.0.12(postcss@8.5.18)
-      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.5.18)
-      '@csstools/postcss-sign-functions': 1.1.4(postcss@8.5.18)
-      '@csstools/postcss-stepped-value-functions': 4.0.9(postcss@8.5.18)
-      '@csstools/postcss-syntax-descriptor-syntax-production': 1.0.1(postcss@8.5.18)
-      '@csstools/postcss-system-ui-font-family': 1.0.0(postcss@8.5.18)
-      '@csstools/postcss-text-decoration-shorthand': 4.0.3(postcss@8.5.18)
-      '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.18)
-      '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.18)
-      autoprefixer: 10.5.2(postcss@8.5.18)
+      '@csstools/postcss-alpha-function': 1.0.1(postcss@8.5.23)
+      '@csstools/postcss-cascade-layers': 5.0.2(postcss@8.5.23)
+      '@csstools/postcss-color-function': 4.0.12(postcss@8.5.23)
+      '@csstools/postcss-color-function-display-p3-linear': 1.0.1(postcss@8.5.23)
+      '@csstools/postcss-color-mix-function': 3.0.12(postcss@8.5.23)
+      '@csstools/postcss-color-mix-variadic-function-arguments': 1.0.2(postcss@8.5.23)
+      '@csstools/postcss-content-alt-text': 2.0.8(postcss@8.5.23)
+      '@csstools/postcss-contrast-color-function': 2.0.12(postcss@8.5.23)
+      '@csstools/postcss-exponential-functions': 2.0.9(postcss@8.5.23)
+      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.5.23)
+      '@csstools/postcss-gamut-mapping': 2.0.11(postcss@8.5.23)
+      '@csstools/postcss-gradients-interpolation-method': 5.0.12(postcss@8.5.23)
+      '@csstools/postcss-hwb-function': 4.0.12(postcss@8.5.23)
+      '@csstools/postcss-ic-unit': 4.0.4(postcss@8.5.23)
+      '@csstools/postcss-initial': 2.0.1(postcss@8.5.23)
+      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.23)
+      '@csstools/postcss-light-dark-function': 2.0.11(postcss@8.5.23)
+      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.5.23)
+      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.5.23)
+      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.5.23)
+      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.5.23)
+      '@csstools/postcss-logical-viewport-units': 3.0.4(postcss@8.5.23)
+      '@csstools/postcss-media-minmax': 2.0.9(postcss@8.5.23)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.5(postcss@8.5.23)
+      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.5.23)
+      '@csstools/postcss-normalize-display-values': 4.0.1(postcss@8.5.23)
+      '@csstools/postcss-oklab-function': 4.0.12(postcss@8.5.23)
+      '@csstools/postcss-position-area-property': 1.0.0(postcss@8.5.23)
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.23)
+      '@csstools/postcss-property-rule-prelude-list': 1.0.0(postcss@8.5.23)
+      '@csstools/postcss-random-function': 2.0.1(postcss@8.5.23)
+      '@csstools/postcss-relative-color-syntax': 3.0.12(postcss@8.5.23)
+      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.5.23)
+      '@csstools/postcss-sign-functions': 1.1.4(postcss@8.5.23)
+      '@csstools/postcss-stepped-value-functions': 4.0.9(postcss@8.5.23)
+      '@csstools/postcss-syntax-descriptor-syntax-production': 1.0.1(postcss@8.5.23)
+      '@csstools/postcss-system-ui-font-family': 1.0.0(postcss@8.5.23)
+      '@csstools/postcss-text-decoration-shorthand': 4.0.3(postcss@8.5.23)
+      '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.23)
+      '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.23)
+      autoprefixer: 10.5.2(postcss@8.5.23)
       browserslist: 4.28.4
-      css-blank-pseudo: 7.0.1(postcss@8.5.18)
-      css-has-pseudo: 7.0.3(postcss@8.5.18)
-      css-prefers-color-scheme: 10.0.0(postcss@8.5.18)
+      css-blank-pseudo: 7.0.1(postcss@8.5.23)
+      css-has-pseudo: 7.0.3(postcss@8.5.23)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.23)
       cssdb: 8.9.0
-      postcss: 8.5.18
-      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.18)
-      postcss-clamp: 4.1.0(postcss@8.5.18)
-      postcss-color-functional-notation: 7.0.12(postcss@8.5.18)
-      postcss-color-hex-alpha: 10.0.0(postcss@8.5.18)
-      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.18)
-      postcss-custom-media: 11.0.6(postcss@8.5.18)
-      postcss-custom-properties: 14.0.6(postcss@8.5.18)
-      postcss-custom-selectors: 8.0.5(postcss@8.5.18)
-      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.18)
-      postcss-double-position-gradients: 6.0.4(postcss@8.5.18)
-      postcss-focus-visible: 10.0.1(postcss@8.5.18)
-      postcss-focus-within: 9.0.1(postcss@8.5.18)
-      postcss-font-variant: 5.0.0(postcss@8.5.18)
-      postcss-gap-properties: 6.0.0(postcss@8.5.18)
-      postcss-image-set-function: 7.0.0(postcss@8.5.18)
-      postcss-lab-function: 7.0.12(postcss@8.5.18)
-      postcss-logical: 8.1.0(postcss@8.5.18)
-      postcss-nesting: 13.0.2(postcss@8.5.18)
-      postcss-opacity-percentage: 3.0.0(postcss@8.5.18)
-      postcss-overflow-shorthand: 6.0.0(postcss@8.5.18)
-      postcss-page-break: 3.0.4(postcss@8.5.18)
-      postcss-place: 10.0.0(postcss@8.5.18)
-      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.18)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.18)
-      postcss-selector-not: 8.0.1(postcss@8.5.18)
+      postcss: 8.5.23
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.23)
+      postcss-clamp: 4.1.0(postcss@8.5.23)
+      postcss-color-functional-notation: 7.0.12(postcss@8.5.23)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.23)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.23)
+      postcss-custom-media: 11.0.6(postcss@8.5.23)
+      postcss-custom-properties: 14.0.6(postcss@8.5.23)
+      postcss-custom-selectors: 8.0.5(postcss@8.5.23)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.23)
+      postcss-double-position-gradients: 6.0.4(postcss@8.5.23)
+      postcss-focus-visible: 10.0.1(postcss@8.5.23)
+      postcss-focus-within: 9.0.1(postcss@8.5.23)
+      postcss-font-variant: 5.0.0(postcss@8.5.23)
+      postcss-gap-properties: 6.0.0(postcss@8.5.23)
+      postcss-image-set-function: 7.0.0(postcss@8.5.23)
+      postcss-lab-function: 7.0.12(postcss@8.5.23)
+      postcss-logical: 8.1.0(postcss@8.5.23)
+      postcss-nesting: 13.0.2(postcss@8.5.23)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.23)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.23)
+      postcss-page-break: 3.0.4(postcss@8.5.23)
+      postcss-place: 10.0.0(postcss@8.5.23)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.23)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.23)
+      postcss-selector-not: 8.0.1(postcss@8.5.23)
 
-  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.18):
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-reduce-idents@6.0.3(postcss@8.5.18):
+  postcss-reduce-idents@6.0.3(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@6.1.0(postcss@8.5.18):
+  postcss-reduce-initial@6.1.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
       caniuse-api: 3.0.0
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-reduce-transforms@6.0.2(postcss@8.5.18):
+  postcss-reduce-transforms@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.18):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-selector-not@8.0.1(postcss@8.5.18):
+  postcss-selector-not@8.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
   postcss-selector-parser@6.1.4:
@@ -16675,35 +16692,29 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sort-media-queries@5.2.0(postcss@8.5.18):
+  postcss-sort-media-queries@5.2.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       sort-css-media-queries: 2.2.0
 
-  postcss-svgo@6.0.3(postcss@8.5.18):
+  postcss-svgo@6.0.3(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       svgo: 3.3.4
 
-  postcss-unique-selectors@6.0.4(postcss@8.5.18):
+  postcss-unique-selectors@6.0.4(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
   postcss-value-parser@4.2.0: {}
 
-  postcss-zindex@6.0.2(postcss@8.5.18):
+  postcss-zindex@6.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss@8.5.18:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.21:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -16949,11 +16960,11 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.108.3(postcss@8.5.18)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -17295,7 +17306,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       strip-json-comments: 3.1.1
 
   run-applescript@7.1.0: {}
@@ -17702,10 +17713,10 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.7
 
-  stylehacks@6.1.1(postcss@8.5.18):
+  stylehacks@6.1.1(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
   sucrase@3.35.1:
@@ -17761,18 +17772,18 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  terser-webpack-plugin@5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.3(postcss@8.5.18)):
+  terser-webpack-plugin@5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     optionalDependencies:
       clean-css: 5.3.3
-      cssnano: 6.1.2(postcss@8.5.18)
+      cssnano: 6.1.2(postcss@8.5.23)
       html-minifier-terser: 7.2.0
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   terser@5.48.0:
     dependencies:
@@ -17848,7 +17859,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -17859,7 +17870,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.5)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.5)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.62.2
       source-map: 0.7.6
@@ -17868,7 +17879,7 @@ snapshots:
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -17928,7 +17939,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -18026,14 +18037,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.18)))(webpack@5.108.3(postcss@8.5.18)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.3(postcss@8.5.23)))(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.3(postcss@8.5.23))
 
   util-deprecate@1.0.2: {}
 
@@ -18070,7 +18081,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -18149,7 +18160,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.18)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.8(tslib@2.8.1)
@@ -18158,11 +18169,11 @@ snapshots:
       range-parser: 1.3.0
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.18)):
+  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18190,10 +18201,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.18))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.23))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18215,7 +18226,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18):
+  webpack@5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -18233,7 +18244,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.3(postcss@8.5.18))
+      minimizer-webpack-plugin: 5.6.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(webpack@5.108.3(postcss@8.5.23))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -18253,14 +18264,14 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpackbar@7.0.0(webpack@5.108.3(postcss@8.5.18)):
+  webpackbar@7.0.0(webpack@5.108.3(postcss@8.5.23)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
       pretty-time: 1.1.0
       std-env: 3.10.0
     optionalDependencies:
-      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
+      webpack: 5.108.3(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)
 
   websocket-driver@0.7.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,20 +8,22 @@ packages:
 # resolves a vulnerable v6 without this workspace-wide security floor.
 overrides:
   "esbuild@>=0.27.3 <0.28.1": 0.28.1
-  "postcss@<8.5.18": 8.5.18
+  "postcss@<8.5.23": 8.5.23
   "serialize-javascript@<=7.0.2": 7.0.7
   "uuid@<11.1.1": 11.1.1
-  "brace-expansion@<1.1.16": 1.1.16
-  "brace-expansion@>=2.0.0 <2.1.2": 2.1.2
-  "brace-expansion@>=5.0.0 <5.0.8": 5.0.8
+  "brace-expansion@<1.1.18": 1.1.18
+  "brace-expansion@>=2.0.0 <2.1.4": 2.1.4
+  "brace-expansion@>=5.0.0 <5.0.9": 5.0.9
   "@fastify/static@<10.1.2": 10.1.2
-  "fast-uri@>=3.0.0 <3.1.4": 3.1.4
+  "fast-uri@>=3.0.0 <3.1.5": 3.1.5
   "find-my-way@<9.6.1": 9.7.0
   "js-yaml@>=4.0.0 <4.3.0": 4.3.0
   "sharp@<0.35.0": 0.35.0
   "svgo@>=3.0.0 <3.3.4": 3.3.4
   "body-parser@<1.20.6": 1.20.6
   "@hono/node-server@<2.0.10": 2.0.10
+  "hono@<4.12.34": 4.12.34
+  "ip-address@<10.3.1": 10.3.1
   "protobufjs@>=7.5.0 <7.6.5": 7.6.5
   "webpack-dev-server@<=5.2.5": 5.2.6
 
@@ -44,4 +46,3 @@ allowBuilds:
 auditConfig:
   ignoreGhsas:
     - GHSA-mh99-v99m-4gvg
-

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,6 +3,7 @@ FROM node:22-bookworm
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
+    busybox-static \
     curl \
     docker.io \
     fonts-noto-color-emoji \
@@ -12,8 +13,11 @@ RUN apt-get update \
     fonts-tlwg-loma-otf \
     fonts-unifont \
     fonts-wqy-zenhei \
+    fuse-overlayfs \
     git \
     gh \
+    iproute2 \
+    iptables \
     jq \
     libasound2 \
     libatk-bridge2.0-0 \
@@ -37,10 +41,22 @@ RUN apt-get update \
     libxkbcommon0 \
     libxrandr2 \
     ripgrep \
+    rootlesskit \
+    slirp4netns \
+    uidmap \
     util-linux \
     xfonts-scalable \
     xvfb \
   && rm -rf /var/lib/apt/lists/*
+
+# Keep the Docker daemon and its socket proxy on identities that the untrusted
+# agent user cannot impersonate. The daemon itself is rootless; the proxy is the
+# only process allowed to reach its raw socket.
+RUN useradd --system --uid 1001 --create-home --home-dir /var/lib/facility-docker facility-docker \
+  && useradd --system --uid 1002 --no-create-home --home-dir /nonexistent facility-proxy \
+  && usermod --append --groups node facility-docker \
+  && usermod --append --groups node,facility-docker facility-proxy \
+  && usermod --add-subuids 100000-165535 --add-subgids 100000-165535 facility-docker
 
 # Pinned 2026-07-19 after `npm view`: claude-code 2.1.215, codex 0.144.6.
 RUN npm i -g @anthropic-ai/claude-code@2.1.215 @openai/codex@0.144.6
@@ -61,7 +77,9 @@ RUN npm ci && npm run build && npm prune --omit=dev
 # Run non-root: agent CLIs (Claude Code) refuse bypass-permissions as root, and
 # a rogue agent process should never hold uid 0.
 RUN mkdir -p /work \
-  && chown -R node:node /work /app \
+  && chown -R node:node /work \
+  && chown -R root:root /app \
+  && chmod -R a-w /app \
   && chmod 0755 /app/runner-entrypoint.sh /app/codebuild-runner.sh
 ENV HOME=/work
 WORKDIR /work

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,7 +1,45 @@
 FROM node:22-bookworm
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git ripgrep ca-certificates \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    docker.io \
+    fonts-noto-color-emoji \
+    fonts-freefont-ttf \
+    fonts-ipafont-gothic \
+    fonts-liberation \
+    fonts-tlwg-loma-otf \
+    fonts-unifont \
+    fonts-wqy-zenhei \
+    git \
+    gh \
+    jq \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    ripgrep \
+    util-linux \
+    xfonts-scalable \
+    xvfb \
   && rm -rf /var/lib/apt/lists/*
 
 # Pinned 2026-07-19 after `npm view`: claude-code 2.1.215, codex 0.144.6.
@@ -17,12 +55,16 @@ RUN corepack enable
 WORKDIR /app
 COPY package.json package-lock.json tsconfig.json ./
 COPY src ./src
+COPY runner-entrypoint.sh codebuild-runner.sh /app/
 RUN npm ci && npm run build && npm prune --omit=dev
 
 # Run non-root: agent CLIs (Claude Code) refuse bypass-permissions as root, and
 # a rogue agent process should never hold uid 0.
-RUN mkdir -p /work && chown -R node:node /work /app
-USER node
+RUN mkdir -p /work \
+  && chown -R node:node /work /app \
+  && chmod 0755 /app/runner-entrypoint.sh /app/codebuild-runner.sh
 ENV HOME=/work
 WORKDIR /work
-ENTRYPOINT ["node", "/app/dist/index.js"]
+USER node
+ENTRYPOINT ["/app/runner-entrypoint.sh"]
+CMD ["node", "/app/dist/index.js"]

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,3 +1,14 @@
+FROM debian:bookworm-slim AS bind-broker-build
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gcc libc6-dev \
+  && rm -rf /var/lib/apt/lists/*
+COPY bind-broker.c /src/bind-broker.c
+RUN gcc -std=c11 -O2 -Wall -Wextra -Werror \
+      -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE \
+      /src/bind-broker.c -Wl,-z,relro,-z,now -pie \
+      -o /facility-bind-broker
+
 FROM node:22-bookworm
 
 RUN apt-get update \
@@ -69,6 +80,7 @@ RUN npm i -g @anthropic-ai/claude-code@2.1.215 @openai/codex@0.144.6
 RUN corepack enable
 
 WORKDIR /app
+COPY --from=bind-broker-build /facility-bind-broker /usr/local/bin/facility-bind-broker
 COPY package.json package-lock.json tsconfig.json ./
 COPY src ./src
 COPY runner-entrypoint.sh codebuild-runner.sh /app/

--- a/runner/bind-broker.c
+++ b/runner/bind-broker.c
@@ -1,0 +1,401 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define MAX_ALIASES 1024
+#define MAX_BATCH_ALIASES 128
+#define MAX_REQUEST_BYTES ((MAX_BATCH_ALIASES * PATH_MAX) + 64)
+#define REQUEST_TIMEOUT_SECONDS 5
+
+static int workspace_fd = -1;
+static char workspace_view[PATH_MAX];
+static uid_t allowed_uid;
+static unsigned int alias_count;
+
+static void fail(const char *message) {
+  perror(message);
+  exit(EXIT_FAILURE);
+}
+
+static bool write_all(int fd, const char *buffer, size_t length) {
+  while (length > 0) {
+    ssize_t written = write(fd, buffer, length);
+    if (written < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    buffer += written;
+    length -= (size_t)written;
+  }
+  return true;
+}
+
+static void respond_error(int client, const char *reason) {
+  char response[256];
+  int length = snprintf(response, sizeof(response), "ERR %s\n", reason);
+  if (length > 0 && (size_t)length < sizeof(response)) {
+    (void)write_all(client, response, (size_t)length);
+  }
+}
+
+static int open_workspace_source(const char *relative_path, struct stat *source_stat) {
+  int current = dup(workspace_fd);
+  if (current < 0) return -1;
+  if (strcmp(relative_path, ".") == 0) {
+    if (fstat(current, source_stat) != 0) {
+      close(current);
+      return -1;
+    }
+    return current;
+  }
+  if (relative_path[0] == '\0' || relative_path[0] == '/' ||
+      relative_path[strlen(relative_path) - 1] == '/') {
+    close(current);
+    errno = EINVAL;
+    return -1;
+  }
+
+  const char *cursor = relative_path;
+  while (*cursor != '\0') {
+    const char *separator = strchr(cursor, '/');
+    size_t length = separator == NULL ? strlen(cursor) : (size_t)(separator - cursor);
+    if (length == 0 || length > NAME_MAX ||
+        (length == 1 && cursor[0] == '.') ||
+        (length == 2 && cursor[0] == '.' && cursor[1] == '.')) {
+      close(current);
+      errno = EINVAL;
+      return -1;
+    }
+    char component[NAME_MAX + 1];
+    memcpy(component, cursor, length);
+    component[length] = '\0';
+    bool intermediate = separator != NULL;
+    int next = openat(current, component, O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    if (next < 0) {
+      close(current);
+      return -1;
+    }
+    struct stat component_stat;
+    if (fstat(next, &component_stat) != 0 || S_ISLNK(component_stat.st_mode) ||
+        (intermediate && !S_ISDIR(component_stat.st_mode))) {
+      close(next);
+      close(current);
+      errno = ELOOP;
+      return -1;
+    }
+    close(current);
+    current = next;
+    cursor = intermediate ? separator + 1 : cursor + length;
+  }
+
+  if (fstat(current, source_stat) != 0 ||
+      (!S_ISDIR(source_stat->st_mode) && !S_ISREG(source_stat->st_mode))) {
+    close(current);
+    errno = EACCES;
+    return -1;
+  }
+  return current;
+}
+
+static bool pin_source(
+    const char *relative_path,
+    char *target,
+    size_t target_size,
+    bool *directory_target) {
+  if (alias_count >= MAX_ALIASES) {
+    errno = ENOSPC;
+    return false;
+  }
+  struct stat source_stat;
+  int source_fd = open_workspace_source(relative_path, &source_stat);
+  if (source_fd < 0) return false;
+
+  char alias_directory[PATH_MAX];
+  int template_length = snprintf(
+      alias_directory, sizeof(alias_directory), "%s/pin-XXXXXX", workspace_view);
+  if (template_length <= 0 || (size_t)template_length >= sizeof(alias_directory) ||
+      mkdtemp(alias_directory) == NULL) {
+    close(source_fd);
+    return false;
+  }
+  if (chmod(alias_directory, 0711) != 0) {
+    (void)rmdir(alias_directory);
+    close(source_fd);
+    return false;
+  }
+  int target_length = snprintf(
+      target,
+      target_size,
+      "%s/%s",
+      alias_directory,
+      S_ISDIR(source_stat.st_mode) ? "source" : "source-file");
+  if (target_length <= 0 || (size_t)target_length >= target_size) {
+    rmdir(alias_directory);
+    close(source_fd);
+    errno = ENAMETOOLONG;
+    return false;
+  }
+
+  bool directory = S_ISDIR(source_stat.st_mode);
+  *directory_target = directory;
+  int placeholder = -1;
+  if (directory) {
+    if (mkdir(target, 0711) != 0) goto rollback;
+  } else {
+    placeholder = open(target, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+    if (placeholder < 0) goto rollback;
+    close(placeholder);
+    placeholder = -1;
+  }
+
+  char descriptor_path[64];
+  int descriptor_length = snprintf(
+      descriptor_path, sizeof(descriptor_path), "/proc/self/fd/%d", source_fd);
+  if (descriptor_length <= 0 || (size_t)descriptor_length >= sizeof(descriptor_path) ||
+      mount(descriptor_path, target, NULL, MS_BIND, NULL) != 0) {
+    goto rollback;
+  }
+
+  struct stat target_stat;
+  if (stat(target, &target_stat) != 0 || target_stat.st_dev != source_stat.st_dev ||
+      target_stat.st_ino != source_stat.st_ino) {
+    (void)umount2(target, MNT_DETACH);
+    goto rollback;
+  }
+  close(source_fd);
+  alias_count += 1;
+  return true;
+
+rollback:
+  if (placeholder >= 0) close(placeholder);
+  if (directory) (void)rmdir(target);
+  else (void)unlink(target);
+  (void)rmdir(alias_directory);
+  close(source_fd);
+  return false;
+}
+
+static bool rollback_source(const char *target, bool directory) {
+  if (umount2(target, MNT_DETACH) != 0) return false;
+  if ((directory ? rmdir(target) : unlink(target)) != 0) return false;
+
+  char alias_directory[PATH_MAX];
+  size_t target_length = strlen(target);
+  if (target_length >= sizeof(alias_directory)) return false;
+  memcpy(alias_directory, target, target_length + 1);
+  char *separator = strrchr(alias_directory, '/');
+  if (separator == NULL || separator == alias_directory) return false;
+  *separator = '\0';
+  size_t view_length = strlen(workspace_view);
+  if (strncmp(alias_directory, workspace_view, view_length) != 0 ||
+      alias_directory[view_length] != '/') {
+    return false;
+  }
+  return rmdir(alias_directory) == 0;
+}
+
+static bool rollback_batch(char (*targets)[PATH_MAX], const bool *directories, size_t count) {
+  bool complete = true;
+  while (count > 0) {
+    count -= 1;
+    if (!rollback_source(targets[count], directories[count])) complete = false;
+    if (alias_count > 0) alias_count -= 1;
+  }
+  return complete;
+}
+
+static void handle_client(int client) {
+  struct ucred credentials;
+  socklen_t credentials_length = sizeof(credentials);
+  if (getsockopt(client, SOL_SOCKET, SO_PEERCRED, &credentials, &credentials_length) != 0 ||
+      credentials_length != sizeof(credentials) || credentials.uid != allowed_uid) {
+    respond_error(client, "workspace_bind_peer_denied");
+    return;
+  }
+
+  struct timeval timeout = {.tv_sec = REQUEST_TIMEOUT_SECONDS, .tv_usec = 0};
+  (void)setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+  (void)setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+  char *request = malloc(MAX_REQUEST_BYTES + 1);
+  if (request == NULL) {
+    respond_error(client, "workspace_bind_request_failed");
+    return;
+  }
+  size_t used = 0;
+  while (used < MAX_REQUEST_BYTES) {
+    ssize_t received = read(client, request + used, MAX_REQUEST_BYTES - used);
+    if (received < 0) {
+      if (errno == EINTR) continue;
+      respond_error(client, "workspace_bind_request_failed");
+      free(request);
+      return;
+    }
+    if (received == 0) break;
+    if (memchr(request + used, '\0', (size_t)received) != NULL) {
+      respond_error(client, "workspace_bind_request_invalid");
+      free(request);
+      return;
+    }
+    used += (size_t)received;
+  }
+  if (used == 0 || used >= MAX_REQUEST_BYTES || request[used - 1] != '\n') {
+    respond_error(client, "workspace_bind_request_invalid");
+    free(request);
+    return;
+  }
+  request[used] = '\0';
+
+  char *header_end = strchr(request, '\n');
+  if (header_end == NULL || strncmp(request, "BATCH ", 6) != 0) {
+    respond_error(client, "workspace_bind_request_invalid");
+    free(request);
+    return;
+  }
+  *header_end = '\0';
+  char *count_end = NULL;
+  errno = 0;
+  unsigned long requested = strtoul(request + 6, &count_end, 10);
+  if (errno != 0 || count_end == request + 6 || *count_end != '\0' || requested == 0 ||
+      requested > MAX_BATCH_ALIASES) {
+    respond_error(client, "workspace_bind_request_invalid");
+    free(request);
+    return;
+  }
+
+  char **relative_paths = calloc(requested, sizeof(*relative_paths));
+  char (*targets)[PATH_MAX] = calloc(requested, sizeof(*targets));
+  bool *directories = calloc(requested, sizeof(*directories));
+  if (relative_paths == NULL || targets == NULL || directories == NULL) {
+    respond_error(client, "workspace_bind_request_failed");
+    free(relative_paths);
+    free(targets);
+    free(directories);
+    free(request);
+    return;
+  }
+
+  char *cursor = header_end + 1;
+  bool valid = true;
+  for (size_t index = 0; index < requested; index += 1) {
+    char *line_end = strchr(cursor, '\n');
+    if (line_end == NULL || line_end == cursor) {
+      valid = false;
+      break;
+    }
+    *line_end = '\0';
+    relative_paths[index] = cursor;
+    cursor = line_end + 1;
+  }
+  if (!valid || *cursor != '\0') {
+    respond_error(client, "workspace_bind_request_invalid");
+    free(relative_paths);
+    free(targets);
+    free(directories);
+    free(request);
+    return;
+  }
+
+  size_t pinned = 0;
+  for (; pinned < requested; pinned += 1) {
+    if (!pin_source(
+            relative_paths[pinned], targets[pinned], sizeof(targets[pinned]),
+            &directories[pinned])) {
+      break;
+    }
+  }
+  if (pinned != requested) {
+    int pin_error = errno;
+    if (!rollback_batch(targets, directories, pinned)) fail("rollback broker aliases");
+    fprintf(stderr, "workspace bind pin denied: %s\n", strerror(pin_error));
+    respond_error(
+        client,
+        pin_error == ENOSPC ? "workspace_bind_alias_limit" : "workspace_bind_source_denied");
+    free(relative_paths);
+    free(targets);
+    free(directories);
+    free(request);
+    return;
+  }
+
+  char response_header[64];
+  int header_length = snprintf(response_header, sizeof(response_header), "OK %lu\n", requested);
+  bool response_ok = header_length > 0 && (size_t)header_length < sizeof(response_header) &&
+                     write_all(client, response_header, (size_t)header_length);
+  for (size_t index = 0; response_ok && index < requested; index += 1) {
+    response_ok = write_all(client, targets[index], strlen(targets[index])) &&
+                  write_all(client, "\n", 1);
+  }
+  (void)response_ok;
+  free(relative_paths);
+  free(targets);
+  free(directories);
+  free(request);
+}
+
+static unsigned long parse_identity(const char *value) {
+  char *end = NULL;
+  errno = 0;
+  unsigned long parsed = strtoul(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' || parsed > UINT32_MAX) {
+    fprintf(stderr, "invalid broker identity\n");
+    exit(EXIT_FAILURE);
+  }
+  return parsed;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 6) {
+    fprintf(stderr, "usage: facility-bind-broker SOCKET WORKSPACE VIEW UID GID\n");
+    return EXIT_FAILURE;
+  }
+  const char *socket_path = argv[1];
+  const char *workspace_root = argv[2];
+  if (realpath(argv[3], workspace_view) == NULL) fail("realpath workspace view");
+  allowed_uid = (uid_t)parse_identity(argv[4]);
+  gid_t allowed_gid = (gid_t)parse_identity(argv[5]);
+  workspace_fd = open(workspace_root, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (workspace_fd < 0) fail("open workspace root");
+
+  int server = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (server < 0) fail("create broker socket");
+  struct sockaddr_un address;
+  memset(&address, 0, sizeof(address));
+  address.sun_family = AF_UNIX;
+  if (strlen(socket_path) >= sizeof(address.sun_path)) {
+    fprintf(stderr, "broker socket path too long\n");
+    return EXIT_FAILURE;
+  }
+  memcpy(address.sun_path, socket_path, strlen(socket_path) + 1);
+  (void)unlink(socket_path);
+  if (bind(server, (struct sockaddr *)&address, sizeof(address)) != 0 ||
+      chown(socket_path, allowed_uid, allowed_gid) != 0 || chmod(socket_path, 0600) != 0 ||
+      listen(server, 16) != 0) {
+    fail("configure broker socket");
+  }
+
+  signal(SIGPIPE, SIG_IGN);
+  for (;;) {
+    int client = accept4(server, NULL, NULL, SOCK_CLOEXEC);
+    if (client < 0) {
+      if (errno == EINTR) continue;
+      fail("accept broker client");
+    }
+    handle_client(client);
+    close(client);
+  }
+}

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -7,9 +7,11 @@ readonly untrusted_uid="${FACILITY_UNTRUSTED_UID:-1000}"
 readonly untrusted_gid="${FACILITY_UNTRUSTED_GID:-1000}"
 readonly docker_runtime="/run/facility-docker"
 readonly proxy_runtime="/run/facility-proxy"
-readonly workspace_view="/run/facility-workspace"
+readonly bind_runtime="/run/facility-binds"
+readonly workspace_view="/work/.facility-mounts"
 readonly raw_socket="${docker_runtime}/docker.sock"
 readonly public_socket="${proxy_runtime}/docker.sock"
+readonly bind_socket="${bind_runtime}/mounter.sock"
 
 credential_vars=(
   AWS_ACCESS_KEY_ID
@@ -31,11 +33,10 @@ proxy_secret_vars=(
 )
 
 dockerd_env=()
-proxy_env=()
 dockerd_pid=""
 proxy_pid=""
+mounter_pid=""
 for name in "${proxy_secret_vars[@]}"; do dockerd_env+=(--unset="$name"); done
-for name in "${proxy_secret_vars[@]}"; do proxy_env+=(--unset="$name"); done
 
 stop_process_group() {
   local pid="$1"
@@ -74,10 +75,11 @@ start_docker() {
 }
 
 start_proxy() {
-  setsid runuser --user "$proxy_user" -- env "${proxy_env[@]}" \
+  setsid runuser --user "$proxy_user" -- env -i \
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     FACILITY_DOCKER_SOCKET="$public_socket" \
     FACILITY_DOCKER_UPSTREAM_SOCKET="$raw_socket" \
-    FACILITY_DOCKER_WORKSPACE_VIEW="$workspace_view" \
+    FACILITY_BIND_MOUNTER_SOCKET="$bind_socket" \
     node /app/dist/docker-proxy.js \
     >>/var/log/facility-docker-proxy.log 2>&1 &
   proxy_pid="$!"
@@ -97,7 +99,73 @@ start_proxy() {
   return 1
 }
 
+start_mounter() {
+  local docker_uid docker_daemon_pid
+  docker_uid="$(id -u "$docker_user")"
+  docker_daemon_pid="$(
+    ps -eo pid=,pgid=,uid=,comm= | awk \
+      -v group="$dockerd_pid" -v uid="$docker_uid" \
+      '$2 == group && $3 == uid && $4 == "dockerd" { print $1 }'
+  )"
+  if [[ -z "$docker_daemon_pid" || "$docker_daemon_pid" == *$'\n'* ]]; then
+    echo "Facility could not identify the rootless Docker mount namespace" >&2
+    return 1
+  fi
+  setsid env -i \
+    /usr/local/bin/facility-bind-broker \
+      "$bind_socket" "/work" "$workspace_view" \
+      "$(id -u "$proxy_user")" "$(id -g "$proxy_user")" \
+    >>/var/log/facility-bind-mounter.log 2>&1 &
+  mounter_pid="$!"
+  local readiness_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 1\n.\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); const lines=response.trimEnd().split("\n"); if(lines[0]!=="OK 1"||lines.length!==2)process.exit(1); console.log(lines[1])}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  for _ in $(seq 1 30); do
+    if [[ -S "$bind_socket" ]]; then
+      # The broker also verifies SO_PEERCRED; filesystem ownership is the first
+      # independent gate before a client reaches that check.
+      if [[ "$(stat -c '%u:%g:%a' "$bind_socket")" != \
+        "$(id -u "$proxy_user"):$(id -g "$proxy_user"):600" ]]; then
+        return 1
+      fi
+      local readiness_alias
+      if readiness_alias="$(runuser --user "$proxy_user" -- env -i \
+        /usr/local/bin/node -e "$readiness_probe" "$bind_socket")" && \
+        [[ "$readiness_alias" == "${workspace_view}/"* ]] && \
+        nsenter --mount="/proc/${docker_daemon_pid}/ns/mnt" -- \
+          findmnt -rn -T "$readiness_alias" -o TARGET | grep -qx "$readiness_alias"; then
+        return 0
+      fi
+    fi
+    if ! kill -0 "$mounter_pid" >/dev/null 2>&1; then return 1; fi
+    sleep 1
+  done
+  return 1
+}
+
 security_smoke() {
+  local broker_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); const timer=setTimeout(()=>process.exit(1),1000); socket.on("connect",()=>{clearTimeout(timer); socket.destroy(); process.exit(0)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  local peer_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); if(response!=="ERR workspace_bind_peer_denied\n"){console.error(`unexpected broker response: ${JSON.stringify(response)}`);process.exit(1)}}); socket.on("error",error=>{clearTimeout(timer); console.error(`broker peer probe failed: ${error.message}`);process.exit(1)});'
+  if ! node -e "$peer_probe" "$bind_socket"; then
+    echo "Security smoke failed: the bind broker did not enforce peer credentials" >&2
+    return 1
+  fi
+  if run_untrusted node -e "$broker_probe" "$bind_socket"; then
+    echo "Security smoke failed: the agent user reached the bind broker" >&2
+    return 1
+  fi
+  if setpriv --reuid="$(id -u "$docker_user")" --regid="$(id -g "$docker_user")" \
+    --clear-groups -- node -e "$broker_probe" "$bind_socket"; then
+    echo "Security smoke failed: rootless Docker reached the bind broker" >&2
+    return 1
+  fi
+  if tr '\000' '\n' <"/proc/${mounter_pid}/environ" | grep -q .; then
+    echo "Security smoke failed: the bind broker retained an environment" >&2
+    return 1
+  fi
+  if run_untrusted test -w "$workspace_view" || \
+    runuser --user "$docker_user" -- test -w "$workspace_view"; then
+    echo "Security smoke failed: an untrusted identity can modify pinned aliases" >&2
+    return 1
+  fi
   if run_untrusted env --unset=RUNNER_TOKEN sh -c \
     'tr "\000" "\n" 2>/dev/null < "/proc/$1/environ" | grep -q "^RUNNER_TOKEN="' \
     facility-security-probe "$$"; then
@@ -179,6 +247,26 @@ security_smoke() {
       echo "Security smoke failed: a rootless child cannot use the restricted Docker socket" >&2
       return 1
     fi
+
+    local race_dir="/work/.facility-security-race"
+    local race_original="/work/.facility-security-race-original"
+    run_untrusted mkdir "$race_dir"
+    run_untrusted sh -c 'printf facility-pinned-bind > "$1/docker.sock"' facility-race "$race_dir"
+    container_id="$(docker create \
+      --mount "type=bind,src=${race_dir}/docker.sock,dst=/probe,readonly" \
+      facility-security-smoke:local cat /probe)"
+    run_untrusted mv "$race_dir" "$race_original"
+    run_untrusted ln -s "$docker_runtime" "$race_dir"
+    for _ in 1 2; do
+      if [[ "$(docker start --attach "$container_id")" != "facility-pinned-bind" ]]; then
+        echo "Security smoke failed: a delayed container start escaped its pinned bind" >&2
+        return 1
+      fi
+    done
+    docker rm "$container_id" >/dev/null
+    run_untrusted rm "$race_dir"
+    run_untrusted rm "$race_original/docker.sock"
+    run_untrusted rmdir "$race_original"
   fi
 
   if docker create --privileged facility-security-smoke:local true >/dev/null 2>&1; then
@@ -210,13 +298,42 @@ security_smoke() {
     return 1
   fi
   run_untrusted ln -s "$runtime_socket" /work/.facility-security-runtime-escape
-  if DOCKER_HOST="unix://${raw_socket}" docker create \
-    --mount "type=bind,src=${workspace_view}/.facility-security-runtime-escape,dst=/runtime.sock" \
+  if docker create \
+    --mount "type=bind,src=/work/.facility-security-runtime-escape,dst=/runtime.sock" \
     facility-security-smoke:local true >/dev/null 2>&1; then
     echo "Security smoke failed: a workspace symlink crossed the protected runtime view" >&2
     return 1
   fi
+  run_untrusted mkdir /work/.facility-security-partial
+  run_untrusted sh -c \
+    'printf safe-partial-bind > "$1/probe"' facility-partial /work/.facility-security-partial
+  local rollback_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 2\n.facility-security-partial/probe\n.facility-security-partial/missing\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); process.exit(response==="ERR workspace_bind_source_denied\n"?0:1)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  local aliases_before aliases_after
+  aliases_before="$(findmnt -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
+  if ! runuser --user "$proxy_user" -- env -i \
+    /usr/local/bin/node -e "$rollback_probe" "$bind_socket"; then
+    echo "Security smoke failed: the bind broker did not reject a partial batch" >&2
+    return 1
+  fi
+  aliases_after="$(findmnt -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
+  if [[ "$aliases_after" != "$aliases_before" ]]; then
+    echo "Security smoke failed: a rejected broker batch leaked a pinned alias" >&2
+    return 1
+  fi
+  if docker create \
+    --mount type=bind,src=/work/.facility-security-partial/probe,dst=/safe \
+    --mount type=bind,src=/work/.facility-security-runtime-escape,dst=/escape \
+    facility-security-smoke:local true >/dev/null 2>&1; then
+    echo "Security smoke failed: a partially pinned request reached Docker" >&2
+    return 1
+  fi
+  run_untrusted rm /work/.facility-security-partial/probe
+  run_untrusted rmdir /work/.facility-security-partial
   run_untrusted rm /work/.facility-security-runtime-escape
+  if ! findmnt -rn -o TARGET | grep -q "^${workspace_view}/"; then
+    echo "Security smoke failed: workspace binds did not use pinned mount aliases" >&2
+    return 1
+  fi
   if [[ "${FACILITY_CODEBUILD_SMOKE_CREATE_ONLY:-}" == "1" ]]; then
     echo "Facility CodeBuild Docker security boundary passed create-only emulation checks"
   else
@@ -224,26 +341,29 @@ security_smoke() {
   fi
 }
 
-mkdir -p "$docker_runtime" "$proxy_runtime" "$workspace_view" \
+mkdir -p "$docker_runtime" "$proxy_runtime" "$bind_runtime" "$workspace_view" \
   /var/lib/facility-docker/docker-fuse /var/lib/facility-docker/docker-vfs /work
 chown -R "$docker_user:$docker_user" "$docker_runtime" /var/lib/facility-docker
 chown -R "$proxy_user:$untrusted_gid" "$proxy_runtime"
 chown root:"$untrusted_gid" /work
 chmod 3770 /work
 chmod 0710 "$docker_runtime" "$proxy_runtime"
+chown root:root "$bind_runtime"
+chmod 0711 "$bind_runtime"
 chown root:root "$workspace_view"
 chmod 0711 "$workspace_view"
-# Bind requests are rewritten to this trusted alias. Linux's nosymfollow mount
-# flag makes a later workspace symlink swap fail in the kernel, closing the
-# check/use race before dockerd can reach any host runtime socket.
-mount --bind /work "$workspace_view"
-mount -o remount,bind,nosymfollow "$workspace_view"
-if ! findmnt -T "$workspace_view" -no OPTIONS | tr ',' '\n' | grep -qx nosymfollow; then
-  echo "Facility requires a kernel that enforces nosymfollow bind mounts" >&2
+# RootlessKit converts inherited mounts to slaves. A dedicated shared mount
+# here is therefore the deterministic master for aliases created later by the
+# root broker; dockerd receives those aliases without exposing the raw daemon.
+mount --bind "$workspace_view" "$workspace_view"
+mount --make-shared "$workspace_view"
+if ! findmnt -rn -T "$workspace_view" -o PROPAGATION | grep -qx shared; then
+  echo "Facility could not establish shared workspace mount propagation" >&2
   exit 1
 fi
 : >/var/log/facility-dockerd.log
 : >/var/log/facility-docker-proxy.log
+: >/var/log/facility-bind-mounter.log
 
 # Neither the runner nor nested builds need link-local metadata endpoints. Block
 # them before untrusted code starts, including traffic forwarded by rootlesskit.
@@ -275,6 +395,11 @@ chmod 0660 "$raw_socket"
 # proxy identity so even a bind-validation TOCTOU cannot give root inside a
 # rootless child access to the unrestricted daemon API.
 chown root:"$proxy_user" "$raw_socket"
+if ! start_mounter; then
+  echo "Facility could not start the transactional bind broker" >&2
+  tail -n 200 /var/log/facility-bind-mounter.log >&2 || true
+  exit 1
+fi
 start_proxy
 
 export DOCKER_HOST="unix://${public_socket}"

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+credential_vars=(
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY
+  AWS_SESSION_TOKEN
+  AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+  AWS_CONTAINER_CREDENTIALS_FULL_URI
+  AWS_WEB_IDENTITY_TOKEN_FILE
+)
+
+dockerd_env=()
+dockerd_pid=""
+for name in "${credential_vars[@]}"; do
+  dockerd_env+=(--unset="$name")
+done
+
+start_docker() {
+  local storage_driver="$1"
+  echo "Starting Facility Docker daemon with ${storage_driver}" >>/var/log/facility-dockerd.log
+  nohup env "${dockerd_env[@]}" dockerd \
+    --host=unix:///var/run/docker.sock \
+    --storage-driver="$storage_driver" \
+    >>/var/log/facility-dockerd.log 2>&1 &
+  dockerd_pid="$!"
+
+  for _ in $(seq 1 60); do
+    if docker info >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! kill -0 "$dockerd_pid" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+stop_docker() {
+  if [[ -n "$dockerd_pid" ]] && kill -0 "$dockerd_pid" >/dev/null 2>&1; then
+    kill "$dockerd_pid" >/dev/null 2>&1 || true
+    wait "$dockerd_pid" >/dev/null 2>&1 || true
+  fi
+  dockerd_pid=""
+}
+
+: >/var/log/facility-dockerd.log
+if ! start_docker overlay2; then
+  echo "overlay2 unavailable; retrying with the portable vfs driver" \
+    >>/var/log/facility-dockerd.log
+  stop_docker
+  rm -f /var/run/docker.sock /var/run/docker.pid
+  rm -rf /var/lib/docker/*
+  start_docker vfs || true
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Facility could not start Docker inside the CodeBuild sandbox" >&2
+  tail -n 200 /var/log/facility-dockerd.log >&2 || true
+  exit 1
+fi
+
+chmod 0660 /var/run/docker.sock
+chown root:node /var/run/docker.sock
+mkdir -p /work
+chown node:node /work
+export HOME=/work
+export XDG_CACHE_HOME=/work/.cache
+export XDG_CONFIG_HOME=/work/.config
+export XDG_DATA_HOME=/work/.local/share
+mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
+chown -R node:node "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" /work/.local
+
+for name in "${credential_vars[@]}"; do
+  unset "$name"
+done
+
+if [[ "${FACILITY_CODEBUILD_SMOKE:-}" == "1" ]]; then
+  docker info --format 'Facility CodeBuild Docker {{.ServerVersion}} is ready'
+  exit 0
+fi
+
+if [[ "$#" -eq 0 ]]; then
+  set -- node /app/dist/index.js
+fi
+
+exec runuser --user node --preserve-environment -- "$@"

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -301,9 +301,14 @@ if [[ "${FACILITY_CODEBUILD_SMOKE:-}" == "1" ]]; then
   exit 0
 fi
 
-if [[ "$#" -eq 0 ]]; then set -- node /app/dist/index.js; fi
+if [[ "$#" -eq 0 ]]; then
+  # Keep the lifecycle credential in the root runner process. It lowers every
+  # repository, model, provisioning, and check child to the untrusted identity.
+  exec node /app/dist/index.js
+fi
 
-# Keep the lifecycle credential in a root runner process. Every repository,
-# model, provisioning, and check command is spawned as the separate `node`
-# identity, so it cannot inspect the runner's process environment.
-exec "$@"
+# A sandbox profile may replace the Facility lifecycle with a custom command.
+# It must not inherit root or the lifecycle credential merely because CodeBuild
+# needs root for the trusted mount/network setup above.
+exec setpriv --reuid="$untrusted_uid" --regid="$untrusted_gid" --clear-groups -- \
+  env --unset=RUNNER_TOKEN "$@"

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -13,6 +13,12 @@ readonly raw_socket="${docker_runtime}/docker.sock"
 readonly public_socket="${proxy_runtime}/docker.sock"
 readonly bind_socket="${bind_runtime}/mounter.sock"
 
+if [[ "${FACILITY_CODEBUILD_SMOKE:-}" == "1" && \
+  "${FACILITY_CODEBUILD_SMOKE_TIMEOUT_INNER:-}" != "1" ]]; then
+  export FACILITY_CODEBUILD_SMOKE_TIMEOUT_INNER=1
+  exec timeout --kill-after=30s 10m "$0" "$@"
+fi
+
 credential_vars=(
   AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY
@@ -42,9 +48,29 @@ stop_process_group() {
   local pid="$1"
   if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
     kill -TERM -- "-$pid" >/dev/null 2>&1 || true
+    for _ in $(seq 1 10); do
+      if ! kill -0 "$pid" >/dev/null 2>&1; then break; fi
+      sleep 1
+    done
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      kill -KILL -- "-$pid" >/dev/null 2>&1 || true
+    fi
     wait "$pid" >/dev/null 2>&1 || true
   fi
 }
+
+cleanup_runtime() {
+  stop_process_group "$proxy_pid"
+  stop_process_group "$mounter_pid"
+  stop_process_group "$dockerd_pid"
+}
+
+if [[ "${FACILITY_CODEBUILD_SMOKE:-}" == "1" && \
+  "${FACILITY_CODEBUILD_SMOKE_TIMEOUT_INNER:-}" == "1" ]]; then
+  trap cleanup_runtime EXIT
+  trap 'exit 124' TERM
+  trap 'exit 130' INT
+fi
 
 run_untrusted() {
   setpriv --reuid="$untrusted_uid" --regid="$untrusted_gid" --clear-groups -- "$@"
@@ -53,6 +79,7 @@ run_untrusted() {
 start_docker() {
   local storage_driver="$1"
   local data_root="$2"
+  echo "Facility CodeBuild: starting rootless Docker (${storage_driver})"
   echo "Starting rootless Facility Docker with ${storage_driver}" >>/var/log/facility-dockerd.log
   setsid runuser --user "$docker_user" -- env "${dockerd_env[@]}" \
     HOME=/var/lib/facility-docker \
@@ -142,6 +169,7 @@ start_mounter() {
 }
 
 security_smoke() {
+  echo "Facility smoke: checking broker identities and environment"
   local broker_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); const timer=setTimeout(()=>process.exit(1),1000); socket.on("connect",()=>{clearTimeout(timer); socket.destroy(); process.exit(0)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
   local peer_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); if(response!=="ERR workspace_bind_peer_denied\n"){console.error(`unexpected broker response: ${JSON.stringify(response)}`);process.exit(1)}}); socket.on("error",error=>{clearTimeout(timer); console.error(`broker peer probe failed: ${error.message}`);process.exit(1)});'
   if ! node -e "$peer_probe" "$bind_socket"; then
@@ -172,6 +200,7 @@ security_smoke() {
     echo "Security smoke failed: the agent user read the runner credential" >&2
     return 1
   fi
+  echo "Facility smoke: building the nested Docker probe"
   if ! run_untrusted env DOCKER_HOST="unix://${public_socket}" docker info \
     >/dev/null 2>&1; then
     echo "Security smoke failed: the agent user cannot reach restricted Docker" >&2
@@ -206,6 +235,7 @@ security_smoke() {
     return 1
   fi
 
+  echo "Facility smoke: checking permitted workspace and socket binds"
   local bind_dir="/work/.facility-security-bind"
   run_untrusted mkdir "$bind_dir"
   run_untrusted sh -c 'printf facility-workspace-bind-ready > "$1/probe"' facility-bind "$bind_dir"
@@ -269,6 +299,7 @@ security_smoke() {
     run_untrusted rmdir "$race_original"
   fi
 
+  echo "Facility smoke: checking denied Docker capabilities and host paths"
   if docker create --privileged facility-security-smoke:local true >/dev/null 2>&1; then
     echo "Security smoke failed: privileged containers reached Docker" >&2
     return 1
@@ -308,6 +339,7 @@ security_smoke() {
   run_untrusted sh -c \
     'printf safe-partial-bind > "$1/probe"' facility-partial /work/.facility-security-partial
   local rollback_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 2\n.facility-security-partial/probe\n.facility-security-partial/missing\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); process.exit(response==="ERR workspace_bind_source_denied\n"?0:1)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  echo "Facility smoke: checking transactional bind rollback"
   local aliases_before aliases_after
   aliases_before="$(findmnt -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
   if ! runuser --user "$proxy_user" -- env -i \
@@ -365,6 +397,8 @@ fi
 : >/var/log/facility-docker-proxy.log
 : >/var/log/facility-bind-mounter.log
 
+echo "Facility CodeBuild: host boundary configured"
+
 # Neither the runner nor nested builds need link-local metadata endpoints. Block
 # them before untrusted code starts, including traffic forwarded by rootlesskit.
 iptables -I OUTPUT 1 -d 169.254.0.0/16 -j REJECT
@@ -390,6 +424,7 @@ if ! DOCKER_HOST="unix://${raw_socket}" docker info >/dev/null 2>&1; then
   tail -n 200 /var/log/facility-dockerd.log >&2 || true
   exit 1
 fi
+echo "Facility CodeBuild: rootless Docker is ready"
 chmod 0660 "$raw_socket"
 # Dockerd keeps its listening descriptor open. Reassign the pathname to the
 # proxy identity so even a bind-validation TOCTOU cannot give root inside a
@@ -400,6 +435,7 @@ if ! start_mounter; then
   tail -n 200 /var/log/facility-bind-mounter.log >&2 || true
   exit 1
 fi
+echo "Facility CodeBuild: transactional bind broker is ready"
 start_proxy
 
 export DOCKER_HOST="unix://${public_socket}"
@@ -408,6 +444,7 @@ if ! docker info >/dev/null 2>&1; then
   tail -n 200 /var/log/facility-docker-proxy.log >&2 || true
   exit 1
 fi
+echo "Facility CodeBuild: restricted Docker proxy is ready"
 
 for name in "${credential_vars[@]}"; do unset "$name"; done
 export HOME=/work

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -307,8 +307,7 @@ if [[ "$#" -eq 0 ]]; then
   exec node /app/dist/index.js
 fi
 
-# A sandbox profile may replace the Facility lifecycle with a custom command.
-# It must not inherit root or the lifecycle credential merely because CodeBuild
-# needs root for the trusted mount/network setup above.
-exec setpriv --reuid="$untrusted_uid" --regid="$untrusted_gid" --clear-groups -- \
-  env --unset=RUNNER_TOKEN "$@"
+# A sandbox profile may replace the Facility lifecycle with a trusted custom
+# runner. It retains RUNNER_TOKEN so it can report lifecycle events/results, but
+# it must not inherit root merely because CodeBuild needs root for setup.
+exec setpriv --reuid="$untrusted_uid" --regid="$untrusted_gid" --clear-groups -- "$@"

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+readonly docker_user="facility-docker"
+readonly proxy_user="facility-proxy"
+readonly untrusted_uid="${FACILITY_UNTRUSTED_UID:-1000}"
+readonly untrusted_gid="${FACILITY_UNTRUSTED_GID:-1000}"
+readonly docker_runtime="/run/facility-docker"
+readonly proxy_runtime="/run/facility-proxy"
+readonly raw_socket="${docker_runtime}/docker.sock"
+readonly public_socket="${proxy_runtime}/docker.sock"
+
 credential_vars=(
   AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY
@@ -9,80 +18,258 @@ credential_vars=(
   AWS_CONTAINER_CREDENTIALS_FULL_URI
   AWS_WEB_IDENTITY_TOKEN_FILE
 )
+proxy_secret_vars=(
+  "${credential_vars[@]}"
+  RUNNER_TOKEN
+  NODE_AUTH_TOKEN
+  ANTHROPIC_API_KEY
+  OPENAI_API_KEY
+  FACILITY_PLATFORM_KEY
+  GITHUB_TOKEN
+  GH_TOKEN
+)
 
 dockerd_env=()
+proxy_env=()
 dockerd_pid=""
-for name in "${credential_vars[@]}"; do
-  dockerd_env+=(--unset="$name")
-done
+proxy_pid=""
+for name in "${proxy_secret_vars[@]}"; do dockerd_env+=(--unset="$name"); done
+for name in "${proxy_secret_vars[@]}"; do proxy_env+=(--unset="$name"); done
+
+stop_process_group() {
+  local pid="$1"
+  if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
+    kill -TERM -- "-$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+  fi
+}
+
+run_untrusted() {
+  setpriv --reuid="$untrusted_uid" --regid="$untrusted_gid" --clear-groups -- "$@"
+}
 
 start_docker() {
   local storage_driver="$1"
-  echo "Starting Facility Docker daemon with ${storage_driver}" >>/var/log/facility-dockerd.log
-  nohup env "${dockerd_env[@]}" dockerd \
-    --host=unix:///var/run/docker.sock \
-    --storage-driver="$storage_driver" \
-    >>/var/log/facility-dockerd.log 2>&1 &
+  local data_root="$2"
+  echo "Starting rootless Facility Docker with ${storage_driver}" >>/var/log/facility-dockerd.log
+  setsid runuser --user "$docker_user" -- env "${dockerd_env[@]}" \
+    HOME=/var/lib/facility-docker \
+    XDG_RUNTIME_DIR="$docker_runtime" \
+    DOCKER_HOST="unix://${raw_socket}" \
+    DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="--net=slirp4netns --disable-host-loopback" \
+    /usr/share/docker.io/contrib/dockerd-rootless.sh \
+      --host="unix://${raw_socket}" \
+      --storage-driver="$storage_driver" \
+      --data-root="$data_root" \
+      >>/var/log/facility-dockerd.log 2>&1 &
   dockerd_pid="$!"
 
-  for _ in $(seq 1 60); do
-    if docker info >/dev/null 2>&1; then
-      return 0
-    fi
-    if ! kill -0 "$dockerd_pid" >/dev/null 2>&1; then
-      return 1
-    fi
+  for _ in $(seq 1 90); do
+    if DOCKER_HOST="unix://${raw_socket}" docker info >/dev/null 2>&1; then return 0; fi
+    if ! kill -0 "$dockerd_pid" >/dev/null 2>&1; then return 1; fi
     sleep 1
   done
   return 1
 }
 
-stop_docker() {
-  if [[ -n "$dockerd_pid" ]] && kill -0 "$dockerd_pid" >/dev/null 2>&1; then
-    kill "$dockerd_pid" >/dev/null 2>&1 || true
-    wait "$dockerd_pid" >/dev/null 2>&1 || true
-  fi
-  dockerd_pid=""
+start_proxy() {
+  setsid runuser --user "$proxy_user" -- env "${proxy_env[@]}" \
+    FACILITY_DOCKER_SOCKET="$public_socket" \
+    FACILITY_DOCKER_UPSTREAM_SOCKET="$raw_socket" \
+    node /app/dist/docker-proxy.js \
+    >>/var/log/facility-docker-proxy.log 2>&1 &
+  proxy_pid="$!"
+  for _ in $(seq 1 30); do
+    if [[ -S "$public_socket" ]]; then
+      # The untrusted process reaches the proxy through the workspace group.
+      # Root inside a rootless child maps to facility-docker on the host, so
+      # owning this public (policy-enforcing) socket also supports Testcontainers.
+      chown "$docker_user:$untrusted_gid" "$public_socket"
+      chmod 0660 "$public_socket"
+      ln -sfn "$public_socket" /var/run/docker.sock
+      return 0
+    fi
+    if ! kill -0 "$proxy_pid" >/dev/null 2>&1; then return 1; fi
+    sleep 1
+  done
+  return 1
 }
 
+security_smoke() {
+  if run_untrusted env --unset=RUNNER_TOKEN sh -c \
+    'tr "\000" "\n" 2>/dev/null < "/proc/$1/environ" | grep -q "^RUNNER_TOKEN="' \
+    facility-security-probe "$$"; then
+    echo "Security smoke failed: the agent user read the runner credential" >&2
+    return 1
+  fi
+  if ! run_untrusted env DOCKER_HOST="unix://${public_socket}" docker info \
+    >/dev/null 2>&1; then
+    echo "Security smoke failed: the agent user cannot reach restricted Docker" >&2
+    return 1
+  fi
+  mkdir /work/.facility-security-root
+  if run_untrusted rmdir /work/.facility-security-root >/dev/null 2>&1; then
+    echo "Security smoke failed: the agent user replaced runner-owned state" >&2
+    return 1
+  fi
+  rmdir /work/.facility-security-root
+  if run_untrusted test -w /app/dist/index.js; then
+    echo "Security smoke failed: the agent user can rewrite the runner" >&2
+    return 1
+  fi
+  local smoke_dir
+  smoke_dir="$(mktemp -d)"
+  trap 'rm -rf -- "$smoke_dir"' RETURN
+  printf 'FROM scratch\nCOPY busybox /bin/busybox\nENTRYPOINT ["/bin/busybox"]\n' \
+    >"$smoke_dir/Dockerfile"
+  cp /bin/busybox "$smoke_dir/busybox"
+  docker build --network=none --tag facility-security-smoke:local "$smoke_dir" >/dev/null
+  local container_id
+  container_id="$(docker create facility-security-smoke:local true)"
+  docker rm "$container_id" >/dev/null
+  local volume_name
+  volume_name="$(docker volume create facility-security-smoke-volume)"
+  docker volume rm "$volume_name" >/dev/null
+  if docker volume create --driver local --opt type=none --opt o=bind \
+    --opt device=/run/facility-docker facility-security-escape >/dev/null 2>&1; then
+    echo "Security smoke failed: a host-path volume reached Docker" >&2
+    return 1
+  fi
+
+  local bind_dir="/work/.facility-security-bind"
+  run_untrusted mkdir "$bind_dir"
+  run_untrusted sh -c 'printf facility-workspace-bind-ready > "$1/probe"' facility-bind "$bind_dir"
+  if [[ "${FACILITY_CODEBUILD_SMOKE_CREATE_ONLY:-}" == "1" ]]; then
+    # Docker Desktop cannot execute an amd64 binary in rootless Docker nested
+    # inside its already-emulated amd64 runner. Still validate the proxy policy
+    # and the exact host identities locally; native CodeBuild must run the full
+    # branch below before deployment is accepted.
+    container_id="$(docker create \
+      --mount "type=bind,src=${bind_dir}/probe,dst=/probe,readonly" \
+      facility-security-smoke:local cat /probe)"
+    docker rm "$container_id" >/dev/null
+    if [[ "$(runuser --user "$docker_user" -- cat "${bind_dir}/probe")" != \
+      "facility-workspace-bind-ready" ]]; then
+      echo "Security smoke failed: the rootless daemon identity cannot read the workspace" >&2
+      return 1
+    fi
+    container_id="$(docker create \
+      --mount "type=bind,src=${public_socket},dst=/var/run/docker.sock" \
+      facility-security-smoke:local sh -c 'test -S /var/run/docker.sock')"
+    docker rm "$container_id" >/dev/null
+    if ! runuser --user "$docker_user" -- test -r "$public_socket" -a -w "$public_socket"; then
+      echo "Security smoke failed: a rootless child cannot use the restricted Docker socket" >&2
+      return 1
+    fi
+  else
+    local bind_value
+    bind_value="$(docker run --rm \
+      --mount "type=bind,src=${bind_dir}/probe,dst=/probe,readonly" \
+      facility-security-smoke:local cat /probe)"
+    if [[ "$bind_value" != "facility-workspace-bind-ready" ]]; then
+      echo "Security smoke failed: rootless Docker cannot read a workspace bind" >&2
+      return 1
+    fi
+    if ! docker run --rm \
+      --mount "type=bind,src=${public_socket},dst=/var/run/docker.sock" \
+      facility-security-smoke:local sh -c \
+        'test -S /var/run/docker.sock && test -r /var/run/docker.sock && test -w /var/run/docker.sock'; then
+      echo "Security smoke failed: a rootless child cannot use the restricted Docker socket" >&2
+      return 1
+    fi
+  fi
+
+  if docker create --privileged facility-security-smoke:local true >/dev/null 2>&1; then
+    echo "Security smoke failed: privileged containers reached Docker" >&2
+    return 1
+  fi
+  if docker create --pid=host facility-security-smoke:local true >/dev/null 2>&1; then
+    echo "Security smoke failed: host PID mode reached Docker" >&2
+    return 1
+  fi
+  if docker create --mount type=bind,src=/proc,dst=/host-proc facility-security-smoke:local true \
+    >/dev/null 2>&1; then
+    echo "Security smoke failed: a host bind mount reached Docker" >&2
+    return 1
+  fi
+  if run_untrusted env DOCKER_HOST="unix://${raw_socket}" docker info \
+    >/dev/null 2>&1; then
+    echo "Security smoke failed: the agent user reached the raw Docker socket" >&2
+    return 1
+  fi
+  if [[ "${FACILITY_CODEBUILD_SMOKE_CREATE_ONLY:-}" == "1" ]]; then
+    echo "Facility CodeBuild Docker security boundary passed create-only emulation checks"
+  else
+    echo "Facility CodeBuild Docker security boundary is ready"
+  fi
+}
+
+mkdir -p "$docker_runtime" "$proxy_runtime" /var/lib/facility-docker/docker-fuse \
+  /var/lib/facility-docker/docker-vfs /work
+chown -R "$docker_user:$docker_user" "$docker_runtime" /var/lib/facility-docker
+chown -R "$proxy_user:$untrusted_gid" "$proxy_runtime"
+chown root:"$untrusted_gid" /work
+chmod 3770 /work
+chmod 0710 "$docker_runtime" "$proxy_runtime"
 : >/var/log/facility-dockerd.log
-if ! start_docker overlay2; then
-  echo "overlay2 unavailable; retrying with the portable vfs driver" \
-    >>/var/log/facility-dockerd.log
-  stop_docker
-  rm -f /var/run/docker.sock /var/run/docker.pid
-  rm -rf /var/lib/docker/*
-  start_docker vfs || true
+: >/var/log/facility-docker-proxy.log
+
+# Neither the runner nor nested builds need link-local metadata endpoints. Block
+# them before untrusted code starts, including traffic forwarded by rootlesskit.
+iptables -I OUTPUT 1 -d 169.254.0.0/16 -j REJECT
+iptables -I FORWARD 1 -d 169.254.0.0/16 -j REJECT
+if command -v ip6tables >/dev/null 2>&1; then
+  ip6tables -I OUTPUT 1 -d fe80::/10 -j REJECT || true
+  ip6tables -I FORWARD 1 -d fe80::/10 -j REJECT || true
+  ip6tables -I OUTPUT 1 -d fd00:ec2::254 -j REJECT || true
+  ip6tables -I FORWARD 1 -d fd00:ec2::254 -j REJECT || true
 fi
 
-if ! docker info >/dev/null 2>&1; then
-  echo "Facility could not start Docker inside the CodeBuild sandbox" >&2
+if ! start_docker fuse-overlayfs /var/lib/facility-docker/docker-fuse; then
+  echo "fuse-overlayfs unavailable; retrying with the portable vfs driver" \
+    >>/var/log/facility-dockerd.log
+  stop_process_group "$dockerd_pid"
+  dockerd_pid=""
+  rm -f "$raw_socket"
+  start_docker vfs /var/lib/facility-docker/docker-vfs || true
+fi
+
+if ! DOCKER_HOST="unix://${raw_socket}" docker info >/dev/null 2>&1; then
+  echo "Facility could not start rootless Docker inside the CodeBuild sandbox" >&2
   tail -n 200 /var/log/facility-dockerd.log >&2 || true
   exit 1
 fi
+chmod 0660 "$raw_socket"
+chgrp "$docker_user" "$raw_socket"
+start_proxy
 
-chmod 0660 /var/run/docker.sock
-chown root:node /var/run/docker.sock
-mkdir -p /work
-chown node:node /work
+export DOCKER_HOST="unix://${public_socket}"
+if ! docker info >/dev/null 2>&1; then
+  echo "Facility could not start the restricted Docker proxy" >&2
+  tail -n 200 /var/log/facility-docker-proxy.log >&2 || true
+  exit 1
+fi
+
+for name in "${credential_vars[@]}"; do unset "$name"; done
 export HOME=/work
 export XDG_CACHE_HOME=/work/.cache
 export XDG_CONFIG_HOME=/work/.config
 export XDG_DATA_HOME=/work/.local/share
-mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
-chown -R node:node "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" /work/.local
-
-for name in "${credential_vars[@]}"; do
-  unset "$name"
-done
+export TMPDIR=/work/.tmp
+mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$TMPDIR"
+chown -R "$untrusted_uid:$untrusted_gid" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" /work/.local \
+  "$TMPDIR"
+chmod -R g+rwX "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" /work/.local "$TMPDIR"
+umask 0002
 
 if [[ "${FACILITY_CODEBUILD_SMOKE:-}" == "1" ]]; then
-  docker info --format 'Facility CodeBuild Docker {{.ServerVersion}} is ready'
+  security_smoke
   exit 0
 fi
 
-if [[ "$#" -eq 0 ]]; then
-  set -- node /app/dist/index.js
-fi
+if [[ "$#" -eq 0 ]]; then set -- node /app/dist/index.js; fi
 
-exec runuser --user node --preserve-environment -- "$@"
+# Keep the lifecycle credential in a root runner process. Every repository,
+# model, provisioning, and check command is spawned as the separate `node`
+# identity, so it cannot inspect the runner's process environment.
+exec "$@"

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -189,6 +189,19 @@ security_smoke() {
     echo "Security smoke failed: the bind broker retained an environment" >&2
     return 1
   fi
+  echo "Facility smoke: checking metadata egress isolation"
+  local isolated_uid
+  for isolated_uid in "$untrusted_uid" "$(id -u "$docker_user")" "$(id -u "$proxy_user")"; do
+    if ! iptables -C OUTPUT -m owner --uid-owner "$isolated_uid" \
+      -d 169.254.0.0/16 -j REJECT; then
+      echo "Security smoke failed: an untrusted identity can reach IPv4 metadata" >&2
+      return 1
+    fi
+  done
+  if iptables -C OUTPUT -d 169.254.0.0/16 -j REJECT >/dev/null 2>&1; then
+    echo "Security smoke failed: metadata isolation also blocked the CodeBuild agent" >&2
+    return 1
+  fi
   if run_untrusted test -w "$workspace_view" || \
     runuser --user "$docker_user" -- test -w "$workspace_view"; then
     echo "Security smoke failed: an untrusted identity can modify pinned aliases" >&2
@@ -400,13 +413,19 @@ fi
 echo "Facility CodeBuild: host boundary configured"
 
 # Neither the runner nor nested builds need link-local metadata endpoints. Block
-# them before untrusted code starts, including traffic forwarded by rootlesskit.
-iptables -I OUTPUT 1 -d 169.254.0.0/16 -j REJECT
+# the identities that can execute repository-controlled work, including the
+# rootlesskit user that originates nested-container traffic. CodeBuild's root
+# agent must retain its control-plane connection so builds can report completion.
+for isolated_uid in "$untrusted_uid" "$(id -u "$docker_user")" "$(id -u "$proxy_user")"; do
+  iptables -I OUTPUT 1 -m owner --uid-owner "$isolated_uid" -d 169.254.0.0/16 -j REJECT
+done
 iptables -I FORWARD 1 -d 169.254.0.0/16 -j REJECT
 if command -v ip6tables >/dev/null 2>&1; then
-  ip6tables -I OUTPUT 1 -d fe80::/10 -j REJECT || true
+  for isolated_uid in "$untrusted_uid" "$(id -u "$docker_user")" "$(id -u "$proxy_user")"; do
+    ip6tables -I OUTPUT 1 -m owner --uid-owner "$isolated_uid" -d fe80::/10 -j REJECT || true
+    ip6tables -I OUTPUT 1 -m owner --uid-owner "$isolated_uid" -d fd00:ec2::254 -j REJECT || true
+  done
   ip6tables -I FORWARD 1 -d fe80::/10 -j REJECT || true
-  ip6tables -I OUTPUT 1 -d fd00:ec2::254 -j REJECT || true
   ip6tables -I FORWARD 1 -d fd00:ec2::254 -j REJECT || true
 fi
 

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -7,6 +7,7 @@ readonly untrusted_uid="${FACILITY_UNTRUSTED_UID:-1000}"
 readonly untrusted_gid="${FACILITY_UNTRUSTED_GID:-1000}"
 readonly docker_runtime="/run/facility-docker"
 readonly proxy_runtime="/run/facility-proxy"
+readonly workspace_view="/run/facility-workspace"
 readonly raw_socket="${docker_runtime}/docker.sock"
 readonly public_socket="${proxy_runtime}/docker.sock"
 
@@ -76,6 +77,7 @@ start_proxy() {
   setsid runuser --user "$proxy_user" -- env "${proxy_env[@]}" \
     FACILITY_DOCKER_SOCKET="$public_socket" \
     FACILITY_DOCKER_UPSTREAM_SOCKET="$raw_socket" \
+    FACILITY_DOCKER_WORKSPACE_VIEW="$workspace_view" \
     node /app/dist/docker-proxy.js \
     >>/var/log/facility-docker-proxy.log 2>&1 &
   proxy_pid="$!"
@@ -197,6 +199,24 @@ security_smoke() {
     echo "Security smoke failed: the agent user reached the raw Docker socket" >&2
     return 1
   fi
+  if runuser --user "$docker_user" -- test -r "$raw_socket" -o -w "$raw_socket"; then
+    echo "Security smoke failed: rootless container identity can open the raw Docker socket" >&2
+    return 1
+  fi
+  local runtime_socket
+  runtime_socket="$(find "$docker_runtime" -type s ! -path "$raw_socket" -print -quit)"
+  if [[ -z "$runtime_socket" ]]; then
+    echo "Security smoke failed: the runtime isolation probe found no internal socket" >&2
+    return 1
+  fi
+  run_untrusted ln -s "$runtime_socket" /work/.facility-security-runtime-escape
+  if DOCKER_HOST="unix://${raw_socket}" docker create \
+    --mount "type=bind,src=${workspace_view}/.facility-security-runtime-escape,dst=/runtime.sock" \
+    facility-security-smoke:local true >/dev/null 2>&1; then
+    echo "Security smoke failed: a workspace symlink crossed the protected runtime view" >&2
+    return 1
+  fi
+  run_untrusted rm /work/.facility-security-runtime-escape
   if [[ "${FACILITY_CODEBUILD_SMOKE_CREATE_ONLY:-}" == "1" ]]; then
     echo "Facility CodeBuild Docker security boundary passed create-only emulation checks"
   else
@@ -204,13 +224,24 @@ security_smoke() {
   fi
 }
 
-mkdir -p "$docker_runtime" "$proxy_runtime" /var/lib/facility-docker/docker-fuse \
-  /var/lib/facility-docker/docker-vfs /work
+mkdir -p "$docker_runtime" "$proxy_runtime" "$workspace_view" \
+  /var/lib/facility-docker/docker-fuse /var/lib/facility-docker/docker-vfs /work
 chown -R "$docker_user:$docker_user" "$docker_runtime" /var/lib/facility-docker
 chown -R "$proxy_user:$untrusted_gid" "$proxy_runtime"
 chown root:"$untrusted_gid" /work
 chmod 3770 /work
 chmod 0710 "$docker_runtime" "$proxy_runtime"
+chown root:root "$workspace_view"
+chmod 0711 "$workspace_view"
+# Bind requests are rewritten to this trusted alias. Linux's nosymfollow mount
+# flag makes a later workspace symlink swap fail in the kernel, closing the
+# check/use race before dockerd can reach any host runtime socket.
+mount --bind /work "$workspace_view"
+mount -o remount,bind,nosymfollow "$workspace_view"
+if ! findmnt -T "$workspace_view" -no OPTIONS | tr ',' '\n' | grep -qx nosymfollow; then
+  echo "Facility requires a kernel that enforces nosymfollow bind mounts" >&2
+  exit 1
+fi
 : >/var/log/facility-dockerd.log
 : >/var/log/facility-docker-proxy.log
 
@@ -240,7 +271,10 @@ if ! DOCKER_HOST="unix://${raw_socket}" docker info >/dev/null 2>&1; then
   exit 1
 fi
 chmod 0660 "$raw_socket"
-chgrp "$docker_user" "$raw_socket"
+# Dockerd keeps its listening descriptor open. Reassign the pathname to the
+# proxy identity so even a bind-validation TOCTOU cannot give root inside a
+# rootless child access to the unrestricted daemon API.
+chown root:"$proxy_user" "$raw_socket"
 start_proxy
 
 export DOCKER_HOST="unix://${public_socket}"

--- a/runner/package.json
+++ b/runner/package.json
@@ -7,7 +7,7 @@
     "facility-runner": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts src/docker-proxy.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/runner/runner-entrypoint.sh
+++ b/runner/runner-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p /work
+export HOME=/work
+export XDG_CACHE_HOME=/work/.cache
+export XDG_CONFIG_HOME=/work/.config
+export XDG_DATA_HOME=/work/.local/share
+mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  chown -R node:node /work
+  exec runuser --user node --preserve-environment -- "$@"
+fi
+
+exec "$@"

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 import { chmod, chown, realpath, rm } from "node:fs/promises";
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import net from "node:net";
 import type { Duplex } from "node:stream";
 
 const DEFAULT_PUBLIC_SOCKET = "/run/facility-proxy/docker.sock";
 const DEFAULT_UPSTREAM_SOCKET = "/run/facility-docker/docker.sock";
+const DEFAULT_WORKSPACE_ROOT = "/work";
+const DEFAULT_WORKSPACE_VIEW = "/run/facility-workspace";
 const MAX_POLICY_BODY_BYTES = 1024 * 1024;
 
 type PolicyDecision =
@@ -22,7 +25,7 @@ export function dockerRequestPolicy(method: string, rawUrl: string): PolicyDecis
   }
   if (
     readOnly &&
-    /^\/(?:containers(?:\/json|\/[^/]+\/(?:json|top|logs|stats|changes|export))|images(?:\/json|\/.+\/(?:json|history|get))|networks(?:\/[^/]+)?|volumes(?:\/[^/]+)?)$/.test(
+    /^\/(?:containers(?:\/json|\/[^/]+\/(?:json|top|logs|stats|changes|export|archive))|images(?:\/json|\/.+\/(?:json|history|get))|networks(?:\/[^/]+)?|volumes(?:\/[^/]+)?)$/.test(
       pathname,
     )
   ) {
@@ -39,7 +42,7 @@ export function dockerRequestPolicy(method: string, rawUrl: string): PolicyDecis
   }
   if (
     method === "POST" &&
-    /^(?:\/auth|\/build|\/build\/prune|\/images\/(?:create|load|prune)|\/images\/.+\/(?:push|tag)|\/containers\/[^/]+\/(?:start|stop|restart|kill|wait|pause|unpause|rename|commit)|\/exec\/[^/]+\/(?:start|resize)|\/networks\/(?:create|prune)|\/networks\/[^/]+\/(?:connect|disconnect)|\/volumes\/prune)$/.test(
+    /^(?:\/auth|\/build|\/build\/prune|\/commit|\/images\/(?:create|load|prune)|\/images\/.+\/(?:push|tag)|\/containers\/[^/]+\/(?:start|stop|restart|kill|wait|pause|unpause|rename)|\/exec\/[^/]+\/(?:start|resize)|\/networks\/(?:create|prune)|\/networks\/[^/]+\/(?:connect|disconnect)|\/volumes\/prune)$/.test(
       pathname,
     )
   ) {
@@ -57,6 +60,7 @@ export function dockerRequestPolicy(method: string, rawUrl: string): PolicyDecis
 export function validateDockerBody(
   kind: "container" | "exec" | "volume",
   value: unknown,
+  workspaceRoot = DEFAULT_WORKSPACE_ROOT,
 ): string | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return "invalid_json_object";
   const body = value as Record<string, unknown>;
@@ -99,13 +103,13 @@ export function validateDockerBody(
     return "host_network_denied";
   }
   for (const source of dockerBindSources(host)) {
-    if (!safeBindSource(source)) return "host_bind_source_denied";
+    if (!safeBindSource(source, workspaceRoot)) return "host_bind_source_denied";
   }
   if (Array.isArray(host.Mounts)) {
     for (const mount of host.Mounts) {
       const type = String(object(mount).Type ?? "").toLowerCase();
       if (type === "bind") {
-        if (!safeBindSource(String(object(mount).Source ?? ""))) {
+        if (!safeBindSource(String(object(mount).Source ?? ""), workspaceRoot)) {
           return "host_bind_source_denied";
         }
       } else if (type === "volume") {
@@ -117,25 +121,44 @@ export function validateDockerBody(
   return null;
 }
 
-export async function validateDockerBindResolution(value: unknown): Promise<string | null> {
+export async function secureDockerBindSources(
+  value: unknown,
+  workspaceRoot = DEFAULT_WORKSPACE_ROOT,
+  workspaceView = DEFAULT_WORKSPACE_VIEW,
+): Promise<string | null> {
   const host = object(object(value).HostConfig);
-  const sources = [
-    ...dockerBindSources(host),
-    ...(Array.isArray(host.Mounts)
-      ? host.Mounts.map(object)
-          .filter((mount) => String(mount.Type ?? "").toLowerCase() === "bind")
-          .map((mount) => String(mount.Source ?? ""))
-      : []),
-  ];
-  for (const source of sources) {
-    if (!source.startsWith("/")) continue;
-    let resolved: string;
-    try {
-      resolved = await realpath(source);
-    } catch {
-      return "host_bind_source_unresolved";
+  const hasBind =
+    (Array.isArray(host.Binds) && host.Binds.length > 0) ||
+    (Array.isArray(host.Mounts) &&
+      host.Mounts.some((mount) => String(object(mount).Type ?? "").toLowerCase() === "bind"));
+  if (!hasBind) return null;
+  let resolvedWorkspaceRoot: string;
+  try {
+    resolvedWorkspaceRoot = await realpath(workspaceRoot);
+  } catch {
+    return "workspace_root_unresolved";
+  }
+  if (Array.isArray(host.Binds)) {
+    for (let index = 0; index < host.Binds.length; index += 1) {
+      const bind = String(host.Binds[index]);
+      const source = bind.split(":", 1)[0] ?? "";
+      const secured = await secureBindSource(source, resolvedWorkspaceRoot, workspaceView);
+      if (typeof secured !== "string") return secured.reason;
+      host.Binds[index] = `${secured}${bind.slice(source.length)}`;
     }
-    if (!safeBindSource(resolved)) return "host_bind_source_escape_denied";
+  }
+  if (Array.isArray(host.Mounts)) {
+    for (const value of host.Mounts) {
+      const mount = object(value);
+      if (String(mount.Type ?? "").toLowerCase() !== "bind") continue;
+      const secured = await secureBindSource(
+        String(mount.Source ?? ""),
+        resolvedWorkspaceRoot,
+        workspaceView,
+      );
+      if (typeof secured !== "string") return secured.reason;
+      mount.Source = secured;
+    }
   }
   return null;
 }
@@ -146,13 +169,17 @@ export async function startDockerProxy(
     upstreamSocket?: string;
     socketUid?: number;
     socketGid?: number;
+    workspaceRoot?: string;
+    workspaceView?: string;
   } = {},
 ) {
   const publicSocket = options.publicSocket ?? DEFAULT_PUBLIC_SOCKET;
   const upstreamSocket = options.upstreamSocket ?? DEFAULT_UPSTREAM_SOCKET;
+  const workspaceRoot = options.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT;
+  const workspaceView = options.workspaceView ?? DEFAULT_WORKSPACE_VIEW;
   await rm(publicSocket, { force: true });
   const server = http.createServer((request, response) => {
-    void handleRequest(request, response, upstreamSocket);
+    void handleRequest(request, response, upstreamSocket, workspaceRoot, workspaceView);
   });
   server.on("upgrade", (request, client, head) => {
     handleUpgrade(request, client, head, upstreamSocket);
@@ -173,6 +200,8 @@ async function handleRequest(
   request: IncomingMessage,
   response: ServerResponse,
   upstreamSocket: string,
+  workspaceRoot: string,
+  workspaceView: string,
 ) {
   const method = request.method ?? "GET";
   const url = request.url ?? "/";
@@ -184,9 +213,12 @@ async function handleRequest(
       body = await readBounded(request, MAX_POLICY_BODY_BYTES);
       const parsed = JSON.parse(body.toString("utf8"));
       const reason =
-        validateDockerBody(decision.validateBody, parsed) ??
-        (decision.validateBody === "container" ? await validateDockerBindResolution(parsed) : null);
+        validateDockerBody(decision.validateBody, parsed, workspaceRoot) ??
+        (decision.validateBody === "container"
+          ? await secureDockerBindSources(parsed, workspaceRoot, workspaceView)
+          : null);
       if (reason) return reject(response, reason);
+      body = Buffer.from(JSON.stringify(parsed));
     } catch (error) {
       const reason = error instanceof Error ? error.message : "invalid_request";
       return reject(response, reason);
@@ -220,37 +252,18 @@ function handleUpgrade(
     client.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 21\r\n\r\ndocker_upgrade_denied");
     return;
   }
-  const upstreamRequest = http.request({
-    socketPath: upstreamSocket,
-    method,
-    path: url,
-    headers: { ...request.headers, host: "docker" },
-  });
-  upstreamRequest.on("upgrade", (response, upstream, upstreamHead) => {
-    writeRawResponseHead(client, response);
-    if (upstreamHead.length > 0) client.write(upstreamHead);
+  const upstream = net.createConnection(upstreamSocket, () => {
+    const headers: string[] = [];
+    for (let index = 0; index < request.rawHeaders.length; index += 2) {
+      headers.push(`${request.rawHeaders[index]}: ${request.rawHeaders[index + 1]}`);
+    }
+    upstream.write(
+      `${method} ${url} HTTP/${request.httpVersion}\r\n${headers.join("\r\n")}\r\n\r\n`,
+    );
     if (head.length > 0) upstream.write(head);
     client.pipe(upstream).pipe(client);
   });
-  // Docker normally upgrades attach/exec to a raw stream. Forward an ordinary
-  // response as well so version differences fail explicitly instead of leaving
-  // the CLI waiting forever for a hijack that never arrived.
-  upstreamRequest.on("response", (response) => {
-    writeRawResponseHead(client, response);
-    response.pipe(client);
-  });
-  upstreamRequest.on("error", () => client.destroy());
-  upstreamRequest.end();
-}
-
-function writeRawResponseHead(client: Duplex, response: IncomingMessage) {
-  const headers: string[] = [];
-  for (let index = 0; index < response.rawHeaders.length; index += 2) {
-    headers.push(`${response.rawHeaders[index]}: ${response.rawHeaders[index + 1]}`);
-  }
-  client.write(
-    `HTTP/${response.httpVersion} ${response.statusCode ?? 502} ${response.statusMessage ?? ""}\r\n${headers.join("\r\n")}\r\n\r\n`,
-  );
+  upstream.on("error", () => client.destroy());
 }
 
 function dockerPath(rawUrl: string) {
@@ -277,11 +290,33 @@ function dockerBindSources(host: Record<string, unknown>) {
   return host.Binds.map((bind) => String(bind).split(":", 1)[0] ?? "");
 }
 
-function safeBindSource(source: string) {
-  if (source === "/work" || source.startsWith("/work/")) return true;
+function safeBindSource(source: string, workspaceRoot = DEFAULT_WORKSPACE_ROOT) {
+  if (source === workspaceRoot || source.startsWith(`${workspaceRoot}/`)) return true;
   if (source === "/var/run/docker.sock" || source === DEFAULT_PUBLIC_SOCKET) return true;
   // No slash means a Docker-managed named volume, not a host bind.
   return /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(source);
+}
+
+async function secureBindSource(
+  source: string,
+  workspaceRoot: string,
+  workspaceView: string,
+): Promise<string | { reason: string }> {
+  if (!source.startsWith("/")) return source;
+  let resolved: string;
+  try {
+    resolved = await realpath(source);
+  } catch {
+    return { reason: "host_bind_source_unresolved" };
+  }
+  if (!safeBindSource(resolved, workspaceRoot)) {
+    return { reason: "host_bind_source_escape_denied" };
+  }
+  if (resolved === workspaceRoot) return workspaceView;
+  if (resolved.startsWith(`${workspaceRoot}/`)) {
+    return `${workspaceView}${resolved.slice(workspaceRoot.length)}`;
+  }
+  return resolved;
 }
 
 function reject(response: ServerResponse, reason: string) {
@@ -305,6 +340,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   startDockerProxy({
     publicSocket: process.env.FACILITY_DOCKER_SOCKET,
     upstreamSocket: process.env.FACILITY_DOCKER_UPSTREAM_SOCKET,
+    workspaceView: process.env.FACILITY_DOCKER_WORKSPACE_VIEW,
   }).catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -274,6 +274,12 @@ async function handleRequest(
   const upstream = http.request({ socketPath: upstreamSocket, method, path: url, headers });
   upstream.on("response", (upstreamResponse) => {
     response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+    // Docker deliberately sends headers before the body for long-lived calls
+    // such as container wait and event streams. Node buffers writeHead() until
+    // body data arrives unless it is flushed explicitly. A foreground
+    // `docker run` waits for the wait subscription before it starts the
+    // container, so buffering these headers deadlocks the whole lifecycle.
+    response.flushHeaders();
     upstreamResponse.pipe(response);
   });
   upstream.on("error", (error) => {

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -2,13 +2,21 @@
 import { chmod, chown, realpath, rm } from "node:fs/promises";
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import net from "node:net";
+import { isAbsolute, relative, sep } from "node:path";
 import type { Duplex } from "node:stream";
 
 const DEFAULT_PUBLIC_SOCKET = "/run/facility-proxy/docker.sock";
 const DEFAULT_UPSTREAM_SOCKET = "/run/facility-docker/docker.sock";
 const DEFAULT_WORKSPACE_ROOT = "/work";
-const DEFAULT_WORKSPACE_VIEW = "/run/facility-workspace";
+const DEFAULT_BIND_MOUNTER_SOCKET = "/run/facility-binds/mounter.sock";
 const MAX_POLICY_BODY_BYTES = 1024 * 1024;
+const MAX_BATCH_BINDS = 128;
+const MAX_BROKER_RESPONSE_BYTES = 1024 * 1024;
+
+type PinBindSources = (sources: string[], workspaceRoot: string) => Promise<string[]>;
+type SecuredBindSource =
+  | { allowed: true; source: string; pin: boolean }
+  | { allowed: false; reason: string };
 
 type PolicyDecision =
   | { allowed: true; validateBody?: "container" | "exec" | "volume" }
@@ -124,7 +132,7 @@ export function validateDockerBody(
 export async function secureDockerBindSources(
   value: unknown,
   workspaceRoot = DEFAULT_WORKSPACE_ROOT,
-  workspaceView = DEFAULT_WORKSPACE_VIEW,
+  pinBindSources: PinBindSources,
 ): Promise<string | null> {
   const host = object(object(value).HostConfig);
   const hasBind =
@@ -138,27 +146,59 @@ export async function secureDockerBindSources(
   } catch {
     return "workspace_root_unresolved";
   }
-  if (Array.isArray(host.Binds)) {
-    for (let index = 0; index < host.Binds.length; index += 1) {
-      const bind = String(host.Binds[index]);
+  const pending: Array<{ source: string; apply: (secured: string) => void }> = [];
+  const binds = host.Binds;
+  if (Array.isArray(binds)) {
+    for (let index = 0; index < binds.length; index += 1) {
+      const bind = String(binds[index]);
       const source = bind.split(":", 1)[0] ?? "";
-      const secured = await secureBindSource(source, resolvedWorkspaceRoot, workspaceView);
-      if (typeof secured !== "string") return secured.reason;
-      host.Binds[index] = `${secured}${bind.slice(source.length)}`;
+      const secured = await secureBindSource(source, resolvedWorkspaceRoot);
+      if (!secured.allowed) return secured.reason;
+      if (secured.pin) {
+        pending.push({
+          source: secured.source,
+          apply: (pinned) => {
+            binds[index] = `${pinned}${bind.slice(source.length)}`;
+          },
+        });
+      } else {
+        binds[index] = `${secured.source}${bind.slice(source.length)}`;
+      }
     }
   }
   if (Array.isArray(host.Mounts)) {
     for (const value of host.Mounts) {
       const mount = object(value);
       if (String(mount.Type ?? "").toLowerCase() !== "bind") continue;
-      const secured = await secureBindSource(
-        String(mount.Source ?? ""),
-        resolvedWorkspaceRoot,
-        workspaceView,
-      );
-      if (typeof secured !== "string") return secured.reason;
-      mount.Source = secured;
+      const secured = await secureBindSource(String(mount.Source ?? ""), resolvedWorkspaceRoot);
+      if (!secured.allowed) return secured.reason;
+      if (secured.pin) {
+        pending.push({
+          source: secured.source,
+          apply: (pinned) => {
+            mount.Source = pinned;
+          },
+        });
+      } else {
+        mount.Source = secured.source;
+      }
     }
+  }
+  if (pending.length === 0) return null;
+  if (pending.length > MAX_BATCH_BINDS) return "workspace_bind_batch_too_large";
+  try {
+    const pinned = await pinBindSources(
+      pending.map(({ source }) => source),
+      resolvedWorkspaceRoot,
+    );
+    if (pinned.length !== pending.length) return "workspace_bind_source_pin_failed";
+    for (let index = 0; index < pending.length; index += 1) {
+      pending[index]?.apply(pinned[index] ?? "");
+    }
+  } catch (error) {
+    return error instanceof Error && error.message.startsWith("workspace_bind_")
+      ? error.message
+      : "workspace_bind_source_pin_failed";
   }
   return null;
 }
@@ -170,16 +210,21 @@ export async function startDockerProxy(
     socketUid?: number;
     socketGid?: number;
     workspaceRoot?: string;
-    workspaceView?: string;
+    bindMounterSocket?: string;
+    pinBindSources?: PinBindSources;
   } = {},
 ) {
   const publicSocket = options.publicSocket ?? DEFAULT_PUBLIC_SOCKET;
   const upstreamSocket = options.upstreamSocket ?? DEFAULT_UPSTREAM_SOCKET;
   const workspaceRoot = options.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT;
-  const workspaceView = options.workspaceView ?? DEFAULT_WORKSPACE_VIEW;
+  const bindMounterSocket = options.bindMounterSocket ?? DEFAULT_BIND_MOUNTER_SOCKET;
+  const pinBindSources =
+    options.pinBindSources ??
+    ((sources: string[], resolvedWorkspaceRoot: string) =>
+      requestPinnedSources(bindMounterSocket, sources, resolvedWorkspaceRoot));
   await rm(publicSocket, { force: true });
   const server = http.createServer((request, response) => {
-    void handleRequest(request, response, upstreamSocket, workspaceRoot, workspaceView);
+    void handleRequest(request, response, upstreamSocket, workspaceRoot, pinBindSources);
   });
   server.on("upgrade", (request, client, head) => {
     handleUpgrade(request, client, head, upstreamSocket);
@@ -201,7 +246,7 @@ async function handleRequest(
   response: ServerResponse,
   upstreamSocket: string,
   workspaceRoot: string,
-  workspaceView: string,
+  pinBindSources: PinBindSources,
 ) {
   const method = request.method ?? "GET";
   const url = request.url ?? "/";
@@ -215,7 +260,7 @@ async function handleRequest(
       const reason =
         validateDockerBody(decision.validateBody, parsed, workspaceRoot) ??
         (decision.validateBody === "container"
-          ? await secureDockerBindSources(parsed, workspaceRoot, workspaceView)
+          ? await secureDockerBindSources(parsed, workspaceRoot, pinBindSources)
           : null);
       if (reason) return reject(response, reason);
       body = Buffer.from(JSON.stringify(parsed));
@@ -297,26 +342,75 @@ function safeBindSource(source: string, workspaceRoot = DEFAULT_WORKSPACE_ROOT) 
   return /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(source);
 }
 
-async function secureBindSource(
-  source: string,
-  workspaceRoot: string,
-  workspaceView: string,
-): Promise<string | { reason: string }> {
-  if (!source.startsWith("/")) return source;
+async function secureBindSource(source: string, workspaceRoot: string): Promise<SecuredBindSource> {
+  if (!source.startsWith("/")) return { allowed: true, source, pin: false };
   let resolved: string;
   try {
     resolved = await realpath(source);
   } catch {
-    return { reason: "host_bind_source_unresolved" };
+    return { allowed: false, reason: "host_bind_source_unresolved" };
   }
   if (!safeBindSource(resolved, workspaceRoot)) {
-    return { reason: "host_bind_source_escape_denied" };
+    return { allowed: false, reason: "host_bind_source_escape_denied" };
   }
-  if (resolved === workspaceRoot) return workspaceView;
-  if (resolved.startsWith(`${workspaceRoot}/`)) {
-    return `${workspaceView}${resolved.slice(workspaceRoot.length)}`;
+  if (resolved === workspaceRoot || resolved.startsWith(`${workspaceRoot}/`)) {
+    return { allowed: true, source: resolved, pin: true };
   }
-  return resolved;
+  return { allowed: true, source: resolved, pin: false };
+}
+
+async function requestPinnedSources(socketPath: string, sources: string[], workspaceRoot: string) {
+  if (sources.length === 0 || sources.length > MAX_BATCH_BINDS) {
+    throw new Error("workspace_bind_batch_too_large");
+  }
+  const relativeSources = sources.map((source) => {
+    const relativeSource = relative(workspaceRoot, source);
+    if (
+      relativeSource === ".." ||
+      relativeSource.startsWith(`..${sep}`) ||
+      isAbsolute(relativeSource)
+    ) {
+      throw new Error("workspace_bind_source_escape_denied");
+    }
+    const normalized = relativeSource === "" ? "." : relativeSource;
+    if (normalized.includes("\n") || normalized.includes("\r")) {
+      throw new Error("workspace_bind_source_denied");
+    }
+    return normalized;
+  });
+  const requestBody = `BATCH ${relativeSources.length}\n${relativeSources.join("\n")}\n`;
+  return await new Promise<string[]>((resolvePinned, reject) => {
+    const client = net.createConnection(socketPath);
+    let response = "";
+    client.setEncoding("utf8");
+    client.setTimeout(5_000, () => client.destroy(new Error("workspace_bind_broker_timeout")));
+    client.on("connect", () => client.end(requestBody));
+    client.on("data", (chunk) => {
+      response += String(chunk);
+      if (response.length > MAX_BROKER_RESPONSE_BYTES) {
+        client.destroy(new Error("workspace_bind_broker_response_too_large"));
+      }
+    });
+    client.on("end", () => {
+      if (!response.endsWith("\n")) {
+        reject(new Error("workspace_bind_source_pin_failed"));
+        return;
+      }
+      const lines = response.slice(0, -1).split("\n");
+      if (lines[0]?.startsWith("ERR workspace_bind_") && lines.length === 1) {
+        reject(new Error(lines[0].slice(4)));
+        return;
+      }
+      if (lines[0] !== `OK ${sources.length}` || lines.length !== sources.length + 1) {
+        reject(new Error("workspace_bind_source_pin_failed"));
+        return;
+      }
+      resolvePinned(lines.slice(1));
+    });
+    client.on("error", (error) =>
+      reject(new Error("workspace_bind_source_pin_failed", { cause: error })),
+    );
+  });
 }
 
 function reject(response: ServerResponse, reason: string) {
@@ -340,7 +434,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   startDockerProxy({
     publicSocket: process.env.FACILITY_DOCKER_SOCKET,
     upstreamSocket: process.env.FACILITY_DOCKER_UPSTREAM_SOCKET,
-    workspaceView: process.env.FACILITY_DOCKER_WORKSPACE_VIEW,
+    bindMounterSocket: process.env.FACILITY_BIND_MOUNTER_SOCKET,
   }).catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+import { chmod, chown, realpath, rm } from "node:fs/promises";
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+
+const DEFAULT_PUBLIC_SOCKET = "/run/facility-proxy/docker.sock";
+const DEFAULT_UPSTREAM_SOCKET = "/run/facility-docker/docker.sock";
+const MAX_POLICY_BODY_BYTES = 1024 * 1024;
+
+type PolicyDecision =
+  | { allowed: true; validateBody?: "container" | "exec" | "volume" }
+  | {
+      allowed: false;
+      reason: string;
+    };
+
+export function dockerRequestPolicy(method: string, rawUrl: string): PolicyDecision {
+  const pathname = dockerPath(rawUrl);
+  const readOnly = method === "GET" || method === "HEAD";
+  if (readOnly && /^\/(?:_ping|version|info|events|system\/df)$/.test(pathname)) {
+    return { allowed: true };
+  }
+  if (
+    readOnly &&
+    /^\/(?:containers(?:\/json|\/[^/]+\/(?:json|top|logs|stats|changes|export))|images(?:\/json|\/.+\/(?:json|history|get))|networks(?:\/[^/]+)?|volumes(?:\/[^/]+)?)$/.test(
+      pathname,
+    )
+  ) {
+    return { allowed: true };
+  }
+  if (method === "POST" && pathname === "/containers/create") {
+    return { allowed: true, validateBody: "container" };
+  }
+  if (method === "POST" && /^\/containers\/[^/]+\/exec$/.test(pathname)) {
+    return { allowed: true, validateBody: "exec" };
+  }
+  if (method === "POST" && pathname === "/volumes/create") {
+    return { allowed: true, validateBody: "volume" };
+  }
+  if (
+    method === "POST" &&
+    /^(?:\/auth|\/build|\/build\/prune|\/images\/(?:create|load|prune)|\/images\/.+\/(?:push|tag)|\/containers\/[^/]+\/(?:start|stop|restart|kill|wait|pause|unpause|rename|commit)|\/exec\/[^/]+\/(?:start|resize)|\/networks\/(?:create|prune)|\/networks\/[^/]+\/(?:connect|disconnect)|\/volumes\/prune)$/.test(
+      pathname,
+    )
+  ) {
+    return { allowed: true };
+  }
+  if (method === "DELETE" && /^\/(?:containers|images|networks|volumes)\/[^/]+$/.test(pathname)) {
+    return { allowed: true };
+  }
+  if (method === "PUT" && /^\/containers\/[^/]+\/archive$/.test(pathname)) {
+    return { allowed: true };
+  }
+  return { allowed: false, reason: `docker_api_denied:${method}:${pathname}` };
+}
+
+export function validateDockerBody(
+  kind: "container" | "exec" | "volume",
+  value: unknown,
+): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "invalid_json_object";
+  const body = value as Record<string, unknown>;
+  if (kind === "exec") return body.Privileged === true ? "privileged_exec_denied" : null;
+  if (kind === "volume") {
+    const driver = String(body.Driver ?? "");
+    if (driver !== "" && driver !== "local") return "volume_driver_denied";
+    if (objectKeys(body.DriverOpts).length > 0) return "volume_driver_options_denied";
+    return null;
+  }
+
+  const host = object(body.HostConfig);
+  if (host.Privileged === true) return "privileged_container_denied";
+  const deniedNonEmpty = [
+    "Devices",
+    "DeviceRequests",
+    "CapAdd",
+    "SecurityOpt",
+    "VolumesFrom",
+    "DeviceCgroupRules",
+  ];
+  for (const field of deniedNonEmpty) {
+    if (nonEmpty(host[field])) return `host_config_${field.toLowerCase()}_denied`;
+  }
+  for (const field of ["MaskedPaths", "ReadonlyPaths"]) {
+    if (Array.isArray(host[field])) return `host_config_${field.toLowerCase()}_denied`;
+  }
+  if (objectKeys(host.Sysctls).length > 0) return "host_config_sysctls_denied";
+  for (const field of ["CgroupParent", "Runtime"]) {
+    if (typeof host[field] === "string" && host[field] !== "") {
+      return `host_config_${field.toLowerCase()}_denied`;
+    }
+  }
+  for (const field of ["PidMode", "IpcMode", "UTSMode", "UsernsMode", "CgroupnsMode"]) {
+    if (typeof host[field] === "string" && host[field] !== "") {
+      return `host_config_${field.toLowerCase()}_denied`;
+    }
+  }
+  if (String(host.NetworkMode ?? "").toLowerCase() === "host") {
+    return "host_network_denied";
+  }
+  for (const source of dockerBindSources(host)) {
+    if (!safeBindSource(source)) return "host_bind_source_denied";
+  }
+  if (Array.isArray(host.Mounts)) {
+    for (const mount of host.Mounts) {
+      const type = String(object(mount).Type ?? "").toLowerCase();
+      if (type === "bind") {
+        if (!safeBindSource(String(object(mount).Source ?? ""))) {
+          return "host_bind_source_denied";
+        }
+      } else if (type === "volume") {
+        const volumeOptions = object(object(mount).VolumeOptions);
+        if ("DriverConfig" in volumeOptions) return "host_mount_volume_driver_denied";
+      } else if (type !== "tmpfs") return "host_mount_denied";
+    }
+  }
+  return null;
+}
+
+export async function validateDockerBindResolution(value: unknown): Promise<string | null> {
+  const host = object(object(value).HostConfig);
+  const sources = [
+    ...dockerBindSources(host),
+    ...(Array.isArray(host.Mounts)
+      ? host.Mounts.map(object)
+          .filter((mount) => String(mount.Type ?? "").toLowerCase() === "bind")
+          .map((mount) => String(mount.Source ?? ""))
+      : []),
+  ];
+  for (const source of sources) {
+    if (!source.startsWith("/")) continue;
+    let resolved: string;
+    try {
+      resolved = await realpath(source);
+    } catch {
+      return "host_bind_source_unresolved";
+    }
+    if (!safeBindSource(resolved)) return "host_bind_source_escape_denied";
+  }
+  return null;
+}
+
+export async function startDockerProxy(
+  options: {
+    publicSocket?: string;
+    upstreamSocket?: string;
+    socketUid?: number;
+    socketGid?: number;
+  } = {},
+) {
+  const publicSocket = options.publicSocket ?? DEFAULT_PUBLIC_SOCKET;
+  const upstreamSocket = options.upstreamSocket ?? DEFAULT_UPSTREAM_SOCKET;
+  await rm(publicSocket, { force: true });
+  const server = http.createServer((request, response) => {
+    void handleRequest(request, response, upstreamSocket);
+  });
+  server.on("upgrade", (request, client, head) => {
+    handleUpgrade(request, client, head, upstreamSocket);
+  });
+  server.on("clientError", (_error, socket) => socket.end("HTTP/1.1 400 Bad Request\r\n\r\n"));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(publicSocket, () => resolve());
+  });
+  await chmod(publicSocket, 0o660);
+  if (options.socketUid !== undefined && options.socketGid !== undefined) {
+    await chown(publicSocket, options.socketUid, options.socketGid);
+  }
+  return server;
+}
+
+async function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  upstreamSocket: string,
+) {
+  const method = request.method ?? "GET";
+  const url = request.url ?? "/";
+  const decision = dockerRequestPolicy(method, url);
+  if (!decision.allowed) return reject(response, decision.reason);
+  let body: Buffer | undefined;
+  if (decision.validateBody) {
+    try {
+      body = await readBounded(request, MAX_POLICY_BODY_BYTES);
+      const parsed = JSON.parse(body.toString("utf8"));
+      const reason =
+        validateDockerBody(decision.validateBody, parsed) ??
+        (decision.validateBody === "container" ? await validateDockerBindResolution(parsed) : null);
+      if (reason) return reject(response, reason);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : "invalid_request";
+      return reject(response, reason);
+    }
+  }
+  const headers = { ...request.headers, host: "docker" };
+  if (body) headers["content-length"] = String(body.length);
+  const upstream = http.request({ socketPath: upstreamSocket, method, path: url, headers });
+  upstream.on("response", (upstreamResponse) => {
+    response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+    upstreamResponse.pipe(response);
+  });
+  upstream.on("error", (error) => {
+    if (!response.headersSent) response.writeHead(502, { "content-type": "text/plain" });
+    response.end(`docker_upstream_error:${error.message}`);
+  });
+  if (body) upstream.end(body);
+  else request.pipe(upstream);
+}
+
+function handleUpgrade(
+  request: IncomingMessage,
+  client: Duplex,
+  head: Buffer,
+  upstreamSocket: string,
+) {
+  const method = request.method ?? "GET";
+  const url = request.url ?? "/";
+  const pathname = dockerPath(url);
+  if (method !== "POST" || !/^\/(?:exec\/[^/]+\/start|containers\/[^/]+\/attach)$/.test(pathname)) {
+    client.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 21\r\n\r\ndocker_upgrade_denied");
+    return;
+  }
+  const upstreamRequest = http.request({
+    socketPath: upstreamSocket,
+    method,
+    path: url,
+    headers: { ...request.headers, host: "docker" },
+  });
+  upstreamRequest.on("upgrade", (response, upstream, upstreamHead) => {
+    writeRawResponseHead(client, response);
+    if (upstreamHead.length > 0) client.write(upstreamHead);
+    if (head.length > 0) upstream.write(head);
+    client.pipe(upstream).pipe(client);
+  });
+  // Docker normally upgrades attach/exec to a raw stream. Forward an ordinary
+  // response as well so version differences fail explicitly instead of leaving
+  // the CLI waiting forever for a hijack that never arrived.
+  upstreamRequest.on("response", (response) => {
+    writeRawResponseHead(client, response);
+    response.pipe(client);
+  });
+  upstreamRequest.on("error", () => client.destroy());
+  upstreamRequest.end();
+}
+
+function writeRawResponseHead(client: Duplex, response: IncomingMessage) {
+  const headers: string[] = [];
+  for (let index = 0; index < response.rawHeaders.length; index += 2) {
+    headers.push(`${response.rawHeaders[index]}: ${response.rawHeaders[index + 1]}`);
+  }
+  client.write(
+    `HTTP/${response.httpVersion} ${response.statusCode ?? 502} ${response.statusMessage ?? ""}\r\n${headers.join("\r\n")}\r\n\r\n`,
+  );
+}
+
+function dockerPath(rawUrl: string) {
+  const pathname = new URL(rawUrl, "http://docker").pathname;
+  return pathname.replace(/^\/v\d+(?:\.\d+)?(?=\/)/, "");
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function nonEmpty(value: unknown) {
+  return Array.isArray(value) ? value.length > 0 : Boolean(value);
+}
+
+function objectKeys(value: unknown) {
+  return value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value) : [];
+}
+
+function dockerBindSources(host: Record<string, unknown>) {
+  if (!Array.isArray(host.Binds)) return [];
+  return host.Binds.map((bind) => String(bind).split(":", 1)[0] ?? "");
+}
+
+function safeBindSource(source: string) {
+  if (source === "/work" || source.startsWith("/work/")) return true;
+  if (source === "/var/run/docker.sock" || source === DEFAULT_PUBLIC_SOCKET) return true;
+  // No slash means a Docker-managed named volume, not a host bind.
+  return /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(source);
+}
+
+function reject(response: ServerResponse, reason: string) {
+  response.writeHead(403, { "content-type": "application/json" });
+  response.end(JSON.stringify({ message: reason }));
+}
+
+async function readBounded(request: IncomingMessage, maxBytes: number) {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > maxBytes) throw new Error("docker_policy_body_too_large");
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  startDockerProxy({
+    publicSocket: process.env.FACILITY_DOCKER_SOCKET,
+    upstreamSocket: process.env.FACILITY_DOCKER_UPSTREAM_SOCKET,
+  }).catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -31,6 +31,11 @@ const sessionStateArchive = join(workRoot, "claude-session-state.tgz");
 const AGENT_PROGRESS_MAX_BYTES = 16 * 1024;
 const SECURITY_REPORT_MAX_BYTES = 256 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
+const PRIVATE_REGISTRY_INSTALL_COMMANDS = new Set([
+  "npm ci",
+  "pnpm install --frozen-lockfile",
+  "yarn install --immutable",
+]);
 let engineSessionId: string | null = null;
 let activeEngineChild: ReturnType<typeof spawn> | null = null;
 let clearInterruptEscalation: (() => void) | null = null;
@@ -72,6 +77,25 @@ async function main() {
       repoToken: hello.repoToken ? String(hello.repoToken) : null,
     });
     steerStop = startSteeringPoll();
+    if (bundle.packageInstallCmd) {
+      const packageToken = hello.packageRegistryToken
+        ? String(hello.packageRegistryToken).trim()
+        : null;
+      if (packageToken) secretsToRedact.add(packageToken);
+      if (packageToken && !privateRegistryInstallCommand(bundle.packageInstallCmd)) {
+        throw new Error("package_install_command_not_allowed_for_private_registry");
+      }
+      const installed = await runPackageInstall(
+        bundle.packageInstallCmd,
+        cwdFor(bundle),
+        bundle.timeoutMin,
+        packageToken,
+      );
+      if (installed !== 0) {
+        await postResult(bundle, "failed", startedAt, { code: "package_install_failed" });
+        return;
+      }
+    }
     if (bundle.provisionCmd) {
       const provision = await runShell(
         bundle.provisionCmd,
@@ -275,11 +299,15 @@ export async function prepareWorkspace(
     await mkdir(root, { recursive: true });
     for (const [fileBase, skill] of skillsByFile) {
       const skillDir = join(root, fileBase);
+      const skillPath = join(skillDir, "SKILL.md");
+      if (await pathExists(skillPath)) {
+        // Existing repositories own their checked-in agent behavior. A
+        // project/org Facility skill may supplement it under another name, but
+        // must never overwrite a repository skill with the same name.
+        continue;
+      }
       await mkdir(skillDir, { recursive: true });
-      await writeFile(
-        join(skillDir, "SKILL.md"),
-        materializedSkillContent(skill.name, skill.content),
-      );
+      await writeFile(skillPath, materializedSkillContent(skill.name, skill.content));
     }
   }
   if (bundle.harness?.files) {
@@ -299,6 +327,16 @@ export async function prepareWorkspace(
   // Register every injected secret for redaction from captured check output.
   for (const secret of [virtualKey, platform.platformKey, platform.repoToken]) {
     if (secret) secretsToRedact.add(secret);
+  }
+}
+
+async function pathExists(path: string) {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
   }
 }
 
@@ -653,10 +691,16 @@ async function directorySize(path: string): Promise<number> {
   return total;
 }
 
-async function runShell(command: string, cwd: string, eventType: string, timeoutMin: number) {
+async function runShell(
+  command: string,
+  cwd: string,
+  eventType: string,
+  timeoutMin: number,
+  envOverrides?: NodeJS.ProcessEnv,
+) {
   const child = spawn("sh", ["-c", command], {
     cwd,
-    env: engineEnv(),
+    env: { ...engineEnv(), ...envOverrides },
     stdio: ["ignore", "pipe", "pipe"],
   });
   const clearTimers = armEngineTimeout(child, timeoutMin);
@@ -674,6 +718,34 @@ async function runShell(command: string, cwd: string, eventType: string, timeout
   await Promise.all(drains);
   clearTimers();
   return code;
+}
+
+export async function runPackageInstall(
+  command: string,
+  cwd: string,
+  timeoutMin: number,
+  packageToken: string | null,
+  userConfigPath = join(workRoot, ".facility-package-npmrc"),
+) {
+  if (!packageToken) return runShell(command, cwd, "shell", timeoutMin);
+  await writeFile(userConfigPath, privateRegistryNpmrc(packageToken), { mode: 0o600 });
+  try {
+    return await runShell(command, cwd, "shell", timeoutMin, {
+      NODE_AUTH_TOKEN: packageToken,
+      NPM_CONFIG_USERCONFIG: userConfigPath,
+    });
+  } finally {
+    await rm(userConfigPath, { force: true });
+  }
+}
+
+export function privateRegistryInstallCommand(command: string) {
+  return PRIVATE_REGISTRY_INSTALL_COMMANDS.has(command.trim());
+}
+
+export function privateRegistryNpmrc(token: string) {
+  if (!token || /[\r\n]/.test(token)) throw new Error("package_registry_token_invalid");
+  return `//npm.pkg.github.com/:_authToken=${token}\n`;
 }
 
 // Cap the self-reported checks file read so a runaway/malicious agent can't OOM
@@ -1554,6 +1626,11 @@ async function fetchJson(url: string, init: RequestInit = {}) {
 export function engineEnv() {
   const env: NodeJS.ProcessEnv = { ...process.env, HOME: "/work" };
   delete env.ANTHROPIC_AUTH_TOKEN;
+  // Registry credentials are granted only to the dedicated dependency-install
+  // child. They must never reach provisioning scripts, checks, or the model.
+  delete env.NODE_AUTH_TOKEN;
+  delete env.NPM_CONFIG_USERCONFIG;
+  delete env.npm_config_userconfig;
   // Never expose the runner's internal-lifecycle credential to the (untrusted)
   // engine or check commands. With RUNNER_TOKEN a compromised agent could call
   // /internal/runs/:id/{events,result} for its own run to forge platform-provenance

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import { createReadStream, createWriteStream } from "node:fs";
 import {
   appendFile,
+  chmod,
+  chown,
   lstat,
   mkdir,
   open,
@@ -24,10 +26,12 @@ import {
 import type { RunBundle, RunEvent } from "./types.js";
 
 const workRoot = "/work";
-const steerFile = join(workRoot, "STEERING.md");
-const transcriptFile = join(workRoot, "engine.stream.jsonl");
+const runtimeRoot = join(workRoot, ".facility-runtime");
+const steerFile = join(runtimeRoot, "STEERING.md");
+const transcriptFile = join(runtimeRoot, "engine.stream.jsonl");
 const sessionStateDir = join(workRoot, ".claude");
-const sessionStateArchive = join(workRoot, "claude-session-state.tgz");
+const sessionStateArchive = join(runtimeRoot, "claude-session-state.tgz");
+const engineStderrFile = join(runtimeRoot, "engine.stderr.log");
 const AGENT_PROGRESS_MAX_BYTES = 16 * 1024;
 const SECURITY_REPORT_MAX_BYTES = 256 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
@@ -76,6 +80,8 @@ async function main() {
       projectId: hello.projectId ? String(hello.projectId) : "",
       repoToken: hello.repoToken ? String(hello.repoToken) : null,
     });
+    await grantWorkspaceToUntrusted();
+    await prepareRunnerRuntime();
     steerStop = startSteeringPoll();
     if (bundle.packageInstallCmd) {
       const packageToken = hello.packageRegistryToken
@@ -418,6 +424,7 @@ async function runJsonProcess(
     cwd,
     env: engineEnv(),
     stdio: [stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    ...untrustedSpawnIdentity(),
   });
   if (stdin !== undefined && child.stdin) {
     // Large learning packets exceed the OS argv limit. Stream the prompt so
@@ -432,7 +439,7 @@ async function runJsonProcess(
     child.kill();
     throw new Error("engine_stdio_unavailable");
   }
-  const stderr = createWriteStream(join(workRoot, "engine.stderr.log"), { flags: "a" });
+  const stderr = createWriteStream(engineStderrFile, { flags: "a" });
   stderrStream.pipe(stderr);
   const clearTimers = armEngineTimeout(child, timeoutMin);
   const rl = createInterface({ input: stdout });
@@ -668,8 +675,8 @@ export function terminateChild(
 
 async function checkoutResumeBranch(cwd: string, branch: string) {
   try {
-    await gitOutput(cwd, ["fetch", "origin", branch]);
-    await gitOutput(cwd, ["checkout", branch]);
+    await gitOutput(cwd, ["fetch", "origin", branch], true);
+    await gitOutput(cwd, ["checkout", branch], true);
   } catch (error) {
     await emit([
       {
@@ -702,6 +709,7 @@ async function runShell(
     cwd,
     env: { ...engineEnv(), ...envOverrides },
     stdio: ["ignore", "pipe", "pipe"],
+    ...untrustedSpawnIdentity(),
   });
   const clearTimers = armEngineTimeout(child, timeoutMin);
   const drains = [child.stdout, child.stderr].map((stream) => {
@@ -729,6 +737,10 @@ export async function runPackageInstall(
 ) {
   if (!packageToken) return runShell(command, cwd, "shell", timeoutMin);
   await writeFile(userConfigPath, privateRegistryNpmrc(packageToken), { mode: 0o600 });
+  const identity = untrustedSpawnIdentity();
+  if (identity.uid !== undefined && identity.gid !== undefined) {
+    await chown(userConfigPath, identity.uid, identity.gid);
+  }
   try {
     return await runShell(command, cwd, "shell", timeoutMin, {
       NODE_AUTH_TOKEN: packageToken,
@@ -835,6 +847,7 @@ export async function runCheckCommand(command: string, cwd: string, timeoutMin: 
     env: engineEnv(),
     stdio: ["ignore", "pipe", "pipe"],
     detached: true,
+    ...untrustedSpawnIdentity(),
   });
   const clearTimers = armProcessGroupTimeout(child, timeoutMin);
   let tail = "";
@@ -862,7 +875,7 @@ async function postResult(
   git?: Record<string, unknown>,
   securityReport?: Record<string, unknown>,
 ) {
-  const stderrTail = await readFile(join(workRoot, "engine.stderr.log"), "utf8").catch(() => "");
+  const stderrTail = await readFile(engineStderrFile, "utf8").catch(() => "");
   await api(`/internal/runs/${currentRunId()}/result`, {
     method: "POST",
     body: JSON.stringify({
@@ -1555,8 +1568,13 @@ function chunk<T>(items: T[], size: number) {
   return chunks;
 }
 
-async function gitOutput(cwd: string, args: string[]) {
-  const child = spawn("git", args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+async function gitOutput(cwd: string, args: string[], trustedBootstrap = false) {
+  const child = spawn("git", ["-c", `safe.directory=${cwd}`, ...args], {
+    cwd,
+    env: trustedBootstrap ? process.env : engineEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+    ...(trustedBootstrap ? {} : untrustedSpawnIdentity()),
+  });
   let stdout = "";
   let stderr = "";
   child.stdout.on("data", (chunk) => {
@@ -1643,6 +1661,42 @@ export function engineEnv() {
   return env;
 }
 
+export function untrustedSpawnIdentity(getuid: (() => number) | undefined = process.getuid): {
+  uid?: number;
+  gid?: number;
+} {
+  if (getuid?.() !== 0) return {};
+  return {
+    uid: Number(process.env.FACILITY_UNTRUSTED_UID ?? "1000"),
+    gid: Number(process.env.FACILITY_UNTRUSTED_GID ?? "1000"),
+  };
+}
+
+async function grantWorkspaceToUntrusted() {
+  const identity = untrustedSpawnIdentity();
+  if (identity.uid === undefined || identity.gid === undefined) return;
+  const workspaceGid = identity.gid;
+  await runCommand("chown", ["-R", `${identity.uid}:${workspaceGid}`, workRoot], workRoot);
+  await runCommand("chmod", ["-R", "g+rwX", workRoot], workRoot);
+  await runCommand("find", [workRoot, "-type", "d", "-exec", "chmod", "g+s", "{}", "+"], workRoot);
+  // Keep the sticky workspace root owned by the lifecycle process. The agent
+  // owns its children, but cannot rename or replace the root-owned runtime
+  // directory created next to them.
+  await chown(workRoot, 0, workspaceGid);
+  await chmod(workRoot, 0o3770);
+}
+
+async function prepareRunnerRuntime() {
+  await mkdir(runtimeRoot, { recursive: true });
+  await writeFile(steerFile, "", { mode: 0o644 });
+  if (process.getuid?.() === 0) {
+    await chown(runtimeRoot, 0, 0);
+    await chmod(runtimeRoot, 0o755);
+    await chown(steerFile, 0, 0);
+    await chmod(steerFile, 0o644);
+  }
+}
+
 function cwdFor(bundle: RunBundle, root = workRoot) {
   return bundle.repo.cloneUrl ? repoDirFor(root) : scratchDirFor(root);
 }
@@ -1719,7 +1773,7 @@ export function composedPrompt(bundle: RunBundle) {
     ? "\n\nProject harness/KB context is in ./harness/SESSION.md - read it first."
     : "";
   const steeringNote =
-    "\n\nHuman steering may arrive in ./STEERING.md while you work (it starts empty). Re-read it after finishing each task or before major decisions; if it contains new instructions, follow them.";
+    "\n\nHuman steering may arrive in /work/.facility-runtime/STEERING.md while you work (it starts empty and is runner-owned). Re-read it after finishing each task or before major decisions; if it contains new instructions, follow them.";
   const conversationNote =
     bundle.scope.type === "conversation" && typeof bundle.scope.message === "string"
       ? `\n\n## Conversation\n${bundle.scope.message}`

--- a/runner/src/types.ts
+++ b/runner/src/types.ts
@@ -7,6 +7,7 @@ export type RunBundle = {
   engineConfig: Record<string, unknown>;
   repo: { cloneUrl: string | null; branch: string | null; installationTokenRef: string | null };
   harness?: { files: Record<string, string> } | null;
+  packageInstallCmd: string | null;
   provisionCmd: string | null;
   checkCmds: string[];
   gatewayUrls: { anthropic: string; openai: string };

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -335,6 +335,18 @@ test("custom CodeBuild lifecycle commands drop root", async () => {
   );
 });
 
+test("CodeBuild metadata egress is scoped to untrusted identities", async () => {
+  const script = await readFile(new URL("../codebuild-runner.sh", import.meta.url), "utf8");
+  expect(script).toContain(
+    'for isolated_uid in "$untrusted_uid" "$(id -u "$docker_user")" "$(id -u "$proxy_user")"; do',
+  );
+  expect(script).toContain(
+    'iptables -I OUTPUT 1 -m owner --uid-owner "$isolated_uid" -d 169.254.0.0/16 -j REJECT',
+  );
+  expect(script).toContain("iptables -I FORWARD 1 -d 169.254.0.0/16 -j REJECT");
+  expect(script).not.toContain("iptables -I OUTPUT 1 -d 169.254.0.0/16 -j REJECT");
+});
+
 function listen(server: http.Server | net.Server, socket: string) {
   return new Promise<void>((resolve, reject) => {
     server.once("error", reject);

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -1,10 +1,15 @@
-import { mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink } from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
-import { dockerRequestPolicy, startDockerProxy, validateDockerBody } from "../src/docker-proxy.js";
+import {
+  dockerRequestPolicy,
+  secureDockerBindSources,
+  startDockerProxy,
+  validateDockerBody,
+} from "../src/docker-proxy.js";
 import { untrustedSpawnIdentity } from "../src/index.js";
 
 const cleanup: Array<() => Promise<void>> = [];
@@ -146,7 +151,7 @@ describe("restricted Docker API", () => {
     expect(upstreamRequests).toBe(1);
   });
 
-  test("rewrites validated workspace binds to the nosymfollow view", async () => {
+  test("rewrites validated workspace binds to root-pinned aliases", async () => {
     const dir = await mkdtemp(join(tmpdir(), "facility-docker-workspace-view-"));
     const workspaceRoot = join(dir, "work");
     const workspaceView = join(dir, "trusted-work");
@@ -159,6 +164,7 @@ describe("restricted Docker API", () => {
     const upstreamSocket = join(dir, "upstream.sock");
     const publicSocket = join(dir, "public.sock");
     const upstreamBodies: Array<Record<string, unknown>> = [];
+    const pinnedSources: string[] = [];
     const upstream = http.createServer(async (request, response) => {
       let body = "";
       for await (const chunk of request) body += chunk.toString();
@@ -171,7 +177,10 @@ describe("restricted Docker API", () => {
       publicSocket,
       upstreamSocket,
       workspaceRoot,
-      workspaceView,
+      pinBindSources: async (resolved) => {
+        pinnedSources.push(...resolved);
+        return resolved.map((_, index) => join(workspaceView, `pin-${index + 1}`));
+      },
     });
     cleanup.push(async () => {
       await close(proxy);
@@ -191,11 +200,13 @@ describe("restricted Docker API", () => {
       {
         Image: "facility-security-smoke:local",
         HostConfig: {
-          Binds: [`${workspaceView}/repo:/repo:ro`],
-          Mounts: [{ Type: "bind", Source: `${workspaceView}/repo`, Target: "/repo-again" }],
+          Binds: [`${workspaceView}/pin-1:/repo:ro`],
+          Mounts: [{ Type: "bind", Source: `${workspaceView}/pin-2`, Target: "/repo-again" }],
         },
       },
     ]);
+    const resolvedSource = await realpath(source);
+    expect(pinnedSources).toEqual([resolvedSource, resolvedSource]);
 
     const denied = await request(publicSocket, "/v1.47/containers/create", {
       Image: "facility-security-smoke:local",
@@ -204,6 +215,33 @@ describe("restricted Docker API", () => {
     expect(denied.status).toBe(403);
     expect(denied.body).toContain("host_bind_source_escape_denied");
     expect(upstreamBodies).toHaveLength(1);
+  });
+
+  test("pins all workspace binds in one transaction before rewriting the request", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-docker-bind-transaction-"));
+    const workspaceRoot = join(dir, "work");
+    const first = join(workspaceRoot, "first");
+    const second = join(workspaceRoot, "second");
+    await mkdir(first, { recursive: true });
+    await mkdir(second);
+    cleanup.push(() => rm(dir, { recursive: true, force: true }));
+    const body = {
+      HostConfig: {
+        Binds: [`${first}:/first:ro`],
+        Mounts: [{ Type: "bind", Source: second, Target: "/second" }],
+      },
+    };
+
+    await expect(
+      secureDockerBindSources(body, workspaceRoot, async (sources) => {
+        expect(sources).toEqual([await realpath(first), await realpath(second)]);
+        throw new Error("workspace_bind_source_denied");
+      }),
+    ).resolves.toBe("workspace_bind_source_denied");
+    expect(body.HostConfig).toEqual({
+      Binds: [`${first}:/first:ro`],
+      Mounts: [{ Type: "bind", Source: second, Target: "/second" }],
+    });
   });
 
   test("forwards a Docker exec upgrade body before waiting for 101", async () => {

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -241,6 +241,13 @@ describe("restricted Docker API", () => {
 test("the CodeBuild runner uses a different identity for untrusted commands", () => {
   expect(untrustedSpawnIdentity(() => 0)).toEqual({ uid: 1000, gid: 1000 });
   expect(untrustedSpawnIdentity(() => 501)).toEqual({});
+});
+
+test("custom CodeBuild commands drop root and the lifecycle credential", async () => {
+  const script = await readFile(new URL("../codebuild-runner.sh", import.meta.url), "utf8");
+  expect(script).toMatch(
+    /exec setpriv --reuid="\$untrusted_uid" --regid="\$untrusted_gid" --clear-groups -- \\\n\s+env --unset=RUNNER_TOKEN "\$@"/,
+  );
 });
 
 function listen(server: http.Server | net.Server, socket: string) {

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -243,10 +243,10 @@ test("the CodeBuild runner uses a different identity for untrusted commands", ()
   expect(untrustedSpawnIdentity(() => 501)).toEqual({});
 });
 
-test("custom CodeBuild commands drop root and the lifecycle credential", async () => {
+test("custom CodeBuild lifecycle commands drop root", async () => {
   const script = await readFile(new URL("../codebuild-runner.sh", import.meta.url), "utf8");
   expect(script).toMatch(
-    /exec setpriv --reuid="\$untrusted_uid" --regid="\$untrusted_gid" --clear-groups -- \\\n\s+env --unset=RUNNER_TOKEN "\$@"/,
+    /exec setpriv --reuid="\$untrusted_uid" --regid="\$untrusted_gid" --clear-groups -- "\$@"/,
   );
 });
 

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -1,0 +1,228 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { dockerRequestPolicy, startDockerProxy, validateDockerBody } from "../src/docker-proxy.js";
+import { untrustedSpawnIdentity } from "../src/index.js";
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (cleanup.length > 0) await cleanup.pop()?.();
+});
+
+describe("restricted Docker API", () => {
+  test("allows build and ordinary container lifecycle calls", () => {
+    expect(dockerRequestPolicy("POST", "/v1.47/build?t=repo%2Fimage")).toEqual({
+      allowed: true,
+    });
+    expect(dockerRequestPolicy("POST", "/v1.47/containers/create")).toEqual({
+      allowed: true,
+      validateBody: "container",
+    });
+    expect(dockerRequestPolicy("POST", "/v1.47/containers/abc/start")).toEqual({
+      allowed: true,
+    });
+    expect(dockerRequestPolicy("POST", "/v1.47/volumes/create")).toEqual({
+      allowed: true,
+      validateBody: "volume",
+    });
+    expect(validateDockerBody("container", { HostConfig: {} })).toBeNull();
+  });
+
+  test("denies daemon administration and runtime privilege escalation", () => {
+    for (const path of ["/plugins/pull", "/swarm/init", "/containers/abc/update"]) {
+      expect(dockerRequestPolicy("POST", path)).toMatchObject({ allowed: false });
+    }
+    for (const [body, reason] of [
+      [{ HostConfig: { Privileged: true } }, "privileged_container_denied"],
+      [{ HostConfig: { PidMode: "host" } }, "host_config_pidmode_denied"],
+      [{ HostConfig: { NetworkMode: "host" } }, "host_network_denied"],
+      [{ HostConfig: { Binds: ["/proc:/host-proc:ro"] } }, "host_bind_source_denied"],
+      [
+        { HostConfig: { Mounts: [{ Type: "bind", Source: "/", Target: "/host" }] } },
+        "host_bind_source_denied",
+      ],
+      [{ HostConfig: { CapAdd: ["SYS_ADMIN"] } }, "host_config_capadd_denied"],
+      [{ HostConfig: { MaskedPaths: [] } }, "host_config_maskedpaths_denied"],
+      [
+        {
+          HostConfig: {
+            Mounts: [
+              {
+                Type: "volume",
+                Source: "escape",
+                Target: "/raw",
+                VolumeOptions: {
+                  DriverConfig: {
+                    Name: "local",
+                    Options: { type: "none", o: "bind", device: "/run/facility-docker" },
+                  },
+                },
+              },
+            ],
+          },
+        },
+        "host_mount_volume_driver_denied",
+      ],
+    ] as const) {
+      expect(validateDockerBody("container", body)).toBe(reason);
+    }
+    expect(validateDockerBody("exec", { Privileged: true })).toBe("privileged_exec_denied");
+    expect(
+      validateDockerBody("volume", {
+        Driver: "local",
+        DriverOpts: { type: "none", o: "bind", device: "/run/facility-docker/docker.sock" },
+      }),
+    ).toBe("volume_driver_options_denied");
+  });
+
+  test("blocks a proc credential-recovery bind before it reaches dockerd", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-docker-proxy-"));
+    const upstreamSocket = join(dir, "upstream.sock");
+    const publicSocket = join(dir, "public.sock");
+    let upstreamRequests = 0;
+    const upstream = http.createServer((_request, response) => {
+      upstreamRequests += 1;
+      response.writeHead(201, { "content-type": "application/json" });
+      response.end("{}");
+    });
+    await listen(upstream, upstreamSocket);
+    const proxy = await startDockerProxy({ publicSocket, upstreamSocket });
+    cleanup.push(async () => {
+      await close(proxy);
+      await close(upstream);
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const denied = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: { Binds: ["/proc:/host-proc:ro"] },
+    });
+    expect(denied.status).toBe(403);
+    expect(denied.body).toContain("host_bind_source_denied");
+    expect(upstreamRequests).toBe(0);
+
+    const deniedVolume = await request(publicSocket, "/v1.47/volumes/create", {
+      Name: "raw-socket",
+      Driver: "local",
+      DriverOpts: { type: "none", o: "bind", device: "/run/facility-docker" },
+    });
+    expect(deniedVolume.status).toBe(403);
+    expect(deniedVolume.body).toContain("volume_driver_options_denied");
+    expect(upstreamRequests).toBe(0);
+
+    const deniedVolumeMount = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: {
+        Mounts: [
+          {
+            Type: "volume",
+            Source: "raw-socket",
+            Target: "/raw",
+            VolumeOptions: {
+              DriverConfig: { Name: "local", Options: { device: "/run/facility-docker" } },
+            },
+          },
+        ],
+      },
+    });
+    expect(deniedVolumeMount.status).toBe(403);
+    expect(deniedVolumeMount.body).toContain("host_mount_volume_driver_denied");
+    expect(upstreamRequests).toBe(0);
+
+    const accepted = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: {},
+    });
+    expect(accepted.status).toBe(201);
+    expect(upstreamRequests).toBe(1);
+  });
+
+  test("forwards the Docker attach protocol upgrade", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-docker-upgrade-"));
+    const upstreamSocket = join(dir, "upstream.sock");
+    const publicSocket = join(dir, "public.sock");
+    const upstream = http.createServer();
+    upstream.on("upgrade", (_request, socket) => {
+      socket.end("HTTP/1.1 101 UPGRADED\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\nready");
+    });
+    await listen(upstream, upstreamSocket);
+    const proxy = await startDockerProxy({ publicSocket, upstreamSocket });
+    cleanup.push(async () => {
+      await close(proxy);
+      await close(upstream);
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    await expect(upgrade(publicSocket, "/v1.47/containers/abc/attach?stream=1")).resolves.toBe(
+      "ready",
+    );
+  });
+});
+
+test("the CodeBuild runner uses a different identity for untrusted commands", () => {
+  expect(untrustedSpawnIdentity(() => 0)).toEqual({ uid: 1000, gid: 1000 });
+  expect(untrustedSpawnIdentity(() => 501)).toEqual({});
+});
+
+function listen(server: http.Server, socket: string) {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socket, resolve);
+  });
+}
+
+function close(server: http.Server) {
+  return new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
+function request(socketPath: string, path: string, body: Record<string, unknown>) {
+  const json = JSON.stringify(body);
+  return new Promise<{ status: number; body: string }>((resolve, reject) => {
+    const req = http.request(
+      {
+        socketPath,
+        method: "POST",
+        path,
+        headers: { "content-type": "application/json", "content-length": Buffer.byteLength(json) },
+      },
+      (response) => {
+        let responseBody = "";
+        response.on("data", (chunk) => {
+          responseBody += chunk.toString();
+        });
+        response.on("end", () => resolve({ status: response.statusCode ?? 0, body: responseBody }));
+      },
+    );
+    req.on("error", reject);
+    req.end(json);
+  });
+}
+
+function upgrade(socketPath: string, path: string) {
+  return new Promise<string>((resolve, reject) => {
+    const req = http.request({
+      socketPath,
+      method: "POST",
+      path,
+      headers: { connection: "Upgrade", upgrade: "tcp" },
+    });
+    req.on("upgrade", (_response, socket, head) => {
+      let body = head.toString();
+      const finish = () => {
+        socket.destroy();
+        resolve(body);
+      };
+      if (body) return finish();
+      socket.once("data", (chunk) => {
+        body += chunk.toString();
+        finish();
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -274,6 +274,53 @@ describe("restricted Docker API", () => {
 
     await expect(upgrade(publicSocket, "/v1.47/exec/abc/start", execBody)).resolves.toBe("ready");
   });
+
+  test("flushes long-lived Docker response headers before the body", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-docker-stream-"));
+    const upstreamSocket = join(dir, "upstream.sock");
+    const publicSocket = join(dir, "public.sock");
+    let finishUpstream = () => {};
+    const upstreamFinished = new Promise<void>((resolve) => {
+      finishUpstream = resolve;
+    });
+    const upstream = http.createServer(async (_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.flushHeaders();
+      await upstreamFinished;
+      response.end("{}");
+    });
+    await listen(upstream, upstreamSocket);
+    const proxy = await startDockerProxy({ publicSocket, upstreamSocket });
+    cleanup.push(async () => {
+      finishUpstream();
+      await close(proxy);
+      await close(upstream);
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const headersReceived = new Promise<number>((resolve, reject) => {
+      const request = http.request(
+        {
+          socketPath: publicSocket,
+          method: "POST",
+          path: "/v1.47/containers/abc/wait",
+          headers: { connection: "close" },
+        },
+        (response) => {
+          resolve(response.statusCode ?? 0);
+          response.resume();
+        },
+      );
+      request.on("error", reject);
+      request.end();
+    });
+    const result = await Promise.race([
+      headersReceived,
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 500)),
+    ]);
+    finishUpstream();
+    expect(result).toBe(200);
+  });
 });
 
 test("the CodeBuild runner uses a different identity for untrusted commands", () => {

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -1,5 +1,6 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import http from "node:http";
+import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -21,6 +22,12 @@ describe("restricted Docker API", () => {
       validateBody: "container",
     });
     expect(dockerRequestPolicy("POST", "/v1.47/containers/abc/start")).toEqual({
+      allowed: true,
+    });
+    expect(dockerRequestPolicy("GET", "/v1.47/containers/abc/archive?path=/tmp/out")).toEqual({
+      allowed: true,
+    });
+    expect(dockerRequestPolicy("POST", "/v1.47/commit?container=abc")).toEqual({
       allowed: true,
     });
     expect(dockerRequestPolicy("POST", "/v1.47/volumes/create")).toEqual({
@@ -139,13 +146,85 @@ describe("restricted Docker API", () => {
     expect(upstreamRequests).toBe(1);
   });
 
-  test("forwards the Docker attach protocol upgrade", async () => {
+  test("rewrites validated workspace binds to the nosymfollow view", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-docker-workspace-view-"));
+    const workspaceRoot = join(dir, "work");
+    const workspaceView = join(dir, "trusted-work");
+    const source = join(workspaceRoot, "repo");
+    const outside = join(dir, "outside");
+    await mkdir(source, { recursive: true });
+    await mkdir(workspaceView);
+    await mkdir(outside);
+    await symlink(outside, join(workspaceRoot, "escape"));
+    const upstreamSocket = join(dir, "upstream.sock");
+    const publicSocket = join(dir, "public.sock");
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const upstream = http.createServer(async (request, response) => {
+      let body = "";
+      for await (const chunk of request) body += chunk.toString();
+      upstreamBodies.push(JSON.parse(body));
+      response.writeHead(201, { "content-type": "application/json" });
+      response.end("{}");
+    });
+    await listen(upstream, upstreamSocket);
+    const proxy = await startDockerProxy({
+      publicSocket,
+      upstreamSocket,
+      workspaceRoot,
+      workspaceView,
+    });
+    cleanup.push(async () => {
+      await close(proxy);
+      await close(upstream);
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const accepted = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: {
+        Binds: [`${source}:/repo:ro`],
+        Mounts: [{ Type: "bind", Source: source, Target: "/repo-again" }],
+      },
+    });
+    expect(accepted.status).toBe(201);
+    expect(upstreamBodies).toEqual([
+      {
+        Image: "facility-security-smoke:local",
+        HostConfig: {
+          Binds: [`${workspaceView}/repo:/repo:ro`],
+          Mounts: [{ Type: "bind", Source: `${workspaceView}/repo`, Target: "/repo-again" }],
+        },
+      },
+    ]);
+
+    const denied = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: { Binds: [`${workspaceRoot}/escape:/host:ro`] },
+    });
+    expect(denied.status).toBe(403);
+    expect(denied.body).toContain("host_bind_source_escape_denied");
+    expect(upstreamBodies).toHaveLength(1);
+  });
+
+  test("forwards a Docker exec upgrade body before waiting for 101", async () => {
     const dir = await mkdtemp(join(tmpdir(), "facility-docker-upgrade-"));
     const upstreamSocket = join(dir, "upstream.sock");
     const publicSocket = join(dir, "public.sock");
-    const upstream = http.createServer();
-    upstream.on("upgrade", (_request, socket) => {
-      socket.end("HTTP/1.1 101 UPGRADED\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\nready");
+    const execBody = JSON.stringify({ Detach: false, Tty: false });
+    const upstream = net.createServer((socket) => {
+      let received = Buffer.alloc(0);
+      socket.on("data", (chunk) => {
+        received = Buffer.concat([received, chunk]);
+        const headersEnd = received.indexOf("\r\n\r\n");
+        if (headersEnd < 0) return;
+        const headers = received.subarray(0, headersEnd).toString();
+        const contentLength = Number(/content-length:\s*(\d+)/i.exec(headers)?.[1] ?? "0");
+        const body = received.subarray(headersEnd + 4);
+        if (body.length < contentLength) return;
+        expect(headers).toContain("POST /v1.47/exec/abc/start HTTP/1.1");
+        expect(body.subarray(0, contentLength).toString()).toBe(execBody);
+        socket.end("HTTP/1.1 101 UPGRADED\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\nready");
+      });
     });
     await listen(upstream, upstreamSocket);
     const proxy = await startDockerProxy({ publicSocket, upstreamSocket });
@@ -155,9 +234,7 @@ describe("restricted Docker API", () => {
       await rm(dir, { recursive: true, force: true });
     });
 
-    await expect(upgrade(publicSocket, "/v1.47/containers/abc/attach?stream=1")).resolves.toBe(
-      "ready",
-    );
+    await expect(upgrade(publicSocket, "/v1.47/exec/abc/start", execBody)).resolves.toBe("ready");
   });
 });
 
@@ -166,14 +243,14 @@ test("the CodeBuild runner uses a different identity for untrusted commands", ()
   expect(untrustedSpawnIdentity(() => 501)).toEqual({});
 });
 
-function listen(server: http.Server, socket: string) {
+function listen(server: http.Server | net.Server, socket: string) {
   return new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(socket, resolve);
   });
 }
 
-function close(server: http.Server) {
+function close(server: http.Server | net.Server) {
   return new Promise<void>((resolve, reject) =>
     server.close((error) => (error ? reject(error) : resolve())),
   );
@@ -202,13 +279,18 @@ function request(socketPath: string, path: string, body: Record<string, unknown>
   });
 }
 
-function upgrade(socketPath: string, path: string) {
+function upgrade(socketPath: string, path: string, body: string) {
   return new Promise<string>((resolve, reject) => {
     const req = http.request({
       socketPath,
       method: "POST",
       path,
-      headers: { connection: "Upgrade", upgrade: "tcp" },
+      headers: {
+        connection: "Upgrade",
+        upgrade: "tcp",
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(body),
+      },
     });
     req.on("upgrade", (_response, socket, head) => {
       let body = head.toString();
@@ -223,6 +305,6 @@ function upgrade(socketPath: string, path: string) {
       });
     });
     req.on("error", reject);
-    req.end();
+    req.end(body);
   });
 }

--- a/runner/test/github-delivery.integration.test.ts
+++ b/runner/test/github-delivery.integration.test.ts
@@ -254,6 +254,7 @@ function runBundle(cloneUrl: string, overrides: Partial<RunBundle> = {}): RunBun
     engineConfig: {},
     repo: { cloneUrl, branch: "main", installationTokenRef: null },
     harness: null,
+    packageInstallCmd: null,
     provisionCmd: null,
     checkCmds: [],
     gatewayUrls: { anthropic: "https://anthropic.test", openai: "https://openai.test" },

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -8,10 +8,13 @@ import {
   buildCodexArgs,
   composedPrompt,
   deliveryReleaseImpact,
+  engineEnv,
   exitCode,
   handleControlMessage,
   parseGitNameStatus,
   prepareWorkspace,
+  privateRegistryInstallCommand,
+  privateRegistryNpmrc,
   publishVerifiedGithubBranchUpdate,
   publishVerifiedGithubChanges,
   readAgentDeliveryMetadata,
@@ -19,6 +22,7 @@ import {
   readAgentUpdateMetadata,
   readSecurityReport,
   requiresAgentProgress,
+  runPackageInstall,
   semanticDeliveryBranch,
   terminateChild,
 } from "../src/index.js";
@@ -34,6 +38,7 @@ function bundle(overrides: Partial<RunBundle> = {}): RunBundle {
     engineConfig: {},
     repo: { cloneUrl: null, branch: null, installationTokenRef: null },
     harness: null,
+    packageInstallCmd: null,
     provisionCmd: null,
     checkCmds: [],
     gatewayUrls: { anthropic: "https://anthropic.test", openai: "https://openai.test" },
@@ -44,6 +49,126 @@ function bundle(overrides: Partial<RunBundle> = {}): RunBundle {
 }
 
 describe("workspace preparation", () => {
+  it("never exposes package registry credentials to the engine environment", () => {
+    const original = process.env.NODE_AUTH_TOKEN;
+    const originalUpperConfig = process.env.NPM_CONFIG_USERCONFIG;
+    const originalLowerConfig = process.env.npm_config_userconfig;
+    process.env.NODE_AUTH_TOKEN = "package-token-for-test";
+    process.env.NPM_CONFIG_USERCONFIG = "/tmp/facility-upper-npmrc";
+    process.env.npm_config_userconfig = "/tmp/facility-lower-npmrc";
+    try {
+      expect(engineEnv().NODE_AUTH_TOKEN).toBeUndefined();
+      expect(engineEnv().NPM_CONFIG_USERCONFIG).toBeUndefined();
+      expect(engineEnv().npm_config_userconfig).toBeUndefined();
+    } finally {
+      if (original === undefined) delete process.env.NODE_AUTH_TOKEN;
+      else process.env.NODE_AUTH_TOKEN = original;
+      if (originalUpperConfig === undefined) delete process.env.NPM_CONFIG_USERCONFIG;
+      else process.env.NPM_CONFIG_USERCONFIG = originalUpperConfig;
+      if (originalLowerConfig === undefined) delete process.env.npm_config_userconfig;
+      else process.env.npm_config_userconfig = originalLowerConfig;
+    }
+  });
+
+  it("limits private registry credentials to deterministic install commands", () => {
+    expect(privateRegistryInstallCommand("pnpm install --frozen-lockfile")).toBe(true);
+    expect(privateRegistryInstallCommand("npm ci")).toBe(true);
+    expect(privateRegistryInstallCommand("pnpm install && curl example.com")).toBe(false);
+  });
+
+  it("creates a user-level npm config for the private package install only", () => {
+    expect(privateRegistryNpmrc("github-package-token")).toBe(
+      "//npm.pkg.github.com/:_authToken=github-package-token\n",
+    );
+    expect(() => privateRegistryNpmrc("token\nmalicious=true")).toThrow(
+      "package_registry_token_invalid",
+    );
+  });
+
+  it("scopes the package token to the install child and removes the npmrc", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-package-install-"));
+    const capturePath = join(root, "captured.json");
+    const npmrcPath = join(root, "install.npmrc");
+    const script = [
+      "const fs=require('node:fs')",
+      `const npmrc=process.env.NPM_CONFIG_USERCONFIG`,
+      `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({token:process.env.NODE_AUTH_TOKEN,npmrc,contents:fs.readFileSync(npmrc,'utf8'),mode:fs.statSync(npmrc).mode & 0o777}))`,
+    ].join(";");
+
+    await expect(
+      runPackageInstall(
+        `node -e ${JSON.stringify(script)}`,
+        root,
+        1,
+        "github-package-token",
+        npmrcPath,
+      ),
+    ).resolves.toBe(0);
+    await expect(readFile(capturePath, "utf8").then(JSON.parse)).resolves.toEqual({
+      token: "github-package-token",
+      npmrc: npmrcPath,
+      contents: "//npm.pkg.github.com/:_authToken=github-package-token\n",
+      mode: 0o600,
+    });
+    await expect(readFile(npmrcPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the private npmrc after an install failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-package-install-failure-"));
+    const npmrcPath = join(root, "install.npmrc");
+    await expect(
+      runPackageInstall("node -e 'process.exit(7)'", root, 1, "github-package-token", npmrcPath),
+    ).resolves.toBe(7);
+    await expect(readFile(npmrcPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves repository-owned skills when Facility has the same skill name", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-runner-"));
+    const source = await mkdtemp(join(tmpdir(), "facility-repo-"));
+    await mkdir(join(source, ".claude", "skills", "team-practice"), { recursive: true });
+    await writeFile(
+      join(source, ".claude", "skills", "team-practice", "SKILL.md"),
+      "# Repository-owned practice\n",
+    );
+    execFileSync("git", ["init", "--initial-branch=main"], { cwd: source });
+    execFileSync("git", ["add", "."], { cwd: source });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Facility Test",
+        "-c",
+        "user.email=test@facility.local",
+        "commit",
+        "-m",
+        "test: seed",
+      ],
+      { cwd: source },
+    );
+
+    await prepareWorkspace(
+      bundle({
+        repo: { cloneUrl: `file://${source}`, branch: "main", installationTokenRef: null },
+        skills: [{ name: "team-practice", content: "# Facility catalog practice" }],
+      }),
+      "virtual-key",
+      {
+        platformKey: null,
+        platformApiUrl: "https://api.test",
+        projectId: "proj_test",
+        repoToken: null,
+      },
+      root,
+    );
+
+    await expect(
+      readFile(join(root, "repo", ".claude", "skills", "team-practice", "SKILL.md"), "utf8"),
+    ).resolves.toBe("# Repository-owned practice\n");
+    await expect(
+      readFile(join(root, "repo", ".agents", "skills", "team-practice", "SKILL.md"), "utf8"),
+    ).resolves.toContain("Facility catalog practice");
+  });
+
   it("keeps runner release classification aligned with the root policy", async () => {
     const rootPolicy = (await import(
       new URL("../../scripts/conventional-commit-subjects.mjs", import.meta.url).href

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.112.5",
+    "@aws-sdk/client-codebuild": "3.1079.0",
     "@aws-sdk/client-cloudwatch-logs": "3.1079.0",
     "@aws-sdk/client-ecs": "3.1079.0",
     "@facility/core": "workspace:*",
@@ -46,7 +47,7 @@
     "pg-boss": "^10.3.2",
     "pino": "^10.1.0",
     "postgres": "^3.4.7",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "uuidv7": "^1.0.2",
     "zod": "^4.1.13"
   },

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -36,7 +36,7 @@ const EnvSchema = z
     // seeded default sandbox profile and `facility doctor` both key off this.
     FACILITY_RUNNER_IMAGE: z.string().default("facility-runner:dev"),
     // Driver the seeded default sandbox profile uses. Must match the deployment:
-    // "docker" for local/self-host, "aws" for the Fargate stack.
+    // "docker" for local/self-host, "aws" for the CodeBuild stack.
     FACILITY_SANDBOX_DRIVER: z.enum(["docker", "aws"]).default("docker"),
     AUTH_IDENTITY_PROVIDER: z.enum(["github", "oidc"]).default("github"),
     AUTH_CALLBACK_URL: OptionalUrl,
@@ -62,6 +62,7 @@ const EnvSchema = z
     S3_SECRET_KEY: z.string().optional(),
     S3_BUCKET: z.string().optional(),
     AWS_REGION: z.string().optional(),
+    PACKAGE_REGISTRY_TOKEN: z.string().trim().min(1).optional(),
     GITHUB_APP_ID: z.string().optional(),
     GITHUB_APP_PRIVATE_KEY: z.string().optional(),
     GITHUB_APP_WEBHOOK_SECRET: z.string().optional(),
@@ -157,6 +158,7 @@ export function readConfig(env = process.env): AppConfig {
     s3SecretKey: parsed.S3_SECRET_KEY,
     s3Bucket: parsed.S3_BUCKET,
     awsRegion: parsed.AWS_REGION,
+    packageRegistryToken: parsed.PACKAGE_REGISTRY_TOKEN,
     githubAppId: parsed.GITHUB_APP_ID,
     githubAppPrivateKey: parsed.GITHUB_APP_PRIVATE_KEY?.replace(/\\n/g, "\n"),
     githubAppWebhookSecret: parsed.GITHUB_APP_WEBHOOK_SECRET,

--- a/services/api/src/doctor.ts
+++ b/services/api/src/doctor.ts
@@ -299,16 +299,14 @@ async function checkSandboxRunner(db: Db, config: AppConfig, orgId: string): Pro
       );
     }
     // A profile can run a platform-lane agent only if its driver matches the
-    // deployment (a docker profile can't launch on the AWS/Fargate stack, and
-    // vice versa) AND — for the docker driver — its image ships the runner. The
-    // aws driver runs a pre-built runner task definition, so its image text is
-    // not the gate there.
+    // deployment and its image ships the runner. Docker launches the profile
+    // image directly; CodeBuild receives it as imageOverride for each build.
     const runnerImage = config.sandboxRunnerImage;
     const driver = config.sandboxDriver;
     const canRunRunner = profiles.some(
       (profile) =>
         profile.driver === driver &&
-        (driver === "aws" || profile.image === runnerImage || /runner/i.test(profile.image)),
+        (profile.image === runnerImage || /runner/i.test(profile.image)),
     );
     if (!canRunRunner) {
       // Fail (not warn): platform-lane execution is the platform's primary

--- a/services/api/src/github/kickstart.ts
+++ b/services/api/src/github/kickstart.ts
@@ -12,20 +12,33 @@ import {
   type FacilityDb,
   githubInstallations,
   insertAuditEvent,
-  projects,
   proposals,
   repos,
 } from "@facility/db";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { ApiError } from "../errors.js";
 import type { AppConfig, Principal } from "../types.js";
 import { raisePlatformIssue } from "../watchtower/issues.js";
 import { FacilityGithubClient, type GithubClientFactory, type TreeItem } from "./client.js";
-import { readRepoFiles } from "./repo-files.js";
+import { decodeContent, readRepoFiles } from "./repo-files.js";
 
 export type KickstartAnswers = RenderAnswers;
 
 export type RepoRow = typeof repos.$inferSelect;
+
+export type FacilityRepoManifest = {
+  packageInstall?: string | null;
+  provision?: string | null;
+  checks?: string[];
+  models?: {
+    build?: string;
+    review?: string;
+    plan?: string;
+    codexBuild?: string;
+    codexPlan?: string;
+  };
+  executionLane?: Record<string, "repo" | "platform">;
+};
 
 const MANAGED_FACILITY_PATHS = [
   ".facility.json",
@@ -90,6 +103,146 @@ export async function createGithubClientForRepo(
     repo: repo.name,
     defaultBranch: repo.defaultBranch,
   });
+}
+
+export function parseFacilityRepoManifest(content: string): FacilityRepoManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new ApiError(400, "facility_manifest_invalid", ".facility.json is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ApiError(400, "facility_manifest_invalid", ".facility.json must be an object");
+  }
+  const value = parsed as Record<string, unknown>;
+  const optionalCommand = (key: string) => {
+    const command = value[key];
+    if (command === undefined || command === null) return command;
+    if (typeof command !== "string" || !command.trim()) {
+      throw new ApiError(
+        400,
+        "facility_manifest_invalid",
+        `${key} must be a command string or null`,
+      );
+    }
+    return command;
+  };
+  let checks: string[] | undefined;
+  if (value.checks !== undefined) {
+    if (!Array.isArray(value.checks) || !value.checks.every((item) => typeof item === "string")) {
+      throw new ApiError(400, "facility_manifest_invalid", "checks must be an array of commands");
+    }
+    checks = value.checks as string[];
+  }
+  let executionLane: Record<string, "repo" | "platform"> | undefined;
+  if (value.executionLane !== undefined) {
+    if (
+      !value.executionLane ||
+      typeof value.executionLane !== "object" ||
+      Array.isArray(value.executionLane) ||
+      !Object.values(value.executionLane).every((lane) => lane === "repo" || lane === "platform")
+    ) {
+      throw new ApiError(
+        400,
+        "facility_manifest_invalid",
+        "executionLane values must be repo or platform",
+      );
+    }
+    executionLane = value.executionLane as Record<string, "repo" | "platform">;
+  }
+  const modelValue = value.models;
+  const models =
+    modelValue && typeof modelValue === "object" && !Array.isArray(modelValue)
+      ? Object.fromEntries(
+          Object.entries(modelValue).filter(
+            ([key, model]) =>
+              ["build", "review", "plan", "codexBuild", "codexPlan"].includes(key) &&
+              typeof model === "string" &&
+              model.trim(),
+          ),
+        )
+      : undefined;
+  return {
+    packageInstall: optionalCommand("packageInstall"),
+    provision: optionalCommand("provision"),
+    checks,
+    models,
+    executionLane,
+  };
+}
+
+export async function syncRepoFacilityConfig(args: {
+  db: FacilityDb;
+  factory?: GithubClientFactory;
+  client?: FacilityGithubClient;
+  repo: RepoRow;
+}) {
+  const client =
+    args.client ??
+    (args.factory ? await createGithubClientForRepo(args.db, args.factory, args.repo) : undefined);
+  if (!client) throw new Error("syncRepoFacilityConfig requires a GitHub client or factory");
+  const current =
+    args.repo.renderAnswers &&
+    typeof args.repo.renderAnswers === "object" &&
+    !Array.isArray(args.repo.renderAnswers)
+      ? (args.repo.renderAnswers as Record<string, unknown>)
+      : {};
+  const content = await readFacilityManifest(client, args.repo.defaultBranch);
+  if (!content) {
+    // Removing the manifest is an explicit opt-out. Clear every repo-owned
+    // runtime override so stale state cannot keep routing or configuring runs.
+    const renderAnswers = clearManifestOverrides(current);
+    await args.db
+      .update(repos)
+      .set({ renderAnswers, updatedAt: new Date() })
+      .where(and(eq(repos.orgId, args.repo.orgId), eq(repos.id, args.repo.id)));
+    return renderAnswers;
+  }
+  const manifest = parseFacilityRepoManifest(content);
+  const renderAnswers = {
+    ...current,
+    packageInstallCmd: manifest.packageInstall ?? null,
+    provisionCmd: manifest.provision ?? null,
+    checkCmds: manifest.checks ?? [],
+    models: manifest.models ?? {},
+    execution_lane: manifest.executionLane ?? {},
+  };
+  await args.db
+    .update(repos)
+    .set({ renderAnswers, updatedAt: new Date() })
+    .where(and(eq(repos.orgId, args.repo.orgId), eq(repos.id, args.repo.id)));
+  return renderAnswers;
+}
+
+function clearManifestOverrides(current: Record<string, unknown>) {
+  return {
+    ...current,
+    packageInstallCmd: null,
+    provisionCmd: null,
+    checkCmds: [],
+    models: {},
+    execution_lane: {},
+  };
+}
+
+async function readFacilityManifest(client: FacilityGithubClient, ref: string) {
+  try {
+    const value = (await client.getContent(".facility.json", ref)) as {
+      type?: string;
+      content?: string;
+      encoding?: string;
+    };
+    if (Array.isArray(value) || value.type !== "file" || typeof value.content !== "string") {
+      return null;
+    }
+    return decodeContent(value.content, value.encoding);
+  } catch (error) {
+    // Absence is a valid, fail-closed repo-lane configuration. Permission and
+    // network failures are not absence and must remain retryable/loud.
+    if ((error as { status?: number }).status === 404) return null;
+    throw error;
+  }
 }
 
 export async function kickstartPreview(
@@ -178,18 +331,6 @@ export async function kickstartRepo(args: {
       updatedAt: new Date(),
     })
     .where(eq(repos.id, args.repo.id));
-  // Persist the resolved acceptance gates into the project's settings too, so the
-  // PLATFORM lane runs them (the runner reads projects.settings.check_cmds as its
-  // fallback). Without this, only the repo lane's vendored workflows would carry
-  // the detected checks and a platform-lane run would have zero gates. Merge with
-  // `||` to preserve default_branch and any other settings keys.
-  await args.db
-    .update(projects)
-    .set({
-      settings: sql`${projects.settings} || ${JSON.stringify({ check_cmds: renderAnswers.checkCmds ?? [] })}::jsonb`,
-      updatedAt: new Date(),
-    })
-    .where(and(eq(projects.orgId, args.repo.orgId), eq(projects.id, args.projectId)));
   await createKickstartProposal(
     args.db,
     args.repo.orgId,

--- a/services/api/src/github/processor.ts
+++ b/services/api/src/github/processor.ts
@@ -25,8 +25,8 @@ import {
   syncRepoIssues,
   upsertGhIssueFromWebhook,
 } from "./issues-sync.js";
-import { verifyFingerprints } from "./kickstart.js";
-import { routeTrigger, type TriggerPayload } from "./router.js";
+import { syncRepoFacilityConfig, verifyFingerprints } from "./kickstart.js";
+import { laneFor, routeTrigger, type TriggerPayload } from "./router.js";
 import { renderGithubRunProgress } from "./run-progress.js";
 
 type WebhookPayload = TriggerPayload & {
@@ -98,7 +98,7 @@ export async function processGithubWebhook(
     if (event.eventType === "installation" || event.eventType === "installation_repositories") {
       await processInstallation(db, event.orgId, payload, enqueue);
     } else if (event.eventType === "push") {
-      await processPush(db, event.orgId, payload, enqueue);
+      await processPush(db, event.orgId, payload, config, factory, enqueue);
     } else if (event.eventType === "issues") {
       await upsertGhIssueFromWebhook(db, event.orgId, payload);
       await processTrigger(
@@ -241,6 +241,8 @@ async function processPush(
   db: FacilityDb,
   orgId: string,
   payload: WebhookPayload,
+  config: AppConfig,
+  factory?: GithubClientFactory,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
 ) {
   const owner = payload.repository?.owner?.login;
@@ -272,6 +274,13 @@ async function processPush(
       (file) => file.path,
     ),
   );
+  if (changed.has(".facility.json")) {
+    await syncRepoFacilityConfig({
+      db,
+      factory: factory ?? createGithubClientFactory(config),
+      repo,
+    });
+  }
   if ([...changed].some((path) => managed.has(path))) {
     await enqueue?.("fingerprints.verify", { repoId: repo.id });
   }
@@ -504,6 +513,10 @@ async function processGithubAgentEvent(
     githubEventMatches(candidate.triggers, eventType, payload),
   );
   if (!agent) return;
+  // Event-driven repository agents are opt-in just like slash commands. The
+  // legacy/default lane is repo, so connecting an existing repository never
+  // silently starts a weaker duplicate reviewer or repair agent.
+  if (laneFor(repo, agent.name) !== "platform") return;
   const pullRequest = pullRequestContext(eventType, payload);
   const pullNumber = pullRequest.number;
   const branch = pullRequest.head;

--- a/services/api/src/github/router.ts
+++ b/services/api/src/github/router.ts
@@ -12,12 +12,19 @@ import {
 } from "@facility/db";
 import { and, desc, eq, gt, sql } from "drizzle-orm";
 import type { FacilityGithubClient } from "./client.js";
+import { syncRepoFacilityConfig } from "./kickstart.js";
 import { renderGithubRunProgress } from "./run-progress.js";
 
 export type TriggerPayload = {
   action?: string;
   comment?: { id?: number; body?: string };
-  issue?: { number?: number; title?: string; body?: string | null; pull_request?: unknown };
+  issue?: {
+    number?: number;
+    title?: string;
+    body?: string | null;
+    node_id?: string;
+    pull_request?: unknown;
+  };
   repository?: { id?: number; name?: string; owner?: { login?: string }; default_branch?: string };
   sender?: { login?: string; type?: string };
 };
@@ -45,7 +52,14 @@ export async function routeTrigger(
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
 ): Promise<{ routed: boolean; reason?: string; runId?: string }> {
   if (payload.sender?.type === "Bot") return { routed: false, reason: "bot_sender" };
-  const body = payload.comment?.body ?? "";
+  if (payload.comment && payload.action && payload.action !== "created") {
+    return { routed: false, reason: "unsupported_action" };
+  }
+  if (!payload.comment && payload.action && payload.action !== "opened") {
+    return { routed: false, reason: "unsupported_action" };
+  }
+  const body =
+    payload.comment?.body ?? [payload.issue?.title ?? "", payload.issue?.body ?? ""].join("\n");
   const resolved = resolveSlashCommand(body);
   if (resolved.ambiguous) return { routed: false, reason: "ambiguous_command" };
   const command = resolved.command;
@@ -55,8 +69,14 @@ export async function routeTrigger(
   const sender = payload.sender?.login;
   const issueNumber = payload.issue?.number;
   const commentId = payload.comment?.id;
-  if (!owner || !name || !sender || !issueNumber || !commentId) {
+  if (!owner || !name || !sender || !issueNumber) {
     return { routed: false, reason: "missing_payload" };
+  }
+  // Updating an existing PR requires a distinct delivery contract (checkout its
+  // head and update it instead of opening another PR). Keep those invocations on
+  // the repository lane until that contract is implemented and verified.
+  if (payload.issue?.pull_request) {
+    return { routed: false, reason: "pull_request_repo_lane" };
   }
   // Scope to the webhook's resolved org — repos are per-org unique (migration
   // 0012), so a global owner/name lookup could route to another tenant's repo.
@@ -69,7 +89,12 @@ export async function routeTrigger(
   )[0];
   if (!repo) return { routed: false, reason: "repo_unmanaged" };
   if (!(await client.userCanWrite(sender))) return { routed: false, reason: "non_writer" };
-  const lane = laneFor(repo, command);
+  // Reconcile from the default branch at handoff time, not only from an earlier
+  // push delivery. This closes the merge/webhook race where the repository
+  // workflow has already yielded to Facility but the database still has the
+  // previous lane configuration.
+  const renderAnswers = await syncRepoFacilityConfig({ db, client, repo });
+  const lane = laneFor({ ...repo, renderAnswers }, resolved.agentCommand ?? command);
   if (lane !== "platform") return { routed: false, reason: "repo_lane" };
   const agent = await findAgentDef(
     db,
@@ -95,7 +120,7 @@ export async function routeTrigger(
     type: "github_comment",
     repo: { id: repo.id, owner, name },
     issue: { number: issueNumber },
-    comment: { id: commentId },
+    ...(commentId ? { comment: { id: commentId } } : {}),
     // Preserve the end-user request in the immutable run scope. The runner
     // treats scope as untrusted data beneath the agent contract, but without
     // this context an agent only received numeric GitHub IDs and could not know
@@ -141,10 +166,16 @@ export async function routeTrigger(
                 architectRunId: accepted.architectRun.id,
                 architectTrigger: accepted.architectRun.trigger,
                 approvedPlan: accepted.proposal.contextMd,
-                approval: { type: "github", login: sender, commentId },
+                approval: { type: "github", login: sender, commentId: commentId ?? null },
               }
             : githubTrigger,
-          gh: { owner, repo: name, issueNumber, commentId },
+          gh: {
+            owner,
+            repo: name,
+            issueNumber,
+            ...(commentId ? { commentId } : {}),
+            ...(payload.issue?.node_id ? { issueNodeId: payload.issue.node_id } : {}),
+          },
           createdBy: { type: "github", login: sender },
         })
         .returning()

--- a/services/api/src/previews.ts
+++ b/services/api/src/previews.ts
@@ -2,7 +2,7 @@ import { newId } from "@facility/core";
 import { createDb, insertAuditEvent, previewSandboxes } from "@facility/db";
 import { and, eq, inArray, lt } from "drizzle-orm";
 import { request as upstreamRequest } from "undici";
-import { type SandboxDriver, sandboxDriver } from "./sandbox/driver.js";
+import { previewSandboxDriver, type SandboxDriver } from "./sandbox/driver.js";
 import type { AppConfig, Principal } from "./types.js";
 
 type Db = ReturnType<typeof createDb>["db"];
@@ -100,7 +100,7 @@ export async function provisionPreview(
     )[0];
     if (preview?.status !== "provisioning" || preview.ref) return preview;
     const spec = previewConfig(preview.config);
-    const driver = driverOverride ?? (await sandboxDriver(config.sandboxDriver));
+    const driver = driverOverride ?? (await previewSandboxDriver(config.sandboxDriver));
     await db
       .update(previewSandboxes)
       .set({ driver: driver.name, updatedAt: new Date() })
@@ -179,7 +179,8 @@ export async function destroyPreview(
   driverOverride?: SandboxDriver,
 ) {
   if (!["destroyed", "expired"].includes(preview.status) && preview.ref) {
-    const driver = driverOverride ?? (await sandboxDriver(preview.driver as "docker" | "aws"));
+    const driver =
+      driverOverride ?? (await previewSandboxDriver(preview.driver as "docker" | "aws"));
     try {
       await driver.destroy(preview.ref);
     } catch (error) {
@@ -253,7 +254,7 @@ export async function reconcilePreviews(config: AppConfig) {
       .where(inArray(previewSandboxes.status, ["provisioning", "running"]));
     for (const preview of active) {
       if (!preview.ref) continue;
-      const driver = await sandboxDriver(preview.driver as "docker" | "aws");
+      const driver = await previewSandboxDriver(preview.driver as "docker" | "aws");
       const state = await driver.status(preview.ref);
       const spec = previewConfig(preview.config);
       const ready =

--- a/services/api/src/previews.ts
+++ b/services/api/src/previews.ts
@@ -270,11 +270,44 @@ export async function reconcilePreviews(config: AppConfig) {
           .where(eq(previewSandboxes.id, preview.id));
         changed.push(preview.id);
       } else if (state === "exited" || state === "lost") {
+        let cleanupError: string | null = null;
+        try {
+          await driver.destroy(preview.ref);
+        } catch (error) {
+          cleanupError = error instanceof Error ? error.message : String(error);
+        }
         await db
           .update(previewSandboxes)
-          .set({ status: "failed", error: `preview_${state}`, updatedAt: new Date() })
+          .set({
+            status: "failed",
+            error: `preview_${state}${cleanupError ? `;cleanup_failed:${cleanupError}` : ""}`,
+            ...(cleanupError ? {} : { ref: null }),
+            updatedAt: new Date(),
+          })
           .where(eq(previewSandboxes.id, preview.id));
         changed.push(preview.id);
+      }
+    }
+    // A transient ECS/Docker failure must not make a failed preview immortal.
+    // Retain its ref on failure and retry cleanup on each reconciliation pass;
+    // clear it only after the task/container and its per-preview definition are
+    // gone.
+    const failedWithRefs = await db
+      .select()
+      .from(previewSandboxes)
+      .where(eq(previewSandboxes.status, "failed"));
+    for (const preview of failedWithRefs) {
+      if (!preview.ref) continue;
+      const driver = await previewSandboxDriver(preview.driver as "docker" | "aws");
+      try {
+        await driver.destroy(preview.ref);
+        await db
+          .update(previewSandboxes)
+          .set({ ref: null, updatedAt: new Date() })
+          .where(eq(previewSandboxes.id, preview.id));
+        changed.push(preview.id);
+      } catch {
+        // Keep the ref for the next bounded worker reconciliation.
       }
     }
     return { changed };

--- a/services/api/src/previews.ts
+++ b/services/api/src/previews.ts
@@ -2,7 +2,7 @@ import { newId } from "@facility/core";
 import { createDb, insertAuditEvent, previewSandboxes } from "@facility/db";
 import { and, eq, inArray, lt } from "drizzle-orm";
 import { request as upstreamRequest } from "undici";
-import { previewSandboxDriver, type SandboxDriver } from "./sandbox/driver.js";
+import { previewSandboxDriver, type SandboxDriver, SandboxLaunchError } from "./sandbox/driver.js";
 import type { AppConfig, Principal } from "./types.js";
 
 type Db = ReturnType<typeof createDb>["db"];
@@ -105,6 +105,7 @@ export async function provisionPreview(
       .update(previewSandboxes)
       .set({ driver: driver.name, updatedAt: new Date() })
       .where(eq(previewSandboxes.id, preview.id));
+    let launchedRef: string | undefined;
     try {
       const launched = await driver.launch({
         runId: `preview:${preview.id}`,
@@ -117,8 +118,26 @@ export async function provisionPreview(
         network: { egress: "unrestricted" },
         servicePort: spec.port,
       });
+      launchedRef = launched.ref;
+      await db
+        .update(previewSandboxes)
+        .set({ driver: driver.name, ref: launched.ref, updatedAt: new Date() })
+        .where(eq(previewSandboxes.id, preview.id));
       if (!launched.endpoint || !allowedOrigin(launched.endpoint, driver.name)) {
-        await driver.destroy(launched.ref).catch(() => undefined);
+        try {
+          await driver.destroy(launched.ref);
+          await db
+            .update(previewSandboxes)
+            .set({ ref: null, updatedAt: new Date() })
+            .where(eq(previewSandboxes.id, preview.id));
+          launchedRef = undefined;
+        } catch (cleanupError) {
+          throw new SandboxLaunchError(
+            "preview_driver_did_not_return_a_private_endpoint_and_cleanup_failed",
+            launched.ref,
+            { cause: cleanupError },
+          );
+        }
         throw new Error("preview_driver_did_not_return_a_private_endpoint");
       }
       const state = await driver.status(launched.ref);
@@ -153,9 +172,15 @@ export async function provisionPreview(
       return updated;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const retryRef = error instanceof SandboxLaunchError ? error.ref : launchedRef;
       await db
         .update(previewSandboxes)
-        .set({ status: "failed", error: message, updatedAt: new Date() })
+        .set({
+          status: "failed",
+          error: message,
+          ...(retryRef ? { ref: retryRef } : {}),
+          updatedAt: new Date(),
+        })
         .where(eq(previewSandboxes.id, preview.id));
       await insertAuditEvent(db, {
         orgId: preview.orgId,
@@ -203,7 +228,7 @@ export async function destroyPreview(
   const updated = (
     await db
       .update(previewSandboxes)
-      .set({ status, originUrl: null, updatedAt: new Date() })
+      .set({ status, ref: null, originUrl: null, updatedAt: new Date() })
       .where(and(eq(previewSandboxes.orgId, preview.orgId), eq(previewSandboxes.id, preview.id)))
       .returning()
   )[0];
@@ -231,7 +256,7 @@ export async function destroyPreviewById(config: AppConfig, previewId: string) {
   }
 }
 
-export async function reconcilePreviews(config: AppConfig) {
+export async function reconcilePreviews(config: AppConfig, driverOverride?: SandboxDriver) {
   const { db, client } = createDb(config.databaseUrl);
   const changed: string[] = [];
   try {
@@ -245,7 +270,7 @@ export async function reconcilePreviews(config: AppConfig) {
         ),
       );
     for (const preview of expired) {
-      await destroyPreview(db, preview, "expired");
+      await destroyPreview(db, preview, "expired", driverOverride);
       changed.push(preview.id);
     }
     const active = await db
@@ -254,7 +279,8 @@ export async function reconcilePreviews(config: AppConfig) {
       .where(inArray(previewSandboxes.status, ["provisioning", "running"]));
     for (const preview of active) {
       if (!preview.ref) continue;
-      const driver = await previewSandboxDriver(preview.driver as "docker" | "aws");
+      const driver =
+        driverOverride ?? (await previewSandboxDriver(preview.driver as "docker" | "aws"));
       const state = await driver.status(preview.ref);
       const spec = previewConfig(preview.config);
       const ready =
@@ -298,7 +324,8 @@ export async function reconcilePreviews(config: AppConfig) {
       .where(eq(previewSandboxes.status, "failed"));
     for (const preview of failedWithRefs) {
       if (!preview.ref) continue;
-      const driver = await previewSandboxDriver(preview.driver as "docker" | "aws");
+      const driver =
+        driverOverride ?? (await previewSandboxDriver(preview.driver as "docker" | "aws"));
       try {
         await driver.destroy(preview.ref);
         await db

--- a/services/api/src/routes/github.ts
+++ b/services/api/src/routes/github.ts
@@ -16,6 +16,7 @@ import type { AppConfig, Principal } from "../types.js";
 const IdParams = z.object({ projectId: z.string(), repoId: z.string().optional() });
 const Answers = z.object({
   defaultBranch: z.string().optional(),
+  packageInstallCmd: z.string().optional(),
   provisionCmd: z.string().optional(),
   checkCmds: z.array(z.string()).optional(),
   modules: z.array(z.string()).optional(),

--- a/services/api/src/routes/internal.ts
+++ b/services/api/src/routes/internal.ts
@@ -1,6 +1,6 @@
 import { open, verifyKey } from "@facility/core";
 import { githubInstallations, insertAuditEvent, repos, runs, steerMessages } from "@facility/db";
-import { and, asc, eq, gt, inArray, isNull, notInArray } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, isNull } from "drizzle-orm";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import {
@@ -15,7 +15,6 @@ import {
   appendRunEvents,
   type RunSandboxState,
   readSandbox,
-  TERMINAL_RUN_STATUSES,
   terminalStatus,
 } from "../sandbox/state.js";
 import type { AppConfig } from "../types.js";
@@ -97,10 +96,14 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
           sandbox: updatedSandbox,
           updatedAt: new Date(),
         })
-        .where(and(eq(runs.id, run.id), notInArray(runs.status, [...TERMINAL_RUN_STATUSES])))
+        .where(and(eq(runs.id, run.id), eq(runs.status, "provisioning")))
         .returning({ id: runs.id });
       if (!claimed) {
-        throw new ApiError(409, "run_terminal", "Run is no longer active");
+        throw new ApiError(
+          409,
+          "run_credentials_already_released",
+          "Run credentials are no longer available",
+        );
       }
       await appendRunEvents(db, run.orgId, run.id, [{ type: "hello", data: {} }]);
       await updateGithubRunProgress(db, run.id, "running", {
@@ -123,6 +126,13 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         // a per-run GitHub App installation token; here it falls back to a
         // configured token for self-host / validation.
         repoToken: await repoTokenForRun(sandbox),
+        // Released through the same one-shot authenticated handshake as the
+        // virtual and clone keys, and only when this run has a dedicated
+        // dependency-install phase. The sandbox task itself has no IAM access
+        // to the registry secret.
+        packageRegistryToken: sandbox.bundle.packageInstallCmd
+          ? (config.packageRegistryToken ?? null)
+          : null,
         gatewayUrls: sandbox.bundle.gatewayUrls,
       };
     },

--- a/services/api/src/sandbox/aws-preview.ts
+++ b/services/api/src/sandbox/aws-preview.ts
@@ -15,7 +15,7 @@ import {
   StopTaskCommand,
   type StopTaskCommandOutput,
 } from "@aws-sdk/client-ecs";
-import type { LaunchSpec, SandboxDriver } from "./driver.js";
+import { type LaunchSpec, type SandboxDriver, SandboxLaunchError } from "./driver.js";
 
 type EcsCommand =
   | RegisterTaskDefinitionCommand
@@ -45,7 +45,7 @@ type AwsPreviewConfig = {
   cpuArchitecture: "X86_64" | "ARM64";
 };
 
-type PreviewRef = { taskArn: string; taskDefinitionArn?: string };
+type PreviewRef = { taskArn?: string; taskDefinitionArn?: string };
 
 /**
  * Preview services need a stable inbound endpoint, which CodeBuild intentionally
@@ -160,9 +160,10 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
         if (!isTaskDefinitionAlreadyGone(deregisterError)) cleanupFailure ??= deregisterError;
       }
       if (cleanupFailure) {
-        throw new AggregateError(
-          [error, cleanupFailure],
+        throw new SandboxLaunchError(
           "AWS preview launch failed and cleanup did not converge",
+          encodeRef({ taskArn, taskDefinitionArn }),
+          { cause: new AggregateError([error, cleanupFailure]) },
         );
       }
       throw error;
@@ -171,7 +172,9 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
 
   async status(ref: string): Promise<"starting" | "running" | "exited" | "lost"> {
     const config = this.config();
-    const task = await this.describe(config.cluster, decodeRef(ref).taskArn);
+    const taskArn = decodeRef(ref).taskArn;
+    if (!taskArn) return "lost";
+    const task = await this.describe(config.cluster, taskArn);
     if (!task) return "lost";
     if (["PROVISIONING", "PENDING", "ACTIVATING"].includes(task.lastStatus ?? "")) {
       return "starting";
@@ -190,6 +193,7 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
   async *logs(ref: string, afterLine = 0): AsyncIterable<string> {
     const config = this.config();
     const taskArn = decodeRef(ref).taskArn;
+    if (!taskArn) return;
     let nextToken: string | undefined;
     let lineNo = 0;
     do {
@@ -222,6 +226,7 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
   async stop(ref: string, opts: { kill?: boolean } = {}): Promise<void> {
     const config = this.config();
     const parsed = decodeRef(ref);
+    if (!parsed.taskArn) return;
     await this.ecs.send(
       new StopTaskCommand({
         cluster: config.cluster,
@@ -236,10 +241,12 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
   async destroy(ref: string): Promise<void> {
     const parsed = decodeRef(ref);
     let failure: unknown;
-    try {
-      await this.stop(ref, { kill: true });
-    } catch (error) {
-      if (!isTaskAlreadyGone(error)) failure = error;
+    if (parsed.taskArn) {
+      try {
+        await this.stop(ref, { kill: true });
+      } catch (error) {
+        if (!isTaskAlreadyGone(error)) failure = error;
+      }
     }
     try {
       if (parsed.taskDefinitionArn) await this.deregister(parsed.taskDefinitionArn);
@@ -324,7 +331,7 @@ function encodeRef(ref: PreviewRef) {
 function decodeRef(ref: string): PreviewRef {
   try {
     const parsed = JSON.parse(Buffer.from(ref, "base64url").toString("utf8")) as PreviewRef;
-    if (parsed.taskArn) return parsed;
+    if (parsed.taskArn || parsed.taskDefinitionArn) return parsed;
   } catch {
     // Legacy ECS previews stored the raw task ARN. Preserve lifecycle cleanup
     // across this deployment instead of abandoning already-running tasks.

--- a/services/api/src/sandbox/aws-preview.ts
+++ b/services/api/src/sandbox/aws-preview.ts
@@ -210,8 +210,18 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
 
   async destroy(ref: string): Promise<void> {
     const parsed = decodeRef(ref);
-    await this.stop(ref, { kill: true });
-    if (parsed.taskDefinitionArn) await this.deregister(parsed.taskDefinitionArn);
+    let failure: unknown;
+    try {
+      await this.stop(ref, { kill: true });
+    } catch (error) {
+      if (!isTaskAlreadyGone(error)) failure = error;
+    }
+    try {
+      if (parsed.taskDefinitionArn) await this.deregister(parsed.taskDefinitionArn);
+    } catch (error) {
+      if (!isTaskDefinitionAlreadyGone(error)) failure ??= error;
+    }
+    if (failure) throw failure;
   }
 
   private async waitForPrivateIp(cluster: string, taskArn: string) {
@@ -343,5 +353,27 @@ function isResourceNotFound(error: unknown) {
     error !== null &&
     ((error as { name?: string }).name === "ResourceNotFoundException" ||
       (error as { Code?: string }).Code === "ResourceNotFoundException")
+  );
+}
+
+function isTaskAlreadyGone(error: unknown) {
+  if (isResourceNotFound(error)) return true;
+  if (typeof error !== "object" || error === null) return false;
+  const name = (error as { name?: string }).name;
+  const message = (error as { message?: string }).message ?? "";
+  return (
+    (name === "ClientException" || name === "InvalidParameterException") &&
+    /task.*(?:not found|does not exist|already (?:stopped|deleted)|is not running)/i.test(message)
+  );
+}
+
+function isTaskDefinitionAlreadyGone(error: unknown) {
+  if (isResourceNotFound(error)) return true;
+  if (typeof error !== "object" || error === null) return false;
+  const name = (error as { name?: string }).name;
+  const message = (error as { message?: string }).message ?? "";
+  return (
+    (name === "ClientException" || name === "InvalidParameterException") &&
+    /task definition.*(?:not found|does not exist|already (?:deregistered|deleted))/i.test(message)
   );
 }

--- a/services/api/src/sandbox/aws-preview.ts
+++ b/services/api/src/sandbox/aws-preview.ts
@@ -1,0 +1,347 @@
+import {
+  CloudWatchLogsClient,
+  GetLogEventsCommand,
+  type GetLogEventsCommandOutput,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  DeregisterTaskDefinitionCommand,
+  DescribeTasksCommand,
+  type DescribeTasksCommandOutput,
+  ECSClient,
+  RegisterTaskDefinitionCommand,
+  type RegisterTaskDefinitionCommandOutput,
+  RunTaskCommand,
+  type RunTaskCommandOutput,
+  StopTaskCommand,
+  type StopTaskCommandOutput,
+} from "@aws-sdk/client-ecs";
+import type { LaunchSpec, SandboxDriver } from "./driver.js";
+
+type EcsCommand =
+  | RegisterTaskDefinitionCommand
+  | DeregisterTaskDefinitionCommand
+  | RunTaskCommand
+  | DescribeTasksCommand
+  | StopTaskCommand;
+type EcsOutput =
+  | RegisterTaskDefinitionCommandOutput
+  | RunTaskCommandOutput
+  | DescribeTasksCommandOutput
+  | StopTaskCommandOutput
+  | Record<string, never>;
+
+type EcsSender = { send(command: EcsCommand): Promise<EcsOutput> };
+type LogsSender = { send(command: GetLogEventsCommand): Promise<GetLogEventsCommandOutput> };
+type Sleep = (milliseconds: number) => Promise<void>;
+
+type AwsPreviewConfig = {
+  cluster: string;
+  subnets: string[];
+  securityGroups: string[];
+  family: string;
+  executionRoleArn: string;
+  taskRoleArn: string;
+  logGroup: string;
+  cpuArchitecture: "X86_64" | "ARM64";
+};
+
+type PreviewRef = { taskArn: string; taskDefinitionArn?: string };
+
+/**
+ * Preview services need a stable inbound endpoint, which CodeBuild intentionally
+ * does not expose. Keep them on isolated, unprivileged Fargate tasks while agent
+ * runs use privileged CodeBuild. Each preview gets an immutable task definition
+ * so its requested image and command are honored instead of reusing the runner.
+ */
+export class AwsPreviewSandboxDriver implements SandboxDriver {
+  readonly name = "aws" as const;
+
+  constructor(
+    private readonly ecs: EcsSender = new ECSClient({ region: process.env.AWS_REGION }),
+    private readonly cloudwatchLogs: LogsSender = new CloudWatchLogsClient({
+      region: process.env.AWS_REGION,
+    }),
+    private readonly env: NodeJS.ProcessEnv = process.env,
+    private readonly sleep: Sleep = (milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  ) {}
+
+  async launch(spec: LaunchSpec): Promise<{ ref: string; endpoint?: string }> {
+    const config = this.config();
+    if (!spec.servicePort) throw new Error("aws_preview_service_port_required");
+    const resources = fargateResources(spec.cpu, spec.memoryMb);
+    const registered = (await this.ecs.send(
+      new RegisterTaskDefinitionCommand({
+        family: config.family,
+        requiresCompatibilities: ["FARGATE"],
+        networkMode: "awsvpc",
+        cpu: resources.cpu,
+        memory: resources.memory,
+        executionRoleArn: config.executionRoleArn,
+        taskRoleArn: config.taskRoleArn,
+        runtimePlatform: {
+          cpuArchitecture: config.cpuArchitecture,
+          operatingSystemFamily: "LINUX",
+        },
+        containerDefinitions: [
+          {
+            name: "preview",
+            image: spec.image,
+            essential: true,
+            ...(spec.cmd ? { command: spec.cmd } : {}),
+            environment: Object.entries(spec.env)
+              .sort(([left], [right]) => left.localeCompare(right))
+              .map(([name, value]) => ({ name, value })),
+            portMappings: [{ containerPort: spec.servicePort, protocol: "tcp" }],
+            logConfiguration: {
+              logDriver: "awslogs",
+              options: {
+                "awslogs-group": config.logGroup,
+                "awslogs-region": requiredEnv(this.env, "AWS_REGION"),
+                "awslogs-stream-prefix": "preview",
+              },
+            },
+          },
+        ],
+      }),
+    )) as RegisterTaskDefinitionCommandOutput;
+    const taskDefinitionArn = registered.taskDefinition?.taskDefinitionArn;
+    if (!taskDefinitionArn) throw new Error("ECS did not register a preview task definition");
+
+    try {
+      const launched = (await this.ecs.send(
+        new RunTaskCommand({
+          cluster: config.cluster,
+          taskDefinition: taskDefinitionArn,
+          launchType: "FARGATE",
+          count: 1,
+          enableExecuteCommand: false,
+          networkConfiguration: {
+            awsvpcConfiguration: {
+              subnets: config.subnets,
+              securityGroups: config.securityGroups,
+              assignPublicIp: "DISABLED",
+            },
+          },
+          tags: [
+            { key: "facility.run", value: spec.runId },
+            { key: "facility.kind", value: "preview" },
+          ],
+        }),
+      )) as RunTaskCommandOutput;
+      if (launched.failures?.length) throw new Error(formatFailures(launched.failures));
+      const taskArn = launched.tasks?.[0]?.taskArn;
+      if (!taskArn) throw new Error("ECS RunTask did not return a preview task ARN");
+      const privateIp =
+        privateIpv4(launched.tasks?.[0]) ?? (await this.waitForPrivateIp(config.cluster, taskArn));
+      return {
+        ref: encodeRef({ taskArn, taskDefinitionArn }),
+        ...(privateIp ? { endpoint: `http://${privateIp}:${spec.servicePort}` } : {}),
+      };
+    } catch (error) {
+      await this.deregister(taskDefinitionArn).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async status(ref: string): Promise<"starting" | "running" | "exited" | "lost"> {
+    const config = this.config();
+    const task = await this.describe(config.cluster, decodeRef(ref).taskArn);
+    if (!task) return "lost";
+    if (["PROVISIONING", "PENDING", "ACTIVATING"].includes(task.lastStatus ?? "")) {
+      return "starting";
+    }
+    if (task.lastStatus === "RUNNING") return "running";
+    if (
+      ["DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED", "DELETED"].includes(
+        task.lastStatus ?? "",
+      )
+    ) {
+      return "exited";
+    }
+    return "lost";
+  }
+
+  async *logs(ref: string, afterLine = 0): AsyncIterable<string> {
+    const config = this.config();
+    const taskArn = decodeRef(ref).taskArn;
+    let nextToken: string | undefined;
+    let lineNo = 0;
+    do {
+      let output: GetLogEventsCommandOutput;
+      try {
+        output = await this.cloudwatchLogs.send(
+          new GetLogEventsCommand({
+            logGroupName: config.logGroup,
+            logStreamName: `preview/preview/${taskId(taskArn)}`,
+            nextToken,
+            startFromHead: true,
+          }),
+        );
+      } catch (error) {
+        if (isResourceNotFound(error)) return;
+        throw error;
+      }
+      for (const event of output.events ?? []) {
+        for (const line of event.message?.split(/\r?\n/) ?? []) {
+          if (!line) continue;
+          lineNo += 1;
+          if (lineNo > afterLine) yield line;
+        }
+      }
+      if (!output.nextForwardToken || output.nextForwardToken === nextToken) return;
+      nextToken = output.nextForwardToken;
+    } while (nextToken);
+  }
+
+  async stop(ref: string, opts: { kill?: boolean } = {}): Promise<void> {
+    const config = this.config();
+    const parsed = decodeRef(ref);
+    await this.ecs.send(
+      new StopTaskCommand({
+        cluster: config.cluster,
+        task: parsed.taskArn,
+        reason: opts.kill
+          ? "Facility preview destroy requested"
+          : "Facility preview stop requested",
+      }),
+    );
+  }
+
+  async destroy(ref: string): Promise<void> {
+    const parsed = decodeRef(ref);
+    await this.stop(ref, { kill: true });
+    if (parsed.taskDefinitionArn) await this.deregister(parsed.taskDefinitionArn);
+  }
+
+  private async waitForPrivateIp(cluster: string, taskArn: string) {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const task = await this.describe(cluster, taskArn);
+      const privateIp = privateIpv4(task);
+      if (privateIp) return privateIp;
+      if (!task || task.lastStatus === "STOPPED") return undefined;
+      await this.sleep(2_000);
+    }
+    return undefined;
+  }
+
+  private async describe(cluster: string, taskArn: string) {
+    const output = (await this.ecs.send(
+      new DescribeTasksCommand({ cluster, tasks: [taskArn] }),
+    )) as DescribeTasksCommandOutput;
+    return output.tasks?.[0];
+  }
+
+  private async deregister(taskDefinitionArn: string) {
+    await this.ecs.send(new DeregisterTaskDefinitionCommand({ taskDefinition: taskDefinitionArn }));
+  }
+
+  private config(): AwsPreviewConfig {
+    const cpuArchitecture = requiredEnv(this.env, "FACILITY_AWS_TASK_CPU_ARCHITECTURE");
+    if (cpuArchitecture !== "X86_64" && cpuArchitecture !== "ARM64") {
+      throw notConfigured("FACILITY_AWS_TASK_CPU_ARCHITECTURE");
+    }
+    return {
+      cluster: requiredEnv(this.env, "FACILITY_AWS_ECS_CLUSTER"),
+      subnets: requiredListEnv(this.env, "FACILITY_AWS_SUBNETS"),
+      securityGroups: requiredListEnv(this.env, "FACILITY_AWS_PREVIEW_SECURITY_GROUPS"),
+      family: requiredEnv(this.env, "FACILITY_AWS_PREVIEW_TASK_FAMILY"),
+      executionRoleArn: requiredEnv(this.env, "FACILITY_AWS_PREVIEW_EXECUTION_ROLE_ARN"),
+      taskRoleArn: requiredEnv(this.env, "FACILITY_AWS_PREVIEW_TASK_ROLE_ARN"),
+      logGroup: requiredEnv(this.env, "FACILITY_AWS_PREVIEW_LOG_GROUP"),
+      cpuArchitecture,
+    };
+  }
+}
+
+export function fargateResources(cpu: number, memoryMb: number) {
+  const requestedCpu = Math.max(0.25, cpu);
+  const requestedMemory = Math.max(512, Math.round(memoryMb));
+  const twoCpuOption = {
+    cpu: "2048",
+    value: 2,
+    memory: [4096, 5120, 6144, 7168, 8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360, 16384],
+  };
+  const fallbackOption = {
+    cpu: "4096",
+    value: 4,
+    memory: [8192, 16384, 24576, 30720],
+  };
+  const options = [
+    { cpu: "256", value: 0.25, memory: [512, 1024, 2048] },
+    { cpu: "512", value: 0.5, memory: [1024, 2048, 3072, 4096] },
+    { cpu: "1024", value: 1, memory: [2048, 3072, 4096, 5120, 6144, 7168, 8192] },
+    twoCpuOption,
+    fallbackOption,
+  ];
+  const option = options.find((candidate) => candidate.value >= requestedCpu) ?? fallbackOption;
+  const memory =
+    option.memory.find((candidate) => candidate >= requestedMemory) ??
+    option.memory.at(-1) ??
+    30720;
+  return { cpu: option.cpu, memory: String(memory) };
+}
+
+function encodeRef(ref: PreviewRef) {
+  return Buffer.from(JSON.stringify(ref)).toString("base64url");
+}
+
+function decodeRef(ref: string): PreviewRef {
+  try {
+    const parsed = JSON.parse(Buffer.from(ref, "base64url").toString("utf8")) as PreviewRef;
+    if (parsed.taskArn) return parsed;
+  } catch {
+    // Legacy ECS previews stored the raw task ARN. Preserve lifecycle cleanup
+    // across this deployment instead of abandoning already-running tasks.
+  }
+  return { taskArn: ref };
+}
+
+function privateIpv4(
+  task: { attachments?: { details?: { name?: string; value?: string }[] }[] } | undefined,
+) {
+  return task?.attachments
+    ?.flatMap((attachment) => attachment.details ?? [])
+    .find((detail) => detail.name === "privateIPv4Address")?.value;
+}
+
+function formatFailures(failures: { arn?: string; reason?: string; detail?: string }[]) {
+  return `ECS RunTask failed: ${failures
+    .map((failure) => [failure.arn, failure.reason, failure.detail].filter(Boolean).join(" "))
+    .join("; ")}`;
+}
+
+function taskId(taskArn: string) {
+  return taskArn.split("/").filter(Boolean).at(-1) ?? taskArn;
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, name: string) {
+  const value = env[name]?.trim();
+  if (!value) throw notConfigured(name);
+  return value;
+}
+
+function requiredListEnv(env: NodeJS.ProcessEnv, name: string) {
+  const values =
+    env[name]
+      ?.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean) ?? [];
+  if (values.length === 0) throw notConfigured(name);
+  return values;
+}
+
+function notConfigured(name: string) {
+  const error = new Error(`AWS preview driver is not configured; missing ${name}`);
+  (error as Error & { code: string }).code = "not_configured";
+  return error;
+}
+
+function isResourceNotFound(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ((error as { name?: string }).name === "ResourceNotFoundException" ||
+      (error as { Code?: string }).Code === "ResourceNotFoundException")
+  );
+}

--- a/services/api/src/sandbox/aws-preview.ts
+++ b/services/api/src/sandbox/aws-preview.ts
@@ -108,6 +108,7 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
     const taskDefinitionArn = registered.taskDefinition?.taskDefinitionArn;
     if (!taskDefinitionArn) throw new Error("ECS did not register a preview task definition");
 
+    let taskArn: string | undefined;
     try {
       const launched = (await this.ecs.send(
         new RunTaskCommand({
@@ -130,7 +131,7 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
         }),
       )) as RunTaskCommandOutput;
       if (launched.failures?.length) throw new Error(formatFailures(launched.failures));
-      const taskArn = launched.tasks?.[0]?.taskArn;
+      taskArn = launched.tasks?.[0]?.taskArn;
       if (!taskArn) throw new Error("ECS RunTask did not return a preview task ARN");
       const privateIp =
         privateIpv4(launched.tasks?.[0]) ?? (await this.waitForPrivateIp(config.cluster, taskArn));
@@ -139,7 +140,31 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
         ...(privateIp ? { endpoint: `http://${privateIp}:${spec.servicePort}` } : {}),
       };
     } catch (error) {
-      await this.deregister(taskDefinitionArn).catch(() => undefined);
+      let cleanupFailure: unknown;
+      if (taskArn) {
+        try {
+          await this.ecs.send(
+            new StopTaskCommand({
+              cluster: config.cluster,
+              task: taskArn,
+              reason: "Facility preview launch failed",
+            }),
+          );
+        } catch (stopError) {
+          if (!isTaskAlreadyGone(stopError)) cleanupFailure = stopError;
+        }
+      }
+      try {
+        await this.deregister(taskDefinitionArn);
+      } catch (deregisterError) {
+        if (!isTaskDefinitionAlreadyGone(deregisterError)) cleanupFailure ??= deregisterError;
+      }
+      if (cleanupFailure) {
+        throw new AggregateError(
+          [error, cleanupFailure],
+          "AWS preview launch failed and cleanup did not converge",
+        );
+      }
       throw error;
     }
   }

--- a/services/api/src/sandbox/aws.ts
+++ b/services/api/src/sandbox/aws.ts
@@ -64,7 +64,6 @@ export class AwsSandboxDriver implements SandboxDriver {
       new StartBuildCommand({
         projectName: config.project,
         idempotencyToken: spec.runId,
-        imageOverride: spec.image,
         computeTypeOverride: codeBuildComputeType(spec.cpu, spec.memoryMb),
         timeoutInMinutesOverride: clamp(Math.round(spec.timeoutMin), 5, 2160),
         environmentVariablesOverride: Object.entries(spec.env)

--- a/services/api/src/sandbox/aws.ts
+++ b/services/api/src/sandbox/aws.ts
@@ -181,7 +181,7 @@ function codeBuildComputeType(cpu: number, memoryMb: number) {
 
 function codeBuildBuildspec(cmd: string[]) {
   const command = ["/app/codebuild-runner.sh", ...cmd].map(shellQuote).join(" ");
-  return `version: 0.2\nphases:\n  build:\n    commands:\n      - ${JSON.stringify(command)}\n`;
+  return `version: 0.2\nrun-as: root\nphases:\n  build:\n    commands:\n      - ${JSON.stringify(command)}\n`;
 }
 
 function shellQuote(value: string) {

--- a/services/api/src/sandbox/aws.ts
+++ b/services/api/src/sandbox/aws.ts
@@ -4,21 +4,24 @@ import {
   type GetLogEventsCommandOutput,
 } from "@aws-sdk/client-cloudwatch-logs";
 import {
-  DescribeTasksCommand,
-  type DescribeTasksCommandOutput,
-  ECSClient,
-  RunTaskCommand,
-  type RunTaskCommandOutput,
-  StopTaskCommand,
-  type StopTaskCommandOutput,
-} from "@aws-sdk/client-ecs";
+  BatchGetBuildsCommand,
+  type BatchGetBuildsCommandOutput,
+  CodeBuildClient,
+  StartBuildCommand,
+  type StartBuildCommandOutput,
+  StopBuildCommand,
+  type StopBuildCommandOutput,
+} from "@aws-sdk/client-codebuild";
 import type { LaunchSpec, SandboxDriver } from "./driver.js";
 
-type EcsCommand = RunTaskCommand | DescribeTasksCommand | StopTaskCommand;
-type EcsCommandOutput = RunTaskCommandOutput | DescribeTasksCommandOutput | StopTaskCommandOutput;
+type CodeBuildCommand = StartBuildCommand | BatchGetBuildsCommand | StopBuildCommand;
+type CodeBuildCommandOutput =
+  | StartBuildCommandOutput
+  | BatchGetBuildsCommandOutput
+  | StopBuildCommandOutput;
 
-type EcsSender = {
-  send(command: EcsCommand): Promise<EcsCommandOutput>;
+type CodeBuildSender = {
+  send(command: CodeBuildCommand): Promise<CodeBuildCommandOutput>;
 };
 
 type LogsSender = {
@@ -27,105 +30,73 @@ type LogsSender = {
 
 type AwsSandboxConfig = {
   region: string;
-  cluster: string;
-  taskDefinition: string;
-  subnets: string[];
-  securityGroups: string[];
-  container: string;
-  logGroup: string;
-  logStreamPrefix: string;
+  project: string;
 };
+
+const STARTING_PHASES = new Set([
+  "SUBMITTED",
+  "QUEUED",
+  "PROVISIONING",
+  "DOWNLOAD_SOURCE",
+  "INSTALL",
+]);
+const EXITED_STATUSES = new Set(["SUCCEEDED", "FAILED", "FAULT", "STOPPED", "TIMED_OUT"]);
 
 export class AwsSandboxDriver implements SandboxDriver {
   readonly name = "aws" as const;
-  private readonly ecs: EcsSender;
+  private readonly codebuild: CodeBuildSender;
   private readonly cloudwatchLogs: LogsSender;
   private readonly env: NodeJS.ProcessEnv;
 
   constructor(
-    ecs: EcsSender = new ECSClient({ region: process.env.AWS_REGION }),
+    codebuild: CodeBuildSender = new CodeBuildClient({ region: process.env.AWS_REGION }),
     cloudwatchLogs: LogsSender = new CloudWatchLogsClient({ region: process.env.AWS_REGION }),
     env: NodeJS.ProcessEnv = process.env,
   ) {
-    this.ecs = ecs;
+    this.codebuild = codebuild;
     this.cloudwatchLogs = cloudwatchLogs;
     this.env = env;
   }
 
   async launch(spec: LaunchSpec): Promise<{ ref: string; endpoint?: string }> {
     const config = this.config();
-    const output = (await this.ecs.send(
-      new RunTaskCommand({
-        cluster: config.cluster,
-        taskDefinition: config.taskDefinition,
-        launchType: "FARGATE",
-        count: 1,
-        overrides: {
-          cpu: ecsCpuUnits(spec.cpu),
-          memory: String(Math.max(128, Math.round(spec.memoryMb))),
-          containerOverrides: [
-            {
-              name: config.container,
-              environment: Object.entries(spec.env).map(([name, value]) => ({ name, value })),
-              ...(spec.cmd ? { command: spec.cmd } : {}),
-            },
-          ],
-        },
-        networkConfiguration: {
-          awsvpcConfiguration: {
-            subnets: config.subnets,
-            securityGroups: config.securityGroups,
-            assignPublicIp: "DISABLED",
-          },
-        },
+    const output = (await this.codebuild.send(
+      new StartBuildCommand({
+        projectName: config.project,
+        idempotencyToken: spec.runId,
+        imageOverride: spec.image,
+        computeTypeOverride: codeBuildComputeType(spec.cpu, spec.memoryMb),
+        timeoutInMinutesOverride: clamp(Math.round(spec.timeoutMin), 5, 2160),
+        environmentVariablesOverride: Object.entries(spec.env)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([name, value]) => ({ name, value, type: "PLAINTEXT" })),
+        ...(spec.cmd ? { buildspecOverride: codeBuildBuildspec(spec.cmd) } : {}),
       }),
-    )) as RunTaskCommandOutput;
-    if (output.failures?.length) {
-      throw new Error(
-        `ECS RunTask failed: ${output.failures
-          .map((failure) => [failure.arn, failure.reason, failure.detail].filter(Boolean).join(" "))
-          .join("; ")}`,
-      );
-    }
-    const taskArn = output.tasks?.[0]?.taskArn;
-    if (!taskArn) throw new Error("ECS RunTask did not return a taskArn");
-    const privateIp = output.tasks?.[0]?.attachments
-      ?.flatMap((attachment) => attachment.details ?? [])
-      .find((detail) => detail.name === "privateIPv4Address")?.value;
-    return {
-      ref: taskArn,
-      ...(spec.servicePort && privateIp
-        ? { endpoint: `http://${privateIp}:${spec.servicePort}` }
-        : {}),
-    };
+    )) as StartBuildCommandOutput;
+    const buildId = output.build?.id;
+    if (!buildId) throw new Error("CodeBuild StartBuild did not return a build id");
+    return { ref: buildId };
   }
 
   async status(ref: string): Promise<"starting" | "running" | "exited" | "lost"> {
-    const config = this.config();
-    const output = (await this.ecs.send(
-      new DescribeTasksCommand({ cluster: config.cluster, tasks: [ref] }),
-    )) as DescribeTasksCommandOutput;
-    const task = output.tasks?.[0];
-    if (!task) return "lost";
-    switch (task.lastStatus) {
-      case "PROVISIONING":
-      case "PENDING":
-      case "ACTIVATING":
-        return "starting";
-      case "RUNNING":
-        return "running";
-      case "DEACTIVATING":
-      case "STOPPING":
-      case "STOPPED":
-      case "DELETED":
-        return "exited";
-      default:
-        return "lost";
+    const build = await this.getBuild(ref);
+    if (!build) return "lost";
+    if (build.buildStatus === "IN_PROGRESS") {
+      return !build.currentPhase || STARTING_PHASES.has(build.currentPhase)
+        ? "starting"
+        : "running";
     }
+    if (build.buildStatus && EXITED_STATUSES.has(build.buildStatus)) return "exited";
+    return "lost";
   }
 
   async *logs(ref: string, afterLine = 0): AsyncIterable<string> {
-    const config = this.config();
+    this.config();
+    const build = await this.getBuild(ref);
+    const logGroupName = build?.logs?.groupName;
+    const logStreamName = build?.logs?.streamName;
+    if (!logGroupName || !logStreamName) return;
+
     let nextToken: string | undefined;
     let lineNo = 0;
     do {
@@ -133,8 +104,8 @@ export class AwsSandboxDriver implements SandboxDriver {
       try {
         output = await this.cloudwatchLogs.send(
           new GetLogEventsCommand({
-            logGroupName: config.logGroup,
-            logStreamName: logStreamName(config, ref),
+            logGroupName,
+            logStreamName,
             nextToken,
             startFromHead: true,
           }),
@@ -157,48 +128,32 @@ export class AwsSandboxDriver implements SandboxDriver {
     } while (nextToken);
   }
 
-  async stop(ref: string, opts: { kill?: boolean } = {}): Promise<void> {
-    const config = this.config();
-    await this.ecs.send(
-      new StopTaskCommand({
-        cluster: config.cluster,
-        task: ref,
-        reason: opts.kill ? "Facility sandbox kill requested" : "Facility sandbox stop requested",
-      }),
-    );
+  async stop(ref: string, _opts: { kill?: boolean } = {}): Promise<void> {
+    this.config();
+    await this.codebuild.send(new StopBuildCommand({ id: ref }));
   }
 
   async destroy(ref: string): Promise<void> {
     await this.stop(ref, { kill: true });
   }
 
+  private async getBuild(ref: string) {
+    this.config();
+    const output = (await this.codebuild.send(
+      new BatchGetBuildsCommand({ ids: [ref] }),
+    )) as BatchGetBuildsCommandOutput;
+    return output.builds?.[0];
+  }
+
   private config(): AwsSandboxConfig {
     const region = stringEnv(this.env.AWS_REGION);
-    const cluster = stringEnv(this.env.FACILITY_AWS_ECS_CLUSTER);
-    const taskDefinition = stringEnv(this.env.FACILITY_AWS_RUNNER_TASK_DEF);
-    const subnets = listEnv(this.env.FACILITY_AWS_SUBNETS);
-    const securityGroups = listEnv(this.env.FACILITY_AWS_SECURITY_GROUPS);
-    const logGroup = stringEnv(this.env.FACILITY_AWS_RUNNER_LOG_GROUP);
+    const project = stringEnv(this.env.FACILITY_AWS_CODEBUILD_PROJECT);
     const missing: string[] = [];
     if (!region) missing.push("AWS_REGION");
-    if (!cluster) missing.push("FACILITY_AWS_ECS_CLUSTER");
-    if (!taskDefinition) missing.push("FACILITY_AWS_RUNNER_TASK_DEF");
-    if (subnets.length === 0) missing.push("FACILITY_AWS_SUBNETS");
-    if (securityGroups.length === 0) missing.push("FACILITY_AWS_SECURITY_GROUPS");
-    if (!logGroup) missing.push("FACILITY_AWS_RUNNER_LOG_GROUP");
+    if (!project) missing.push("FACILITY_AWS_CODEBUILD_PROJECT");
     if (missing.length > 0) this.notConfigured(missing.join(", "));
-    const container = stringEnv(this.env.FACILITY_AWS_RUNNER_CONTAINER) ?? "runner";
-    if (!region || !cluster || !taskDefinition || !logGroup) this.notConfigured("AWS sandbox env");
-    return {
-      region,
-      cluster,
-      taskDefinition,
-      subnets,
-      securityGroups,
-      container,
-      logGroup,
-      logStreamPrefix: stringEnv(this.env.FACILITY_AWS_RUNNER_LOG_STREAM_PREFIX) ?? container,
-    };
+    if (!region || !project) this.notConfigured("AWS sandbox env");
+    return { region, project };
   }
 
   private notConfigured(missing: string): never {
@@ -213,25 +168,24 @@ function stringEnv(value: string | undefined) {
   return trimmed ? trimmed : undefined;
 }
 
-function listEnv(value: string | undefined) {
-  return (
-    value
-      ?.split(",")
-      .map((item) => item.trim())
-      .filter(Boolean) ?? []
-  );
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
 }
 
-function ecsCpuUnits(cpu: number) {
-  return String(Math.max(256, Math.round(cpu * 1024)));
+function codeBuildComputeType(cpu: number, memoryMb: number) {
+  if (cpu > 8 || memoryMb > 15_360) return "BUILD_GENERAL1_XLARGE" as const;
+  if (cpu > 4 || memoryMb > 7_168) return "BUILD_GENERAL1_LARGE" as const;
+  if (cpu > 2 || memoryMb > 3_072) return "BUILD_GENERAL1_MEDIUM" as const;
+  return "BUILD_GENERAL1_SMALL" as const;
 }
 
-function logStreamName(config: AwsSandboxConfig, taskArn: string) {
-  return `${config.logStreamPrefix}/${config.container}/${taskId(taskArn)}`;
+function codeBuildBuildspec(cmd: string[]) {
+  const command = ["/app/codebuild-runner.sh", ...cmd].map(shellQuote).join(" ");
+  return `version: 0.2\nphases:\n  build:\n    commands:\n      - ${JSON.stringify(command)}\n`;
 }
 
-function taskId(taskArn: string) {
-  return taskArn.split("/").filter(Boolean).at(-1) ?? taskArn;
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function isResourceNotFound(error: unknown) {

--- a/services/api/src/sandbox/driver.ts
+++ b/services/api/src/sandbox/driver.ts
@@ -29,3 +29,9 @@ export async function sandboxDriver(name: SandboxDriverName): Promise<SandboxDri
   const { AwsSandboxDriver } = await import("./aws.js");
   return new AwsSandboxDriver();
 }
+
+export async function previewSandboxDriver(name: SandboxDriverName): Promise<SandboxDriver> {
+  if (name === "docker") return sandboxDriver(name);
+  const { AwsPreviewSandboxDriver } = await import("./aws-preview.js");
+  return new AwsPreviewSandboxDriver();
+}

--- a/services/api/src/sandbox/driver.ts
+++ b/services/api/src/sandbox/driver.ts
@@ -12,6 +12,17 @@ export type LaunchSpec = {
   servicePort?: number;
 };
 
+export class SandboxLaunchError extends Error {
+  constructor(
+    message: string,
+    readonly ref: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "SandboxLaunchError";
+  }
+}
+
 export interface SandboxDriver {
   name: SandboxDriverName;
   launch(spec: LaunchSpec): Promise<{ ref: string; endpoint?: string }>;

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -1293,9 +1293,11 @@ async function buildRunBundle(
       .limit(1)
   )[0];
   const timeoutMin = resourceNumber(profile.resources, "timeout_min", 60);
+  const packageInstallCmd = resolvePackageInstallCmd(profile, repo?.renderAnswers);
   const provisionCmd = resolveProvisionCmd(profile, repo?.renderAnswers);
-  const checkCmds = resolveCheckCmds(profile, project?.settings);
-  const contract = renderRunContract(rawContract, provisionCmd, checkCmds);
+  const checkCmds = resolveCheckCmds(profile, repo?.renderAnswers, project?.settings);
+  const provisionSummary = [packageInstallCmd, provisionCmd].filter(Boolean).join(" && ") || null;
+  const contract = renderRunContract(rawContract, provisionSummary, checkCmds);
   const githubBranch = typeof runGh.branch === "string" ? runGh.branch : null;
   const checkoutBranch = githubPullRequestMode(run.mode) && githubBranch ? githubBranch : null;
   // Point the agent CLIs directly at the gateway service. Anthropic's SDK
@@ -1308,7 +1310,7 @@ async function buildRunBundle(
     engine: normalizeEngine(agent.engine || run.engine),
     contract,
     skills,
-    engineConfig: objectOrEmpty(agent.model),
+    engineConfig: resolveRepoEngineConfig(agent.name, agent.model, repo?.renderAnswers),
     repo: repo
       ? {
           cloneUrl: `https://github.com/${repo.owner}/${repo.name}.git`,
@@ -1316,6 +1318,7 @@ async function buildRunBundle(
           installationTokenRef: repo.installationId,
         }
       : { cloneUrl: null, branch: null, installationTokenRef: null },
+    packageInstallCmd,
     provisionCmd,
     // Acceptance gates: a sandbox profile's setup.check_cmds is an explicit
     // platform-level override; otherwise fall back to the project's own configured
@@ -1946,9 +1949,38 @@ function arrayField(value: unknown, key: string) {
 // Resolve the run's acceptance-gate commands: a sandbox profile's explicit
 // setup.check_cmds override wins; otherwise the project's own configured checks
 // (settings.check_cmds). Empty when neither is set.
-export function resolveCheckCmds(profile: { setup: unknown }, projectSettings: unknown): string[] {
+export function resolveCheckCmds(
+  profile: { setup: unknown },
+  renderAnswers: unknown,
+  projectSettings: unknown,
+): string[] {
   const profileChecks = arrayField(profile.setup, "check_cmds");
-  return profileChecks.length > 0 ? profileChecks : arrayField(projectSettings, "check_cmds");
+  if (profileChecks.length > 0) return profileChecks;
+  const answers = objectOrEmpty(renderAnswers);
+  if (Object.hasOwn(answers, "checkCmds")) return arrayField(answers, "checkCmds");
+  if (Object.hasOwn(answers, "check_cmds")) return arrayField(answers, "check_cmds");
+  return arrayField(projectSettings, "check_cmds");
+}
+
+export function resolveRepoEngineConfig(agentName: string, base: unknown, renderAnswers: unknown) {
+  const config = objectOrEmpty(base);
+  const models = objectOrEmpty(objectOrEmpty(renderAnswers).models);
+  const override =
+    agentName === "architect"
+      ? stringValue(models.plan)
+      : agentName === "builder"
+        ? stringValue(models.build)
+        : agentName === "review"
+          ? stringValue(models.review)
+          : agentName === "codex-architect"
+            ? stringValue(models.codexPlan)
+            : agentName === "codex-builder"
+              ? stringValue(models.codexBuild)
+              : undefined;
+  if (!override) return config;
+  return agentName.startsWith("codex-")
+    ? { ...config, primary: override }
+    : { ...config, model: override };
 }
 
 // The sandbox profile is an explicit platform override. Otherwise use the
@@ -1959,6 +1991,18 @@ export function resolveProvisionCmd(profile: { setup: unknown }, renderAnswers: 
     stringField(profile.setup, "provisionCmd") ??
     stringField(renderAnswers, "provisionCmd") ??
     stringField(renderAnswers, "provision_cmd")
+  );
+}
+
+// Dependency installation is a separate phase so a private-registry token can
+// be scoped to that child process and never reach provisioning scripts, checks,
+// or the model runtime.
+export function resolvePackageInstallCmd(profile: { setup: unknown }, renderAnswers: unknown) {
+  return (
+    stringField(profile.setup, "package_install_cmd") ??
+    stringField(profile.setup, "packageInstallCmd") ??
+    stringField(renderAnswers, "packageInstallCmd") ??
+    stringField(renderAnswers, "package_install_cmd")
   );
 }
 

--- a/services/api/src/sandbox/state.ts
+++ b/services/api/src/sandbox/state.ts
@@ -17,6 +17,7 @@ export type RunBundle = {
     branch: string | null;
     installationTokenRef: string | null;
   };
+  packageInstallCmd: string | null;
   provisionCmd: string | null;
   checkCmds: string[];
   gatewayUrls: { anthropic: string; openai: string };

--- a/services/api/src/schedules.ts
+++ b/services/api/src/schedules.ts
@@ -4,11 +4,13 @@ import {
   createDb,
   insertAuditEvent,
   projects,
+  repos,
   runEvents,
   runs,
   schedulerWatermarks,
 } from "@facility/db";
 import { and, eq, not, sql } from "drizzle-orm";
+import { laneFor } from "./github/router.js";
 import type { AppConfig } from "./types.js";
 
 type Enqueue = (
@@ -33,6 +35,7 @@ const weekdayNumbers: Record<string, number> = {
 };
 const SCHEDULE_WATERMARK = "agent.schedules";
 const MAX_CATCH_UP_MINUTES = 24 * 60;
+const REPOSITORY_SCHEDULED_AGENTS = new Set(["security-sweep"]);
 
 export async function runAgentSchedules(config: AppConfig, enqueue: Enqueue, now = new Date()) {
   const { db, client } = createDb(config.databaseUrl);
@@ -49,6 +52,7 @@ export async function runAgentSchedules(config: AppConfig, enqueue: Enqueue, now
         ),
       );
     const currentMinute = minuteFloor(now);
+    const projectRepos = await db.select().from(repos);
     const watermark = (
       await db
         .select()
@@ -59,6 +63,14 @@ export async function runAgentSchedules(config: AppConfig, enqueue: Enqueue, now
     const instants = catchUpMinutes(watermark?.lastTick, currentMinute);
     let created = 0;
     for (const { agent } of rows) {
+      if (
+        REPOSITORY_SCHEDULED_AGENTS.has(agent.name) &&
+        !projectRepos.some(
+          (repo) => repo.projectId === agent.projectId && laneFor(repo, agent.name) === "platform",
+        )
+      ) {
+        continue;
+      }
       const triggers = scheduleTriggers(agent.triggers);
       for (const [index, trigger] of triggers.entries()) {
         for (const instant of instants) {

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -51,6 +51,7 @@ export type AppConfig = {
   s3SecretKey?: string;
   s3Bucket?: string;
   awsRegion?: string;
+  packageRegistryToken?: string;
   githubAppId?: string;
   githubAppPrivateKey?: string;
   githubAppWebhookSecret?: string;

--- a/services/api/test/aws-preview-sandbox.test.ts
+++ b/services/api/test/aws-preview-sandbox.test.ts
@@ -122,6 +122,67 @@ describe("AWS preview sandbox driver", () => {
     expect(commands.at(-1)).toBeInstanceOf(DeregisterTaskDefinitionCommand);
   });
 
+  it("still deregisters a preview definition when stopping the task fails", async () => {
+    const commands: unknown[] = [];
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof StopTaskCommand) {
+          throw Object.assign(new Error("The referenced task was not found."), {
+            name: "InvalidParameterException",
+          });
+        }
+        if (command instanceof DeregisterTaskDefinitionCommand) {
+          throw Object.assign(new Error("The task definition does not exist."), {
+            name: "ResourceNotFoundException",
+          });
+        }
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+    );
+    const ref = Buffer.from(
+      JSON.stringify({
+        taskArn: "arn:aws:ecs:eu-west-1:123:task/facility-prod/gone",
+        taskDefinitionArn: "arn:aws:ecs:eu-west-1:123:task-definition/facility-prod-preview:9",
+      }),
+    ).toString("base64url");
+    await expect(driver.destroy(ref)).resolves.toBeUndefined();
+    expect(commands[0]).toBeInstanceOf(StopTaskCommand);
+    expect(commands[1]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
+  it("retains real stop failures after deregistering for a later cleanup retry", async () => {
+    const commands: unknown[] = [];
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof StopTaskCommand) {
+          throw Object.assign(new Error("not authorized"), { name: "AccessDeniedException" });
+        }
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+    );
+    const ref = Buffer.from(
+      JSON.stringify({
+        taskArn: "arn:aws:ecs:eu-west-1:123:task/facility-prod/denied",
+        taskDefinitionArn: "arn:aws:ecs:eu-west-1:123:task-definition/facility-prod-preview:10",
+      }),
+    ).toString("base64url");
+    await expect(driver.destroy(ref)).rejects.toThrow("not authorized");
+    expect(commands[0]).toBeInstanceOf(StopTaskCommand);
+    expect(commands[1]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
   it("fails closed when the dedicated preview role configuration is absent", async () => {
     const driver = new AwsPreviewSandboxDriver(
       { send: async () => ({}) } as never,

--- a/services/api/test/aws-preview-sandbox.test.ts
+++ b/services/api/test/aws-preview-sandbox.test.ts
@@ -122,6 +122,46 @@ describe("AWS preview sandbox driver", () => {
     expect(commands.at(-1)).toBeInstanceOf(DeregisterTaskDefinitionCommand);
   });
 
+  it("stops a launched preview when private-IP discovery fails", async () => {
+    const commands: unknown[] = [];
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof RegisterTaskDefinitionCommand) {
+          return { taskDefinition: { taskDefinitionArn: "arn:aws:ecs:task-definition/preview:9" } };
+        }
+        if (command instanceof RunTaskCommand) {
+          return { tasks: [{ taskArn: "arn:aws:ecs:task/facility-prod/launched" }] };
+        }
+        if (command instanceof DescribeTasksCommand) throw new Error("transient describe failure");
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+      async () => undefined,
+    );
+    await expect(
+      driver.launch({
+        runId: "preview:describe-failure",
+        image: "example.invalid/preview:latest",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 60,
+        servicePort: 3000,
+      }),
+    ).rejects.toThrow("transient describe failure");
+    expect(commands).toHaveLength(5);
+    expect(commands[0]).toBeInstanceOf(RegisterTaskDefinitionCommand);
+    expect(commands[1]).toBeInstanceOf(RunTaskCommand);
+    expect(commands[2]).toBeInstanceOf(DescribeTasksCommand);
+    expect(commands[3]).toBeInstanceOf(StopTaskCommand);
+    expect(commands[4]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
   it("still deregisters a preview definition when stopping the task fails", async () => {
     const commands: unknown[] = [];
     const ecs = {

--- a/services/api/test/aws-preview-sandbox.test.ts
+++ b/services/api/test/aws-preview-sandbox.test.ts
@@ -1,0 +1,149 @@
+import {
+  DeregisterTaskDefinitionCommand,
+  DescribeTasksCommand,
+  RegisterTaskDefinitionCommand,
+  RunTaskCommand,
+  StopTaskCommand,
+} from "@aws-sdk/client-ecs";
+import { describe, expect, it } from "vitest";
+import { AwsPreviewSandboxDriver, fargateResources } from "../src/sandbox/aws-preview.js";
+
+const previewEnv = {
+  AWS_REGION: "eu-west-1",
+  FACILITY_AWS_ECS_CLUSTER: "facility-prod",
+  FACILITY_AWS_SUBNETS: "subnet-a,subnet-b",
+  FACILITY_AWS_PREVIEW_SECURITY_GROUPS: "sg-preview",
+  FACILITY_AWS_PREVIEW_TASK_FAMILY: "facility-prod-preview",
+  FACILITY_AWS_PREVIEW_EXECUTION_ROLE_ARN: "arn:aws:iam::123:role/preview-execution",
+  FACILITY_AWS_PREVIEW_TASK_ROLE_ARN: "arn:aws:iam::123:role/preview-task",
+  FACILITY_AWS_PREVIEW_LOG_GROUP: "/facility/prod/preview",
+  FACILITY_AWS_TASK_CPU_ARCHITECTURE: "X86_64",
+};
+
+describe("AWS preview sandbox driver", () => {
+  it("registers the requested image and launches an unprivileged Fargate service", async () => {
+    const commands: unknown[] = [];
+    const responses = [
+      {
+        taskDefinition: {
+          taskDefinitionArn: "arn:aws:ecs:eu-west-1:123:task-definition/facility-prod-preview:7",
+        },
+      },
+      { tasks: [{ taskArn: "arn:aws:ecs:eu-west-1:123:task/facility-prod/task-1" }] },
+      {
+        tasks: [
+          {
+            taskArn: "arn:aws:ecs:eu-west-1:123:task/facility-prod/task-1",
+            lastStatus: "PENDING",
+            attachments: [{ details: [{ name: "privateIPv4Address", value: "10.0.2.41" }] }],
+          },
+        ],
+      },
+      { tasks: [{ lastStatus: "RUNNING" }] },
+      {},
+      {},
+    ];
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        return responses.shift() ?? {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+      async () => undefined,
+    );
+    const launched = await driver.launch({
+      runId: "preview:sbx_1",
+      image: "123.dkr.ecr.eu-west-1.amazonaws.com/widget:abc123",
+      cmd: ["node", "server.js"],
+      env: { PORT: "3000", FACILITY_PREVIEW: "1" },
+      cpu: 1,
+      memoryMb: 1024,
+      timeoutMin: 60,
+      servicePort: 3000,
+    });
+    expect(launched.endpoint).toBe("http://10.0.2.41:3000");
+    expect(commands[0]).toBeInstanceOf(RegisterTaskDefinitionCommand);
+    expect((commands[0] as RegisterTaskDefinitionCommand).input).toMatchObject({
+      family: "facility-prod-preview",
+      cpu: "1024",
+      memory: "2048",
+      executionRoleArn: "arn:aws:iam::123:role/preview-execution",
+      taskRoleArn: "arn:aws:iam::123:role/preview-task",
+      containerDefinitions: [
+        {
+          image: "123.dkr.ecr.eu-west-1.amazonaws.com/widget:abc123",
+          command: ["node", "server.js"],
+          portMappings: [{ containerPort: 3000, protocol: "tcp" }],
+        },
+      ],
+    });
+    expect(commands[1]).toBeInstanceOf(RunTaskCommand);
+    expect(commands[2]).toBeInstanceOf(DescribeTasksCommand);
+    await expect(driver.status(launched.ref)).resolves.toBe("running");
+    await driver.destroy(launched.ref);
+    expect(commands[4]).toBeInstanceOf(StopTaskCommand);
+    expect(commands[5]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
+  it("deregisters the per-preview definition when task launch is denied", async () => {
+    const commands: unknown[] = [];
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof RegisterTaskDefinitionCommand) {
+          return { taskDefinition: { taskDefinitionArn: "arn:aws:ecs:task-definition/preview:8" } };
+        }
+        if (command instanceof RunTaskCommand) {
+          return { failures: [{ reason: "ACCESS_DENIED", detail: "policy denied" }] };
+        }
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+    );
+    await expect(
+      driver.launch({
+        runId: "preview:denied",
+        image: "example.invalid/preview:latest",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 60,
+        servicePort: 3000,
+      }),
+    ).rejects.toThrow("ACCESS_DENIED policy denied");
+    expect(commands.at(-1)).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
+  it("fails closed when the dedicated preview role configuration is absent", async () => {
+    const driver = new AwsPreviewSandboxDriver(
+      { send: async () => ({}) } as never,
+      { send: async () => ({}) } as never,
+      { ...previewEnv, FACILITY_AWS_PREVIEW_TASK_ROLE_ARN: "" },
+    );
+    await expect(
+      driver.launch({
+        runId: "preview:missing",
+        image: "preview:latest",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 60,
+        servicePort: 3000,
+      }),
+    ).rejects.toMatchObject({ code: "not_configured" });
+  });
+
+  it("rounds requests up to a valid Fargate CPU/memory pair", () => {
+    expect(fargateResources(1, 1024)).toEqual({ cpu: "1024", memory: "2048" });
+    expect(fargateResources(0.4, 1500)).toEqual({ cpu: "512", memory: "2048" });
+    expect(fargateResources(4, 8192)).toEqual({ cpu: "4096", memory: "8192" });
+  });
+});

--- a/services/api/test/aws-preview-sandbox.test.ts
+++ b/services/api/test/aws-preview-sandbox.test.ts
@@ -162,6 +162,100 @@ describe("AWS preview sandbox driver", () => {
     expect(commands[4]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
   });
 
+  it("returns a retryable ref when launch cleanup cannot stop the task", async () => {
+    const commands: unknown[] = [];
+    const taskArn = "arn:aws:ecs:eu-west-1:123:task/facility-prod/leaked";
+    const taskDefinitionArn = "arn:aws:ecs:eu-west-1:123:task-definition/preview:10";
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof RegisterTaskDefinitionCommand) {
+          return { taskDefinition: { taskDefinitionArn } };
+        }
+        if (command instanceof RunTaskCommand) return { tasks: [{ taskArn }] };
+        if (command instanceof DescribeTasksCommand) throw new Error("describe failed");
+        if (command instanceof StopTaskCommand) {
+          throw Object.assign(new Error("not authorized"), { name: "AccessDeniedException" });
+        }
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+      async () => undefined,
+    );
+    const expectedRef = Buffer.from(JSON.stringify({ taskArn, taskDefinitionArn })).toString(
+      "base64url",
+    );
+    await expect(
+      driver.launch({
+        runId: "preview:cleanup-failure",
+        image: "example.invalid/preview:latest",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 60,
+        servicePort: 3000,
+      }),
+    ).rejects.toMatchObject({
+      name: "SandboxLaunchError",
+      message: "AWS preview launch failed and cleanup did not converge",
+      ref: expectedRef,
+    });
+    expect(commands.at(-2)).toBeInstanceOf(StopTaskCommand);
+    expect(commands.at(-1)).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
+  it("retries definition-only cleanup when RunTask and deregistration both fail", async () => {
+    const commands: unknown[] = [];
+    const taskDefinitionArn = "arn:aws:ecs:eu-west-1:123:task-definition/preview:11";
+    let deregistrationFails = true;
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof RegisterTaskDefinitionCommand) {
+          return { taskDefinition: { taskDefinitionArn } };
+        }
+        if (command instanceof RunTaskCommand) {
+          return { failures: [{ reason: "CAPACITY", detail: "try later" }] };
+        }
+        if (command instanceof DeregisterTaskDefinitionCommand && deregistrationFails) {
+          throw new Error("transient deregistration failure");
+        }
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+    );
+    const expectedRef = Buffer.from(JSON.stringify({ taskDefinitionArn })).toString("base64url");
+    let retryRef = "";
+    try {
+      await driver.launch({
+        runId: "preview:definition-cleanup-failure",
+        image: "example.invalid/preview:latest",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 60,
+        servicePort: 3000,
+      });
+    } catch (error) {
+      expect(error).toMatchObject({ name: "SandboxLaunchError", ref: expectedRef });
+      retryRef = (error as { ref: string }).ref;
+    }
+    expect(retryRef).toBe(expectedRef);
+    deregistrationFails = false;
+    const beforeRetry = commands.length;
+    await driver.destroy(retryRef);
+    expect(commands.slice(beforeRetry)).toHaveLength(1);
+    expect(commands.at(-1)).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
   it("still deregisters a preview definition when stopping the task fails", async () => {
     const commands: unknown[] = [];
     const ecs = {

--- a/services/api/test/aws-sandbox.test.ts
+++ b/services/api/test/aws-sandbox.test.ts
@@ -41,7 +41,7 @@ describe("AwsSandboxDriver", () => {
       ],
     });
     expect((command as StartBuildCommand | undefined)?.input.buildspecOverride).toBe(
-      "version: 0.2\nphases:\n  build:\n    commands:\n      - \"'/app/codebuild-runner.sh' 'node' 'runner'\\\"'\\\"'s script.js'\"\n",
+      "version: 0.2\nrun-as: root\nphases:\n  build:\n    commands:\n      - \"'/app/codebuild-runner.sh' 'node' 'runner'\\\"'\\\"'s script.js'\"\n",
     );
   });
 

--- a/services/api/test/aws-sandbox.test.ts
+++ b/services/api/test/aws-sandbox.test.ts
@@ -1,127 +1,162 @@
 import { GetLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
-import { DescribeTasksCommand, RunTaskCommand, StopTaskCommand } from "@aws-sdk/client-ecs";
+import {
+  BatchGetBuildsCommand,
+  StartBuildCommand,
+  StopBuildCommand,
+} from "@aws-sdk/client-codebuild";
 import { describe, expect, it } from "vitest";
 import { AwsSandboxDriver } from "../src/sandbox/aws.js";
 
 const env = {
   AWS_REGION: "us-east-1",
-  FACILITY_AWS_ECS_CLUSTER: "facility-test",
-  FACILITY_AWS_RUNNER_TASK_DEF: "facility-test-runner",
-  FACILITY_AWS_SUBNETS: "subnet-a,subnet-b",
-  FACILITY_AWS_SECURITY_GROUPS: "sg-runner",
-  FACILITY_AWS_RUNNER_CONTAINER: "runner",
-  FACILITY_AWS_RUNNER_LOG_GROUP: "/facility/test/runner",
+  FACILITY_AWS_CODEBUILD_PROJECT: "facility-test-runner",
 };
 
 describe("AwsSandboxDriver", () => {
-  it("runs a Fargate task with env overrides and private awsvpc networking", async () => {
-    const ecs = new FakeEcsClient();
-    const driver = new AwsSandboxDriver(ecs, new FakeLogsClient(), env);
+  it("starts an isolated CodeBuild sandbox with deterministic overrides", async () => {
+    const codebuild = new FakeCodeBuildClient();
+    const driver = new AwsSandboxDriver(codebuild, new FakeLogsClient(), env);
     const launched = await driver.launch({
       runId: "run_test",
       image: "facility-runner:dev",
-      env: { RUN_ID: "run_test", RUNNER_TOKEN: "secret" },
-      cpu: 1,
-      memoryMb: 2048,
+      env: { RUNNER_TOKEN: "secret", RUN_ID: "run_test" },
+      cpu: 8,
+      memoryMb: 15_360,
       timeoutMin: 30,
-      cmd: ["node", "runner.js"],
+      cmd: ["node", "runner's script.js"],
     });
 
-    expect(launched).toEqual({
-      ref: "arn:aws:ecs:us-east-1:123456789012:task/facility-test/task-1",
+    expect(launched).toEqual({ ref: "facility-test-runner:build-1" });
+    const command = codebuild.commands[0];
+    expect(command).toBeInstanceOf(StartBuildCommand);
+    expect((command as StartBuildCommand | undefined)?.input).toMatchObject({
+      projectName: "facility-test-runner",
+      idempotencyToken: "run_test",
+      imageOverride: "facility-runner:dev",
+      computeTypeOverride: "BUILD_GENERAL1_LARGE",
+      timeoutInMinutesOverride: 30,
+      environmentVariablesOverride: [
+        { name: "RUN_ID", value: "run_test", type: "PLAINTEXT" },
+        { name: "RUNNER_TOKEN", value: "secret", type: "PLAINTEXT" },
+      ],
     });
-    const command = ecs.commands[0];
-    expect(command).toBeInstanceOf(RunTaskCommand);
-    expect(command?.input).toMatchObject({
-      cluster: "facility-test",
-      taskDefinition: "facility-test-runner",
-      launchType: "FARGATE",
-      overrides: {
-        containerOverrides: [
-          {
-            name: "runner",
-            command: ["node", "runner.js"],
-            environment: [
-              { name: "RUN_ID", value: "run_test" },
-              { name: "RUNNER_TOKEN", value: "secret" },
-            ],
-          },
-        ],
-      },
-      networkConfiguration: {
-        awsvpcConfiguration: {
-          subnets: ["subnet-a", "subnet-b"],
-          securityGroups: ["sg-runner"],
-          assignPublicIp: "DISABLED",
-        },
-      },
+    expect((command as StartBuildCommand | undefined)?.input.buildspecOverride).toBe(
+      "version: 0.2\nphases:\n  build:\n    commands:\n      - \"'/app/codebuild-runner.sh' 'node' 'runner'\\\"'\\\"'s script.js'\"\n",
+    );
+  });
+
+  it("maps CodeBuild phases and terminal states", async () => {
+    const codebuild = new FakeCodeBuildClient();
+    const driver = new AwsSandboxDriver(codebuild, new FakeLogsClient(), env);
+    codebuild.builds.push(
+      { buildStatus: "IN_PROGRESS", currentPhase: "PROVISIONING" },
+      { buildStatus: "IN_PROGRESS", currentPhase: "BUILD" },
+      { buildStatus: "SUCCEEDED", currentPhase: "COMPLETED" },
+      undefined,
+    );
+
+    await expect(driver.status("build-starting")).resolves.toBe("starting");
+    await expect(driver.status("build-running")).resolves.toBe("running");
+    await expect(driver.status("build-complete")).resolves.toBe("exited");
+    await expect(driver.status("build-missing")).resolves.toBe("lost");
+    expect(codebuild.commands.every((command) => command instanceof BatchGetBuildsCommand)).toBe(
+      true,
+    );
+  });
+
+  it("stops CodeBuild sandboxes", async () => {
+    const codebuild = new FakeCodeBuildClient();
+    const driver = new AwsSandboxDriver(codebuild, new FakeLogsClient(), env);
+
+    await driver.stop("facility-test-runner:build-1");
+
+    const command = codebuild.commands[0];
+    expect(command).toBeInstanceOf(StopBuildCommand);
+    expect((command as StopBuildCommand | undefined)?.input).toEqual({
+      id: "facility-test-runner:build-1",
     });
   });
 
-  it("maps ECS task states", async () => {
-    const ecs = new FakeEcsClient();
-    const driver = new AwsSandboxDriver(ecs, new FakeLogsClient(), env);
-    ecs.describeStatuses.push("RUNNING", "STOPPED", undefined);
-
-    await expect(driver.status("task-running")).resolves.toBe("running");
-    await expect(driver.status("task-stopped")).resolves.toBe("exited");
-    await expect(driver.status("task-missing")).resolves.toBe("lost");
-  });
-
-  it("stops ECS tasks", async () => {
-    const ecs = new FakeEcsClient();
-    const driver = new AwsSandboxDriver(ecs, new FakeLogsClient(), env);
-
-    await driver.stop("task-1");
-
-    const command = ecs.commands[0];
-    expect(command).toBeInstanceOf(StopTaskCommand);
-    expect(command?.input).toMatchObject({
-      cluster: "facility-test",
-      task: "task-1",
-      reason: "Facility sandbox stop requested",
+  it("discovers and reads the exact CloudWatch stream returned by CodeBuild", async () => {
+    const codebuild = new FakeCodeBuildClient();
+    codebuild.builds.push({
+      buildStatus: "IN_PROGRESS",
+      currentPhase: "BUILD",
+      logs: { groupName: "/facility/test/runner", streamName: "runner/build-1" },
     });
-  });
-
-  it("reads CloudWatch log lines from the runner task stream", async () => {
     const logs = new FakeLogsClient();
     logs.events.push({ message: "first\nsecond" }, { message: "third" });
-    const driver = new AwsSandboxDriver(new FakeEcsClient(), logs, env);
+    const driver = new AwsSandboxDriver(codebuild, logs, env);
 
     const lines: string[] = [];
-    for await (const line of driver.logs(
-      "arn:aws:ecs:us-east-1:123456789012:task/facility-test/task-1",
-      1,
-    )) {
-      lines.push(line);
-    }
+    for await (const line of driver.logs("facility-test-runner:build-1", 1)) lines.push(line);
 
     expect(lines).toEqual(["second", "third"]);
     const command = logs.commands[0];
     expect(command).toBeInstanceOf(GetLogEventsCommand);
     expect(command?.input).toMatchObject({
       logGroupName: "/facility/test/runner",
-      logStreamName: "runner/runner/task-1",
+      logStreamName: "runner/build-1",
       startFromHead: true,
     });
   });
+
+  it("fails closed when configuration or the returned build id is missing", async () => {
+    const codebuild = new FakeCodeBuildClient();
+    const unconfigured = new AwsSandboxDriver(codebuild, new FakeLogsClient(), {
+      AWS_REGION: "us-east-1",
+    });
+    await expect(
+      unconfigured.launch({
+        runId: "run_test",
+        image: "runner",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 1,
+      }),
+    ).rejects.toMatchObject({ code: "not_configured" });
+
+    codebuild.returnBuildId = false;
+    const configured = new AwsSandboxDriver(codebuild, new FakeLogsClient(), env);
+    await expect(
+      configured.launch({
+        runId: "run_test",
+        image: "runner",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 1,
+      }),
+    ).rejects.toThrow("CodeBuild StartBuild did not return a build id");
+    expect(
+      (codebuild.commands[0] as StartBuildCommand | undefined)?.input.timeoutInMinutesOverride,
+    ).toBe(5);
+  });
 });
 
-class FakeEcsClient {
-  readonly commands: Array<RunTaskCommand | DescribeTasksCommand | StopTaskCommand> = [];
-  readonly describeStatuses: Array<string | undefined> = [];
+type Build = {
+  buildStatus?: string;
+  currentPhase?: string;
+  logs?: { groupName?: string; streamName?: string };
+};
 
-  async send(command: RunTaskCommand | DescribeTasksCommand | StopTaskCommand) {
+class FakeCodeBuildClient {
+  readonly commands: Array<StartBuildCommand | BatchGetBuildsCommand | StopBuildCommand> = [];
+  readonly builds: Array<Build | undefined> = [];
+  returnBuildId = true;
+
+  async send(command: StartBuildCommand | BatchGetBuildsCommand | StopBuildCommand) {
     this.commands.push(command);
-    if (command instanceof RunTaskCommand) {
+    if (command instanceof StartBuildCommand) {
       return {
         $metadata: {},
-        tasks: [{ taskArn: "arn:aws:ecs:us-east-1:123456789012:task/facility-test/task-1" }],
+        build: this.returnBuildId ? { id: "facility-test-runner:build-1" } : {},
       };
     }
-    if (command instanceof DescribeTasksCommand) {
-      const lastStatus = this.describeStatuses.shift();
-      return { $metadata: {}, tasks: lastStatus ? [{ lastStatus }] : [] };
+    if (command instanceof BatchGetBuildsCommand) {
+      const build = this.builds.shift();
+      return { $metadata: {}, builds: build ? [build] : [] };
     }
     return { $metadata: {} };
   }

--- a/services/api/test/aws-sandbox.test.ts
+++ b/services/api/test/aws-sandbox.test.ts
@@ -18,7 +18,7 @@ describe("AwsSandboxDriver", () => {
     const driver = new AwsSandboxDriver(codebuild, new FakeLogsClient(), env);
     const launched = await driver.launch({
       runId: "run_test",
-      image: "facility-runner:dev",
+      image: "attacker.example/runner:latest",
       env: { RUNNER_TOKEN: "secret", RUN_ID: "run_test" },
       cpu: 8,
       memoryMb: 15_360,
@@ -32,7 +32,6 @@ describe("AwsSandboxDriver", () => {
     expect((command as StartBuildCommand | undefined)?.input).toMatchObject({
       projectName: "facility-test-runner",
       idempotencyToken: "run_test",
-      imageOverride: "facility-runner:dev",
       computeTypeOverride: "BUILD_GENERAL1_LARGE",
       timeoutInMinutesOverride: 30,
       environmentVariablesOverride: [
@@ -40,6 +39,7 @@ describe("AwsSandboxDriver", () => {
         { name: "RUNNER_TOKEN", value: "secret", type: "PLAINTEXT" },
       ],
     });
+    expect((command as StartBuildCommand | undefined)?.input).not.toHaveProperty("imageOverride");
     expect((command as StartBuildCommand | undefined)?.input.buildspecOverride).toBe(
       "version: 0.2\nrun-as: root\nphases:\n  build:\n    commands:\n      - \"'/app/codebuild-runner.sh' 'node' 'runner'\\\"'\\\"'s script.js'\"\n",
     );

--- a/services/api/test/config.test.ts
+++ b/services/api/test/config.test.ts
@@ -51,6 +51,12 @@ describe("API configuration", () => {
     ).toThrow("GitHub organization must be a login, not a URL");
   });
 
+  it("trims the optional package registry credential for scoped runner handoff", () => {
+    expect(readConfig({ ...validEnv, PACKAGE_REGISTRY_TOKEN: "  package-token\n" })).toMatchObject({
+      packageRegistryToken: "package-token",
+    });
+  });
+
   it("rejects the direct GitHub organization restriction in broker mode", () => {
     expect(() =>
       readConfig({

--- a/services/api/test/github.test.ts
+++ b/services/api/test/github.test.ts
@@ -20,8 +20,9 @@ import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../src/app.js";
 import { FacilityGithubClient } from "../src/github/client.js";
+import { parseFacilityRepoManifest, syncRepoFacilityConfig } from "../src/github/kickstart.js";
 import { githubEventMatches, processGithubWebhook } from "../src/github/processor.js";
-import { githubRequestContext, resolveSlashCommand } from "../src/github/router.js";
+import { githubRequestContext, resolveSlashCommand, routeTrigger } from "../src/github/router.js";
 import { createPreviewRecord } from "../src/previews.js";
 import type { AppConfig } from "../src/types.js";
 
@@ -418,6 +419,7 @@ describe("github integration", async () => {
       owner: "octo",
       name: repoName,
       defaultBranch: "main",
+      renderAnswers: { execution_lane: { review: "platform" } },
     });
     const agent = (
       await db
@@ -605,6 +607,167 @@ describe("github integration", async () => {
       command: "builder",
       agentCommand: "codex-builder",
       ambiguous: false,
+    });
+  });
+
+  it("routes only creation actions and denies replay-prone GitHub updates", async () => {
+    const issue = {
+      issue: { number: 42, title: "/architect", body: "Plan it" },
+      repository: { owner: { login: "octo" }, name: "repo" },
+      sender: { login: "writer", type: "User" },
+    };
+    await expect(
+      routeTrigger({} as never, "org_test", {} as never, { ...issue, action: "edited" }),
+    ).resolves.toEqual({ routed: false, reason: "unsupported_action" });
+    await expect(
+      routeTrigger({} as never, "org_test", {} as never, {
+        ...issue,
+        action: "edited",
+        comment: { id: 7, body: "/architect" },
+      }),
+    ).resolves.toEqual({ routed: false, reason: "unsupported_action" });
+  });
+
+  it("validates the repository-owned platform lane manifest", () => {
+    expect(
+      parseFacilityRepoManifest(
+        JSON.stringify({
+          packageInstall: "pnpm install --frozen-lockfile",
+          provision: "pnpm run local:setup:ui",
+          checks: ["pnpm verify"],
+          models: { build: "opusplan", plan: "claude-fable-5" },
+          executionLane: {
+            architect: "platform",
+            builder: "platform",
+            review: "repo",
+          },
+        }),
+      ),
+    ).toEqual({
+      packageInstall: "pnpm install --frozen-lockfile",
+      provision: "pnpm run local:setup:ui",
+      checks: ["pnpm verify"],
+      models: { build: "opusplan", plan: "claude-fable-5" },
+      executionLane: { architect: "platform", builder: "platform", review: "repo" },
+    });
+    expect(() =>
+      parseFacilityRepoManifest(JSON.stringify({ executionLane: { review: "sometimes" } })),
+    ).toThrow("executionLane values must be repo or platform");
+  });
+
+  it("reconciles the repository manifest at handoff time and fails closed when removed", async () => {
+    const org = (await db.select().from(orgs).orderBy(asc(orgs.createdAt)).limit(1))[0];
+    if (!org) throw new Error("seeded org missing");
+    const suffix = newId("evt");
+    const projectId = newId("proj");
+    const repoId = newId("repo");
+    await db.insert(projects).values({
+      id: projectId,
+      orgId: org.id,
+      name: "Manifest handoff",
+      slug: `manifest-handoff-${suffix}`,
+      settings: {},
+    });
+    const [repo] = await db
+      .insert(repos)
+      .values({
+        id: repoId,
+        orgId: org.id,
+        projectId,
+        owner: "octo",
+        name: `manifest-${suffix}`,
+        defaultBranch: "main",
+        renderAnswers: { execution_lane: { architect: "repo" }, preserved: true },
+      })
+      .returning();
+    if (!repo) throw new Error("manifest repo missing");
+    const manifest = JSON.stringify({
+      packageInstall: "pnpm install --frozen-lockfile",
+      provision: "pnpm run local:setup:ui",
+      checks: ["pnpm verify"],
+      executionLane: { architect: "platform", builder: "platform" },
+    });
+    const facilityClient = new FacilityGithubClient(
+      {
+        rest: {
+          repos: {
+            getContent: async () => ({
+              data: {
+                type: "file",
+                encoding: "base64",
+                content: Buffer.from(manifest).toString("base64"),
+              },
+            }),
+          },
+        },
+      } as never,
+      { owner: repo.owner, repo: repo.name, defaultBranch: repo.defaultBranch },
+    );
+
+    await expect(
+      syncRepoFacilityConfig({ db, client: facilityClient, repo }),
+    ).resolves.toMatchObject({
+      packageInstallCmd: "pnpm install --frozen-lockfile",
+      provisionCmd: "pnpm run local:setup:ui",
+      checkCmds: ["pnpm verify"],
+      execution_lane: { architect: "platform", builder: "platform" },
+      preserved: true,
+    });
+    const [project] = await db.select().from(projects).where(eq(projects.id, projectId));
+    expect(project?.settings).toEqual({});
+
+    const [syncedRepo] = await db.select().from(repos).where(eq(repos.id, repoId));
+    if (!syncedRepo) throw new Error("synced repo missing");
+    const laneOnlyClient = new FacilityGithubClient(
+      {
+        rest: {
+          repos: {
+            getContent: async () => ({
+              data: {
+                type: "file",
+                encoding: "base64",
+                content: Buffer.from(
+                  JSON.stringify({ executionLane: { architect: "platform" } }),
+                ).toString("base64"),
+              },
+            }),
+          },
+        },
+      } as never,
+      { owner: repo.owner, repo: repo.name, defaultBranch: repo.defaultBranch },
+    );
+    await syncRepoFacilityConfig({ db, client: laneOnlyClient, repo: syncedRepo });
+    const [clearedRepo] = await db.select().from(repos).where(eq(repos.id, repoId));
+    expect(clearedRepo?.renderAnswers).toMatchObject({
+      packageInstallCmd: null,
+      provisionCmd: null,
+      checkCmds: [],
+      models: {},
+      execution_lane: { architect: "platform" },
+      preserved: true,
+    });
+    if (!clearedRepo) throw new Error("cleared repo missing");
+    const missingClient = new FacilityGithubClient(
+      {
+        rest: {
+          repos: {
+            getContent: async () => {
+              throw Object.assign(new Error("not found"), { status: 404 });
+            },
+          },
+        },
+      } as never,
+      { owner: repo.owner, repo: repo.name, defaultBranch: repo.defaultBranch },
+    );
+    await syncRepoFacilityConfig({ db, client: missingClient, repo: clearedRepo });
+    const [optedOutRepo] = await db.select().from(repos).where(eq(repos.id, repoId));
+    expect(optedOutRepo?.renderAnswers).toMatchObject({
+      packageInstallCmd: null,
+      provisionCmd: null,
+      checkCmds: [],
+      models: {},
+      execution_lane: {},
+      preserved: true,
     });
   });
 

--- a/services/api/test/orchestrator-checks.test.ts
+++ b/services/api/test/orchestrator-checks.test.ts
@@ -3,7 +3,9 @@ import {
   platformDeliveryFailure,
   renderRunContract,
   resolveCheckCmds,
+  resolvePackageInstallCmd,
   resolveProvisionCmd,
+  resolveRepoEngineConfig,
   runSafePermissions,
 } from "../src/sandbox/orchestrator.js";
 
@@ -18,33 +20,89 @@ describe("platform delivery boundaries", () => {
 
 describe("resolveCheckCmds — acceptance-gate source of truth", () => {
   it("uses the project's configured checks when the sandbox profile has none", () => {
-    expect(resolveCheckCmds({ setup: {} }, { check_cmds: ["pnpm test", "pnpm lint"] })).toEqual([
-      "pnpm test",
-      "pnpm lint",
-    ]);
+    expect(resolveCheckCmds({ setup: {} }, {}, { check_cmds: ["pnpm test", "pnpm lint"] })).toEqual(
+      ["pnpm test", "pnpm lint"],
+    );
   });
 
   it("lets an explicit sandbox-profile override win over project checks", () => {
     expect(
-      resolveCheckCmds({ setup: { check_cmds: ["make ci"] } }, { check_cmds: ["pnpm test"] }),
+      resolveCheckCmds(
+        { setup: { check_cmds: ["make ci"] } },
+        { checkCmds: ["pnpm repo-test"] },
+        { check_cmds: ["pnpm project-test"] },
+      ),
     ).toEqual(["make ci"]);
   });
 
   it("is empty when neither profile nor project configures checks", () => {
-    expect(resolveCheckCmds({ setup: {} }, { check_cmds: [] })).toEqual([]);
-    expect(resolveCheckCmds({ setup: {} }, undefined)).toEqual([]);
-    expect(resolveCheckCmds({ setup: null }, null)).toEqual([]);
+    expect(resolveCheckCmds({ setup: {} }, {}, { check_cmds: [] })).toEqual([]);
+    expect(resolveCheckCmds({ setup: {} }, undefined, undefined)).toEqual([]);
+    expect(resolveCheckCmds({ setup: null }, null, null)).toEqual([]);
   });
 
   it("ignores non-string entries", () => {
-    expect(resolveCheckCmds({ setup: {} }, { check_cmds: ["ok", 3, null, "fine"] })).toEqual([
+    expect(resolveCheckCmds({ setup: {} }, {}, { check_cmds: ["ok", 3, null, "fine"] })).toEqual([
       "ok",
       "fine",
     ]);
   });
+
+  it("keeps checks repository-specific when a project has multiple repos", () => {
+    expect(
+      resolveCheckCmds(
+        { setup: {} },
+        { checkCmds: ["pnpm --filter repo-a test"] },
+        { check_cmds: ["legacy project check"] },
+      ),
+    ).toEqual(["pnpm --filter repo-a test"]);
+    expect(resolveCheckCmds({ setup: {} }, { checkCmds: [] }, { check_cmds: ["legacy"] })).toEqual(
+      [],
+    );
+  });
+});
+
+describe("repository-specific model overrides", () => {
+  it("applies only the selected repo's engine model", () => {
+    expect(
+      resolveRepoEngineConfig(
+        "architect",
+        { model: "default-model", effort: "high" },
+        { models: { plan: "repo-a-plan" } },
+      ),
+    ).toEqual({ model: "repo-a-plan", effort: "high" });
+    expect(
+      resolveRepoEngineConfig(
+        "codex-builder",
+        { primary: "default-codex", reasoning_effort: "high" },
+        { models: { codexBuild: "repo-a-codex" } },
+      ),
+    ).toEqual({ primary: "repo-a-codex", reasoning_effort: "high" });
+  });
+
+  it("does not let another repo's absent override mutate the project default", () => {
+    expect(resolveRepoEngineConfig("builder", { model: "default" }, { models: {} })).toEqual({
+      model: "default",
+    });
+  });
 });
 
 describe("platform run repository setup", () => {
+  it("keeps dependency installation separate from repository provisioning", () => {
+    expect(
+      resolvePackageInstallCmd(
+        { setup: {} },
+        { packageInstallCmd: "pnpm install --frozen-lockfile" },
+      ),
+    ).toBe("pnpm install --frozen-lockfile");
+    expect(
+      resolvePackageInstallCmd(
+        { setup: { package_install_cmd: "npm ci" } },
+        { packageInstallCmd: "pnpm install" },
+      ),
+    ).toBe("npm ci");
+  });
+
   it("uses the kickstart provision command when the profile has no override", () => {
     expect(resolveProvisionCmd({ setup: {} }, { provisionCmd: "pnpm install" })).toBe(
       "pnpm install",

--- a/services/api/test/previews.test.ts
+++ b/services/api/test/previews.test.ts
@@ -11,9 +11,10 @@ import {
   destroyPreview,
   provisionPreview,
   proxyPreviewRequest,
+  reconcilePreviews,
   rewritePreviewHtml,
 } from "../src/previews.js";
-import type { SandboxDriver } from "../src/sandbox/driver.js";
+import { type SandboxDriver, SandboxLaunchError } from "../src/sandbox/driver.js";
 import type { AppConfig, Principal } from "../src/types.js";
 
 const databaseUrl =
@@ -210,6 +211,7 @@ describe("SSO-protected preview sandboxes", async () => {
 
       const destroyed = await destroyPreview(db, stored, "destroyed", driver);
       expect(destroyed?.status).toBe("destroyed");
+      expect(destroyed?.ref).toBeNull();
       expect(destroyed?.originUrl).toBeNull();
       expect(destroyedRef).toBe("preview-container");
 
@@ -255,5 +257,56 @@ describe("SSO-protected preview sandboxes", async () => {
         server.close((error) => (error ? reject(error) : resolve())),
       );
     }
+  });
+
+  it("persists a leaked launch ref and clears it on reconciliation", async () => {
+    const preview = await createPreviewRecord(db, {
+      orgId,
+      projectId,
+      image: "ghcr.io/example/app:sha-cleanup-retry",
+      port: 3000,
+      ttlHours: 24,
+      createdBy: { type: "user", id: "preview-owner" },
+    });
+    if (!preview) throw new Error("preview cleanup fixture missing");
+    const leakedRef = "preview-task-that-needs-retry";
+    const leakingDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => {
+        throw new SandboxLaunchError("launch_cleanup_failed", leakedRef);
+      },
+      status: async () => "lost",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+    await expect(provisionPreview(config, preview.id, leakingDriver)).rejects.toThrow(
+      "launch_cleanup_failed",
+    );
+    const retained = (
+      await db.select().from(previewSandboxes).where(eq(previewSandboxes.id, preview.id)).limit(1)
+    )[0];
+    expect(retained).toMatchObject({
+      status: "failed",
+      ref: leakedRef,
+      error: "launch_cleanup_failed",
+    });
+
+    let destroyedRef = "";
+    const cleanupDriver: SandboxDriver = {
+      ...leakingDriver,
+      launch: async () => ({ ref: "unused" }),
+      destroy: async (ref) => {
+        destroyedRef = ref;
+      },
+    };
+    await expect(reconcilePreviews(config, cleanupDriver)).resolves.toMatchObject({
+      changed: expect.arrayContaining([preview.id]),
+    });
+    expect(destroyedRef).toBe(leakedRef);
+    const reconciled = (
+      await db.select().from(previewSandboxes).where(eq(previewSandboxes.id, preview.id)).limit(1)
+    )[0];
+    expect(reconciled).toMatchObject({ status: "failed", ref: null });
   });
 });

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -72,6 +72,7 @@ describe("sandbox api", async () => {
     sandboxDriver: "docker",
     webUrl: "http://localhost:3000",
     facilityInsecureDev: true,
+    packageRegistryToken: "package-token",
     logLevel: "silent",
   };
   const { db, client } = createDb(databaseUrl);
@@ -639,6 +640,7 @@ describe("sandbox api", async () => {
           branch: "main",
           installationTokenRef: installation.id,
         },
+        packageInstallCmd: "pnpm install --frozen-lockfile",
         provisionCmd: null,
         checkCmds: [],
         gatewayUrls: { anthropic: "http://gateway/anthropic", openai: "http://gateway/openai" },
@@ -661,6 +663,7 @@ describe("sandbox api", async () => {
     expect(response.statusCode).toBe(200);
     const hello = response.json();
     expect(hello.repoToken).toBe("installation-token");
+    expect(hello.packageRegistryToken).toBe("package-token");
     expect(hello.bundleUrl).not.toContain("?");
     const bundlePath = new URL(hello.bundleUrl).pathname;
     expect((await app.inject({ method: "GET", url: bundlePath })).statusCode).toBe(401);
@@ -677,7 +680,61 @@ describe("sandbox api", async () => {
       repo: "private-repo",
       permissions: { contents: "read" },
     });
+    const replay = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/hello`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(replay.statusCode).toBe(409);
+    expect(replay.json().error.code).toBe("virtual_key_revealed");
     app.githubInstallationTokenFactory = undefined;
+  });
+
+  it("does not release the package token when no dedicated install phase exists", async () => {
+    const token = `frt_no_package_${Date.now()}`;
+    const runId = newId("run");
+    const run = await insertRunnerRun(token, "provisioning", runId, {
+      runnerTokenHash: await hashKey(token),
+      sealedVirtualKey: await seal("fvk_no_package", masterKey),
+      bundle: {
+        runId,
+        mode: "architect",
+        engine: "byo",
+        contract: "contract",
+        skills: [],
+        engineConfig: {},
+        repo: { cloneUrl: null, branch: null, installationTokenRef: null },
+        packageInstallCmd: null,
+        provisionCmd: null,
+        checkCmds: [],
+        gatewayUrls: { anthropic: "http://gateway/anthropic", openai: "http://gateway/openai" },
+        scope: {},
+        timeoutMin: 60,
+      },
+    });
+    const response = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/hello`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json().packageRegistryToken).toBeNull();
+  });
+
+  it("denies credential release after a run is terminal", async () => {
+    const token = `frt_terminal_${Date.now()}`;
+    const run = await insertRunnerRun(token, "failed", newId("run"), {
+      runnerTokenHash: await hashKey(token),
+      sealedVirtualKey: await seal("fvk_terminal", masterKey),
+      bundle: { packageInstallCmd: "pnpm install --frozen-lockfile" },
+    });
+    const response = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/hello`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("run_terminal");
   });
 
   it("redacts sealed run credentials from run read APIs", async () => {


### PR DESCRIPTION
## What changes

- Adds an authoritative `.facility.json` for existing repositories, with independent `platform` and `repo` lane routing while preserving repository-owned skills, guards, hooks, workflows, checks, model overrides, schedules, and GitHub event routing.
- Runs platform lanes in a fixed, Terraform-deployed AWS CodeBuild runner image. Inbound preview workloads remain on unprivileged ECS/Fargate.
- Gives platform lanes nested Docker through a rootless daemon and a policy-enforcing proxy. The untrusted agent cannot reach the raw socket, runner credentials, AWS credentials, Facility runtime files, host namespaces/devices, metadata endpoints, or unsafe bind mounts.
- Pins workspace bind sources transactionally through a root broker, while keeping CodeBuild control-plane egress available only to the trusted root agent.
- Makes preview cleanup convergent by persisting partial AWS resources and retrying cleanup after launch or destroy failures.
- Installs private GitHub Packages dependencies with a one-shot npm credential that is removed after the install child exits.

## Why

Facility needs a `platform` lane for `theam/tam-os` that can build and run Docker without weakening the existing AI SDLC or exposing the production control plane. CodeBuild supplies the privileged outer sandbox required for rootless nested Docker; the runner maintains a separate untrusted execution identity and a restricted Docker API boundary.

The deployed CodeBuild project always uses the audited Facility runner image. Repository configuration cannot override that image and inherit the CodeBuild service role.

No development OpenAI or Anthropic key is added, forwarded, or deployed by this change. Provider credentials will be configured directly in Facility later.

## Verification

- [x] `pnpm verify` passes locally
  - clean typecheck and build
  - database: 1 file / 8 tests
  - CLI: 67 tests
  - API: 29 files / 258 tests
  - gateway: 2 files / 34 tests
  - runner: 5 files / 80 tests
  - repository guards: 2 passed / 0 failed
  - dependency audit: no known vulnerabilities
- [x] Behaviour verified beyond the test suite
  - local amd64 privileged emulation emitted `Facility CodeBuild Docker security boundary passed create-only emulation checks`
  - production native x86 CodeBuild build `d9356f4b-e6ad-4ad4-8c7e-5e2e1f3df102` completed `SUCCEEDED`
  - native smoke exercised UID-scoped metadata isolation, rootless Docker, permitted and denied binds, Docker capability policy, pinned-bind race resistance, and transactional rollback
  - production API and MCP health/readiness return 200; application redirects unauthenticated users to login
  - Terraform detailed plan returns exit 0 with no drift after deployment
- [x] Documentation updated
  - updated AWS self-hosting, sandbox architecture, CLI, existing-repository, and Terraform guidance

Independent subagent review approved the final diff with P0 = 0, P1 = 0, and P2 = 0. The reviewer checked IAM, Docker escape paths, lifecycle credentials, metadata egress, cleanup convergence, streaming semantics, and TAM compatibility.

A model-backed TAM lane is intentionally not executed with development provider keys. The CodeBuild execution boundary is live; provider credentials can be added directly in Facility afterward as requested.
