### PR TITLE
fix(runner): support Supabase Docker lifecycle

### DIFF
--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -72,15 +72,47 @@ export function validateDockerBody(
 ): string | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return "invalid_json_object";
   const body = value as Record<string, unknown>;
-  if (kind === "exec") return body.Privileged === true ? "privileged_exec_denied" : null;
+  if (kind === "exec") {
+    if (hasNonCanonicalKey(body, ["Privileged"])) return "docker_json_key_casing_denied";
+    return body.Privileged === true ? "privileged_exec_denied" : null;
+  }
   if (kind === "volume") {
+    if (hasNonCanonicalKey(body, ["Driver", "DriverOpts"])) {
+      return "docker_json_key_casing_denied";
+    }
     const driver = String(body.Driver ?? "");
     if (driver !== "" && driver !== "local") return "volume_driver_denied";
     if (objectKeys(body.DriverOpts).length > 0) return "volume_driver_options_denied";
     return null;
   }
 
+  if (hasNonCanonicalKey(body, ["HostConfig"])) return "docker_json_key_casing_denied";
   const host = object(body.HostConfig);
+  const protectedHostFields = [
+    "Privileged",
+    "Devices",
+    "DeviceRequests",
+    "CapAdd",
+    "VolumesFrom",
+    "DeviceCgroupRules",
+    "SecurityOpt",
+    "MaskedPaths",
+    "ReadonlyPaths",
+    "Sysctls",
+    "CgroupParent",
+    "Runtime",
+    "PidMode",
+    "IpcMode",
+    "UTSMode",
+    "UsernsMode",
+    "CgroupnsMode",
+    "NetworkMode",
+    "Binds",
+    "Mounts",
+  ];
+  // encoding/json matches Go struct fields case-insensitively. Reject aliases
+  // instead of validating one spelling and forwarding a dangerous equivalent.
+  if (hasNonCanonicalKey(host, protectedHostFields)) return "docker_json_key_casing_denied";
   if (host.Privileged === true) return "privileged_container_denied";
   const deniedNonEmpty = [
     "Devices",
@@ -123,13 +155,20 @@ export function validateDockerBody(
   }
   if (Array.isArray(host.Mounts)) {
     for (const mount of host.Mounts) {
-      const type = String(object(mount).Type ?? "").toLowerCase();
+      const mountObject = object(mount);
+      if (hasNonCanonicalKey(mountObject, ["Type", "Source", "VolumeOptions"])) {
+        return "docker_json_key_casing_denied";
+      }
+      const type = String(mountObject.Type ?? "").toLowerCase();
       if (type === "bind") {
-        if (!safeBindSource(String(object(mount).Source ?? ""), workspaceRoot)) {
+        if (!safeBindSource(String(mountObject.Source ?? ""), workspaceRoot)) {
           return "host_bind_source_denied";
         }
       } else if (type === "volume") {
-        const volumeOptions = object(object(mount).VolumeOptions);
+        const volumeOptions = object(mountObject.VolumeOptions);
+        if (hasNonCanonicalKey(volumeOptions, ["DriverConfig"])) {
+          return "docker_json_key_casing_denied";
+        }
         if ("DriverConfig" in volumeOptions) return "host_mount_volume_driver_denied";
       } else if (type !== "tmpfs") return "host_mount_denied";
     }
@@ -342,6 +381,18 @@ function nonEmpty(value: unknown) {
 
 function objectKeys(value: unknown) {
   return value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value) : [];
+}
+
+function hasNonCanonicalKey(record: Record<string, unknown>, canonicalKeys: string[]) {
+  const canonicalByLowercase = new Map(canonicalKeys.map((key) => [key.toLowerCase(), key]));
+  return Object.keys(record).some((key) => {
+    // Go's encoding/json uses Unicode simple-fold matching (for example, a
+    // long-s can match an ASCII s). Docker schema keys are ASCII, so reject
+    // non-ASCII spellings at the schema levels this policy validates.
+    if ([...key].some((character) => (character.codePointAt(0) ?? 0) > 0x7f)) return true;
+    const canonical = canonicalByLowercase.get(key.toLowerCase());
+    return canonical !== undefined && key !== canonical;
+  });
 }
 
 function dockerBindSources(host: Record<string, unknown>) {

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -50,7 +50,7 @@ export function dockerRequestPolicy(method: string, rawUrl: string): PolicyDecis
   }
   if (
     method === "POST" &&
-    /^(?:\/auth|\/build|\/build\/prune|\/commit|\/images\/(?:create|load|prune)|\/images\/.+\/(?:push|tag)|\/containers\/[^/]+\/(?:start|stop|restart|kill|wait|pause|unpause|rename)|\/exec\/[^/]+\/(?:start|resize)|\/networks\/(?:create|prune)|\/networks\/[^/]+\/(?:connect|disconnect)|\/volumes\/prune)$/.test(
+    /^(?:\/auth|\/build|\/build\/prune|\/commit|\/images\/(?:create|load|prune)|\/images\/.+\/(?:push|tag)|\/containers\/prune|\/containers\/[^/]+\/(?:start|stop|restart|kill|wait|pause|unpause|rename)|\/exec\/[^/]+\/(?:start|resize)|\/networks\/(?:create|prune)|\/networks\/[^/]+\/(?:connect|disconnect)|\/volumes\/prune)$/.test(
       pathname,
     )
   ) {
@@ -86,12 +86,20 @@ export function validateDockerBody(
     "Devices",
     "DeviceRequests",
     "CapAdd",
-    "SecurityOpt",
     "VolumesFrom",
     "DeviceCgroupRules",
   ];
   for (const field of deniedNonEmpty) {
     if (nonEmpty(host[field])) return `host_config_${field.toLowerCase()}_denied`;
+  }
+  // Supabase's Vector container mounts the restricted proxy socket and disables
+  // SELinux relabeling for that bind. Keep every unconfined profile denied.
+  if (
+    nonEmpty(host.SecurityOpt) &&
+    (!Array.isArray(host.SecurityOpt) ||
+      host.SecurityOpt.some((option) => option !== "label:disable"))
+  ) {
+    return "host_config_securityopt_denied";
   }
   for (const field of ["MaskedPaths", "ReadonlyPaths"]) {
     if (Array.isArray(host[field])) return `host_config_${field.toLowerCase()}_denied`;

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -66,6 +66,8 @@ describe("restricted Docker API", () => {
       ],
       [{ HostConfig: { CapAdd: ["SYS_ADMIN"] } }, "host_config_capadd_denied"],
       [{ HostConfig: { SecurityOpt: ["seccomp=unconfined"] } }, "host_config_securityopt_denied"],
+      [{ HostConfig: { SecurityOpt: "label:disable" } }, "host_config_securityopt_denied"],
+      [{ HostConfig: { SecurityOpt: [1] } }, "host_config_securityopt_denied"],
       [
         { HostConfig: { SecurityOpt: ["label:disable", "apparmor=unconfined"] } },
         "host_config_securityopt_denied",
@@ -215,6 +217,14 @@ describe("restricted Docker API", () => {
     });
     expect(deniedUnconfined.status).toBe(403);
     expect(deniedUnconfined.body).toContain("host_config_securityopt_denied");
+    expect(upstreamRequests).toBe(2);
+
+    const deniedMalformedSecurityOpt = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: { SecurityOpt: "label:disable" },
+    });
+    expect(deniedMalformedSecurityOpt.status).toBe(403);
+    expect(deniedMalformedSecurityOpt.body).toContain("host_config_securityopt_denied");
     expect(upstreamRequests).toBe(2);
 
     const deniedCasingAlias = await request(publicSocket, "/v1.47/containers/create", {

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -70,6 +70,36 @@ describe("restricted Docker API", () => {
         { HostConfig: { SecurityOpt: ["label:disable", "apparmor=unconfined"] } },
         "host_config_securityopt_denied",
       ],
+      [{ hostconfig: { Privileged: true } }, "docker_json_key_casing_denied"],
+      [{ HostConfig: { securityopt: ["seccomp=unconfined"] } }, "docker_json_key_casing_denied"],
+      [{ HostConfig: { ſecurityOpt: ["seccomp=unconfined"] } }, "docker_json_key_casing_denied"],
+      [
+        {
+          HostConfig: {
+            SecurityOpt: ["label:disable"],
+            securityopt: ["seccomp=unconfined"],
+          },
+        },
+        "docker_json_key_casing_denied",
+      ],
+      [{ HostConfig: { binds: ["/proc:/host-proc:ro"] } }, "docker_json_key_casing_denied"],
+      [
+        { HostConfig: { Mounts: [{ type: "bind", source: "/", Target: "/host" }] } },
+        "docker_json_key_casing_denied",
+      ],
+      [
+        {
+          HostConfig: {
+            Mounts: [
+              {
+                Type: "volume",
+                VolumeOptions: { driverconfig: { Name: "local", Options: {} } },
+              },
+            ],
+          },
+        },
+        "docker_json_key_casing_denied",
+      ],
       [{ HostConfig: { MaskedPaths: [] } }, "host_config_maskedpaths_denied"],
       [
         {
@@ -95,12 +125,19 @@ describe("restricted Docker API", () => {
       expect(validateDockerBody("container", body)).toBe(reason);
     }
     expect(validateDockerBody("exec", { Privileged: true })).toBe("privileged_exec_denied");
+    expect(validateDockerBody("exec", { privileged: true })).toBe("docker_json_key_casing_denied");
     expect(
       validateDockerBody("volume", {
         Driver: "local",
         DriverOpts: { type: "none", o: "bind", device: "/run/facility-docker/docker.sock" },
       }),
     ).toBe("volume_driver_options_denied");
+    expect(
+      validateDockerBody("volume", {
+        Driver: "local",
+        driveropts: { type: "none", o: "bind", device: "/run/facility-docker/docker.sock" },
+      }),
+    ).toBe("docker_json_key_casing_denied");
   });
 
   test("blocks a proc credential-recovery bind before it reaches dockerd", async () => {
@@ -178,6 +215,40 @@ describe("restricted Docker API", () => {
     });
     expect(deniedUnconfined.status).toBe(403);
     expect(deniedUnconfined.body).toContain("host_config_securityopt_denied");
+    expect(upstreamRequests).toBe(2);
+
+    const deniedCasingAlias = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: {
+        SecurityOpt: ["label:disable"],
+        securityopt: ["seccomp=unconfined"],
+      },
+    });
+    expect(deniedCasingAlias.status).toBe(403);
+    expect(deniedCasingAlias.body).toContain("docker_json_key_casing_denied");
+    expect(upstreamRequests).toBe(2);
+
+    const deniedHostConfigAlias = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      hostconfig: { privileged: true },
+    });
+    expect(deniedHostConfigAlias.status).toBe(403);
+    expect(deniedHostConfigAlias.body).toContain("docker_json_key_casing_denied");
+    expect(upstreamRequests).toBe(2);
+
+    const deniedExecAlias = await request(publicSocket, "/v1.47/containers/abc/exec", {
+      privileged: true,
+    });
+    expect(deniedExecAlias.status).toBe(403);
+    expect(deniedExecAlias.body).toContain("docker_json_key_casing_denied");
+    expect(upstreamRequests).toBe(2);
+
+    const deniedVolumeAlias = await request(publicSocket, "/v1.47/volumes/create", {
+      Driver: "local",
+      driveropts: { type: "none", o: "bind", device: "/run/facility-docker/docker.sock" },
+    });
+    expect(deniedVolumeAlias.status).toBe(403);
+    expect(deniedVolumeAlias.body).toContain("docker_json_key_casing_denied");
     expect(upstreamRequests).toBe(2);
   });
 

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -29,6 +29,12 @@ describe("restricted Docker API", () => {
     expect(dockerRequestPolicy("POST", "/v1.47/containers/abc/start")).toEqual({
       allowed: true,
     });
+    expect(
+      dockerRequestPolicy(
+        "POST",
+        "/v1.47/containers/prune?filters=%7B%22label%22%3A%7B%22com.supabase.cli.project%3Dtam-os%22%3Atrue%7D%7D",
+      ),
+    ).toEqual({ allowed: true });
     expect(dockerRequestPolicy("GET", "/v1.47/containers/abc/archive?path=/tmp/out")).toEqual({
       allowed: true,
     });
@@ -40,6 +46,9 @@ describe("restricted Docker API", () => {
       validateBody: "volume",
     });
     expect(validateDockerBody("container", { HostConfig: {} })).toBeNull();
+    expect(
+      validateDockerBody("container", { HostConfig: { SecurityOpt: ["label:disable"] } }),
+    ).toBeNull();
   });
 
   test("denies daemon administration and runtime privilege escalation", () => {
@@ -56,6 +65,11 @@ describe("restricted Docker API", () => {
         "host_bind_source_denied",
       ],
       [{ HostConfig: { CapAdd: ["SYS_ADMIN"] } }, "host_config_capadd_denied"],
+      [{ HostConfig: { SecurityOpt: ["seccomp=unconfined"] } }, "host_config_securityopt_denied"],
+      [
+        { HostConfig: { SecurityOpt: ["label:disable", "apparmor=unconfined"] } },
+        "host_config_securityopt_denied",
+      ],
       [{ HostConfig: { MaskedPaths: [] } }, "host_config_maskedpaths_denied"],
       [
         {
@@ -145,10 +159,26 @@ describe("restricted Docker API", () => {
 
     const accepted = await request(publicSocket, "/v1.47/containers/create", {
       Image: "facility-security-smoke:local",
-      HostConfig: {},
+      HostConfig: { SecurityOpt: ["label:disable"] },
     });
     expect(accepted.status).toBe(201);
     expect(upstreamRequests).toBe(1);
+
+    const pruned = await request(
+      publicSocket,
+      "/v1.47/containers/prune?filters=%7B%22label%22%3A%7B%22com.supabase.cli.project%3Dtam-os%22%3Atrue%7D%7D",
+      {},
+    );
+    expect(pruned.status).toBe(201);
+    expect(upstreamRequests).toBe(2);
+
+    const deniedUnconfined = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "facility-security-smoke:local",
+      HostConfig: { SecurityOpt: ["seccomp=unconfined"] },
+    });
+    expect(deniedUnconfined.status).toBe(403);
+    expect(deniedUnconfined.body).toContain("host_config_securityopt_denied");
+    expect(upstreamRequests).toBe(2);
   });
 
   test("rewrites validated workspace binds to root-pinned aliases", async () => {


### PR DESCRIPTION
## What changes

- Allow container pruning in each run's dedicated ephemeral Docker daemon.
- Allow only Supabase's exact `label:disable` security option while continuing to deny unconfined seccomp/AppArmor profiles and other privilege escalation.
- Reject case-insensitive and Unicode-folded aliases for every security-sensitive Docker JSON field before Docker's Go decoder can reinterpret them.
- Add unit and proxy-integration regressions for the accepted and denied paths.

## Why

Production run `run_019fd1b186507622b3e7af336a8842ac` completed checkout, dependency installation, Supabase pull, and database migrations on `runner:b23ea1e`, then failed because the restricted Docker proxy denied Supabase CLI v2.98.2's container cleanup and Vector socket-label configuration.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (exact HEAD image `runner:pr-76-9fbc1db` passed privileged CodeBuild `facility-prod-runner:04202df8-8925-4b2d-b5ed-5c99fa713b26`)
- [x] Documentation updated, or no user-facing change (no configuration or public API changes)
