### PR TITLE
fix(runner): retry rate-limited lifecycle events

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -35,6 +35,9 @@ const engineStderrFile = join(runtimeRoot, "engine.stderr.log");
 const AGENT_PROGRESS_MAX_BYTES = 16 * 1024;
 const SECURITY_REPORT_MAX_BYTES = 256 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
+const RATE_LIMIT_RETRY_LIMIT = 8;
+const DEFAULT_RETRY_AFTER_MS = 1_000;
+const MAX_RETRY_AFTER_MS = 60_000;
 const PRIVATE_REGISTRY_INSTALL_COMMANDS = new Set([
   "npm ci",
   "pnpm install --frozen-lockfile",
@@ -550,12 +553,15 @@ async function uploadTranscript() {
     .catch(() => 0);
   if (size === 0) return;
   try {
-    await api(`/internal/runs/${currentRunId()}/transcript`, {
-      method: "POST",
-      headers: { "content-type": "application/x-ndjson" },
-      body: createReadStream(transcriptFile) as unknown as RequestInit["body"],
-      duplex: "half",
-    } as RequestInit & { duplex: "half" });
+    await api(
+      `/internal/runs/${currentRunId()}/transcript`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-ndjson" },
+        duplex: "half",
+      } as RequestInit & { duplex: "half" },
+      () => createReadStream(transcriptFile) as unknown as RequestInit["body"],
+    );
   } catch {
     await emit([{ type: "artifact_error", data: { kind: "transcript_upload_failed" } }]).catch(
       () => undefined,
@@ -611,12 +617,15 @@ async function uploadSessionState(bundle: RunBundle) {
       ]).catch(() => undefined);
       return;
     }
-    await api(`/internal/runs/${currentRunId()}/session-state`, {
-      method: "POST",
-      headers: { "content-type": "application/gzip" },
-      body: createReadStream(sessionStateArchive) as unknown as RequestInit["body"],
-      duplex: "half",
-    } as RequestInit & { duplex: "half" });
+    await api(
+      `/internal/runs/${currentRunId()}/session-state`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/gzip" },
+        duplex: "half",
+      } as RequestInit & { duplex: "half" },
+      () => createReadStream(sessionStateArchive) as unknown as RequestInit["body"],
+    );
   } catch (error) {
     await emit([
       {
@@ -1623,22 +1632,63 @@ async function emit(events: RunEvent[]) {
   });
 }
 
-async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
+async function api<T>(
+  path: string,
+  init: RequestInit = {},
+  bodyFactory?: () => RequestInit["body"],
+): Promise<T> {
   const headers: Record<string, string> = { authorization: `Bearer ${runnerToken()}` };
   if (init.body) headers["content-type"] = "application/json";
-  return fetchJson(`${apiUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...headers,
-      ...(init.headers ?? {}),
+  return fetchJson(
+    `${apiUrl()}${path}`,
+    {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers ?? {}),
+      },
     },
-  }) as Promise<T>;
+    bodyFactory,
+  ) as Promise<T>;
 }
 
-async function fetchJson(url: string, init: RequestInit = {}) {
-  const response = await fetch(url, init);
-  if (!response.ok) throw new Error(`${url} failed ${response.status}: ${await response.text()}`);
-  return response.json();
+export function retryAfterMs(value: string | null, now = Date.now()) {
+  if (value) {
+    const trimmed = value.trim();
+    if (/^\d+$/.test(trimmed)) {
+      const seconds = Number(trimmed);
+      return Math.min(seconds * 1_000, MAX_RETRY_AFTER_MS);
+    }
+    if (/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s/.test(trimmed)) {
+      const date = Date.parse(trimmed);
+      if (Number.isFinite(date)) {
+        return Math.min(Math.max(0, date - now), MAX_RETRY_AFTER_MS);
+      }
+    }
+  }
+  return DEFAULT_RETRY_AFTER_MS;
+}
+
+export async function fetchJson(
+  url: string,
+  init: RequestInit = {},
+  bodyFactory?: () => RequestInit["body"],
+) {
+  for (let attempt = 0; ; attempt += 1) {
+    const response = await fetch(url, bodyFactory ? { ...init, body: bodyFactory() } : init);
+    if (response.ok) return response.json();
+    const body = await response.text();
+    if (response.status !== 429 || attempt >= RATE_LIMIT_RETRY_LIMIT) {
+      throw new Error(`${url} failed ${response.status}: ${body}`);
+    }
+    // The global API limiter rejects the request before a route handler runs,
+    // so replaying the runner's JSON request after Retry-After cannot duplicate
+    // an accepted event or terminal result. Awaiting here applies backpressure
+    // to noisy child processes instead of turning a temporary 429 into a crash.
+    await new Promise((resolve) =>
+      setTimeout(resolve, retryAfterMs(response.headers.get("retry-after"))),
+    );
+  }
 }
 
 export function engineEnv() {

--- a/runner/test/http-retry.integration.test.ts
+++ b/runner/test/http-retry.integration.test.ts
@@ -1,0 +1,131 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { fetchJson, retryAfterMs } from "../src/index.js";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
+  );
+});
+
+describe("runner HTTP rate-limit recovery", () => {
+  it("parses numeric and HTTP-date Retry-After values with a bounded fallback", () => {
+    const now = Date.parse("2026-08-05T10:00:00.000Z");
+    expect(retryAfterMs("4", now)).toBe(4_000);
+    expect(retryAfterMs("Wed, 05 Aug 2026 10:00:03 GMT", now)).toBe(3_000);
+    expect(retryAfterMs("3600", now)).toBe(60_000);
+    expect(retryAfterMs("-1", now)).toBe(1_000);
+    expect(retryAfterMs("0x10", now)).toBe(1_000);
+    expect(retryAfterMs("1e2", now)).toBe(1_000);
+    expect(retryAfterMs("invalid", now)).toBe(1_000);
+    expect(retryAfterMs(null, now)).toBe(1_000);
+  });
+
+  it("creates a fresh streaming body for every upload attempt", async () => {
+    const bodies: string[] = [];
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        bodies.push(body);
+        response.setHeader("content-type", "application/json");
+        if (bodies.length === 1) {
+          response.statusCode = 429;
+          response.setHeader("retry-after", "0");
+          response.end(JSON.stringify({ error: "rate_limited" }));
+          return;
+        }
+        response.end(JSON.stringify({ uploaded: true }));
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const payload = "streamed transcript\n";
+
+    await expect(
+      fetchJson(
+        `http://127.0.0.1:${port}/transcript`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/x-ndjson" },
+          duplex: "half",
+        } as RequestInit & { duplex: "half" },
+        () => Readable.from(payload) as unknown as RequestInit["body"],
+      ),
+    ).resolves.toEqual({ uploaded: true });
+    expect(bodies).toEqual([payload, payload]);
+  });
+
+  it("replays an authenticated event batch after a deterministic 429", async () => {
+    const requests: Array<{ authorization: string | undefined; body: string }> = [];
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        requests.push({ authorization: request.headers.authorization, body });
+        response.setHeader("content-type", "application/json");
+        if (requests.length === 1) {
+          response.statusCode = 429;
+          response.setHeader("retry-after", "0");
+          response.end(JSON.stringify({ error: "rate_limited" }));
+          return;
+        }
+        response.end(JSON.stringify({ count: 1 }));
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const payload = JSON.stringify([{ type: "shell", data: { text: "installed" } }]);
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/internal/runs/run_test/events`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer runner-test-token",
+          "content-type": "application/json",
+        },
+        body: payload,
+      }),
+    ).resolves.toEqual({ count: 1 });
+    expect(requests).toEqual([
+      { authorization: "Bearer runner-test-token", body: payload },
+      { authorization: "Bearer runner-test-token", body: payload },
+    ]);
+  });
+
+  it("fails closed after the bounded number of rate-limit retries", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.statusCode = 429;
+      response.setHeader("content-type", "application/json");
+      response.setHeader("retry-after", "0");
+      response.end(JSON.stringify({ error: "still_rate_limited" }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(fetchJson(`http://127.0.0.1:${port}/events`)).rejects.toThrow("failed 429");
+    expect(attempts).toBe(9);
+  });
+});

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -173,6 +173,30 @@ describe("sandbox api", async () => {
     expect((stored?.data as { text?: string })?.text).toBe(text);
   });
 
+  it("rejects rate-limited runner events before persisting them", async () => {
+    const token = "frt_rate_limit";
+    const run = await insertRunnerRun(token, "running");
+    const limited = await buildApp(config, { rateLimitMax: 1 });
+    await limited.ready();
+    try {
+      const request = {
+        method: "POST" as const,
+        url: `/internal/runs/${run.id}/events`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: [{ type: "shell", data: { text: "installed" } }],
+      };
+      expect((await limited.inject(request)).statusCode).toBe(200);
+      expect((await limited.inject(request)).statusCode).toBe(429);
+      const persisted = await db
+        .select({ seq: runEvents.seq })
+        .from(runEvents)
+        .where(eq(runEvents.runId, run.id));
+      expect(persisted).toHaveLength(1);
+    } finally {
+      await limited.close();
+    }
+  });
+
   it("aws driver fails loudly as not_configured when env is missing", async () => {
     await expect(
       new AwsSandboxDriver().launch({


### PR DESCRIPTION
## What changes

- Retry runner control-plane requests that receive HTTP 429, honoring valid numeric and HTTP-date `Retry-After` values.
- Bound retries to nine total attempts so persistent throttling still fails closed.
- Recreate transcript and session-state streams for every retry instead of reusing consumed bodies.
- Prove that the real API limiter rejects duplicate event requests before persistence.

## Why

A production tam-os builder successfully cloned the private repository and installed dependencies, then crashed before starting the agent when a high-volume shell event received 429 from the Facility API. Applying backpressure preserves lifecycle events and artifacts instead of terminating the runner.

## Verification

- [x] `pnpm verify` passes in GitHub CI.
- [x] Runner tests: 6 files, 85 tests; typecheck and build pass.
- [x] API sandbox integration: 1 file, 22 tests.
- [x] GitHub `sandbox-e2e`, `self-host-build`, commit and PR-title checks pass.
- [x] AWS CodeBuild privileged smoke passed with the exact PR image: `facility-prod-runner:f08e8801-a9e0-4e76-9ad8-df05e15e7688`.
- [x] Independent subagent re-review and final shipping review approved the updated HEAD without findings.
- [x] No user-facing configuration or API contract changes.