### PR TITLE
fix(builder)!: require objectives and bound delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ FACILITY_INSECURE_DEV=1
 FACILITY_SANDBOX_DRIVER=docker
 # Image the seeded default sandbox profile uses to run platform-lane agents
 # (Claude Code, Codex) on the docker driver. Its entrypoint must be the Facility
-# runner — build it with `docker build -t facility-runner:dev runner/`. In the
+# runner — build it with `docker build -f runner/Dockerfile -t facility-runner:dev .`. In the
 # cloud the same image is selected per CodeBuild sandbox.
 FACILITY_RUNNER_IMAGE=facility-runner:dev
 # URLs as resolved from inside a sandbox, not necessarily browser-facing URLs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
               runner/ \
+              packages/run-objective/ \
               services/api/src/sandbox/ \
               services/api/test/sandbox.e2e.test.ts \
               Dockerfile \
@@ -204,7 +205,7 @@ jobs:
 
       - name: Build the runner image
         if: steps.policy.outputs.required == 'true'
-        run: docker build --pull -t facility-runner:dev runner
+        run: docker build --pull -f runner/Dockerfile -t facility-runner:dev .
 
       - name: Exercise the privileged CodeBuild boundary
         if: steps.policy.outputs.required == 'true'

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -97,7 +97,7 @@ jobs:
           - image: runner
             dockerfile: runner/Dockerfile
             target: ""
-            context: runner
+            context: .
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/db/package.json packages/db/
 COPY packages/sdk/package.json packages/sdk/
 COPY packages/mcp/package.json packages/mcp/
 COPY packages/harness/package.json packages/harness/
+COPY packages/run-objective/package.json packages/run-objective/
 COPY services/api/package.json services/api/
 COPY services/gateway/package.json services/gateway/
 RUN pnpm install --frozen-lockfile --filter '@facility/core...' \

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ To run agents in local Docker sandboxes, also build the runner image named in
 `.env`:
 
 ```bash
-docker build -t facility-runner:dev runner/
+docker build -f runner/Dockerfile -t facility-runner:dev .
 ```
 
 To delegate all of this to Claude Code or Codex, paste this prompt:

--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -21,7 +21,7 @@ A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
 **driver matches the deployment** and that can run the Facility runner:
 
 - **docker** (local/self-host) — the profile's image entrypoint must be the
-  runner. Build it with `docker build -t facility-runner:dev runner/` and set
+  runner. Build it with `docker build -f runner/Dockerfile -t facility-runner:dev .` and set
   `FACILITY_RUNNER_IMAGE` (default `facility-runner:dev`). A bare base image like
   `node:22-bookworm` only supports **BYO-command** runs.
 - **aws** (CodeBuild) — each run starts a private CodeBuild job using the runner

--- a/apps/docs/docs/reference/cli.md
+++ b/apps/docs/docs/reference/cli.md
@@ -108,6 +108,13 @@ they can be used directly as CI gates.
 one JSON object with parsed events in `--json` mode. `sessions watch --json`
 is the deliberate JSONL exception because it is an unbounded event stream.
 
+`sessions trigger <project> <agent> --input <json-or-text>` carries the manual
+run's objective. Builder agents require a non-empty text or structured input;
+Facility rejects objective-free manual builder runs instead of letting an agent
+guess what to implement.
+Programmatic callers must likewise provide a non-empty `message`, `approvedPlan`,
+structured `input`, or governed issue number when they trigger a builder.
+
 `facility doctor` checks the current repository. Add `--platform` to use the
 current saved profile, `--profile <name>` to select one, or pass `--url` and
 `--key` together. Remote plaintext targets require `--allow-insecure`, exactly

--- a/apps/web/components/agents/agent-detail.tsx
+++ b/apps/web/components/agents/agent-detail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isBuilderMode } from "@facility/run-objective";
 import {
   Button,
   Divider,
@@ -104,12 +105,23 @@ export function AgentDetail(props: Props) {
   }
 
   async function runNow() {
+    const trigger: Record<string, unknown> = { type: "manual", source: "agent-page" };
+    if (isBuilderMode(agent.name)) {
+      const objective = window.prompt(`Run ${agent.name} — what should it do?`);
+      if (objective === null) return;
+      const message = objective.trim();
+      if (!message) {
+        setNote({ scope: "run", text: "an objective is required to start this builder" });
+        return;
+      }
+      trigger.message = message;
+    }
     setBusy("run");
     setNote(null);
     const res = await clientApi<{ id: string }>("POST", `/v1/projects/${projectId}/runs`, {
       agentDefId: agent.id,
       mode: agent.name,
-      trigger: { type: "manual", source: "agent-page" },
+      trigger,
     });
     setBusy(null);
     if (!res.ok) return setNote({ scope: "run", text: res.message });

--- a/apps/web/components/run/cockpit.tsx
+++ b/apps/web/components/run/cockpit.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isBuilderMode, runObjectiveText } from "@facility/run-objective";
 import { Button, Cell, cx, Eyebrow, HairlineGrid, Metric, StatusDot, toneFor } from "@facility/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RunTranscript } from "@/components/run/transcript";
@@ -436,13 +437,28 @@ export function RunCockpit({
 
   async function retryRun() {
     if (!window.confirm("Retry this run with the same project and agent?")) return;
+    const trigger: Record<string, unknown> = {
+      ...(run.trigger ?? {}),
+      source: "web",
+      retryOf: run.id,
+    };
+    if (isBuilderMode(run.mode) && !runObjectiveText(trigger)) {
+      const objective = window.prompt("Retry this builder — what should it do?");
+      if (objective === null) return;
+      const message = objective.trim();
+      if (!message) {
+        setAction({ tone: "bad", message: "an objective is required to retry this builder" });
+        return;
+      }
+      trigger.message = message;
+    }
     setBusy("retry");
     setAction(null);
     try {
       const body: Record<string, unknown> = {
         mode: run.mode,
         engine: run.engine,
-        trigger: { ...(run.trigger ?? {}), source: "web", retryOf: run.id },
+        trigger,
       };
       if (run.agentDefId) body.agentDefId = run.agentDefId;
       else {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@facility/run-objective": "workspace:*",
     "@facility/sdk": "workspace:*",
     "@facility/ui": "workspace:*",
     "@milkdown/crepe": "^7.21.3",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
   # This one-shot service never runs an agent; it only makes the image available
   # to the host Docker daemon used by api/worker.
   runner-image:
-    build: { context: ./runner }
+    build: { context: ., dockerfile: runner/Dockerfile }
     image: ${FACILITY_RUNNER_IMAGE:-facility-runner:dev}
     entrypoint: ["/bin/true"]
     restart: "no"

--- a/infra/build-images.sh
+++ b/infra/build-images.sh
@@ -73,4 +73,4 @@ retag_and_push api worker
 build_and_push gateway Dockerfile gateway
 build_and_push mcp Dockerfile mcp
 build_and_push web apps/web/Dockerfile web
-build_and_push runner runner/Dockerfile "" "$ROOT_DIR/runner"
+build_and_push runner runner/Dockerfile "" "$ROOT_DIR"

--- a/packages/run-objective/package.json
+++ b/packages/run-objective/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@facility/run-objective",
+  "version": "0.3.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": [
+    "src"
+  ],
+  "types": "./src/index.d.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.15"
+  }
+}

--- a/packages/run-objective/src/index.d.ts
+++ b/packages/run-objective/src/index.d.ts
@@ -1,0 +1,2 @@
+export declare function isBuilderMode(mode: string): boolean;
+export declare function runObjectiveText(value: unknown): string | null;

--- a/packages/run-objective/src/index.js
+++ b/packages/run-objective/src/index.js
@@ -1,0 +1,38 @@
+/** @param {string} mode */
+export function isBuilderMode(mode) {
+  return mode === "builder" || mode.endsWith("-builder");
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+export function runObjectiveText(value) {
+  const trigger = objectValue(value);
+  for (const candidate of [trigger.message, trigger.approvedPlan, trigger.input]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+
+  const input = trigger.input;
+  if (
+    (Array.isArray(input) && input.length > 0) ||
+    (input !== null && typeof input === "object" && Object.keys(input).length > 0)
+  ) {
+    return JSON.stringify(input, null, 2);
+  }
+
+  const issue = objectValue(trigger.issue);
+  const issueNumber = issue.number;
+  if (typeof issueNumber === "number" && Number.isInteger(issueNumber) && issueNumber > 0) {
+    return `Implement the governed GitHub issue #${issueNumber} described in Scope.`;
+  }
+  return null;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {Record<string, unknown>}
+ */
+function objectValue(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : {};
+}

--- a/packages/run-objective/test/index.test.ts
+++ b/packages/run-objective/test/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isBuilderMode, runObjectiveText } from "../src/index.js";
+
+describe("run objective policy", () => {
+  it("recognizes every governed builder objective source", () => {
+    expect(runObjectiveText({ message: "  Fix the builder  " })).toBe("Fix the builder");
+    expect(runObjectiveText({ approvedPlan: "Ship the approved plan" })).toBe(
+      "Ship the approved plan",
+    );
+    expect(runObjectiveText({ input: "Fix the CLI builder" })).toBe("Fix the CLI builder");
+    expect(runObjectiveText({ input: { objective: "Fix the structured CLI builder" } })).toBe(
+      '{\n  "objective": "Fix the structured CLI builder"\n}',
+    );
+    expect(runObjectiveText({ issue: { number: 42 } })).toBe(
+      "Implement the governed GitHub issue #42 described in Scope.",
+    );
+  });
+
+  it("rejects empty and malformed objective sources", () => {
+    for (const trigger of [
+      undefined,
+      {},
+      { message: "   " },
+      { approvedPlan: "" },
+      { input: {} },
+      { input: [] },
+      { issue: { number: 0 } },
+      { issue: { number: 1.5 } },
+    ]) {
+      expect(runObjectiveText(trigger)).toBeNull();
+    }
+  });
+
+  it("recognizes canonical and prefixed builder modes", () => {
+    expect(isBuilderMode("builder")).toBe(true);
+    expect(isBuilderMode("codex-builder")).toBe(true);
+    expect(isBuilderMode("architect")).toBe(false);
+  });
+});

--- a/packages/run-objective/tsconfig.json
+++ b/packages/run-objective/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.js", "src/**/*.d.ts", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@facility/run-objective':
+        specifier: workspace:*
+        version: link:../../packages/run-objective
       '@facility/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -164,6 +167,15 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.22.5
+      vitest:
+        specifier: ^4.0.15
+        version: 4.1.9(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.5)(yaml@2.9.0))
+
+  packages/run-objective:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.0.15
         version: 4.1.9(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.5)(yaml@2.9.0))
@@ -282,6 +294,9 @@ importers:
 
   runner:
     dependencies:
+      '@facility/run-objective':
+        specifier: file:../packages/run-objective
+        version: link:../packages/run-objective
       zod:
         specifier: ^4.1.13
         version: 4.4.3
@@ -325,6 +340,9 @@ importers:
       '@facility/harness':
         specifier: workspace:*
         version: link:../../packages/harness
+      '@facility/run-objective':
+        specifier: workspace:*
+        version: link:../../packages/run-objective
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim AS bind-broker-build
 RUN apt-get update \
   && apt-get install -y --no-install-recommends gcc libc6-dev \
   && rm -rf /var/lib/apt/lists/*
-COPY bind-broker.c /src/bind-broker.c
+COPY runner/bind-broker.c /src/bind-broker.c
 RUN gcc -std=c11 -O2 -Wall -Wextra -Werror \
       -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE \
       /src/bind-broker.c -Wl,-z,relro,-z,now -pie \
@@ -81,9 +81,11 @@ RUN corepack enable
 
 WORKDIR /app
 COPY --from=bind-broker-build /facility-bind-broker /usr/local/bin/facility-bind-broker
-COPY package.json package-lock.json tsconfig.json ./
-COPY src ./src
-COPY runner-entrypoint.sh codebuild-runner.sh /app/
+COPY runner/package.json runner/package-lock.json runner/tsconfig.json ./
+COPY packages/run-objective/package.json /packages/run-objective/
+COPY packages/run-objective/src /packages/run-objective/src
+COPY runner/src ./src
+COPY runner/runner-entrypoint.sh runner/codebuild-runner.sh /app/
 RUN npm ci && npm run build && npm prune --omit=dev
 
 # Run non-root: agent CLIs (Claude Code) refuse bypass-permissions as root, and

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@facility/runner",
       "version": "0.3.0",
       "dependencies": {
+        "@facility/run-objective": "file:../packages/run-objective",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -17,6 +18,14 @@
         "@types/node": "^24.10.1",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.15"
+      }
+    },
+    "../packages/run-objective": {
+      "name": "@facility/run-objective",
+      "version": "0.3.0",
+      "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.15"
       }
@@ -467,6 +476,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@facility/run-objective": {
+      "resolved": "../packages/run-objective",
+      "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/runner/package.json
+++ b/runner/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@facility/run-objective": "file:../packages/run-objective",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -18,6 +18,7 @@ import {
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { pathToFileURL } from "node:url";
+import { runObjectiveText } from "@facility/run-objective";
 import {
   parseClaudeSessionId,
   parseClaudeStreamJsonLine,
@@ -39,6 +40,8 @@ const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
 const RATE_LIMIT_RETRY_LIMIT = 8;
 const DEFAULT_RETRY_AFTER_MS = 1_000;
 const MAX_RETRY_AFTER_MS = 60_000;
+const GIT_COMMAND_TIMEOUT_MS = 2 * 60_000;
+const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 const EVENT_BATCH_MAX = 50;
 // Fastify's JSON body limit is 1 MiB. Leave room for envelope overhead and
 // future schema fields while retaining the old ability to send one large line.
@@ -214,8 +217,14 @@ async function main() {
           : await runChecks(bundle, cwdFor(bundle))
         : false;
     const engineAndChecksSucceeded = engineCode === 0 && checksPassed && securityReportConfigured;
+    if (engineAndChecksSucceeded) {
+      await emit([{ type: "delivery", data: { status: "preparing" } }]);
+    }
     const git = engineAndChecksSucceeded ? await shipGitChanges(bundle) : undefined;
     const deliveryError = engineAndChecksSucceeded ? deliveryFailure(bundle, git) : null;
+    if (engineAndChecksSucceeded) {
+      await emit([deliveryStatusEvent(git, deliveryError)]);
+    }
     const succeeded = engineAndChecksSucceeded && deliveryError === null;
     await postResult(
       bundle,
@@ -1036,6 +1045,22 @@ export function requiresDelivery(mode: string) {
   return mode === "builder" || mode.endsWith("-builder");
 }
 
+export function deliveryStatusEvent(
+  git: Record<string, unknown> | undefined,
+  deliveryError: string | null,
+): RunEvent {
+  const pushError = typeof git?.pushError === "string" ? git.pushError : null;
+  const error = pushError ?? deliveryError;
+  return {
+    type: "delivery",
+    data: {
+      status: error ? "failed" : "prepared",
+      changed: git?.changed === true,
+      ...(error ? { error } : {}),
+    },
+  };
+}
+
 function isSecurityMode(mode: string) {
   return ["security", "security_sweep"].includes(normalizedMode(mode));
 }
@@ -1637,7 +1662,8 @@ async function availableGithubBranch(
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const suffix = attempt === 0 ? "" : `-${runId.slice(-8)}${attempt === 1 ? "" : `-${attempt}`}`;
     const candidate = `${requested}${suffix}`;
-    const response = await request(
+    const response = await githubFetch(
+      request,
       `https://api.github.com/repos/${repo}/git/ref/heads/${candidate
         .split("/")
         .map(encodeURIComponent)
@@ -1652,23 +1678,40 @@ async function availableGithubBranch(
   throw new Error("github_semantic_branch_unavailable");
 }
 
-async function githubRequest<T = Record<string, unknown>>(
+export async function githubRequest<T = Record<string, unknown>>(
   request: typeof fetch,
   url: string,
   token: string,
   init: RequestInit,
+  timeoutMs = GITHUB_REQUEST_TIMEOUT_MS,
 ) {
-  const response = await request(url, {
-    ...init,
-    headers: {
-      ...githubHeaders(token),
-      "content-type": "application/json",
-      ...(init.headers ?? {}),
+  const response = await githubFetch(
+    request,
+    url,
+    {
+      ...init,
+      headers: {
+        ...githubHeaders(token),
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
     },
-  });
+    timeoutMs,
+  );
   const text = await response.text();
   if (!response.ok) throw new Error(`github_signed_delivery_http_${response.status}: ${text}`);
   return (text ? JSON.parse(text) : {}) as T;
+}
+
+async function githubFetch(
+  request: typeof fetch,
+  url: string,
+  init: RequestInit,
+  timeoutMs = GITHUB_REQUEST_TIMEOUT_MS,
+) {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal;
+  return request(url, { ...init, signal });
 }
 
 function githubHeaders(token: string) {
@@ -1687,13 +1730,26 @@ function chunk<T>(items: T[], size: number) {
   return chunks;
 }
 
-async function gitOutput(cwd: string, args: string[], trustedBootstrap = false) {
+export async function gitOutput(
+  cwd: string,
+  args: string[],
+  trustedBootstrap = false,
+  timeoutMs = GIT_COMMAND_TIMEOUT_MS,
+) {
   const child = spawn("git", ["-c", `safe.directory=${cwd}`, ...args], {
     cwd,
     env: trustedBootstrap ? process.env : engineEnv(),
     stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
     ...(trustedBootstrap ? {} : untrustedSpawnIdentity()),
   });
+  let timedOut = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    signalProcessGroup(child, "SIGTERM");
+    killTimer = setTimeout(() => signalProcessGroup(child, "SIGKILL"), 5_000);
+  }, timeoutMs);
   let stdout = "";
   let stderr = "";
   child.stdout.on("data", (chunk) => {
@@ -1703,6 +1759,16 @@ async function gitOutput(cwd: string, args: string[], trustedBootstrap = false) 
     stderr += chunk.toString();
   });
   const code = await exitCode(child);
+  clearTimeout(timeout);
+  if (timedOut) {
+    if (killTimer) clearTimeout(killTimer);
+    // The Git parent can exit on SIGTERM while an inherited process group
+    // member ignores it. Escalate once more before returning so clearing the
+    // grace timer cannot orphan that resistant descendant.
+    signalProcessGroup(child, "SIGKILL");
+    throw new Error(`git ${args[0] ?? "command"} timed out after ${timeoutMs}ms`);
+  }
+  if (killTimer) clearTimeout(killTimer);
   if (code !== 0) throw new Error(redactSecrets(`git ${args[0]} exited ${code}: ${stderr}`));
   return stdout;
 }
@@ -1948,19 +2014,11 @@ function armEngineTimeout(child: ReturnType<typeof spawn>, timeoutMin: number) {
 // hung command's descendants die with it instead of being orphaned. Falls back to
 // signalling just the child if the group is already gone.
 function armProcessGroupTimeout(child: ReturnType<typeof spawn>, timeoutMin: number) {
-  const signalGroup = (signal: NodeJS.Signals) => {
-    try {
-      if (child.pid) process.kill(-child.pid, signal);
-      else child.kill(signal);
-    } catch {
-      child.kill(signal);
-    }
-  };
   let killTimer: ReturnType<typeof setTimeout> | undefined;
   const termTimer = setTimeout(
     () => {
-      signalGroup("SIGTERM");
-      killTimer = setTimeout(() => signalGroup("SIGKILL"), 15_000);
+      signalProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(() => signalProcessGroup(child, "SIGKILL"), 15_000);
     },
     Math.max(1, timeoutMin - 2) * 60_000,
   );
@@ -1968,6 +2026,15 @@ function armProcessGroupTimeout(child: ReturnType<typeof spawn>, timeoutMin: num
     clearTimeout(termTimer);
     if (killTimer) clearTimeout(killTimer);
   };
+}
+
+function signalProcessGroup(child: ReturnType<typeof spawn>, signal: NodeJS.Signals) {
+  try {
+    if (child.pid) process.kill(-child.pid, signal);
+    else child.kill(signal);
+  } catch {
+    child.kill(signal);
+  }
 }
 
 export function composedPrompt(bundle: RunBundle) {
@@ -1980,6 +2047,9 @@ export function composedPrompt(bundle: RunBundle) {
     bundle.scope.type === "conversation" && typeof bundle.scope.message === "string"
       ? `\n\n## Conversation\n${bundle.scope.message}`
       : "";
+  const objective = runObjectiveText(bundle.scope);
+  const objectiveNote =
+    bundle.scope.type !== "conversation" && objective ? `\n\n## Run objective\n${objective}` : "";
   const progressNote = requiresAgentProgress(bundle.mode)
     ? `\n\n## Live GitHub progress\nBefore substantive work, create \`.agent-sdlc/progress.md\` with a short task-specific context and a Markdown checkbox list of the steps you decided this task needs. Update it whenever you start or finish a step so a reviewer can understand real progress from GitHub. Keep it accurate and concise; do not put secrets, generic lifecycle milestones, or the final response in it. Facility transports this file into the existing GitHub progress comment.`
     : "";
@@ -2006,7 +2076,7 @@ export function composedPrompt(bundle: RunBundle) {
   const repairDeliveryNote = repairRepositoryMode(normalizedMode(bundle.mode))
     ? `\n\n## Agent-owned PR update\nIf and only if you make verified repository changes, create \`.agent-sdlc/delivery.json\` before finishing with exactly \`{"branch":"<the existing PR branch>","commitMessage":"<matching Conventional Commit type>: describe the correction"}\`. Facility will add a signed commit to that same branch through the GitHub App. The branch must exactly match the checked-out PR branch. Choose a truthful Conventional Commit type whose release impact is no greater than the existing pull request range; do not add \`!\` or a \`BREAKING CHANGE:\` footer unless that range is already breaking. If a truthful message would raise the impact, leave the manifest absent and report that the PR title must be updated first. Do not run \`git push\`, create another branch or pull request, force-push, or depend on \`gh\`. If no code change is needed, do not create the manifest.`
     : "";
-  return `${bundle.contract}\n\nScope:\n${JSON.stringify(bundle.scope, null, 2)}${harnessNote}${steeringNote}${conversationNote}${progressNote}${repositoryOutputNote}${githubEventNote}${projectSkillsNote}${deliveryNote}${repairDeliveryNote}`;
+  return `${bundle.contract}\n\nScope:\n${JSON.stringify(bundle.scope, null, 2)}${harnessNote}${steeringNote}${conversationNote}${objectiveNote}${progressNote}${repositoryOutputNote}${githubEventNote}${projectSkillsNote}${deliveryNote}${repairDeliveryNote}`;
 }
 
 export function buildCodexArgs(bundle: RunBundle) {

--- a/runner/test/github-timeout.integration.test.ts
+++ b/runner/test/github-timeout.integration.test.ts
@@ -1,0 +1,60 @@
+import { createServer } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import { githubRequest } from "../src/index.js";
+
+describe("signed GitHub delivery timeout", () => {
+  it("aborts a request after an unresponsive local server accepts it", async () => {
+    const sockets = new Set<Socket>();
+    let resolveRequestAccepted: (() => void) | undefined;
+    const requestAccepted = new Promise<void>((resolve) => {
+      resolveRequestAccepted = resolve;
+    });
+    let resolveConnectionClosed: (() => void) | undefined;
+    const connectionClosed = new Promise<void>((resolve) => {
+      resolveConnectionClosed = resolve;
+    });
+    const server = createServer(() => {
+      // Intentionally never send headers: this deterministic local endpoint
+      // represents an upstream that accepted the connection and then stalled.
+      resolveRequestAccepted?.();
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.once("close", () => {
+        sockets.delete(socket);
+        resolveConnectionClosed?.();
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const pendingRequest = githubRequest(
+        fetch,
+        `http://127.0.0.1:${port}/graphql`,
+        "installation-token",
+        { method: "POST", body: "{}" },
+        500,
+      );
+      await requestAccepted;
+      await expect(pendingRequest).rejects.toMatchObject({ name: "TimeoutError" });
+      await Promise.race([
+        connectionClosed,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("timed-out request connection remained open")), 2_000),
+        ),
+      ]);
+      expect(sockets.size).toBe(0);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      expect(sockets.size).toBe(0);
+    }
+  });
+});

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -6,19 +6,23 @@ import {
   readdir,
   readFile,
   realpath,
+  rm,
   symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildClaudeCodeArgs,
   buildCodexArgs,
   composedPrompt,
   deliveryReleaseImpact,
+  deliveryStatusEvent,
   engineEnv,
   exitCode,
+  githubRequest,
+  gitOutput,
   handleControlMessage,
   parseGitNameStatus,
   prepareWorkspace,
@@ -853,6 +857,170 @@ describe("workspace preparation", () => {
       restoreEnv("OPENAI_API_KEY", previousEnv.openai);
       restoreEnv("FACILITY_PLATFORM_KEY", previousEnv.platform);
     }
+  });
+});
+
+describe("bounded Git delivery commands", () => {
+  it("terminates a Git process group that exceeds its delivery deadline", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-git-timeout-"));
+    const pidPath = join(root, ".facility-hang.pid");
+    try {
+      await expect(
+        gitOutput(
+          root,
+          [
+            "-c",
+            "alias.facility-hang=!sleep 30 & echo $! > .facility-hang.pid; wait",
+            "facility-hang",
+          ],
+          true,
+          100,
+        ),
+      ).rejects.toThrow("git -c timed out after 100ms");
+
+      const descendantPid = Number((await readFile(pidPath, "utf8")).trim());
+      expect(Number.isInteger(descendantPid)).toBe(true);
+      await expectProcessToExit(descendantPid);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("escalates after the Git parent exits when a descendant ignores SIGTERM", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-git-kill-timeout-"));
+    const pidPath = join(root, ".facility-resistant.pid");
+    try {
+      await expect(
+        gitOutput(
+          root,
+          [
+            "-c",
+            "alias.facility-hang=!sh -c 'trap \"\" TERM; echo $$ > .facility-resistant.pid; while :; do sleep 1; done' >/dev/null 2>&1 & wait",
+            "facility-hang",
+          ],
+          true,
+          100,
+        ),
+      ).rejects.toThrow("git -c timed out after 100ms");
+
+      const descendantPid = Number((await readFile(pidPath, "utf8")).trim());
+      expect(Number.isInteger(descendantPid)).toBe(true);
+      await expectProcessToExit(descendantPid);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts a signed-delivery HTTP request at its deadline", async () => {
+    const requestSignals: AbortSignal[] = [];
+    const request = vi.fn((_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const requestSignal = init?.signal;
+      if (requestSignal) requestSignals.push(requestSignal);
+      return new Promise<Response>((_resolve, reject) => {
+        requestSignal?.addEventListener("abort", () => reject(requestSignal.reason), {
+          once: true,
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      githubRequest(request, "https://api.github.test/graphql", "installation-token", {}, 10),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(requestSignals[0]?.aborted).toBe(true);
+  });
+});
+
+describe("delivery phase reporting", () => {
+  it.each([
+    {
+      name: "a signed delivery failure",
+      git: { changed: true, pushError: "github request timed out" },
+      deliveryError: "delivery_push_failed",
+      expectedError: "github request timed out",
+    },
+    {
+      name: "a builder without a repository",
+      git: undefined,
+      deliveryError: "delivery_repo_not_configured",
+      expectedError: "delivery_repo_not_configured",
+    },
+    {
+      name: "a builder without changes",
+      git: { changed: false },
+      deliveryError: "delivery_no_changes",
+      expectedError: "delivery_no_changes",
+    },
+  ])("does not announce $name as prepared", ({ git, deliveryError, expectedError }) => {
+    expect(deliveryStatusEvent(git, deliveryError)).toEqual({
+      type: "delivery",
+      data: {
+        status: "failed",
+        changed: git?.changed === true,
+        error: expectedError,
+      },
+    });
+  });
+
+  it("announces a valid delivery as prepared", () => {
+    expect(deliveryStatusEvent({ changed: true }, null)).toEqual({
+      type: "delivery",
+      data: { status: "prepared", changed: true },
+    });
+  });
+});
+
+async function expectProcessToExit(pid: number) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`process ${pid} survived its Git command timeout`);
+}
+
+describe("run prompt composition", () => {
+  it("promotes a manual run message to an explicit objective", () => {
+    const prompt = composedPrompt(
+      bundle({ scope: { type: "manual", source: "agent-page", message: "  Fix the builder  " } }),
+    );
+
+    expect(prompt).toContain("## Run objective\nFix the builder");
+  });
+
+  it("promotes CLI text input to the same explicit objective", () => {
+    const prompt = composedPrompt(
+      bundle({ scope: { source: "cli", agentName: "builder", input: "Fix the CLI builder" } }),
+    );
+
+    expect(prompt).toContain("## Run objective\nFix the CLI builder");
+  });
+
+  it("promotes approved plans, structured input, and governed issues", () => {
+    const objectives: Array<[Record<string, unknown>, string]> = [
+      [{ approvedPlan: "Ship the approved plan" }, "Ship the approved plan"],
+      [
+        { input: { objective: "Fix the structured CLI builder" } },
+        '{\n  "objective": "Fix the structured CLI builder"\n}',
+      ],
+      [{ issue: { number: 42 } }, "Implement the governed GitHub issue #42 described in Scope."],
+    ];
+
+    for (const [scope, objective] of objectives) {
+      expect(composedPrompt(bundle({ scope }))).toContain(`## Run objective\n${objective}`);
+    }
+  });
+
+  it("keeps conversation messages in their conversation section", () => {
+    const prompt = composedPrompt(
+      bundle({ scope: { type: "conversation", message: "Continue the discussion" } }),
+    );
+
+    expect(prompt).toContain("## Conversation\nContinue the discussion");
+    expect(prompt).not.toContain("## Run objective");
   });
 });
 

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -26,6 +26,7 @@
     "@facility/core": "workspace:*",
     "@facility/db": "workspace:*",
     "@facility/harness": "workspace:*",
+    "@facility/run-objective": "workspace:*",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.1.0",
     "@fastify/formbody": "^8.0.2",

--- a/services/api/src/doctor.ts
+++ b/services/api/src/doctor.ts
@@ -350,7 +350,7 @@ async function checkSandboxRunner(db: Db, config: AppConfig, orgId: string): Pro
             "sandbox_runner",
             "Sandbox runner image",
             `The runner image "${runnerImage}" is not present on the Docker daemon; the first platform-lane run will try to pull it.`,
-            `Pre-build or pull it (e.g. \`docker build -t ${runnerImage} runner/\`) — a local-only tag or an unreachable registry will fail that pull.`,
+            `Pre-build or pull it (e.g. \`docker build -f runner/Dockerfile -t ${runnerImage} .\`) — a local-only tag or an unreachable registry will fail that pull.`,
           );
         }
       } catch {

--- a/services/api/src/routes/v1/runs.ts
+++ b/services/api/src/routes/v1/runs.ts
@@ -8,6 +8,7 @@ import {
   steerMessages,
   withOrg,
 } from "@facility/db";
+import { isBuilderMode, runObjectiveText } from "@facility/run-objective";
 import { and, desc, eq, notInArray, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply } from "fastify";
 import postgres from "postgres";
@@ -178,18 +179,19 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
           "plan_acceptance runs can only be created by the approved-plan executor",
         );
       }
+      const agent = await resolveRunAgentDef(p.orgId, projectId, body);
+      const trigger = validatedRunTrigger(agent.name, body.trigger);
       // Preserve issue provenance across generic dispatch (retries pass the
       // source run's trigger): without this, a retried issue-run loses its
       // gh linkage and disappears from the issue's history and the pipeline.
-      const triggerRepo = body.trigger?.repo as { owner?: unknown; name?: unknown } | undefined;
-      const triggerIssue = body.trigger?.issue as { number?: unknown } | undefined;
+      const triggerRepo = trigger.repo as { owner?: unknown; name?: unknown } | undefined;
+      const triggerIssue = trigger.issue as { number?: unknown } | undefined;
       const gh =
         typeof triggerRepo?.owner === "string" &&
         typeof triggerRepo?.name === "string" &&
         typeof triggerIssue?.number === "number"
           ? { owner: triggerRepo.owner, repo: triggerRepo.name, issueNumber: triggerIssue.number }
           : {};
-      const agent = await resolveRunAgentDef(p.orgId, projectId, body);
       const run = (
         await db
           .insert(runs)
@@ -206,7 +208,7 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
             // caller-supplied default made CLI/MCP-triggered Claude/BYO runs look
             // like Codex runs even though orchestration correctly used the agent.
             engine: agent.engine,
-            trigger: body.trigger ?? {},
+            trigger,
             gh,
             createdBy: { type: p.type, id: p.id },
           })
@@ -706,6 +708,12 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
       return redactRunSecrets(run);
     },
   );
+}
+
+function validatedRunTrigger(agentName: string, value: Record<string, unknown> | undefined) {
+  const trigger = { ...value };
+  if (!isBuilderMode(agentName) || runObjectiveText(trigger)) return trigger;
+  throw new ApiError(400, "run_objective_required", "A builder run requires a non-empty objective");
 }
 
 function parentGhForResume(value: unknown) {

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -829,7 +829,7 @@ describe("api", async () => {
         payload: {
           mode: "builder",
           engine: "codex",
-          trigger: { agentName: target.agent.name },
+          trigger: { agentName: target.agent.name, message: "Exercise agent resolution" },
         },
       });
       expect(run.statusCode).toBe(200);
@@ -842,7 +842,12 @@ describe("api", async () => {
         method: "POST",
         url: `/v1/projects/${target.projectId}/runs`,
         headers: { cookie },
-        payload: { mode: "builder", engine: "codex", agentDefId: target.agent.id },
+        payload: {
+          mode: "builder",
+          engine: "codex",
+          agentDefId: target.agent.id,
+          trigger: { message: "Exercise id-based agent resolution" },
+        },
       });
       expect(runById.statusCode).toBe(200);
       expect(runById.json().agentDefId).toBe(target.agent.id);
@@ -4134,7 +4139,12 @@ describe("api", async () => {
       method: "POST",
       url: `/v1/projects/${other.json().id}/runs`,
       headers: { cookie },
-      payload: { mode: "builder", engine: "codex", agentDefId: otherAgent?.id },
+      payload: {
+        mode: "builder",
+        engine: "codex",
+        agentDefId: otherAgent?.id,
+        trigger: { type: "manual", message: "Exercise cross-project run reads" },
+      },
     });
     const denied = await app.inject({
       method: "GET",
@@ -4681,12 +4691,120 @@ describe("api", async () => {
       method: "POST",
       url: `/v1/projects/${project.json().id}/runs`,
       headers: { cookie },
-      payload: { mode: "manual", engine: "codex", agentDefId: agent.id },
+      payload: {
+        mode: "manual",
+        engine: "codex",
+        agentDefId: agent.id,
+        trigger: { type: "manual", message: "Exercise effective engine selection" },
+      },
     });
 
     expect(run.statusCode).toBe(200);
     expect(run.json().engine).toBe("claude_code");
     expect(run.json().mode).toBe(agent.name);
+  });
+
+  it("requires an objective for builder runs without governed issue context", async () => {
+    const project = await app.inject({
+      method: "POST",
+      url: "/v1/projects",
+      headers: { cookie },
+      payload: { name: "Builder Objective", slug: `builder-objective-${Date.now()}` },
+    });
+    const builder = (
+      await db
+        .select()
+        .from(agentDefs)
+        .where(and(eq(agentDefs.projectId, project.json().id), eq(agentDefs.name, "builder")))
+        .limit(1)
+    )[0];
+    if (!builder) throw new Error("seeded builder fixture missing");
+    const runsBeforeRejection = await db
+      .select({ id: runs.id })
+      .from(runs)
+      .where(eq(runs.projectId, project.json().id));
+
+    for (const trigger of [
+      { type: "manual", source: "agent-page" },
+      { type: "manual", source: "agent-page", message: "   " },
+    ]) {
+      const rejected = await app.inject({
+        method: "POST",
+        url: `/v1/projects/${project.json().id}/runs`,
+        headers: { cookie },
+        payload: { agentDefId: builder.id, trigger },
+      });
+      expect(rejected.statusCode).toBe(400);
+      expect(rejected.json().error.code).toBe("run_objective_required");
+    }
+    expect(
+      await db.select({ id: runs.id }).from(runs).where(eq(runs.projectId, project.json().id)),
+    ).toHaveLength(runsBeforeRejection.length);
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${project.json().id}/runs`,
+      headers: { cookie },
+      payload: {
+        agentDefId: builder.id,
+        trigger: {
+          type: "manual",
+          source: "agent-page",
+          message: "Implement the next approved Platform task",
+        },
+      },
+    });
+    expect(accepted.statusCode).toBe(200);
+    expect(accepted.json().trigger).toMatchObject({
+      type: "manual",
+      source: "agent-page",
+      message: "Implement the next approved Platform task",
+    });
+
+    for (const trigger of [
+      { source: "web", approvedPlan: "Ship the approved Platform plan" },
+      { source: "cli", input: "Implement the requested CLI task" },
+    ]) {
+      const objectiveRun = await app.inject({
+        method: "POST",
+        url: `/v1/projects/${project.json().id}/runs`,
+        headers: { cookie },
+        payload: { agentDefId: builder.id, trigger },
+      });
+      expect(objectiveRun.statusCode).toBe(200);
+    }
+
+    const issueRetry = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${project.json().id}/runs`,
+      headers: { cookie },
+      payload: {
+        agentDefId: builder.id,
+        trigger: {
+          type: "web_issue",
+          source: "web",
+          retryOf: accepted.json().id,
+          repo: { owner: "theam", name: "tam-os" },
+          issue: { number: 42 },
+        },
+      },
+    });
+    expect(issueRetry.statusCode).toBe(200);
+
+    const cliInput = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${project.json().id}/runs`,
+      headers: { cookie },
+      payload: {
+        agentDefId: builder.id,
+        trigger: {
+          source: "cli",
+          agentName: "builder",
+          input: { objective: "Implement the next approved Platform task" },
+        },
+      },
+    });
+    expect(cliInput.statusCode).toBe(200);
   });
 
   it("creates and dispatches each scheduled run exactly once per UTC minute", async () => {
@@ -5589,7 +5707,11 @@ describe("api", async () => {
       method: "POST",
       url: `/v1/projects/${target.projectId}/runs`,
       headers: { cookie },
-      payload: { mode: "manual", agentDefId: target.agent.id },
+      payload: {
+        mode: "manual",
+        agentDefId: target.agent.id,
+        trigger: { type: "manual", message: "Exercise terminal webhook delivery" },
+      },
     });
     expect(run.statusCode).toBe(200);
     expect(
@@ -5651,7 +5773,12 @@ describe("api", async () => {
       method: "POST",
       url: `/v1/projects/${target.projectId}/runs`,
       headers: { cookie },
-      payload: { mode: "builder", engine: "codex", agentDefId: target.agent.id },
+      payload: {
+        mode: "builder",
+        engine: "codex",
+        agentDefId: target.agent.id,
+        trigger: { type: "manual", message: "Exercise terminal steering rejection" },
+      },
     });
     const canceled = await app.inject({
       method: "POST",


### PR DESCRIPTION
## What changes

- Require an explicit objective for builder agents created through `POST /v1/projects/:projectId/runs`, while keeping empty triggers valid for non-builders.
- Propagate governed objectives into a dedicated runner prompt section and ask for an objective from the web UI on manual builder runs and retries.
- Bound Git and signed GitHub delivery work, terminate resistant process groups, and report failed delivery phases accurately.
- Build the runner from the repository root so the shared objective package is available in Docker, Compose, CI, and production image builds.

## Why

- Manual builder runs could start without a task and therefore complete only a placeholder action such as “hello”.
- A hung Git or GitHub delivery operation could leave a completed agent run stuck indefinitely.
- The runner now shares one objective interpretation across the API, web UI, and execution environment.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite: built API, web, and runner Docker images; built the real Compose `runner-image`; exercised missing-objective/no-row API denial, resistant Git descendants, and timed-out signed GitHub requests and socket teardown against deterministic local fakes; repeated the timeout integration 10 times sequentially and 5 times concurrently
- [x] Documentation updated, or no user-facing change

Independent reviews approved exact commit `1bd12b3717c3fc37a5d7d3a805d62e275820ed46`.