### PR TITLE
fix(runner): batch lifecycle events

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -38,6 +38,11 @@ const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
 const RATE_LIMIT_RETRY_LIMIT = 8;
 const DEFAULT_RETRY_AFTER_MS = 1_000;
 const MAX_RETRY_AFTER_MS = 60_000;
+const EVENT_BATCH_MAX = 50;
+// Fastify's JSON body limit is 1 MiB. Leave room for envelope overhead and
+// future schema fields while retaining the old ability to send one large line.
+const EVENT_BATCH_MAX_BYTES = 900 * 1024;
+const EVENT_BATCH_FLUSH_MS = 100;
 const PRIVATE_REGISTRY_INSTALL_COMMANDS = new Set([
   "npm ci",
   "pnpm install --frozen-lockfile",
@@ -721,12 +726,7 @@ async function runShell(
     ...untrustedSpawnIdentity(),
   });
   const clearTimers = armEngineTimeout(child, timeoutMin);
-  const drains = [child.stdout, child.stderr].map((stream) => {
-    const rl = createInterface({ input: stream });
-    return (async () => {
-      for await (const line of rl) await emit([{ type: eventType, data: { text: line } }]);
-    })();
-  });
+  const drains = [child.stdout, child.stderr].map((stream) => drainLineEvents(stream, eventType));
   const code = await exitCode(child);
   // Wait for both stream readers to finish draining before returning, so no
   // output line is emitted AFTER the caller records the run's result (a late
@@ -735,6 +735,114 @@ async function runShell(
   await Promise.all(drains);
   clearTimers();
   return code;
+}
+
+export async function drainLineEvents(
+  stream: NodeJS.ReadableStream,
+  eventType: string,
+  send: (events: RunEvent[]) => Promise<unknown> = emit,
+  options: { batchSize?: number; maxBatchBytes?: number; flushMs?: number } = {},
+) {
+  const batchSize = options.batchSize ?? EVENT_BATCH_MAX;
+  const maxBatchBytes = options.maxBatchBytes ?? EVENT_BATCH_MAX_BYTES;
+  const flushMs = options.flushMs ?? EVENT_BATCH_FLUSH_MS;
+  if (!Number.isInteger(batchSize) || batchSize < 1) throw new Error("invalid_event_batch_size");
+  if (!Number.isInteger(maxBatchBytes) || maxBatchBytes < 1)
+    throw new Error("invalid_event_batch_max_bytes");
+  if (!Number.isFinite(flushMs) || flushMs < 0) throw new Error("invalid_event_batch_flush_ms");
+
+  const lines = createInterface({ input: stream });
+  let buffered: RunEvent[] = [];
+  // Opening and closing brackets are always present in the serialized array.
+  let bufferedBytes = 2;
+  let flushTimer: ReturnType<typeof setTimeout> | undefined;
+  let activeDelivery: Promise<void> | undefined;
+  let deliveryError: unknown;
+
+  const clearFlushTimer = () => {
+    if (flushTimer) clearTimeout(flushTimer);
+    flushTimer = undefined;
+  };
+  const scheduleFlush = () => {
+    if (flushTimer || activeDelivery || buffered.length === 0 || deliveryError) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = undefined;
+      startDelivery();
+    }, flushMs);
+  };
+  const startDelivery = () => {
+    if (activeDelivery || buffered.length === 0 || deliveryError) return;
+    clearFlushTimer();
+    const batch = buffered;
+    buffered = [];
+    bufferedBytes = 2;
+    const current = Promise.resolve().then(async () => {
+      await send(batch);
+    });
+    activeDelivery = current;
+    // Keep at most one active delivery and one bounded pending batch. A timer
+    // must never snapshot another partial batch while the API is throttling.
+    void current.then(
+      () => {
+        if (activeDelivery !== current) return;
+        activeDelivery = undefined;
+        if (buffered.length >= batchSize) startDelivery();
+        else scheduleFlush();
+      },
+      (error: unknown) => {
+        if (activeDelivery !== current) return;
+        activeDelivery = undefined;
+        deliveryError = error;
+        clearFlushTimer();
+        // Wake a reader waiting on more process output so the delivery failure
+        // is surfaced even when the underlying stream remains open.
+        lines.close();
+      },
+    );
+  };
+  const dispatchPending = async () => {
+    clearFlushTimer();
+    if (!activeDelivery) startDelivery();
+    else {
+      await activeDelivery;
+      if (deliveryError) throw deliveryError;
+      if (!activeDelivery && buffered.length > 0) startDelivery();
+    }
+  };
+
+  try {
+    for await (const line of lines) {
+      const event: RunEvent = { type: eventType, data: { text: line } };
+      const eventBytes = Buffer.byteLength(JSON.stringify(redactRunEvent(event)));
+      const separatorBytes = buffered.length === 0 ? 0 : 1;
+      if (buffered.length > 0 && bufferedBytes + separatorBytes + eventBytes > maxBatchBytes) {
+        // Flush the existing batch before adding a line that would exceed the
+        // request budget. A single large line is still sent on its own, as it
+        // was before batching, because splitting one event would change it.
+        await dispatchPending();
+      }
+
+      bufferedBytes += (buffered.length === 0 ? 0 : 1) + eventBytes;
+      buffered.push(event);
+      if (buffered.length >= batchSize || bufferedBytes >= maxBatchBytes) {
+        // Preserve stream backpressure at one pending batch while the API is
+        // throttling instead of chaining unbounded timer-created requests.
+        await dispatchPending();
+      } else {
+        scheduleFlush();
+      }
+    }
+    clearFlushTimer();
+    while (activeDelivery || buffered.length > 0) {
+      if (deliveryError) throw deliveryError;
+      if (!activeDelivery) startDelivery();
+      if (activeDelivery) await activeDelivery;
+    }
+    if (deliveryError) throw deliveryError;
+  } finally {
+    clearFlushTimer();
+    lines.close();
+  }
 }
 
 export async function runPackageInstall(
@@ -1619,13 +1727,17 @@ export function redactEventData(
   return value;
 }
 
+function redactRunEvent(event: RunEvent): RunEvent {
+  return event.data
+    ? { ...event, data: redactEventData(event.data) as Record<string, unknown> }
+    : event;
+}
+
 async function emit(events: RunEvent[]) {
   if (events.length === 0) return;
   // Central redaction: every event that reaches run_events (readable by any
   // runs:read principal) is scrubbed here, regardless of which producer emitted it.
-  const safe = events.map((event) =>
-    event.data ? { ...event, data: redactEventData(event.data) as Record<string, unknown> } : event,
-  );
+  const safe = events.map(redactRunEvent);
   await api(`/internal/runs/${currentRunId()}/events`, {
     method: "POST",
     body: JSON.stringify(safe),

--- a/runner/test/event-batching.test.ts
+++ b/runner/test/event-batching.test.ts
@@ -1,0 +1,155 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { drainLineEvents } from "../src/index.js";
+import type { RunEvent } from "../src/types.js";
+
+describe("runner lifecycle event batching", () => {
+  it("batches noisy command output while preserving every line in order", async () => {
+    const stream = new PassThrough();
+    const deliveries: RunEvent[][] = [];
+    const draining = drainLineEvents(
+      stream,
+      "shell",
+      async (events) => {
+        deliveries.push(events);
+      },
+      { batchSize: 25, flushMs: 1_000 },
+    );
+    const expected = Array.from({ length: 60 }, (_, index) => `line-${index}`);
+
+    stream.end(`${expected.join("\n")}\n`);
+    await draining;
+
+    expect(deliveries.map((events) => events.length)).toEqual([25, 25, 10]);
+    expect(deliveries.flatMap((events) => events.map((event) => event.data?.text))).toEqual(
+      expected,
+    );
+  });
+
+  it("flushes sparse output without waiting for the process to exit", async () => {
+    const stream = new PassThrough();
+    let resolveFirstDelivery: (() => void) | undefined;
+    const firstDelivery = new Promise<void>((resolve) => {
+      resolveFirstDelivery = resolve;
+    });
+    const deliveries: RunEvent[][] = [];
+    const draining = drainLineEvents(
+      stream,
+      "assistant",
+      async (events) => {
+        deliveries.push(events);
+        resolveFirstDelivery?.();
+      },
+      { batchSize: 25, flushMs: 10 },
+    );
+
+    stream.write("working\n");
+    await expect(
+      Promise.race([
+        firstDelivery.then(() => "delivered"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timeout"), 500)),
+      ]),
+    ).resolves.toBe("delivered");
+    expect(deliveries).toEqual([[{ type: "assistant", data: { text: "working" } }]]);
+
+    stream.end();
+    await draining;
+  });
+
+  it("coalesces one bounded pending batch while delivery is blocked", async () => {
+    const stream = new PassThrough();
+    let resolveBlockedDelivery: (() => void) | undefined;
+    const blockedDelivery = new Promise<void>((resolve) => {
+      resolveBlockedDelivery = resolve;
+    });
+    let resolveDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      resolveDeliveryStarted = resolve;
+    });
+    const deliveries: RunEvent[][] = [];
+    const draining = drainLineEvents(
+      stream,
+      "shell",
+      async (events) => {
+        deliveries.push(events);
+        if (deliveries.length === 1) {
+          resolveDeliveryStarted?.();
+          await blockedDelivery;
+        }
+      },
+      { batchSize: 5, flushMs: 5 },
+    );
+
+    stream.write("line-0\n");
+    await deliveryStarted;
+    for (let index = 1; index < 11; index += 1) {
+      stream.write(`line-${index}\n`);
+      await new Promise((resolve) => setTimeout(resolve, 8));
+    }
+
+    resolveBlockedDelivery?.();
+    stream.end();
+    await draining;
+
+    expect(deliveries.map((events) => events.length)).toEqual([1, 5, 5]);
+    expect(deliveries.flatMap((events) => events.map((event) => event.data?.text))).toEqual(
+      Array.from({ length: 11 }, (_, index) => `line-${index}`),
+    );
+  });
+
+  it("splits long lines before a serialized batch reaches the request budget", async () => {
+    const stream = new PassThrough();
+    const deliveries: RunEvent[][] = [];
+    const draining = drainLineEvents(stream, "shell", async (events) => {
+      deliveries.push(events);
+    });
+    const line = "x".repeat(21 * 1024);
+
+    stream.end(`${Array.from({ length: 50 }, () => line).join("\n")}\n`);
+    await draining;
+
+    expect(deliveries.length).toBeGreaterThan(1);
+    expect(deliveries.flat()).toHaveLength(50);
+    for (const events of deliveries) {
+      expect(Buffer.byteLength(JSON.stringify(events))).toBeLessThanOrEqual(900 * 1024);
+    }
+  });
+
+  it("propagates a failed batch delivery", async () => {
+    const stream = new PassThrough();
+    const draining = drainLineEvents(stream, "shell", async () => {
+      throw new Error("delivery_failed");
+    });
+
+    stream.end("line\n");
+    await expect(draining).rejects.toThrow("delivery_failed");
+  });
+
+  it("propagates a failed delivery while the source stream remains open", async () => {
+    const stream = new PassThrough();
+    let rejectDelivery: ((error: Error) => void) | undefined;
+    const delivery = new Promise<void>((_resolve, reject) => {
+      rejectDelivery = reject;
+    });
+    let resolveDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      resolveDeliveryStarted = resolve;
+    });
+    const draining = drainLineEvents(
+      stream,
+      "shell",
+      async () => {
+        resolveDeliveryStarted?.();
+        await delivery;
+      },
+      { batchSize: 5, flushMs: 5 },
+    );
+
+    stream.write("line\n");
+    await deliveryStarted;
+    rejectDelivery?.(new Error("delivery_failed_while_open"));
+
+    await expect(draining).rejects.toThrow("delivery_failed_while_open");
+    stream.destroy();
+  });
+});


### PR DESCRIPTION
## What changes

- Batch noisy shell and agent output into at most 50 lifecycle events per API request.
- Cap multi-event request bodies at 900 KiB, measured after secret redaction, below Fastify's 1 MiB limit.
- Flush sparse output after 100 ms so interactive progress remains live.
- Preserve per-stream ordering and bound backpressure to one active delivery plus one pending batch.
- Propagate delivery failures even while the source stream remains open.
- Cover burst, timed, throttled, oversized and failed delivery paths with deterministic tests.

## Why

PR #74 made the runner recover safely from API 429 responses. Production run `run_019fd18e63567af491bd850fb11669d8` proved recovery, but the cold Supabase provision emitted hundreds of Docker progress lines and advanced in large bursts separated by limiter windows. Batching keeps the limiter as a safety boundary while reducing normal lifecycle traffic by up to 50x without allowing an unbounded retry queue.

## Verification

- [ ] `pnpm verify` passes locally
  - Lint, 15/15 typechecks, 10/10 clean builds, DB and CLI passed.
  - The full matrix then hit the pre-existing scheduled-run fixture failure (`caughtUpMinutes` expected 2, received 0); that exact test passes isolated.
  - Runner: 7 files, 91 tests; typecheck, build, Biome and diff-check pass.
- [x] Behaviour verified beyond the test suite (say how)
  - Exact image `runner:pr-75-2ff4773` passed privileged AWS CodeBuild smoke `facility-prod-runner:6138d898-a98a-4e46-b39a-6c1ab288ddbc`.
  - Independent adversarial review passed 50 UTF-8/escaping/byte/timer scenarios with no loss or reordering and at most one active send.
- [x] Documentation updated, or no user-facing change
  - No user-facing configuration or API contract changes.
