### PR TITLE
fix(runner): prepare Claude platform sessions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./crypto.js";
 export * from "./detect.js";
 export * from "./fingerprints.js";
 export * from "./ids.js";
+export * from "./models.js";
 export * from "./object-store.js";
 export * from "./permissions.js";
 export * from "./pricing.js";

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -1,0 +1,39 @@
+export type FacilityEngine = "claude_code" | "codex" | "byo";
+
+export const CLAUDE_CODE_MODEL_POLICY_VERSION = "2.1.215";
+
+// Claude Code resolves these CLI aliases before it calls the provider. A
+// run-scoped virtual key must therefore allow the concrete wire model(s), not
+// the alias passed on Claude's command line. These exact request values were
+// captured from the official Linux binary with Facility's custom base URL for
+// the pinned version in runner/Dockerfile; its version-lock test forces this
+// policy to be reviewed on CLI upgrades.
+const CLAUDE_CODE_WIRE_MODELS: Readonly<Record<string, readonly string[]>> = {
+  opusplan: ["claude-opus-4-8", "claude-sonnet-5"],
+  opus: ["claude-opus-4-8"],
+  opus48: ["opus48"],
+  sonnet: ["claude-sonnet-5"],
+  sonnet46: ["sonnet46"],
+  haiku: ["claude-haiku-4-5-20251001"],
+  haiku45: ["haiku45"],
+  fable: ["claude-fable-5"],
+  fable5: ["fable5"],
+};
+
+/** Resolve an engine config into the exact provider models its virtual key may use. */
+export function allowedModelsForEngine(
+  engine: FacilityEngine,
+  config: Record<string, unknown>,
+): string[] | undefined {
+  // BYO commands own their provider/model routing. Their config may contain
+  // model metadata, but Facility must not reinterpret it as a gateway policy.
+  if (engine === "byo") return undefined;
+  const configured = [config.model, config.primary].find(
+    (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+  );
+  if (!configured) return undefined;
+  // Codex's primary value is already the wire model passed to its provider;
+  // unlike Claude Code, the pinned CLI has no client-side model aliases here.
+  if (engine === "codex") return [configured];
+  return [...(CLAUDE_CODE_WIRE_MODELS[configured] ?? [configured])];
+}

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/crypto.js";
 import { diffManifest, manifestFor } from "../src/fingerprints.js";
 import { newId } from "../src/ids.js";
+import { allowedModelsForEngine, CLAUDE_CODE_MODEL_POLICY_VERSION } from "../src/models.js";
 import { can } from "../src/permissions.js";
 import { costCents } from "../src/pricing.js";
 import { validateProviderBaseUrl } from "../src/provider-url.js";
@@ -35,6 +36,49 @@ import {
 import { renderFacilityInit } from "../src/render.js";
 
 const masterKey = Buffer.alloc(32, 7).toString("base64");
+
+describe("run-scoped model policy", () => {
+  it("expands Claude Code's hybrid model into its concrete wire models", () => {
+    expect(allowedModelsForEngine("claude_code", { model: "opusplan" })).toEqual([
+      "claude-opus-4-8",
+      "claude-sonnet-5",
+    ]);
+  });
+
+  it("matches every alias emitted by Claude Code 2.1.215 through a custom base URL", () => {
+    expect(allowedModelsForEngine("claude_code", { model: "opus" })).toEqual(["claude-opus-4-8"]);
+    expect(allowedModelsForEngine("claude_code", { model: "opus48" })).toEqual(["opus48"]);
+    expect(allowedModelsForEngine("claude_code", { model: "sonnet" })).toEqual(["claude-sonnet-5"]);
+    expect(allowedModelsForEngine("claude_code", { model: "sonnet46" })).toEqual(["sonnet46"]);
+    expect(allowedModelsForEngine("claude_code", { model: "haiku" })).toEqual([
+      "claude-haiku-4-5-20251001",
+    ]);
+    expect(allowedModelsForEngine("claude_code", { model: "haiku45" })).toEqual(["haiku45"]);
+    expect(allowedModelsForEngine("claude_code", { model: "fable" })).toEqual(["claude-fable-5"]);
+    expect(allowedModelsForEngine("claude_code", { model: "fable5" })).toEqual(["fable5"]);
+  });
+
+  it("restricts Codex primary models and preserves exact model ids", () => {
+    expect(allowedModelsForEngine("codex", { primary: "gpt-5.6-sol" })).toEqual(["gpt-5.6-sol"]);
+    expect(allowedModelsForEngine("claude_code", { model: "claude-fable-5" })).toEqual([
+      "claude-fable-5",
+    ]);
+    expect(allowedModelsForEngine("claude_code", { model: "future-alias" })).toEqual([
+      "future-alias",
+    ]);
+  });
+
+  it("leaves BYO routing unrestricted even when its command has model metadata", () => {
+    expect(
+      allowedModelsForEngine("byo", { model: "metadata-model", primary: "metadata-primary" }),
+    ).toBeUndefined();
+  });
+
+  it("fails CI when the pinned Claude Code version changes without reviewing its alias map", () => {
+    const dockerfile = readFileSync(new URL("../../../runner/Dockerfile", import.meta.url), "utf8");
+    expect(dockerfile).toContain(`@anthropic-ai/claude-code@${CLAUDE_CODE_MODEL_POLICY_VERSION}`);
+  });
+});
 
 describe("ids", () => {
   it("creates prefixed uuidv7 ids", () => {

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { createReadStream, createWriteStream } from "node:fs";
+import { createReadStream, createWriteStream, constants as fsConstants } from "node:fs";
 import {
   appendFile,
   chmod,
@@ -10,6 +10,7 @@ import {
   open,
   readdir,
   readFile,
+  realpath,
   rm,
   stat,
   writeFile,
@@ -359,6 +360,7 @@ async function runEngine(bundle: RunBundle, startedAt: number) {
   if (interruptRequested) return 130;
   if (bundle.engine === "claude_code") {
     const restored = await restoreSessionState(bundle);
+    await trustClaudeWorkspace(cwdFor(bundle));
     const args = buildClaudeCodeArgs(bundle, restored);
     addModelFlags(args, bundle.engineConfig);
     return runJsonProcess(
@@ -1821,6 +1823,44 @@ export function engineEnv() {
   // which are separately authorized and cannot touch run lifecycle.)
   delete env.RUNNER_TOKEN;
   return env;
+}
+
+/**
+ * Trust only Facility's ephemeral workspace so Claude Code honors the checked-in
+ * project settings and guards without an interactive first-run dialog.
+ *
+ * Provisioning runs before the engine and is untrusted, so replace any path it
+ * left behind with an exclusive, no-follow create. A raced path fails closed
+ * instead of letting the lifecycle process overwrite a symlink target as root.
+ */
+export async function trustClaudeWorkspace(
+  workspace: string,
+  home = workRoot,
+  identity = untrustedSpawnIdentity(),
+) {
+  const configPath = join(home, ".claude.json");
+  const trustedWorkspace = await realpath(workspace);
+  await rm(configPath, { force: true });
+  const handle = await open(
+    configPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    await handle.writeFile(
+      `${JSON.stringify({ projects: { [trustedWorkspace]: { hasTrustDialogAccepted: true } } })}\n`,
+    );
+    // Keep ownership and mode changes bound to the descriptor opened with
+    // O_NOFOLLOW. A path-based chown/chmod after close would let an untrusted
+    // background process swap in a symlink between those operations.
+    if (identity.uid !== undefined && identity.gid !== undefined) {
+      await handle.chown(identity.uid, identity.gid);
+    }
+    await handle.chmod(0o600);
+  } finally {
+    await handle.close();
+  }
+  return configPath;
 }
 
 export function untrustedSpawnIdentity(getuid: (() => number) | undefined = process.getuid): {

--- a/runner/test/claude-trust.integration.test.ts
+++ b/runner/test/claude-trust.integration.test.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { exitCode, trustClaudeWorkspace } from "../src/index.js";
+
+describe("Claude Code workspace trust integration", () => {
+  it("is readable by a non-interactive engine child through its HOME", async () => {
+    const home = await mkdtemp(join(tmpdir(), "facility-claude-home-"));
+    const workspace = join(home, "repo");
+    await mkdir(workspace);
+    await trustClaudeWorkspace(workspace, home, {});
+
+    const script = [
+      "const fs=require('node:fs')",
+      "const path=require('node:path')",
+      "const config=JSON.parse(fs.readFileSync(path.join(process.env.HOME,'.claude.json'),'utf8'))",
+      "process.stdout.write(JSON.stringify(config.projects[process.cwd()]))",
+    ].join(";");
+    const child = spawn(process.execPath, ["-e", script], {
+      cwd: workspace,
+      env: { ...process.env, HOME: home },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => (stdout += chunk));
+    child.stderr?.on("data", (chunk) => (stderr += chunk));
+
+    await expect(exitCode(child)).resolves.toBe(0);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ hasTrustDialogAccepted: true });
+  });
+});

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -1,5 +1,14 @@
 import { execFileSync, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -25,6 +34,7 @@ import {
   runPackageInstall,
   semanticDeliveryBranch,
   terminateChild,
+  trustClaudeWorkspace,
 } from "../src/index.js";
 import type { RunBundle } from "../src/types.js";
 
@@ -49,6 +59,42 @@ function bundle(overrides: Partial<RunBundle> = {}): RunBundle {
 }
 
 describe("workspace preparation", () => {
+  it("writes scoped Claude trust without following an untrusted config symlink", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-claude-trust-"));
+    const repo = join(root, "repo");
+    const protectedPath = join(root, "protected");
+    await mkdir(repo);
+    await writeFile(protectedPath, "do not replace\n");
+    await symlink(protectedPath, join(root, ".claude.json"));
+    const identity = {
+      uid: process.getuid?.() ?? 1000,
+      gid: process.getgid?.() ?? 1000,
+    };
+
+    const configPath = await trustClaudeWorkspace(repo, root, identity);
+
+    await expect(readFile(protectedPath, "utf8")).resolves.toBe("do not replace\n");
+    await expect(readFile(configPath, "utf8").then(JSON.parse)).resolves.toEqual({
+      projects: { [await realpath(repo)]: { hasTrustDialogAccepted: true } },
+    });
+    const info = await lstat(configPath);
+    expect(info.isFile()).toBe(true);
+    expect(info.isSymbolicLink()).toBe(false);
+    expect(info.mode & 0o777).toBe(0o600);
+    expect(info.uid).toBe(identity.uid);
+    expect(info.gid).toBe(identity.gid);
+  });
+
+  it("fails closed when an untrusted process occupies the config path with a directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-claude-trust-denied-"));
+    const repo = join(root, "repo");
+    await mkdir(repo);
+    await mkdir(join(root, ".claude.json"));
+
+    await expect(trustClaudeWorkspace(repo, root, {})).rejects.toThrow();
+    expect((await lstat(join(root, ".claude.json"))).isDirectory()).toBe(true);
+  });
+
   it("never exposes package registry credentials to the engine environment", () => {
     const original = process.env.NODE_AUTH_TOKEN;
     const originalUpperConfig = process.env.NPM_CONFIG_USERCONFIG;

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -1,4 +1,5 @@
 import {
+  allowedModelsForEngine,
   type FacilityReceipt,
   FacilityReceiptSchema,
   generateApiKey,
@@ -74,8 +75,11 @@ type FinishRunDeps = {
   githubClientFactory?: GithubClientFactory;
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>;
 };
+type DispatchRunDeps = {
+  sandboxDriver?: (name: SandboxDriverName) => Promise<SandboxDriver>;
+};
 
-export async function dispatchRun(config: AppConfig, job: DispatchJob) {
+export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: DispatchRunDeps = {}) {
   if (!job.runId || !job.orgId) throw new Error("runs.dispatch requires runId and orgId");
   const { db, client } = createDb(config.databaseUrl);
   // Track credentials + the launched sandbox as they come into existence so a
@@ -108,7 +112,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob) {
       prefix: virtualKey.lookup,
       last4: virtualKey.last4,
       hash: virtualKey.hash,
-      allowedModels: modelNames(bundle.engineConfig),
+      allowedModels: allowedModelsForEngine(bundle.engine, bundle.engineConfig),
       expiresAt: new Date(Date.now() + bundle.timeoutMin * 60_000),
     });
     // Track the moment it exists — before any further step that could throw.
@@ -141,7 +145,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob) {
 
     const runnerToken = `frt_${crypto.randomUUID().replaceAll("-", "")}${crypto.randomUUID().replaceAll("-", "")}`;
     const driverName = normalizeDriver(profile.driver);
-    const driver = await sandboxDriver(driverName);
+    const driver = await (deps.sandboxDriver ?? sandboxDriver)(driverName);
     const launchSpec: LaunchSpec = {
       runId: run.id,
       image: profile.image,
@@ -2027,11 +2031,6 @@ function command(value: unknown) {
   return Array.isArray(candidate)
     ? candidate.filter((item): item is string => typeof item === "string")
     : undefined;
-}
-
-function modelNames(value: Record<string, unknown>) {
-  const model = value.model;
-  return typeof model === "string" ? [model] : undefined;
 }
 
 function objectOrEmpty(value: unknown): Record<string, unknown> {

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -10,10 +10,12 @@ import {
   migrate,
   projects,
   registryItems,
+  registryVersions,
   repos,
   roles,
   runEvents,
   runs,
+  sandboxProfiles,
   seed,
   virtualKeys,
 } from "@facility/db";
@@ -24,7 +26,8 @@ import { buildApp } from "../src/app.js";
 import { verifyStoredReceipts } from "../src/receipt-integrity.js";
 import { AwsSandboxDriver } from "../src/sandbox/aws.js";
 import { DockerSandboxDriver } from "../src/sandbox/docker.js";
-import { finishRun, reconcileSandboxes } from "../src/sandbox/orchestrator.js";
+import type { SandboxDriver } from "../src/sandbox/driver.js";
+import { dispatchRun, finishRun, reconcileSandboxes } from "../src/sandbox/orchestrator.js";
 import { appendRunEvents } from "../src/sandbox/state.js";
 import type { AppConfig } from "../src/types.js";
 
@@ -134,6 +137,124 @@ describe("sandbox api", async () => {
         throw { statusCode: 500, message: "daemon boom" };
       }).imageExists("runner:dev"),
     ).rejects.toMatchObject({ statusCode: 500 });
+  });
+
+  it("dispatch persists engine-specific model policy on each run key", async () => {
+    const suffix = Date.now();
+    const contract = (
+      await db
+        .insert(registryItems)
+        .values({
+          id: newId("item"),
+          orgId,
+          scope: "project",
+          projectId,
+          kind: "agent_contract",
+          name: `model-policy-${suffix}`,
+          latestVersion: 1,
+        })
+        .returning()
+    )[0];
+    if (!contract) throw new Error("model policy contract fixture missing");
+    await db.insert(registryVersions).values({
+      id: newId("ver"),
+      orgId,
+      itemId: contract.id,
+      version: 1,
+      content: "Exercise the configured model.",
+      contentHash: `model-policy-${suffix}`,
+      status: "active",
+    });
+    const profile = (
+      await db
+        .insert(sandboxProfiles)
+        .values({
+          id: newId("sbx"),
+          orgId,
+          projectId,
+          name: `model-policy-${suffix}`,
+          driver: "docker",
+          image: "facility-runner:test",
+          resources: { timeout_min: 5 },
+        })
+        .returning()
+    )[0];
+    if (!profile) throw new Error("model policy sandbox fixture missing");
+
+    const driver: SandboxDriver = {
+      name: "docker",
+      launch: async (spec) => ({ ref: `fake-${spec.runId}` }),
+      status: async () => "running",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+    const cases = [
+      {
+        name: "claude",
+        engine: "claude_code",
+        model: { model: "opusplan" },
+        expected: ["claude-opus-4-8", "claude-sonnet-5"],
+      },
+      {
+        name: "codex",
+        engine: "codex",
+        model: { primary: "gpt-5.6-sol" },
+        expected: ["gpt-5.6-sol"],
+      },
+      {
+        name: "byo",
+        engine: "byo",
+        model: { model: "metadata-only", cmd: "true" },
+        expected: null,
+      },
+    ] as const;
+
+    for (const fixture of cases) {
+      const agent = (
+        await db
+          .insert(agentDefs)
+          .values({
+            id: newId("agent"),
+            orgId,
+            projectId,
+            name: `model-policy-${fixture.name}-${suffix}`,
+            engine: fixture.engine,
+            model: fixture.model,
+            contractItemId: contract.id,
+            sandboxProfileId: profile.id,
+            triggers: [],
+            permissions: [],
+            enabled: true,
+          })
+          .returning()
+      )[0];
+      if (!agent) throw new Error(`${fixture.name} agent fixture missing`);
+      const run = (
+        await db
+          .insert(runs)
+          .values({
+            id: newId("run"),
+            orgId,
+            projectId,
+            agentDefId: agent.id,
+            mode: "custom",
+            engine: fixture.engine,
+            trigger: {},
+            createdBy: { type: "user", id: "model-policy-test" },
+          })
+          .returning()
+      )[0];
+      if (!run) throw new Error(`${fixture.name} run fixture missing`);
+
+      await dispatchRun(config, { runId: run.id, orgId }, { sandboxDriver: async () => driver });
+
+      const [key] = await db
+        .select({ allowedModels: virtualKeys.allowedModels })
+        .from(virtualKeys)
+        .where(eq(virtualKeys.runId, run.id));
+      expect(key?.allowedModels).toEqual(fixture.expected);
+    }
   });
 
   it("appendRunEvents allocates contiguous seqs under concurrent appends", async () => {

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -1,4 +1,4 @@
-import { generateApiKey, newId, seal } from "@facility/core";
+import { allowedModelsForEngine, generateApiKey, newId, seal } from "@facility/core";
 import type { FacilityDb } from "@facility/db";
 import {
   budgets,
@@ -446,7 +446,65 @@ describe("gateway", async () => {
     await waitForRequestCount(1);
   });
 
-  it("6b. unpriced models fail closed before upstream unless the key is explicit zero-cost", async () => {
+  it("6a. Claude Code opusplan keys admit only the concrete hybrid wire models", async () => {
+    const setup = await setupVirtualKey({
+      provider: "anthropic",
+      baseUrl: `${stubOrigin}/anthropic/v1`,
+      allowedModels: allowedModelsForEngine("claude_code", { model: "opusplan" }),
+    });
+    expect(
+      (
+        await postAnthropic(setup.secret, {
+          model: "claude-opus-4-8",
+          messages: [],
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await postAnthropic(setup.secret, {
+          model: "claude-sonnet-5",
+          messages: [],
+        })
+      ).status,
+    ).toBe(200);
+    const denied = await postAnthropic(setup.secret, {
+      model: "claude-haiku-4-5",
+      messages: [],
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({ error: { type: "blocked_policy" } });
+    expect(stubState.anthropicCalls).toBe(2);
+  });
+
+  it("6b. Codex primary keys admit only their exact wire model", async () => {
+    const setup = await setupVirtualKey({
+      provider: "openai",
+      baseUrl: `${stubOrigin}/openai/v1`,
+      allowedModels: allowedModelsForEngine("codex", { primary: "gpt-5.6-sol" }),
+    });
+    expect((await postOpenAi(setup.secret, { model: "gpt-5.6-sol", messages: [] })).status).toBe(
+      200,
+    );
+    const denied = await postOpenAi(setup.secret, { model: "gpt-5.5", messages: [] });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({ error: { type: "blocked_policy" } });
+    expect(stubState.openaiCalls).toBe(1);
+  });
+
+  it("6c. BYO model metadata does not restrict gateway routing", async () => {
+    const setup = await setupVirtualKey({
+      provider: "anthropic",
+      baseUrl: `${stubOrigin}/anthropic/v1`,
+      allowedModels: allowedModelsForEngine("byo", { model: "metadata-only" }),
+    });
+    expect(
+      (await postAnthropic(setup.secret, { model: "claude-sonnet-5", messages: [] })).status,
+    ).toBe(200);
+    expect(stubState.anthropicCalls).toBe(1);
+  });
+
+  it("6d. unpriced models fail closed before upstream unless the key is explicit zero-cost", async () => {
     const blocked = await setupVirtualKey({
       provider: "anthropic",
       baseUrl: `${stubOrigin}/anthropic/v1`,


### PR DESCRIPTION
## Summary

- trust only the canonical ephemeral Claude workspace so checked-in settings, guards, hooks, and skills work in non-interactive CodeBuild runs
- derive run-key model allowlists from the exact wire values emitted by pinned Claude Code 2.1.215 and from Codex's configured primary model
- keep BYO routing unrestricted even when its command config contains model metadata
- add unit, gateway, runner integration, and DB-backed dispatch regressions for the success and denial paths

## Production failure fixed

The real `tam-os` builder progressed through clone, Supabase bootstrap, migrations, reset, and Playwright installation, then failed because Claude Code rejected `/work/repo` as untrusted and the `opusplan` virtual key denied `claude-sonnet-5`.

## Verification

- `COMPOSE_ENV_FILES=/dev/null pnpm verify`
- API: 29 files, 260 tests passed
- Gateway: 2 files, 37 tests passed
- Runner: 8 files, 95 tests passed
- Core: 2 files, 26 tests passed
- Repository guards: 2 passed
- Dependency audit: no known vulnerabilities
- External Claude review: APPROVE
- Independent subagent review of `01f7ecd4f1a40b35b192e243a54fe23ce0d8e196`: APPROVE, no P0-P3 findings

No Anthropic or OpenAI development credentials are added or enabled by this change.
