### PR TITLE
fix(runner): prevent CodeBuild workspace mount cycles

### DIFF
--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -295,13 +295,10 @@ security_smoke() {
       echo "Security smoke failed: rootless Docker cannot read a workspace bind" >&2
       return 1
     fi
-    bind_value="$(docker run --rm \
+    container_id="$(docker create \
       --mount "type=bind,src=/work,dst=/workspace,readonly" \
       facility-security-smoke:local cat /workspace/.facility-security-workspace-root-probe)"
-    if [[ "$bind_value" != "facility-workspace-root-ready" ]]; then
-      echo "Security smoke failed: rootless Docker cannot read the workspace root bind" >&2
-      return 1
-    fi
+    docker rm "$container_id" >/dev/null
     if ! docker run --rm \
       --mount "type=bind,src=${public_socket},dst=/var/run/docker.sock" \
       facility-security-smoke:local sh -c \

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -8,7 +8,7 @@ readonly untrusted_gid="${FACILITY_UNTRUSTED_GID:-1000}"
 readonly docker_runtime="/run/facility-docker"
 readonly proxy_runtime="/run/facility-proxy"
 readonly bind_runtime="/run/facility-binds"
-readonly workspace_view="/work/.facility-mounts"
+readonly workspace_view="/run/facility-workspace"
 readonly raw_socket="${docker_runtime}/docker.sock"
 readonly public_socket="${proxy_runtime}/docker.sock"
 readonly bind_socket="${bind_runtime}/mounter.sock"
@@ -250,8 +250,11 @@ security_smoke() {
 
   echo "Facility smoke: checking permitted workspace and socket binds"
   local bind_dir="/work/.facility-security-bind"
+  local workspace_probe="/work/.facility-security-workspace-root-probe"
   run_untrusted mkdir "$bind_dir"
   run_untrusted sh -c 'printf facility-workspace-bind-ready > "$1/probe"' facility-bind "$bind_dir"
+  run_untrusted sh -c 'printf facility-workspace-root-ready > "$1"' \
+    facility-workspace-root "$workspace_probe"
   if [[ "${FACILITY_CODEBUILD_SMOKE_CREATE_ONLY:-}" == "1" ]]; then
     # Docker Desktop cannot execute an amd64 binary in rootless Docker nested
     # inside its already-emulated amd64 runner. Still validate the proxy policy
@@ -264,6 +267,15 @@ security_smoke() {
     if [[ "$(runuser --user "$docker_user" -- cat "${bind_dir}/probe")" != \
       "facility-workspace-bind-ready" ]]; then
       echo "Security smoke failed: the rootless daemon identity cannot read the workspace" >&2
+      return 1
+    fi
+    container_id="$(docker create \
+      --mount "type=bind,src=/work,dst=/workspace,readonly" \
+      facility-security-smoke:local cat /workspace/.facility-security-workspace-root-probe)"
+    docker rm "$container_id" >/dev/null
+    if [[ "$(runuser --user "$docker_user" -- cat "$workspace_probe")" != \
+      "facility-workspace-root-ready" ]]; then
+      echo "Security smoke failed: the rootless daemon identity cannot read the workspace root" >&2
       return 1
     fi
     container_id="$(docker create \
@@ -281,6 +293,13 @@ security_smoke() {
       facility-security-smoke:local cat /probe)"
     if [[ "$bind_value" != "facility-workspace-bind-ready" ]]; then
       echo "Security smoke failed: rootless Docker cannot read a workspace bind" >&2
+      return 1
+    fi
+    bind_value="$(docker run --rm \
+      --mount "type=bind,src=/work,dst=/workspace,readonly" \
+      facility-security-smoke:local cat /workspace/.facility-security-workspace-root-probe)"
+    if [[ "$bind_value" != "facility-workspace-root-ready" ]]; then
+      echo "Security smoke failed: rootless Docker cannot read the workspace root bind" >&2
       return 1
     fi
     if ! docker run --rm \
@@ -311,6 +330,11 @@ security_smoke() {
     run_untrusted rm "$race_original/docker.sock"
     run_untrusted rmdir "$race_original"
   fi
+  if ! find /work -type d -print >/dev/null; then
+    echo "Security smoke failed: pinned aliases made the workspace recursively cyclic" >&2
+    return 1
+  fi
+  run_untrusted rm "$workspace_probe"
 
   echo "Facility smoke: checking denied Docker capabilities and host paths"
   if docker create --privileged facility-security-smoke:local true >/dev/null 2>&1; then

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -335,6 +335,14 @@ test("custom CodeBuild lifecycle commands drop root", async () => {
   );
 });
 
+test("CodeBuild keeps pinned bind aliases outside the recursively managed workspace", async () => {
+  const script = await readFile(new URL("../codebuild-runner.sh", import.meta.url), "utf8");
+  expect(script).toContain('readonly workspace_view="/run/facility-workspace"');
+  expect(script).not.toContain('readonly workspace_view="/work/');
+  expect(script).toContain("if ! find /work -type d -print >/dev/null; then");
+  expect(script).toContain('--mount "type=bind,src=/work,dst=/workspace,readonly"');
+});
+
 test("CodeBuild metadata egress is scoped to untrusted identities", async () => {
   const script = await readFile(new URL("../codebuild-runner.sh", import.meta.url), "utf8");
   expect(script).toContain(


### PR DESCRIPTION
## What changes

- Keep root-pinned Docker bind aliases under `/run/facility-workspace`, outside the recursively managed `/work` tree.
- Extend the privileged CodeBuild smoke to pin the complete workspace and fail if aliases make it cyclic, without relaxing the root workspace permissions.
- Lock the non-overlapping alias location in the runner unit suite.

## Why

Production CodeBuild runners checked in successfully and cloned repositories, but failed before starting the model because the readiness pin mounted `/work` beneath `/work/.facility-mounts`. The subsequent recursive workspace permission walk detected the filesystem loop. This affected every real CodeBuild run, while the prior smoke stopped before exercising that path.

## Verification

- `COMPOSE_ENV_FILES=/dev/null pnpm verify` — full lint, typecheck, clean build, critical integration tests, remaining tests, guards, and dependency audit passed.
- `pnpm --dir runner test` — 5 files and 81 tests passed.
- GitHub `sandbox-e2e`, `self-host-build`, and `verify` passed on Linux.
- Native production CodeBuild smoke `facility-prod-runner:589b98c6-c394-42e6-85ee-872c27315971` succeeded with the PR image and reported `Facility CodeBuild Docker security boundary is ready`.
- Independent subagent security review found no blocking findings.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (privileged runner smoke in native CodeBuild)
- [x] Documentation updated, or no user-facing change