### PR TITLE
fix(runner): create missing workspace bind directories

### DIFF
--- a/runner/bind-broker.c
+++ b/runner/bind-broker.c
@@ -53,7 +53,10 @@ static void respond_error(int client, const char *reason) {
   }
 }
 
-static int open_workspace_source(const char *relative_path, struct stat *source_stat) {
+static int open_workspace_source(
+    const char *relative_path,
+    bool create_directory,
+    struct stat *source_stat) {
   int current = dup(workspace_fd);
   if (current < 0) return -1;
   if (strcmp(relative_path, ".") == 0) {
@@ -86,6 +89,37 @@ static int open_workspace_source(const char *relative_path, struct stat *source_
     component[length] = '\0';
     bool intermediate = separator != NULL;
     int next = openat(current, component, O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    if (next < 0 && !intermediate && create_directory && errno == ENOENT) {
+      struct stat parent_stat;
+      if (fstat(current, &parent_stat) != 0) {
+        close(current);
+        return -1;
+      }
+      bool created = false;
+      if (mkdirat(current, component, 0770) == 0) {
+        created = true;
+      } else if (errno != EEXIST) {
+        close(current);
+        return -1;
+      }
+      next = openat(
+          current,
+          component,
+          (created ? O_RDONLY | O_DIRECTORY : O_PATH) | O_NOFOLLOW | O_CLOEXEC);
+      if (next < 0) {
+        if (created) (void)unlinkat(current, component, AT_REMOVEDIR);
+        close(current);
+        return -1;
+      }
+      if (created &&
+          (fchown(next, parent_stat.st_uid, parent_stat.st_gid) != 0 ||
+           fchmod(next, 0770) != 0)) {
+        close(next);
+        (void)unlinkat(current, component, AT_REMOVEDIR);
+        close(current);
+        return -1;
+      }
+    }
     if (next < 0) {
       close(current);
       return -1;
@@ -114,6 +148,7 @@ static int open_workspace_source(const char *relative_path, struct stat *source_
 
 static bool pin_source(
     const char *relative_path,
+    bool create_directory,
     char *target,
     size_t target_size,
     bool *directory_target) {
@@ -122,7 +157,7 @@ static bool pin_source(
     return false;
   }
   struct stat source_stat;
-  int source_fd = open_workspace_source(relative_path, &source_stat);
+  int source_fd = open_workspace_source(relative_path, create_directory, &source_stat);
   if (source_fd < 0) return false;
 
   char alias_directory[PATH_MAX];
@@ -210,6 +245,8 @@ static bool rollback_source(const char *target, bool directory) {
 }
 
 static bool rollback_batch(char (*targets)[PATH_MAX], const bool *directories, size_t count) {
+  // MKDIR sources intentionally persist like Docker's `-v` host-directory
+  // creation. This transaction covers only the privileged mount aliases.
   bool complete = true;
   while (count > 0) {
     count -= 1;
@@ -278,11 +315,14 @@ static void handle_client(int client) {
   }
 
   char **relative_paths = calloc(requested, sizeof(*relative_paths));
+  bool *create_directories = calloc(requested, sizeof(*create_directories));
   char (*targets)[PATH_MAX] = calloc(requested, sizeof(*targets));
   bool *directories = calloc(requested, sizeof(*directories));
-  if (relative_paths == NULL || targets == NULL || directories == NULL) {
+  if (relative_paths == NULL || create_directories == NULL || targets == NULL ||
+      directories == NULL) {
     respond_error(client, "workspace_bind_request_failed");
     free(relative_paths);
+    free(create_directories);
     free(targets);
     free(directories);
     free(request);
@@ -298,12 +338,21 @@ static void handle_client(int client) {
       break;
     }
     *line_end = '\0';
-    relative_paths[index] = cursor;
+    if (strncmp(cursor, "OPEN ", 5) == 0 && cursor[5] != '\0') {
+      relative_paths[index] = cursor + 5;
+    } else if (strncmp(cursor, "MKDIR ", 6) == 0 && cursor[6] != '\0') {
+      relative_paths[index] = cursor + 6;
+      create_directories[index] = true;
+    } else {
+      valid = false;
+      break;
+    }
     cursor = line_end + 1;
   }
   if (!valid || *cursor != '\0') {
     respond_error(client, "workspace_bind_request_invalid");
     free(relative_paths);
+    free(create_directories);
     free(targets);
     free(directories);
     free(request);
@@ -313,8 +362,8 @@ static void handle_client(int client) {
   size_t pinned = 0;
   for (; pinned < requested; pinned += 1) {
     if (!pin_source(
-            relative_paths[pinned], targets[pinned], sizeof(targets[pinned]),
-            &directories[pinned])) {
+            relative_paths[pinned], create_directories[pinned], targets[pinned],
+            sizeof(targets[pinned]), &directories[pinned])) {
       break;
     }
   }
@@ -326,6 +375,7 @@ static void handle_client(int client) {
         client,
         pin_error == ENOSPC ? "workspace_bind_alias_limit" : "workspace_bind_source_denied");
     free(relative_paths);
+    free(create_directories);
     free(targets);
     free(directories);
     free(request);
@@ -342,6 +392,7 @@ static void handle_client(int client) {
   }
   (void)response_ok;
   free(relative_paths);
+  free(create_directories);
   free(targets);
   free(directories);
   free(request);

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -144,7 +144,7 @@ start_mounter() {
       "$(id -u "$proxy_user")" "$(id -g "$proxy_user")" \
     >>/var/log/facility-bind-mounter.log 2>&1 &
   mounter_pid="$!"
-  local readiness_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 1\n.\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); const lines=response.trimEnd().split("\n"); if(lines[0]!=="OK 1"||lines.length!==2)process.exit(1); console.log(lines[1])}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  local readiness_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 1\nOPEN .\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); const lines=response.trimEnd().split("\n"); if(lines[0]!=="OK 1"||lines.length!==2)process.exit(1); console.log(lines[1])}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
   for _ in $(seq 1 30); do
     if [[ -S "$bind_socket" ]]; then
       # The broker also verifies SO_PEERCRED; filesystem ownership is the first
@@ -372,7 +372,7 @@ security_smoke() {
   run_untrusted mkdir /work/.facility-security-partial
   run_untrusted sh -c \
     'printf safe-partial-bind > "$1/probe"' facility-partial /work/.facility-security-partial
-  local rollback_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 2\n.facility-security-partial/probe\n.facility-security-partial/missing\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); process.exit(response==="ERR workspace_bind_source_denied\n"?0:1)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  local rollback_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 2\nOPEN .facility-security-partial/probe\nOPEN .facility-security-partial/missing\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); process.exit(response==="ERR workspace_bind_source_denied\n"?0:1)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
   echo "Facility smoke: checking transactional bind rollback"
   local aliases_before aliases_after
   aliases_before="$(findmnt -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
@@ -386,6 +386,12 @@ security_smoke() {
     echo "Security smoke failed: a rejected broker batch leaked a pinned alias" >&2
     return 1
   fi
+  local malformed_broker_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 1\nMKDIR \n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); process.exit(response==="ERR workspace_bind_request_invalid\n"?0:1)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
+  if ! runuser --user "$proxy_user" -- env -i \
+    /usr/local/bin/node -e "$malformed_broker_probe" "$bind_socket"; then
+    echo "Security smoke failed: the bind broker accepted a malformed creation request" >&2
+    return 1
+  fi
   if docker create \
     --mount type=bind,src=/work/.facility-security-partial/probe,dst=/safe \
     --mount type=bind,src=/work/.facility-security-runtime-escape,dst=/escape \
@@ -396,6 +402,37 @@ security_smoke() {
   run_untrusted rm /work/.facility-security-partial/probe
   run_untrusted rmdir /work/.facility-security-partial
   run_untrusted rm /work/.facility-security-runtime-escape
+  echo "Facility smoke: checking Docker-compatible missing bind directories"
+  run_untrusted mkdir /work/.facility-security-create
+  local created_bind_container
+  if ! created_bind_container="$(docker create \
+    --mount type=bind,src=/work/.facility-security-create/created,dst=/created \
+    facility-security-smoke:local true)"; then
+    echo "Security smoke failed: a missing terminal bind directory was not created safely" >&2
+    return 1
+  fi
+  if [[ ! -d /work/.facility-security-create/created || \
+    -L /work/.facility-security-create/created ]]; then
+    echo "Security smoke failed: the bind broker did not create a real workspace directory" >&2
+    return 1
+  fi
+  docker rm "$created_bind_container" >/dev/null
+  run_untrusted ln -s /work/.facility-security-create/absent \
+    /work/.facility-security-create/dangling
+  if docker create \
+    --mount type=bind,src=/work/.facility-security-create/dangling,dst=/escape \
+    facility-security-smoke:local true >/dev/null 2>&1; then
+    echo "Security smoke failed: a dangling terminal symlink reached Docker" >&2
+    return 1
+  fi
+  if docker create \
+    --mount type=bind,src=/work/.facility-security-create/missing/child,dst=/escape \
+    facility-security-smoke:local true >/dev/null 2>&1; then
+    echo "Security smoke failed: a missing intermediate bind path reached Docker" >&2
+    return 1
+  fi
+  run_untrusted rm /work/.facility-security-create/dangling
+  rmdir /work/.facility-security-create/created /work/.facility-security-create
   if ! findmnt -rn -o TARGET | grep -q "^${workspace_view}/"; then
     echo "Security smoke failed: workspace binds did not use pinned mount aliases" >&2
     return 1

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -2,7 +2,7 @@
 import { chmod, chown, realpath, rm } from "node:fs/promises";
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import net from "node:net";
-import { isAbsolute, relative, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import type { Duplex } from "node:stream";
 
 const DEFAULT_PUBLIC_SOCKET = "/run/facility-proxy/docker.sock";
@@ -13,9 +13,10 @@ const MAX_POLICY_BODY_BYTES = 1024 * 1024;
 const MAX_BATCH_BINDS = 128;
 const MAX_BROKER_RESPONSE_BYTES = 1024 * 1024;
 
-type PinBindSources = (sources: string[], workspaceRoot: string) => Promise<string[]>;
+type BindSourceRequest = { source: string; createIfMissing: boolean };
+type PinBindSources = (sources: BindSourceRequest[], workspaceRoot: string) => Promise<string[]>;
 type SecuredBindSource =
-  | { allowed: true; source: string; pin: boolean }
+  | { allowed: true; source: string; pin: boolean; createIfMissing: boolean }
   | { allowed: false; reason: string };
 
 type PolicyDecision =
@@ -193,7 +194,7 @@ export async function secureDockerBindSources(
   } catch {
     return "workspace_root_unresolved";
   }
-  const pending: Array<{ source: string; apply: (secured: string) => void }> = [];
+  const pending: Array<BindSourceRequest & { apply: (secured: string) => void }> = [];
   const binds = host.Binds;
   if (Array.isArray(binds)) {
     for (let index = 0; index < binds.length; index += 1) {
@@ -204,6 +205,7 @@ export async function secureDockerBindSources(
       if (secured.pin) {
         pending.push({
           source: secured.source,
+          createIfMissing: secured.createIfMissing,
           apply: (pinned) => {
             binds[index] = `${pinned}${bind.slice(source.length)}`;
           },
@@ -222,6 +224,7 @@ export async function secureDockerBindSources(
       if (secured.pin) {
         pending.push({
           source: secured.source,
+          createIfMissing: secured.createIfMissing,
           apply: (pinned) => {
             mount.Source = pinned;
           },
@@ -235,7 +238,7 @@ export async function secureDockerBindSources(
   if (pending.length > MAX_BATCH_BINDS) return "workspace_bind_batch_too_large";
   try {
     const pinned = await pinBindSources(
-      pending.map(({ source }) => source),
+      pending.map(({ source, createIfMissing }) => ({ source, createIfMissing })),
       resolvedWorkspaceRoot,
     );
     if (pinned.length !== pending.length) return "workspace_bind_source_pin_failed";
@@ -267,7 +270,7 @@ export async function startDockerProxy(
   const bindMounterSocket = options.bindMounterSocket ?? DEFAULT_BIND_MOUNTER_SOCKET;
   const pinBindSources =
     options.pinBindSources ??
-    ((sources: string[], resolvedWorkspaceRoot: string) =>
+    ((sources: BindSourceRequest[], resolvedWorkspaceRoot: string) =>
       requestPinnedSources(bindMounterSocket, sources, resolvedWorkspaceRoot));
   await rm(publicSocket, { force: true });
   const server = http.createServer((request, response) => {
@@ -408,27 +411,64 @@ function safeBindSource(source: string, workspaceRoot = DEFAULT_WORKSPACE_ROOT) 
 }
 
 async function secureBindSource(source: string, workspaceRoot: string): Promise<SecuredBindSource> {
-  if (!source.startsWith("/")) return { allowed: true, source, pin: false };
+  if (!source.startsWith("/")) {
+    return { allowed: true, source, pin: false, createIfMissing: false };
+  }
   let resolved: string;
   try {
     resolved = await realpath(source);
-  } catch {
-    return { allowed: false, reason: "host_bind_source_unresolved" };
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") {
+      return { allowed: false, reason: "host_bind_source_unresolved" };
+    }
+    const leaf = basename(source);
+    if (!leaf || leaf === "." || leaf === "..") {
+      return { allowed: false, reason: "host_bind_source_unresolved" };
+    }
+    let resolvedParent: string;
+    try {
+      resolvedParent = await realpath(dirname(source));
+    } catch {
+      return { allowed: false, reason: "host_bind_source_unresolved" };
+    }
+    resolved = join(resolvedParent, leaf);
+    if (!workspacePath(resolved, workspaceRoot)) {
+      return { allowed: false, reason: "host_bind_source_escape_denied" };
+    }
+    // Docker's `-v` semantics create a missing terminal directory. Delegate
+    // that operation to the descriptor-walking broker so a concurrent symlink
+    // replacement cannot move creation or the eventual bind outside /work.
+    return { allowed: true, source: resolved, pin: true, createIfMissing: true };
   }
   if (!safeBindSource(resolved, workspaceRoot)) {
     return { allowed: false, reason: "host_bind_source_escape_denied" };
   }
   if (resolved === workspaceRoot || resolved.startsWith(`${workspaceRoot}/`)) {
-    return { allowed: true, source: resolved, pin: true };
+    return { allowed: true, source: resolved, pin: true, createIfMissing: false };
   }
-  return { allowed: true, source: resolved, pin: false };
+  return { allowed: true, source: resolved, pin: false, createIfMissing: false };
 }
 
-async function requestPinnedSources(socketPath: string, sources: string[], workspaceRoot: string) {
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function workspacePath(source: string, workspaceRoot: string) {
+  const relativeSource = relative(workspaceRoot, source);
+  return (
+    relativeSource !== ".." && !relativeSource.startsWith(`..${sep}`) && !isAbsolute(relativeSource)
+  );
+}
+
+async function requestPinnedSources(
+  socketPath: string,
+  sources: BindSourceRequest[],
+  workspaceRoot: string,
+) {
   if (sources.length === 0 || sources.length > MAX_BATCH_BINDS) {
     throw new Error("workspace_bind_batch_too_large");
   }
-  const relativeSources = sources.map((source) => {
+  const relativeSources = sources.map(({ source, createIfMissing }) => {
     const relativeSource = relative(workspaceRoot, source);
     if (
       relativeSource === ".." ||
@@ -441,7 +481,7 @@ async function requestPinnedSources(socketPath: string, sources: string[], works
     if (normalized.includes("\n") || normalized.includes("\r")) {
       throw new Error("workspace_bind_source_denied");
     }
-    return normalized;
+    return `${createIfMissing ? "MKDIR" : "OPEN"} ${normalized}`;
   });
   const requestBody = `BATCH ${relativeSources.length}\n${relativeSources.join("\n")}\n`;
   return await new Promise<string[]>((resolvePinned, reject) => {

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -275,7 +275,7 @@ describe("restricted Docker API", () => {
     const upstreamSocket = join(dir, "upstream.sock");
     const publicSocket = join(dir, "public.sock");
     const upstreamBodies: Array<Record<string, unknown>> = [];
-    const pinnedSources: string[] = [];
+    const pinnedSources: Array<{ source: string; createIfMissing: boolean }> = [];
     const upstream = http.createServer(async (request, response) => {
       let body = "";
       for await (const chunk of request) body += chunk.toString();
@@ -317,7 +317,10 @@ describe("restricted Docker API", () => {
       },
     ]);
     const resolvedSource = await realpath(source);
-    expect(pinnedSources).toEqual([resolvedSource, resolvedSource]);
+    expect(pinnedSources).toEqual([
+      { source: resolvedSource, createIfMissing: false },
+      { source: resolvedSource, createIfMissing: false },
+    ]);
 
     const denied = await request(publicSocket, "/v1.47/containers/create", {
       Image: "facility-security-smoke:local",
@@ -325,6 +328,67 @@ describe("restricted Docker API", () => {
     });
     expect(denied.status).toBe(403);
     expect(denied.body).toContain("host_bind_source_escape_denied");
+    expect(upstreamBodies).toHaveLength(1);
+  });
+
+  test("creates and pins a missing terminal workspace directory for Docker -v semantics", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-docker-missing-bind-"));
+    const workspaceRoot = join(dir, "work");
+    const sourceParent = join(workspaceRoot, "repo", "supabase");
+    const source = join(sourceParent, "snippets");
+    const workspaceView = join(dir, "trusted-work");
+    await mkdir(sourceParent, { recursive: true });
+    await mkdir(workspaceView);
+    const upstreamSocket = join(dir, "upstream.sock");
+    const publicSocket = join(dir, "public.sock");
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const upstream = http.createServer(async (request, response) => {
+      let body = "";
+      for await (const chunk of request) body += chunk.toString();
+      upstreamBodies.push(JSON.parse(body));
+      response.writeHead(201, { "content-type": "application/json" });
+      response.end("{}");
+    });
+    await listen(upstream, upstreamSocket);
+    const proxy = await startDockerProxy({
+      publicSocket,
+      upstreamSocket,
+      workspaceRoot,
+      pinBindSources: async (sources) => {
+        const resolvedSource = join(await realpath(sourceParent), "snippets");
+        expect(sources).toEqual([{ source: resolvedSource, createIfMissing: true }]);
+        await mkdir(source);
+        return [join(workspaceView, "pin-1", "source")];
+      },
+    });
+    cleanup.push(async () => {
+      await close(proxy);
+      await close(upstream);
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    const accepted = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "supabase/studio:local",
+      HostConfig: { Binds: [`${source}:/workspaces/default/snippets:rw`] },
+    });
+    expect(accepted.status).toBe(201);
+    expect(upstreamBodies).toEqual([
+      {
+        Image: "supabase/studio:local",
+        HostConfig: {
+          Binds: [`${workspaceView}/pin-1/source:/workspaces/default/snippets:rw`],
+        },
+      },
+    ]);
+
+    const unresolved = await request(publicSocket, "/v1.47/containers/create", {
+      Image: "supabase/studio:local",
+      HostConfig: {
+        Binds: [`${workspaceRoot}/missing-parent/snippets:/workspaces/default/snippets:rw`],
+      },
+    });
+    expect(unresolved.status).toBe(403);
+    expect(unresolved.body).toContain("host_bind_source_unresolved");
     expect(upstreamBodies).toHaveLength(1);
   });
 
@@ -345,7 +409,10 @@ describe("restricted Docker API", () => {
 
     await expect(
       secureDockerBindSources(body, workspaceRoot, async (sources) => {
-        expect(sources).toEqual([await realpath(first), await realpath(second)]);
+        expect(sources).toEqual([
+          { source: await realpath(first), createIfMissing: false },
+          { source: await realpath(second), createIfMissing: false },
+        ]);
         throw new Error("workspace_bind_source_denied");
       }),
     ).resolves.toBe("workspace_bind_source_denied");


### PR DESCRIPTION
## What changes

- Restores Docker `-v` semantics for a missing terminal workspace directory while retaining Facility's root-pinned bind aliases.
- Extends the descriptor-walking broker protocol with explicit `OPEN` and `MKDIR` operations; only `MKDIR` may create the final component, and every path component remains `O_NOFOLLOW`.
- Adds proxy regression coverage for Supabase Studio's missing `supabase/snippets` bind plus privileged smoke coverage for success, malformed requests, dangling symlinks, and missing intermediate paths.

## Why

The real `tam-os` builder reached Supabase migrations after #76, then failed when Supabase Studio mounted a missing `supabase/snippets` directory. A normal Docker daemon creates that directory for a `-v` bind. Facility's restricted proxy instead returned `host_bind_source_unresolved`, so provisioning stopped before the agent could run.

## Verification

- [x] `COMPOSE_ENV_FILES=/dev/null pnpm verify` passes locally (runner 92, API 259, gateway 34; builds, guards, and audit pass; one pre-existing optional-chain lint warning remains).
- [x] Behaviour verified beyond the test suite: the Linux broker compiles with `-Wall -Wextra -Werror`, and a privileged nested-Docker smoke passed the permitted create plus malformed, dangling-symlink, missing-intermediate, rollback, identity, and escape checks.
- [x] No user-facing documentation change; this restores documented Docker bind behavior inside the CodeBuild runner.
