### PR TITLE
ci: pass API URL to release web build

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -82,22 +82,30 @@ jobs:
             dockerfile: Dockerfile
             target: api
             context: .
+            build_args: ""
           - image: gateway
             dockerfile: Dockerfile
             target: gateway
             context: .
+            build_args: ""
           - image: mcp
             dockerfile: Dockerfile
             target: mcp
             context: .
+            build_args: ""
           - image: web
             dockerfile: apps/web/Dockerfile
             target: web
             context: .
+            # The official image serves Facility's hosted control plane. AWS
+            # self-hosters with a different api_url must build their web image
+            # for that deployment, as documented in the runbook.
+            build_args: FACILITY_API_URL=https://api.facility.tam-os.com
           - image: runner
             dockerfile: runner/Dockerfile
             target: ""
             context: .
+            build_args: ""
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -124,6 +132,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
+          build-args: ${{ matrix.build_args }}
           platforms: linux/amd64
           outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -132,6 +132,16 @@ test("CI gates release images and the reusable publisher stages digests before p
     "the isolated build checkout must be stamped before Docker consumes it",
   );
   assert.match(imagesWorkflow, /push-by-digest=true,name-canonical=true,push=true/);
+  assert.match(
+    buildJob,
+    /- image: web[\s\S]*?build_args: FACILITY_API_URL=https:\/\/api\.facility\.tam-os\.com/,
+    "the release web image must receive the API URL compiled into its rewrites",
+  );
+  assert.match(
+    buildJob,
+    /build-args: \$\{\{ matrix\.build_args \}\}/,
+    "the matrix build arguments must reach docker/build-push-action",
+  );
   assert.match(imagesWorkflow, /promote:\n {4}needs: \[plan, build\]/);
   assert.match(imagesWorkflow, /node scripts\/images\.mjs promote/);
   assert.match(


### PR DESCRIPTION
## What changes

- Passes `FACILITY_API_URL=https://api.facility.tam-os.com` to the official GHCR web image build.
- Keeps all non-web image matrix entries argument-free.
- Adds a regression assertion that the web build argument is present and forwarded to `docker/build-push-action`.

## Why

The `0.4.0` release published to npm but its GHCR image set was not promoted because `apps/web/Dockerfile` requires a non-empty `FACILITY_API_URL` and the release workflow supplied no build argument. Recording `v0.4.0` establishes the partial npm release boundary; this fix lets the already-merged breaking stories change publish cleanly as `0.5.0`.

Self-hosted AWS deployments remain unchanged: their runbook requires rebuilding the web image with that deployment's own `api_url` because Next.js compiles the rewrite destination into the image.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite: the exact release-style web Docker build completed with `--build-arg FACILITY_API_URL=https://api.facility.tam-os.com`, and `node scripts/version.mjs` resolves the next release as `0.5.0` from the new `v0.4.0` boundary.
- [x] Documentation updated, or no user-facing change: existing AWS documentation already requires per-deployment web rebuilds for non-hosted API URLs.
