### PR TITLE
feat(github): make CI authoritative for platform delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ itself when the team wants agents running in its own CI.
 
 | Goal | Facility provides | Available with |
 |---|---|---|
-| Take work from an issue to a pull request | `/architect` investigates and proposes a plan; a human invokes `/builder`; the builder implements, runs the repository's checks, pushes a branch, and opens a PR. | Installer or platform |
+| Take work from an issue to a pull request | `/architect` investigates and proposes a plan; a human invokes `/builder`; the builder implements and publishes a reviewable PR. Platform runs publish a draft before GitHub CI decides acceptance. | Installer or platform |
 | Keep accountability with people | A person accepts the plan; at Gate 2 a person validates the live preview, reviews the PR, and squash-merges it. Agents cannot approve, merge, or push to protected branches. | Installer or platform |
 | Give agents a usable job site | Each run starts with the repository's provision command, then follows `STANDARD.md`, relevant skills, specialist review, and the configured test/build commands. | Installer or platform |
 | Validate behavior before merge | Facility can provision a private Docker or AWS preview from a project-defined image, wait for its readiness endpoint, and expose it only through the SSO-authenticated proxy. Existing provider previews remain supported. | Installer or platform |
@@ -375,11 +375,15 @@ Whichever setup you choose, work follows the same reviewed path:
 1. Work starts as an issue or another owned signal.
 2. `/architect` inspects the real repository and proposes a plan in the issue.
 3. A human accepts that plan by invoking `/builder`.
-4. `/builder` provisions the environment, implements the complete change, runs
-   the configured checks, and opens a pull request.
+4. `/builder` provisions the environment and implements the complete change.
+   Repo-lane builders run the configured checks before opening a PR. A
+   platform-lane builder runs focused checks and Facility immediately publishes
+   its signed commit as a draft PR.
 5. Facility or the configured deployment provider creates a live, isolated preview for fast validation.
 6. Automated review, deterministic guards, and the repository's CI examine the
-   result.
+   result. GitHub CI is authoritative for platform-lane delivery; failed checks
+   can dispatch the configured CI-doctor on the same branch, and Facility marks
+   the draft ready only after the current head's aggregate rollup succeeds.
 7. At Gate 2, a human validates the preview, reviews the PR, and squash-merges it.
 8. The run leaves a receipt; the watchtower joins it with the eventual outcome
    and reports health over time.
@@ -389,6 +393,12 @@ GitHub workflows in your existing CI and has no platform dependency at run
 time. The **platform lane** runs the same contracts in an isolated sandbox and
 adds live streaming, steering, centralized credentials, and platform-enforced
 budgets. A project can move one trigger at a time between lanes.
+
+Platform CI repair is limited to branches produced by that project's Facility
+builder runs. It retries at most three changed heads by default; set the project
+setting `ci_repair_max_attempts` to an integer from 1 through 10 to change the
+limit. Exhaustion leaves the draft PR and its failing checks intact for human
+iteration.
 
 Read [the method](apps/docs/docs/concepts/method.md) for the reasoning behind the roles, gates,
 standards, guards, and watchtower.

--- a/packages/cli/templates/prompts/builder.md
+++ b/packages/cli/templates/prompts/builder.md
@@ -19,8 +19,8 @@ and how far you got. A partial deliverable is a failure.
 You are NOT on a bare checkout. A prior CI step already installed dependencies
 and ran the provision command (`{{PROVISION_CMD}}`), and you run with full
 bypass permissions on an isolated, ephemeral runner. Never claim the
-environment is unavailable — verify by running the checks. In platform runs,
-Facility owns the final signed commit, push, and GitHub App pull-request call;
+environment is unavailable. In platform runs, Facility owns the final signed
+commit, push, and GitHub App pull-request call;
 you supply its exact semantic branch, commit message, PR title, and PR body in
 the delivery manifest described in the injected prompt. Do not require `gh`, a
 writable clone credential, or a local signing key.
@@ -30,7 +30,11 @@ writable clone credential, or a local signing key.
 - Do the full scope the task requires and finish it; keep each edit clean,
   cohesive, and aligned with existing patterns. Read only the code you need;
   run independent commands in parallel.
-- Verify by actually running the relevant checks: {{CHECKS_INLINE}}.
+- Verify by actually running relevant checks. In a repo-lane builder, run the
+  configured suite (`{{CHECKS_INLINE}}`). In a platform sandbox, run focused
+  checks that help you iterate, but do not duplicate that complete suite:
+  GitHub Actions runs it authoritatively on the durable draft PR and CI repair
+  agents continue on that same branch if it fails.
 - Apply the repo skills in `.claude/skills/` — `working-to-standard` while
   implementing, `maintainable-software` for design judgment,
   `reviewing-to-standard` when you self-review. They are part of this
@@ -45,7 +49,7 @@ writable clone credential, or a local signing key.
   no agent/tool prefix in branch names.
 - Signed bot authorship is the complete attribution. Never add a
   `Co-authored-by` trailer for the requester or any other person.
-- For issue-triggered work, author the complete non-draft PR metadata in
+- For issue-triggered work, author the complete PR metadata in
   `.agent-sdlc/delivery.json`; Facility transports it exactly. A generic title,
   boilerplate body, or link that asks a human to create the PR is not delivery.
 - Finish with one concise, team-lead-ready summary: what changed and why, the
@@ -54,11 +58,13 @@ writable clone credential, or a local signing key.
 </output_contract>
 
 <completion_criteria>
-Done only when the change is implemented (not proposed), the right checks were
-run and pass (or a failure is explicitly reported with what ran), and the
-completion checklist in `STANDARD.md` is satisfied. The workflow independently
-re-runs the configured checks and fails closed unless a semantic branch, verified
-commit, bot-authored PR, and machine-readable delivery receipt all exist.
+Done only when the change is implemented (not proposed), the checks appropriate
+to the execution lane were run and reported accurately, and the completion
+checklist in `STANDARD.md` is satisfied. The repo lane fails closed on its
+configured checks. The platform lane fails closed unless a semantic branch,
+verified commit, bot-authored draft PR, and machine-readable delivery receipt
+all exist; GitHub Actions owns final acceptance and failed CI remains visible
+for bounded repair iterations on that same PR.
 </completion_criteria>
 
 <safety_rules>

--- a/packages/db/migrations/0031_github_ci_repair_dedupe.sql
+++ b/packages/db/migrations/0031_github_ci_repair_dedupe.sql
@@ -1,0 +1,12 @@
+CREATE UNIQUE INDEX IF NOT EXISTS runs_ci_doctor_branch_head_sha_uidx
+  ON runs (
+    org_id,
+    project_id,
+    (gh->>'owner'),
+    (gh->>'repo'),
+    (gh->>'branch'),
+    (trigger #>> '{pullRequest,headSha}')
+  )
+  WHERE mode IN ('ci_doctor', 'ci-doctor')
+    AND trigger->>'event' = 'workflow_run'
+    AND trigger #>> '{pullRequest,headSha}' IS NOT NULL;

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -169,12 +169,13 @@ async function main() {
         },
       ]);
     }
-    // Platform-owned acceptance gates run independently of the engine's own
-    // exit code and self-report: a run only succeeds if the engine succeeded AND
-    // every configured check command passes. Skip them when the engine already
-    // failed (the run fails regardless). Without this an agent could report
-    // success while its required checks are red.
-    const checksConfigured = !requiresDelivery(bundle.mode) || bundle.checkCmds.length > 0;
+    // GitHub-backed deliveries publish their signed branch first and let GitHub
+    // Actions own acceptance. That preserves the work as a draft PR and lets a
+    // CI-doctor iterate on the same branch instead of spending the sandbox's
+    // lifetime duplicating CI before any reviewable artifact exists.
+    const githubCi = githubCiOwnsAcceptance(bundle);
+    const checksConfigured =
+      githubCi || !requiresDelivery(bundle.mode) || bundle.checkCmds.length > 0;
     if (!checksConfigured) {
       await emit([
         {
@@ -196,6 +197,20 @@ async function main() {
     // (address-review, ci-doctor — they push commits too), and custom/BYO
     // modes that use checks as generic acceptance.
     const readOnlyMode = readOnlyRepositoryMode(normalizedMode(bundle.mode));
+    if (githubCi && engineCode === 0) {
+      await emit([
+        {
+          type: "check",
+          data: {
+            self_reported: false,
+            name: "GitHub CI acceptance",
+            status: "skipped",
+            reason: "deferred_to_github",
+            note: "The signed draft pull request is the durable CI boundary",
+          },
+        },
+      ]);
+    }
     if (readOnlyMode && bundle.checkCmds.length > 0 && engineCode === 0) {
       await emit([
         {
@@ -212,7 +227,7 @@ async function main() {
     }
     const checksPassed =
       engineCode === 0 && checksConfigured && progressConfigured
-        ? readOnlyMode
+        ? githubCi || readOnlyMode
           ? true
           : await runChecks(bundle, cwdFor(bundle))
         : false;
@@ -1043,6 +1058,12 @@ async function postResult(
 
 export function requiresDelivery(mode: string) {
   return mode === "builder" || mode.endsWith("-builder");
+}
+
+export function githubCiOwnsAcceptance(bundle: Pick<RunBundle, "mode" | "repo">): boolean {
+  if (!bundle.repo.cloneUrl?.startsWith("https://github.com/")) return false;
+  const mode = normalizedMode(bundle.mode);
+  return requiresDelivery(bundle.mode) || repairRepositoryMode(mode);
 }
 
 export function deliveryStatusEvent(
@@ -2071,7 +2092,7 @@ export function composedPrompt(bundle: RunBundle) {
         .join("\n")}`
     : "";
   const deliveryNote = requiresDelivery(bundle.mode)
-    ? `\n\n## Agent-owned delivery\nFacility will create the signed commit, push, and non-draft pull request with the GitHub App after your engine exits. You own all delivery metadata. Before finishing, create \`.agent-sdlc/delivery.json\` with exactly this shape:\n\n\`\`\`json\n{\n  "branch": "feature/task-slug",\n  "commitMessage": "feat: describe the change",\n  "pullRequest": {\n    "title": "feat: describe the change",\n    "body": "## Summary\\n- ...\\n\\n## Context\\n- ...\\n\\n## Verification\\n- ...\\n\\n## Linked issues\\n- Closes #123"\n  }\n}\n\`\`\`\n\nThe branch must be semantic; the commit and PR title must use Conventional Commits and have the same release impact. If the commit has a \`BREAKING CHANGE:\` footer, mark the PR title with \`!\` too. The PR body must be your complete team-lead-ready description. Do not commit this managed file. Do not require \`gh\`, a writable clone token, or a local signing key: Facility transports your exact metadata and fails closed if it is absent or invalid.`
+    ? `\n\n## Agent-owned delivery\nFacility will create the signed commit, push, and draft pull request with the GitHub App after your engine exits. GitHub Actions is the authoritative acceptance boundary: do not duplicate the repository's full configured CI suite inside this sandbox. Run focused checks that help you iterate on the changed behavior, report their results accurately, and let the durable draft PR retain the work while CI and repair agents continue. You own all delivery metadata. Before finishing, create \`.agent-sdlc/delivery.json\` with exactly this shape:\n\n\`\`\`json\n{\n  "branch": "feature/task-slug",\n  "commitMessage": "feat: describe the change",\n  "pullRequest": {\n    "title": "feat: describe the change",\n    "body": "## Summary\\n- ...\\n\\n## Context\\n- ...\\n\\n## Verification\\n- ...\\n\\n## Linked issues\\n- Closes #123"\n  }\n}\n\`\`\`\n\nThe branch must be semantic; the commit and PR title must use Conventional Commits and have the same release impact. If the commit has a \`BREAKING CHANGE:\` footer, mark the PR title with \`!\` too. The PR body must be your complete team-lead-ready description. Do not commit this managed file. Do not require \`gh\`, a writable clone token, or a local signing key: Facility transports your exact metadata and fails closed if it is absent or invalid.`
     : "";
   const repairDeliveryNote = repairRepositoryMode(normalizedMode(bundle.mode))
     ? `\n\n## Agent-owned PR update\nIf and only if you make verified repository changes, create \`.agent-sdlc/delivery.json\` before finishing with exactly \`{"branch":"<the existing PR branch>","commitMessage":"<matching Conventional Commit type>: describe the correction"}\`. Facility will add a signed commit to that same branch through the GitHub App. The branch must exactly match the checked-out PR branch. Choose a truthful Conventional Commit type whose release impact is no greater than the existing pull request range; do not add \`!\` or a \`BREAKING CHANGE:\` footer unless that range is already breaking. If a truthful message would raise the impact, leave the manifest absent and report that the PR title must be updated first. Do not run \`git push\`, create another branch or pull request, force-push, or depend on \`gh\`. If no code change is needed, do not create the manifest.`

--- a/runner/test/checks.test.ts
+++ b/runner/test/checks.test.ts
@@ -4,6 +4,7 @@ import {
   checkEvent,
   deliveryFailure,
   engineEnv,
+  githubCiOwnsAcceptance,
   parseSelfReportedChecks,
   redactEventData,
   redactSecrets,
@@ -65,6 +66,24 @@ describe("builder delivery invariant", () => {
     expect(requiresDelivery("codex-builder")).toBe(true);
     expect(requiresDelivery("architect")).toBe(false);
     expect(requiresDelivery("review")).toBe(false);
+  });
+
+  it("defers GitHub builder and repair acceptance to the durable pull request", () => {
+    expect(githubCiOwnsAcceptance({ mode: "builder", repo })).toBe(true);
+    expect(githubCiOwnsAcceptance({ mode: "codex-builder", repo })).toBe(true);
+    expect(githubCiOwnsAcceptance({ mode: "ci-doctor", repo })).toBe(true);
+    expect(githubCiOwnsAcceptance({ mode: "address-review", repo })).toBe(true);
+  });
+
+  it("keeps local gates for non-GitHub and non-delivery runs", () => {
+    expect(
+      githubCiOwnsAcceptance({
+        mode: "builder",
+        repo: { ...repo, cloneUrl: "https://gitlab.example/acme/project.git" },
+      }),
+    ).toBe(false);
+    expect(githubCiOwnsAcceptance({ mode: "review", repo })).toBe(false);
+    expect(githubCiOwnsAcceptance({ mode: "custom", repo })).toBe(false);
   });
 
   it("rejects no-op, unpushed, and push-failed builder results", () => {

--- a/services/api/src/github/client.ts
+++ b/services/api/src/github/client.ts
@@ -63,9 +63,33 @@ export type Octokit = {
           closed_at?: string | null;
           merged_at?: string | null;
           html_url: string;
+          node_id?: string;
+          head?: { sha?: string };
           user?: { login?: string } | null;
         };
       }>;
+    };
+    actions?: {
+      listJobsForWorkflowRun: (args: Record<string, unknown>) => Promise<{
+        data: {
+          jobs?: Array<{
+            id: number;
+            name: string;
+            status?: string | null;
+            conclusion?: string | null;
+            html_url?: string | null;
+            steps?: Array<{
+              number?: number;
+              name?: string;
+              status?: string | null;
+              conclusion?: string | null;
+            }>;
+          }>;
+        };
+      }>;
+      downloadJobLogsForWorkflowRunJob?: (
+        args: Record<string, unknown>,
+      ) => Promise<{ data: unknown }>;
     };
     issues: {
       create: (
@@ -81,6 +105,16 @@ export type Octokit = {
       updateComment: (
         args: Record<string, unknown>,
       ) => Promise<{ data: { id: number; html_url?: string } }>;
+      get?: (args: Record<string, unknown>) => Promise<{
+        data: {
+          number: number;
+          title: string;
+          body?: string | null;
+          html_url: string;
+          user?: { login?: string } | null;
+          labels?: Array<string | { name?: string }>;
+        };
+      }>;
       addAssignees?: (args: Record<string, unknown>) => Promise<{
         data: { assignees?: Array<{ login?: string | null }> };
       }>;
@@ -106,6 +140,13 @@ export type GithubInstallationTokenFactory = (input: {
   repo: string;
   permissions?: Record<string, string>;
 }) => Promise<string>;
+
+export class GithubIssueContextTooLargeError extends Error {
+  constructor() {
+    super("GitHub issue comments exceed the governed context limit");
+    this.name = "GithubIssueContextTooLargeError";
+  }
+}
 
 export function createGithubClientFactory(config: AppConfig): GithubClientFactory {
   if (!config.githubAppId || !config.githubAppPrivateKey) {
@@ -311,6 +352,7 @@ export class FacilityGithubClient {
     body: string;
     head: string;
     base?: string;
+    draft?: boolean;
   }): Promise<{ number: number; url: string }> {
     this.refuseDefaultBranch(args.head);
     const response = await this.octokit.rest.pulls.create({
@@ -320,8 +362,79 @@ export class FacilityGithubClient {
       body: args.body,
       head: args.head,
       base: args.base ?? this.repo.defaultBranch,
+      draft: args.draft ?? false,
     });
     return { number: response.data.number, url: response.data.html_url };
+  }
+
+  async markPullRequestReadyForReview(number: number, expectedHeadSha: string): Promise<boolean> {
+    if (!this.octokit.rest.pulls.get || !this.octokit.graphql) {
+      throw new Error("GitHub draft pull-request transitions are unavailable");
+    }
+    const response = await this.octokit.rest.pulls.get({
+      owner: this.repo.owner,
+      repo: this.repo.repo,
+      pull_number: number,
+    });
+    if (response.data.draft !== true || response.data.head?.sha !== expectedHeadSha) return false;
+    const pullRequestId = response.data.node_id;
+    if (!pullRequestId) throw new Error("GitHub pull request node id is unavailable");
+    await this.octokit.graphql(
+      `mutation FacilityMarkPullRequestReady($pullRequestId: ID!) {
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+          pullRequest { number isDraft }
+        }
+      }`,
+      { pullRequestId },
+    );
+    return true;
+  }
+
+  async getWorkflowFailureContext(runId: number) {
+    const actions = this.octokit.rest.actions;
+    if (!actions?.listJobsForWorkflowRun) return { jobs: [] };
+    const response = await actions.listJobsForWorkflowRun({
+      owner: this.repo.owner,
+      repo: this.repo.repo,
+      run_id: runId,
+      filter: "latest",
+      per_page: 100,
+    });
+    const failed = (response.data.jobs ?? []).filter((job) =>
+      ["failure", "timed_out", "cancelled", "action_required"].includes(job.conclusion ?? ""),
+    );
+    const jobs = await Promise.all(
+      failed.slice(0, 5).map(async (job) => {
+        let logTail: string | null = null;
+        if (actions.downloadJobLogsForWorkflowRunJob) {
+          try {
+            const logs = await actions.downloadJobLogsForWorkflowRunJob({
+              owner: this.repo.owner,
+              repo: this.repo.repo,
+              job_id: job.id,
+            });
+            logTail = workflowLogText(logs.data).slice(-16_000) || null;
+          } catch {
+            // Failed steps still give the repair agent a deterministic target.
+          }
+        }
+        return {
+          id: job.id,
+          name: job.name,
+          conclusion: job.conclusion ?? "failure",
+          url: job.html_url ?? null,
+          failedSteps: (job.steps ?? [])
+            .filter((step) => step.conclusion && step.conclusion !== "success")
+            .map((step) => ({
+              number: step.number ?? null,
+              name: step.name ?? "unknown step",
+              conclusion: step.conclusion ?? null,
+            })),
+          logTail,
+        };
+      }),
+    );
+    return { jobs };
   }
 
   async listPullRequestSnapshots(params: {
@@ -527,7 +640,10 @@ export class FacilityGithubClient {
     return response.data;
   }
 
-  async listIssueComments(number: number): Promise<
+  async listIssueComments(
+    number: number,
+    maxChars?: number,
+  ): Promise<
     Array<{
       id: number;
       author: string;
@@ -538,20 +654,52 @@ export class FacilityGithubClient {
     }>
   > {
     if (!this.octokit.rest.issues.listComments) return [];
-    const response = await this.octokit.rest.issues.listComments({
+    const comments: Array<{
+      id: number;
+      author: string;
+      authorType: string;
+      body: string;
+      createdAt: string;
+      url: string;
+    }> = [];
+    let serializedChars = 2;
+    for (let page = 1; ; page += 1) {
+      const response = await this.octokit.rest.issues.listComments({
+        owner: this.repo.owner,
+        repo: this.repo.repo,
+        issue_number: number,
+        page,
+        per_page: 100,
+      });
+      const mapped = response.data.map((comment) => ({
+        id: comment.id,
+        author: comment.user?.login ?? "unknown",
+        authorType: comment.user?.type ?? "User",
+        body: comment.body ?? "",
+        createdAt: comment.created_at,
+        url: comment.html_url,
+      }));
+      for (const comment of mapped) {
+        serializedChars += JSON.stringify(comment).length + 1;
+        if (maxChars !== undefined && serializedChars > maxChars) {
+          throw new GithubIssueContextTooLargeError();
+        }
+        comments.push(comment);
+      }
+      if (response.data.length < 100) return comments;
+    }
+  }
+
+  async getIssue(number: number) {
+    if (!this.octokit.rest.issues.get) {
+      throw new Error("GitHub issue retrieval is unavailable");
+    }
+    const response = await this.octokit.rest.issues.get({
       owner: this.repo.owner,
       repo: this.repo.repo,
       issue_number: number,
-      per_page: 100,
     });
-    return response.data.map((comment) => ({
-      id: comment.id,
-      author: comment.user?.login ?? "unknown",
-      authorType: comment.user?.type ?? "User",
-      body: comment.body ?? "",
-      createdAt: comment.created_at,
-      url: comment.html_url,
-    }));
+    return response.data;
   }
 
   async getPullRequest(number: number): Promise<{
@@ -656,6 +804,13 @@ export class FacilityGithubClient {
     }
     return { ...node, closingIssuesReferences: { nodes } };
   }
+}
+
+function workflowLogText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
+  if (value instanceof ArrayBuffer) return Buffer.from(value).toString("utf8");
+  return "";
 }
 
 type ClosingIssueNode = {

--- a/services/api/src/github/processor.ts
+++ b/services/api/src/github/processor.ts
@@ -1,13 +1,16 @@
 import { newId } from "@facility/core";
 import {
   agentDefs,
+  auditEvents,
   type FacilityDb,
+  ghPullRequests,
   githubInstallations,
   inboundEvents,
   insertAuditEvent,
   integrations,
   outcomes,
   previewSandboxes,
+  projects,
   repos,
   runEvents,
   runs,
@@ -26,7 +29,11 @@ import {
   syncRepoIssues,
   upsertGhIssueFromWebhook,
 } from "./issues-sync.js";
-import { syncRepoFacilityConfig, verifyFingerprints } from "./kickstart.js";
+import {
+  createGithubClientForRepo,
+  syncRepoFacilityConfig,
+  verifyFingerprints,
+} from "./kickstart.js";
 import {
   refreshGhPullRequest,
   refreshPullRequestsForSignal,
@@ -75,6 +82,16 @@ type WebhookPayload = TriggerPayload & {
     head_branch?: string;
     head_sha?: string;
     pull_requests?: Array<{ number?: number; head?: { ref?: string }; base?: { ref?: string } }>;
+    failureContext?: {
+      jobs: Array<{
+        id: number;
+        name: string;
+        conclusion: string;
+        url: string | null;
+        failedSteps: Array<{ number: number | null; name: string; conclusion: string | null }>;
+        logTail: string | null;
+      }>;
+    };
   };
   deployment_status?: {
     id?: number;
@@ -196,7 +213,7 @@ export async function processGithubWebhook(
       if (isTerminalPullRequestSignal(event.eventType, payload)) {
         await refreshPullRequestsBestEffort(
           () =>
-            refreshPullRequestsFromSignal(
+            refreshPullRequestsAndPromoteReady(
               db,
               event.orgId,
               payload,
@@ -213,7 +230,7 @@ export async function processGithubWebhook(
       if (isTerminalPullRequestSignal(event.eventType, payload)) {
         await refreshPullRequestsBestEffort(
           () =>
-            refreshPullRequestsFromSignal(
+            refreshPullRequestsAndPromoteReady(
               db,
               event.orgId,
               payload,
@@ -227,7 +244,7 @@ export async function processGithubWebhook(
       if (isTerminalPullRequestSignal(event.eventType, payload)) {
         await refreshPullRequestsBestEffort(
           () =>
-            refreshPullRequestsFromSignal(
+            refreshPullRequestsAndPromoteReady(
               db,
               event.orgId,
               payload,
@@ -611,24 +628,9 @@ async function processWorkflowRun(
   factory: GithubClientFactory,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
 ) {
-  if (payload.action !== "completed" || !payload.workflow_run?.name?.startsWith("facility-"))
-    return;
-  const owner = payload.repository?.owner?.login;
-  const name = payload.repository?.name;
-  if (!owner || !name || payload.workflow_run.conclusion !== "failure") return;
-  const repo = (
-    await db
-      .select()
-      .from(repos)
-      .where(and(eq(repos.orgId, orgId), eq(repos.owner, owner), eq(repos.name, name)))
-      .limit(1)
-  )[0];
-  if (!repo) return;
-  // Store as an audit-visible health signal; watchtower escalation is a later worker chunk.
-  await auditGithub(db, repo.orgId, "github.workflow.failed", repo, {
-    workflow: payload.workflow_run.name,
-    url: payload.workflow_run.html_url,
-  });
+  if (payload.action !== "completed") return;
+  const workflowRun = payload.workflow_run;
+  if (workflowRun?.conclusion !== "failure") return;
   await processGithubAgentEvent(db, orgId, eventId, "workflow_run", payload, factory, enqueue);
 }
 
@@ -673,44 +675,119 @@ async function processGithubAgentEvent(
   // legacy/default lane is repo, so connecting an existing repository never
   // silently starts a weaker duplicate reviewer or repair agent.
   if (laneFor(repo, agent.name) !== "platform") return;
-  const pullRequest = pullRequestContext(eventType, payload);
+  let pullRequest = pullRequestContext(eventType, payload);
+  const workflowBranch = pullRequest.head;
+  if (eventType === "workflow_run" && workflowBranch && !pullRequest.number) {
+    const mirrored = (
+      await db
+        .select()
+        .from(ghPullRequests)
+        .where(
+          and(
+            eq(ghPullRequests.repoId, repo.id),
+            eq(ghPullRequests.state, "open"),
+            eq(ghPullRequests.headRef, workflowBranch),
+          ),
+        )
+        .orderBy(desc(ghPullRequests.updatedAt))
+        .limit(1)
+    )[0];
+    if (mirrored) {
+      pullRequest = {
+        number: mirrored.number,
+        title: mirrored.title,
+        body: mirrored.bodyMd,
+        url: mirrored.htmlUrl,
+        head: mirrored.headRef,
+        headSha: payload.workflow_run?.head_sha ?? mirrored.headSha,
+        base: mirrored.baseRef,
+      };
+    }
+  }
   const pullNumber = pullRequest.number;
   const branch = pullRequest.head;
   const deliveryContext = branch ? await githubDeliveryContext(db, repo, branch) : null;
-  const run = (
-    await db
-      .insert(runs)
-      .values({
-        id: newId("run"),
-        orgId,
-        projectId: repo.projectId,
-        agentDefId: agent.id,
-        mode: agent.name.replace(/-/g, "_"),
-        engine: agent.engine,
-        trigger: {
-          type: "github_event",
-          event: eventType,
-          action: payload.action ?? null,
-          delivery: eventId,
-          repository: { owner, name, defaultBranch: repo.defaultBranch },
-          pullRequest,
-          review: payload.review ?? null,
-          workflowRun: payload.workflow_run ?? null,
-          deliveryContext,
-        },
-        gh: {
+  if (eventType === "workflow_run") {
+    if (!pullNumber || !branch || !pullRequest.headSha || !deliveryContext) return;
+    await auditGithub(db, repo.orgId, "github.workflow.failed", repo, {
+      workflow: payload.workflow_run?.name,
+      url: payload.workflow_run?.html_url,
+      pullNumber,
+      branch,
+      headSha: pullRequest.headSha,
+    });
+    const eligibility = await ciRepairEligibility(db, repo, branch, pullRequest.headSha);
+    if (!eligibility.allowed) {
+      if (eligibility.reason === "attempts_exhausted") {
+        if (await ciRepairExhaustionReported(db, repo, branch, pullRequest.headSha)) return;
+        const client = new FacilityGithubClient(await factory(installationId), {
           owner,
           repo: name,
-          ...(pullNumber ? { issueNumber: pullNumber } : {}),
-          ...(branch ? { branch } : {}),
-        },
-        createdBy: {
-          type: "github",
-          id: payload.sender?.login ?? `${eventType}-webhook`,
-        },
-      })
-      .returning()
-  )[0];
+          defaultBranch: repo.defaultBranch,
+        });
+        await client
+          .createIssueComment(
+            pullNumber,
+            `Facility stopped automatic CI repair after ${eligibility.maxAttempts} attempts. The draft PR and failing GitHub checks remain available for human iteration.`,
+          )
+          .catch(() => undefined);
+        await auditGithub(db, orgId, "github.ci_repair.exhausted", repo, {
+          pullNumber,
+          branch,
+          headSha: pullRequest.headSha,
+          attempts: eligibility.attempts,
+          maxAttempts: eligibility.maxAttempts,
+        });
+      }
+      return;
+    }
+    const workflowRun = payload.workflow_run;
+    const workflowRunId = workflowRun?.id;
+    if (workflowRun && workflowRunId) {
+      const client = new FacilityGithubClient(await factory(installationId), {
+        owner,
+        repo: name,
+        defaultBranch: repo.defaultBranch,
+      });
+      workflowRun.failureContext = await client
+        .getWorkflowFailureContext(workflowRunId)
+        .catch(() => ({ jobs: [] }));
+    }
+  }
+  const values = {
+    id: newId("run"),
+    orgId,
+    projectId: repo.projectId,
+    agentDefId: agent.id,
+    mode: agent.name.replace(/-/g, "_"),
+    engine: agent.engine,
+    trigger: {
+      type: "github_event",
+      event: eventType,
+      action: payload.action ?? null,
+      delivery: eventId,
+      repository: { owner, name, defaultBranch: repo.defaultBranch },
+      pullRequest,
+      review: payload.review ?? null,
+      workflowRun: payload.workflow_run ?? null,
+      deliveryContext,
+    },
+    gh: {
+      owner,
+      repo: name,
+      ...(pullNumber ? { issueNumber: pullNumber } : {}),
+      ...(branch ? { branch } : {}),
+    },
+    createdBy: {
+      type: "github",
+      id: payload.sender?.login ?? `${eventType}-webhook`,
+    },
+  };
+  const inserted =
+    eventType === "workflow_run"
+      ? await db.insert(runs).values(values).onConflictDoNothing().returning()
+      : await db.insert(runs).values(values).returning();
+  const run = inserted[0];
   if (!run) return;
   await db.insert(runEvents).values({
     orgId,
@@ -789,6 +866,8 @@ async function githubDeliveryContext(
         and(
           eq(runs.orgId, repo.orgId),
           eq(runs.projectId, repo.projectId),
+          sql`${runs.gh}->>'owner' = ${repo.owner}`,
+          sql`${runs.gh}->>'repo' = ${repo.name}`,
           sql`${runs.gh}->>'branch' = ${branch}`,
           // The builder run owns the accepted plan and original request. Newer
           // review/repair runs on the same branch must not erase that lineage.
@@ -811,6 +890,8 @@ async function githubDeliveryContext(
           eq(runs.orgId, repo.orgId),
           eq(runs.projectId, repo.projectId),
           eq(runs.status, "succeeded"),
+          sql`${runs.gh}->>'owner' = ${repo.owner}`,
+          sql`${runs.gh}->>'repo' = ${repo.name}`,
           sql`${runs.gh}->>'branch' = ${branch}`,
           inArray(runs.mode, ["address_review", "address-review", "ci_doctor", "ci-doctor"]),
         ),
@@ -853,6 +934,85 @@ async function githubDeliveryContext(
       };
     }),
   };
+}
+
+async function ciRepairEligibility(
+  db: FacilityDb,
+  repo: typeof repos.$inferSelect,
+  branch: string,
+  headSha: string,
+) {
+  const project = (
+    await db
+      .select({ settings: projects.settings })
+      .from(projects)
+      .where(and(eq(projects.orgId, repo.orgId), eq(projects.id, repo.projectId)))
+      .limit(1)
+  )[0];
+  const configured = objectValue(project?.settings).ci_repair_max_attempts;
+  const maxAttempts =
+    typeof configured === "number" && Number.isInteger(configured) && configured >= 1
+      ? Math.min(configured, 10)
+      : 3;
+  const repairRuns = await db
+    .select({ trigger: runs.trigger })
+    .from(runs)
+    .where(
+      and(
+        eq(runs.orgId, repo.orgId),
+        eq(runs.projectId, repo.projectId),
+        sql`${runs.gh}->>'owner' = ${repo.owner}`,
+        sql`${runs.gh}->>'repo' = ${repo.name}`,
+        sql`${runs.gh}->>'branch' = ${branch}`,
+        inArray(runs.mode, ["ci_doctor", "ci-doctor"]),
+        sql`${runs.trigger}->>'event' = 'workflow_run'`,
+      ),
+    );
+  const duplicate = repairRuns.some(
+    (run) => objectValue(objectValue(run.trigger).pullRequest).headSha === headSha,
+  );
+  if (duplicate) {
+    return {
+      allowed: false,
+      reason: "duplicate_head_sha" as const,
+      attempts: repairRuns.length,
+      maxAttempts,
+    };
+  }
+  if (repairRuns.length >= maxAttempts) {
+    return {
+      allowed: false,
+      reason: "attempts_exhausted" as const,
+      attempts: repairRuns.length,
+      maxAttempts,
+    };
+  }
+  return { allowed: true, reason: "eligible" as const, attempts: repairRuns.length, maxAttempts };
+}
+
+async function ciRepairExhaustionReported(
+  db: FacilityDb,
+  repo: typeof repos.$inferSelect,
+  branch: string,
+  headSha: string,
+) {
+  const reported = (
+    await db
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.orgId, repo.orgId),
+          eq(auditEvents.projectId, repo.projectId),
+          eq(auditEvents.action, "github.ci_repair.exhausted"),
+          sql`${auditEvents.target}->>'id' = ${repo.id}`,
+          sql`${auditEvents.payload}->>'branch' = ${branch}`,
+          sql`${auditEvents.payload}->>'headSha' = ${headSha}`,
+        ),
+      )
+      .limit(1)
+  )[0];
+  return Boolean(reported);
 }
 
 function objectValue(value: unknown): Record<string, unknown> {
@@ -1064,7 +1224,7 @@ async function refreshPullRequestFromWebhook(
   await refreshGhPullRequest(db, factory, repo, number);
 }
 
-async function refreshPullRequestsFromSignal(
+async function refreshPullRequestsAndPromoteReady(
   db: FacilityDb,
   orgId: string,
   payload: WebhookPayload,
@@ -1096,7 +1256,65 @@ async function refreshPullRequestsFromSignal(
     payload.check_suite?.head_sha ??
     payload.workflow_run?.head_sha ??
     payload.sha;
-  return refreshPullRequestsForSignal(db, factory, repo, { numbers, headSha });
+  const refreshed = await refreshPullRequestsForSignal(db, factory, repo, { numbers, headSha });
+  await promotePassingFacilityDrafts(db, factory, repo, { numbers, headSha });
+  return refreshed;
+}
+
+async function promotePassingFacilityDrafts(
+  db: FacilityDb,
+  factory: GithubClientFactory,
+  repo: typeof repos.$inferSelect,
+  input: { numbers: number[]; headSha?: string | null },
+) {
+  const candidates = await db
+    .select()
+    .from(ghPullRequests)
+    .where(
+      and(
+        eq(ghPullRequests.repoId, repo.id),
+        eq(ghPullRequests.state, "open"),
+        eq(ghPullRequests.draft, true),
+        eq(ghPullRequests.ciState, "success"),
+        sql`${ghPullRequests.ciHeadSha} = ${ghPullRequests.headSha}`,
+        input.headSha
+          ? eq(ghPullRequests.headSha, input.headSha)
+          : input.numbers.length
+            ? inArray(ghPullRequests.number, input.numbers)
+            : sql`false`,
+      ),
+    );
+  if (!candidates.length) return;
+  const client = await createGithubClientForRepo(db, factory, repo);
+  let firstError: unknown;
+  for (const pull of candidates) {
+    try {
+      const deliveryContext = await githubDeliveryContext(db, repo, pull.headRef);
+      if (!deliveryContext) continue;
+      const transitioned = await client.markPullRequestReadyForReview(pull.number, pull.headSha);
+      if (!transitioned) continue;
+      await db
+        .update(ghPullRequests)
+        .set({ draft: false, updatedAt: new Date() })
+        .where(
+          and(
+            eq(ghPullRequests.orgId, repo.orgId),
+            eq(ghPullRequests.repoId, repo.id),
+            eq(ghPullRequests.number, pull.number),
+            eq(ghPullRequests.headSha, pull.headSha),
+            eq(ghPullRequests.ciState, "success"),
+          ),
+        );
+      await auditGithub(db, repo.orgId, "github.pr.ready", repo, {
+        pullNumber: pull.number,
+        branch: pull.headRef,
+        headSha: pull.headSha,
+      });
+    } catch (error) {
+      firstError ??= error;
+    }
+  }
+  if (firstError) throw firstError;
 }
 
 /**

--- a/services/api/src/github/router.ts
+++ b/services/api/src/github/router.ts
@@ -11,7 +11,8 @@ import {
   runs,
 } from "@facility/db";
 import { and, desc, eq, gt, sql } from "drizzle-orm";
-import type { FacilityGithubClient } from "./client.js";
+import { ApiError } from "../errors.js";
+import { type FacilityGithubClient, GithubIssueContextTooLargeError } from "./client.js";
 import { syncRepoFacilityConfig } from "./kickstart.js";
 import { renderGithubRunProgress } from "./run-progress.js";
 
@@ -24,10 +25,24 @@ export type TriggerPayload = {
     body?: string | null;
     node_id?: string;
     pull_request?: unknown;
+    user?: { login?: string };
+    labels?: Array<string | { name?: string }>;
+    html_url?: string;
   };
   repository?: { id?: number; name?: string; owner?: { login?: string }; default_branch?: string };
   sender?: { login?: string; type?: string };
 };
+
+export type GithubIssueCommentContext = {
+  id: number;
+  author: string;
+  authorType: string;
+  body: string;
+  createdAt: string;
+  url: string;
+};
+
+export const ISSUE_CONTEXT_MAX_CHARS = 512 * 1024;
 
 const COMMAND_RE =
   /(?:^|\n)\s*\/(builder|architect|codex-builder|codex-architect)(?=$|[\s,.:;!?)])/g;
@@ -103,6 +118,9 @@ export async function routeTrigger(
     resolved.agentCommand ?? command,
   );
   if (!agent) return { routed: false, reason: "no_agent" };
+  const issueComments = await loadGithubIssueComments(client, issueNumber);
+  const request = githubRequestContext(payload, issueComments);
+  assertGithubRequestContextSize(request);
   const accepted =
     command === "builder"
       ? await githubPlanAcceptance(db, {
@@ -126,7 +144,7 @@ export async function routeTrigger(
     // treats scope as untrusted data beneath the agent contract, but without
     // this context an agent only received numeric GitHub IDs and could not know
     // what work the user requested.
-    request: githubRequestContext(payload),
+    request,
   };
   const run = await db.transaction(async (tx) => {
     if (accepted?.proposal) {
@@ -358,12 +376,54 @@ async function githubPlanAcceptance(
   return null;
 }
 
-export function githubRequestContext(payload: TriggerPayload) {
+export function githubRequestContext(
+  payload: TriggerPayload,
+  comments: GithubIssueCommentContext[] = [],
+) {
   return {
     title: nullableText(payload.issue?.title),
     body: nullableText(payload.issue?.body),
     comment: nullableText(payload.comment?.body),
+    author: nullableText(payload.issue?.user?.login),
+    url: nullableText(payload.issue?.html_url),
+    labels: (payload.issue?.labels ?? []).flatMap((label) => {
+      const name = typeof label === "string" ? label : label.name;
+      return typeof name === "string" && name.trim() ? [name.trim()] : [];
+    }),
+    comments: comments.map((entry) => ({
+      id: entry.id,
+      author: entry.author,
+      authorType: entry.authorType,
+      body: entry.body,
+      createdAt: entry.createdAt,
+      url: entry.url,
+    })),
   };
+}
+
+export function assertGithubRequestContextSize(context: unknown) {
+  if (JSON.stringify(context).length > ISSUE_CONTEXT_MAX_CHARS) {
+    throw new ApiError(
+      413,
+      "issue_context_too_large",
+      "The complete GitHub issue context is too large for a governed run",
+    );
+  }
+}
+
+export async function loadGithubIssueComments(client: FacilityGithubClient, issueNumber: number) {
+  try {
+    return await client.listIssueComments(issueNumber, ISSUE_CONTEXT_MAX_CHARS);
+  } catch (error) {
+    if (error instanceof GithubIssueContextTooLargeError) {
+      throw new ApiError(
+        413,
+        "issue_context_too_large",
+        "The complete GitHub issue context is too large for a governed run",
+      );
+    }
+    throw error;
+  }
 }
 
 function nullableText(value: unknown) {

--- a/services/api/src/routes/v1/github.ts
+++ b/services/api/src/routes/v1/github.ts
@@ -17,7 +17,12 @@ import { z } from "zod";
 import { ApiError, notFound } from "../../errors.js";
 import { createGithubClientFactory, type GithubClientFactory } from "../../github/client.js";
 import { createGithubClientForRepo } from "../../github/kickstart.js";
-import { findAgentDef } from "../../github/router.js";
+import {
+  assertGithubRequestContextSize,
+  findAgentDef,
+  githubRequestContext,
+  loadGithubIssueComments,
+} from "../../github/router.js";
 import {
   assemblePipelineStories,
   classifyPipeline,
@@ -866,11 +871,44 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
           .limit(1)
       )[0];
       if (!repo) throw notFound("Repository not found");
+      // Resolve the local contract before spending a GitHub API request on
+      // context that cannot be dispatched.
+      const agent = await findAgentDef(db, p.orgId, projectId, body.agent);
+      if (!agent) throw new ApiError(400, "agent_not_found", "Agent definition not found");
+      const githubFactory =
+        app.githubClientFactory ??
+        (config.githubAppId && config.githubAppPrivateKey
+          ? createGithubClientFactory(config)
+          : undefined);
+      if (!githubFactory) {
+        throw new ApiError(
+          503,
+          "github_app_unconfigured",
+          "GitHub App credentials are required to load the complete issue context",
+        );
+      }
+      const githubClient = await createGithubClientForRepo(db, githubFactory, repo);
+      const [githubIssue, issueComments] = await Promise.all([
+        githubClient.getIssue(number),
+        loadGithubIssueComments(githubClient, number),
+      ]);
+      const issueRequest = githubRequestContext(
+        {
+          issue: {
+            number: githubIssue.number,
+            title: githubIssue.title,
+            body: githubIssue.body,
+            user: { login: githubIssue.user?.login },
+            labels: githubIssue.labels ?? [],
+            html_url: githubIssue.html_url,
+          },
+        },
+        issueComments,
+      );
+      assertGithubRequestContextSize(issueRequest);
       // No GitHub userCanWrite check: platform RBAC `runs:trigger` is the authority
       // for control-plane-originated dispatch.
       // No execution_lane gate: an explicit control-plane trigger is platform-lane intent.
-      const agent = await findAgentDef(db, p.orgId, projectId, body.agent);
-      if (!agent) throw new ApiError(400, "agent_not_found", "Agent definition not found");
       const run = (
         await db
           .insert(runs)
@@ -886,6 +924,7 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
               ...(p.githubLogin ? { githubLogin: p.githubLogin } : {}),
               repo: { id: repo.id, owner: repo.owner, name: repo.name },
               issue: { number },
+              request: issueRequest,
             },
             gh: { owner: repo.owner, repo: repo.name, issueNumber: number },
             createdBy: { type: p.type, id: p.id },
@@ -901,11 +940,6 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
         data: { queue: "runs.dispatch" },
       });
       await app.enqueue("runs.dispatch", { runId: run.id, orgId: p.orgId });
-      const githubFactory =
-        app.githubClientFactory ??
-        (config.githubAppId && config.githubAppPrivateKey
-          ? createGithubClientFactory(config)
-          : undefined);
       if (p.type === "user") {
         await assignIssueBestEffort(
           db,

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -880,6 +880,7 @@ async function openRunPullRequest(
     base: repo.defaultBranch,
     title: git.pullRequestTitle as string,
     body: pullRequestBody,
+    draft: true,
   });
   const nextGh = { ...gh, branch: git.branch, pr: { number: pr.number, url: pr.url } };
   await db.update(runs).set({ gh: nextGh, updatedAt: new Date() }).where(eq(runs.id, run.id));
@@ -932,7 +933,7 @@ async function openRunPullRequest(
     actor: { type: "agent", id: run.id },
     action: "github.pr.created",
     target: { type: "run", id: run.id },
-    payload: { runId: run.id, branch: git.branch, pr },
+    payload: { runId: run.id, branch: git.branch, pr, draft: true },
   });
   await requestConfiguredPreview(db, run, repo, pr.number, git.headSha, client, deps).catch(
     async (error) => {

--- a/services/api/test/github-platform-lane.test.ts
+++ b/services/api/test/github-platform-lane.test.ts
@@ -1102,6 +1102,11 @@ describe("github platform lane", async () => {
       headRef: "feature/ci-doctor",
       headSha: "ci-doctor-sha",
     });
+    await insertRun({
+      status: "succeeded",
+      trigger: { request: { title: "Repair the failing build" } },
+      gh: { owner, repo: repo.name, branch: "feature/ci-doctor" },
+    });
     const installation = (
       await db
         .select()
@@ -1129,7 +1134,8 @@ describe("github platform lane", async () => {
         repository: { owner: { login: owner }, name: repo.name },
         sender: { login: "maintainer" },
         workflow_run: {
-          name: "facility-guards",
+          id: 991,
+          name: "build",
           conclusion: "failure",
           head_branch: "feature/ci-doctor",
           head_sha: "ci-doctor-sha",
@@ -1149,7 +1155,27 @@ describe("github platform lane", async () => {
           graphql: async () => {
             throw new Error("GraphQL rate limited");
           },
-          rest: {},
+          rest: {
+            actions: {
+              listJobsForWorkflowRun: async () => ({
+                data: {
+                  jobs: [
+                    {
+                      id: 992,
+                      name: "test",
+                      conclusion: "failure",
+                      html_url: "https://github.test/jobs/992",
+                      steps: [{ number: 4, name: "pnpm test", conclusion: "failure" }],
+                    },
+                  ],
+                },
+              }),
+              downloadJobLogsForWorkflowRunJob: async () => ({ data: "expected true to be false" }),
+            },
+            issues: {
+              createComment: async () => ({ data: { id: 993 } }),
+            },
+          },
         }) as never,
       async (queue, data) => {
         enqueued.push({ queue, data });
@@ -1165,6 +1191,22 @@ describe("github platform lane", async () => {
       .from(runs)
       .where(and(eq(runs.projectId, projectId), sql`${runs.trigger}->>'delivery' = ${eventId}`));
     expect(run?.mode).toBe("ci_doctor");
+    expect(run?.trigger).toMatchObject({
+      workflowRun: {
+        name: "build",
+        failureContext: {
+          jobs: [
+            {
+              id: 992,
+              name: "test",
+              failedSteps: [{ number: 4, name: "pnpm test", conclusion: "failure" }],
+              logTail: "expected true to be false",
+            },
+          ],
+        },
+      },
+      deliveryContext: { producingRunId: expect.any(String) },
+    });
     expect(enqueued).toContainEqual({ queue: "runs.dispatch", data: { runId: run?.id, orgId } });
     const [processed] = await db.select().from(inboundEvents).where(eq(inboundEvents.id, eventId));
     expect(processed?.processedAt).not.toBeNull();
@@ -1183,6 +1225,306 @@ describe("github platform lane", async () => {
         message: "GitHub pull-request snapshot refresh failed; scheduled reconciliation will retry",
       },
     ]);
+
+    const duplicateEventId = newId("evt");
+    const [original] = await db.select().from(inboundEvents).where(eq(inboundEvents.id, eventId));
+    if (!original) throw new Error("workflow event fixture missing");
+    await db.insert(inboundEvents).values({
+      ...original,
+      id: duplicateEventId,
+      processedAt: null,
+      error: null,
+    });
+    await processGithubWebhook(
+      db,
+      config,
+      { inboundEventId: duplicateEventId },
+      async () =>
+        ({
+          graphql: async () => {
+            throw new Error("GraphQL rate limited");
+          },
+          rest: {},
+        }) as never,
+    );
+    const repairRuns = await db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.projectId, projectId),
+          eq(runs.mode, "ci_doctor"),
+          sql`${runs.gh}->>'branch' = 'feature/ci-doctor'`,
+        ),
+      );
+    expect(repairRuns).toHaveLength(1);
+  });
+
+  it("repairs only Facility delivery branches and stops at the configured attempt limit", async () => {
+    const owner = `workflow-policy-${Date.now()}`;
+    const repo = await insertRepoWithInstallation(owner);
+    await db
+      .update(repos)
+      .set({ renderAnswers: { execution_lane: { "ci-doctor": "platform" } } })
+      .where(eq(repos.id, repo.id));
+    await db
+      .update(projects)
+      .set({ settings: { ci_repair_max_attempts: 1 } })
+      .where(and(eq(projects.orgId, orgId), eq(projects.id, projectId)));
+    await insertAgent("ci-doctor", [
+      { type: "github", event: "workflow_run", action: "completed" },
+    ]);
+    const installation = (
+      await db
+        .select()
+        .from(githubInstallations)
+        .where(eq(githubInstallations.id, repo.installationId ?? ""))
+        .limit(1)
+    )[0];
+    const integration = (
+      await db
+        .insert(integrations)
+        .values({ id: newId("int"), orgId, kind: "github", name: `policy-${Date.now()}` })
+        .returning()
+    )[0];
+    if (!installation || !integration) throw new Error("CI policy fixtures missing");
+
+    const deliverFailure = async (branch: string, headSha: string) => {
+      const eventId = newId("evt");
+      await db.insert(inboundEvents).values({
+        id: eventId,
+        orgId,
+        integrationId: integration.id,
+        eventType: "workflow_run",
+        verified: true,
+        payload: {
+          action: "completed",
+          installation: { id: installation.installationId },
+          repository: { owner: { login: owner }, name: repo.name },
+          workflow_run: {
+            id: nextInstallationId(),
+            name: "build",
+            conclusion: "failure",
+            head_branch: branch,
+            head_sha: headSha,
+            pull_requests: [],
+          },
+        },
+      });
+      const comments: string[] = [];
+      await processGithubWebhook(
+        db,
+        config,
+        { inboundEventId: eventId },
+        async () =>
+          ({
+            graphql: async () => {
+              throw new Error("snapshot unavailable");
+            },
+            rest: {
+              issues: {
+                createComment: async (input: { body: string }) => {
+                  comments.push(input.body);
+                  return { data: { id: 1 } };
+                },
+              },
+            },
+          }) as never,
+      );
+      return { eventId, comments };
+    };
+
+    await insertPullRequest(repo.id, 72_200, {
+      draft: true,
+      headRef: "feature/not-produced-by-facility",
+      headSha: "unrelated-sha",
+    });
+    const otherRepo = await insertRepo({ owner, name: "other-repo" });
+    await insertRun({
+      status: "succeeded",
+      trigger: { request: { title: "A different repository's delivery" } },
+      gh: { owner, repo: otherRepo.name, branch: "feature/not-produced-by-facility" },
+    });
+    const unrelated = await deliverFailure("feature/not-produced-by-facility", "unrelated-sha");
+    expect(
+      await db.select().from(runs).where(sql`${runs.trigger}->>'delivery' = ${unrelated.eventId}`),
+    ).toHaveLength(0);
+
+    const branch = "feature/facility-repair-limit";
+    await insertPullRequest(repo.id, 72_201, {
+      draft: true,
+      headRef: branch,
+      headSha: "repair-sha-2",
+    });
+    await insertRun({
+      status: "succeeded",
+      trigger: { request: { title: "Facility delivery" } },
+      gh: { owner, repo: repo.name, branch },
+    });
+    await insertRun({
+      mode: "ci_doctor",
+      status: "succeeded",
+      trigger: {
+        type: "github_event",
+        event: "workflow_run",
+        pullRequest: { headSha: "repair-sha-1" },
+      },
+      gh: { owner, repo: repo.name, branch },
+    });
+    const exhausted = await deliverFailure(branch, "repair-sha-2");
+    expect(
+      await db.select().from(runs).where(sql`${runs.trigger}->>'delivery' = ${exhausted.eventId}`),
+    ).toHaveLength(0);
+    expect(exhausted.comments).toEqual([
+      "Facility stopped automatic CI repair after 1 attempts. The draft PR and failing GitHub checks remain available for human iteration.",
+    ]);
+    const repeatedExhaustion = await deliverFailure(branch, "repair-sha-2");
+    expect(repeatedExhaustion.comments).toHaveLength(0);
+    const exhaustionAudits = await db
+      .select()
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.action, "github.ci_repair.exhausted"),
+          sql`${auditEvents.target}->>'id' = ${repo.id}`,
+          sql`${auditEvents.payload}->>'branch' = ${branch}`,
+          sql`${auditEvents.payload}->>'headSha' = 'repair-sha-2'`,
+        ),
+      );
+    expect(exhaustionAudits).toHaveLength(1);
+    const [draft] = await db
+      .select()
+      .from(ghPullRequests)
+      .where(and(eq(ghPullRequests.repoId, repo.id), eq(ghPullRequests.number, 72_201)));
+    expect(draft?.draft).toBe(true);
+    await db
+      .update(projects)
+      .set({ settings: {} })
+      .where(and(eq(projects.orgId, orgId), eq(projects.id, projectId)));
+  });
+
+  it("marks a Facility draft ready only after the current GitHub CI rollup succeeds", async () => {
+    const owner = `ready-${Date.now()}`;
+    const repo = await insertRepoWithInstallation(owner);
+    const installation = (
+      await db
+        .select()
+        .from(githubInstallations)
+        .where(eq(githubInstallations.id, repo.installationId ?? ""))
+        .limit(1)
+    )[0];
+    const integration = (
+      await db
+        .insert(integrations)
+        .values({ id: newId("int"), orgId, kind: "github", name: `ready-${Date.now()}` })
+        .returning()
+    )[0];
+    if (!installation || !integration) throw new Error("ready fixtures missing");
+    const facilityBranch = "feature/facility-ready";
+    const unrelatedBranch = "feature/unrelated-draft";
+    await insertRun({
+      status: "succeeded",
+      trigger: { request: { title: "Facility delivery" } },
+      gh: { owner, repo: repo.name, branch: facilityBranch },
+    });
+    await insertPullRequest(repo.id, 72_300, {
+      draft: true,
+      headRef: facilityBranch,
+      headSha: "ready-sha",
+      ciState: "pending",
+      ciHeadSha: "ready-sha",
+    });
+    await insertPullRequest(repo.id, 72_301, {
+      draft: true,
+      headRef: unrelatedBranch,
+      headSha: "unrelated-ready-sha",
+      ciState: "pending",
+      ciHeadSha: "unrelated-ready-sha",
+    });
+    const readyMutations: Record<string, unknown>[] = [];
+    const factory = async () =>
+      ({
+        graphql: async (query: string, variables: Record<string, unknown>) => {
+          if (query.includes("markPullRequestReadyForReview")) {
+            readyMutations.push(variables);
+            return { markPullRequestReadyForReview: { pullRequest: { number: 72_300 } } };
+          }
+          const number = Number(variables.number);
+          const facility = number === 72_300;
+          const headSha = facility ? "ready-sha" : "unrelated-ready-sha";
+          const headRef = facility ? facilityBranch : unrelatedBranch;
+          return {
+            repository: {
+              pullRequest: {
+                number,
+                title: `PR ${number}`,
+                state: "OPEN",
+                isDraft: true,
+                author: { login: "octocat" },
+                headRefName: headRef,
+                headRefOid: headSha,
+                baseRefName: "main",
+                url: `https://github.test/${owner}/${repo.name}/pull/${number}`,
+                createdAt: "2026-08-01T00:00:00Z",
+                updatedAt: "2026-08-01T00:00:00Z",
+                closingIssuesReferences: { nodes: [] },
+                commits: {
+                  nodes: [{ commit: { oid: headSha, statusCheckRollup: { state: "SUCCESS" } } }],
+                },
+              },
+            },
+          };
+        },
+        rest: {
+          pulls: {
+            get: async (input: { pull_number: number }) => ({
+              data: {
+                number: input.pull_number,
+                title: `PR ${input.pull_number}`,
+                state: "open",
+                draft: true,
+                html_url: `https://github.test/pulls/${input.pull_number}`,
+                node_id: `PR_${input.pull_number}`,
+                head: {
+                  sha: input.pull_number === 72_300 ? "ready-sha" : "unrelated-ready-sha",
+                },
+              },
+            }),
+          },
+        },
+      }) as never;
+    const deliverSuccess = async (number: number, headSha: string) => {
+      const eventId = newId("evt");
+      await db.insert(inboundEvents).values({
+        id: eventId,
+        orgId,
+        integrationId: integration.id,
+        eventType: "check_suite",
+        verified: true,
+        payload: {
+          action: "completed",
+          installation: { id: installation.installationId },
+          repository: { owner: { login: owner }, name: repo.name },
+          check_suite: {
+            status: "completed",
+            conclusion: "success",
+            head_sha: headSha,
+            pull_requests: [{ number }],
+          },
+        },
+      });
+      await processGithubWebhook(db, config, { inboundEventId: eventId }, factory);
+    };
+
+    await deliverSuccess(72_300, "ready-sha");
+    await deliverSuccess(72_301, "unrelated-ready-sha");
+    const mirrored = await db
+      .select()
+      .from(ghPullRequests)
+      .where(eq(ghPullRequests.repoId, repo.id));
+    expect(mirrored.find((pull) => pull.number === 72_300)?.draft).toBe(false);
+    expect(mirrored.find((pull) => pull.number === 72_301)?.draft).toBe(true);
+    expect(readyMutations).toEqual([{ pullRequestId: "PR_72300" }]);
   });
 
   it("lists mirrored issues with pagination, state filtering, and linked runs", async () => {
@@ -1665,6 +2007,27 @@ describe("github platform lane", async () => {
       ({
         rest: {
           issues: {
+            get: async (input: { issue_number: number }) => ({
+              data: {
+                number: input.issue_number,
+                title: "Deliver complete error states",
+                body: "Update agencies and people detail routes.",
+                user: { login: "issue-author" },
+                labels: [{ name: "delivery" }, { name: "frontend" }],
+                html_url: `https://github.test/issues/${input.issue_number}`,
+              },
+            }),
+            listComments: async () => ({
+              data: [
+                {
+                  id: 4401,
+                  user: { login: "maintainer", type: "User" },
+                  body: "Keep the existing loading behavior.",
+                  created_at: "2026-08-01T00:00:00Z",
+                  html_url: "https://github.test/comments/4401",
+                },
+              ],
+            }),
             createComment: async () => ({ data: { id: 1, html_url: "https://example.test/c" } }),
             addAssignees: async (input: { issue_number: number; assignees: string[] }) => {
               assigned.push({ number: input.issue_number, logins: input.assignees });
@@ -1732,6 +2095,24 @@ describe("github platform lane", async () => {
     });
     expect(response.statusCode).toBe(200);
     expect(response.json().gh.issueNumber).toBe(44);
+    expect(response.json().trigger.request).toEqual({
+      title: "Deliver complete error states",
+      body: "Update agencies and people detail routes.",
+      comment: null,
+      author: "issue-author",
+      url: "https://github.test/issues/44",
+      labels: ["delivery", "frontend"],
+      comments: [
+        {
+          id: 4401,
+          author: "maintainer",
+          authorType: "User",
+          body: "Keep the existing loading behavior.",
+          createdAt: "2026-08-01T00:00:00Z",
+          url: "https://github.test/comments/4401",
+        },
+      ],
+    });
     const event = (
       await db.select().from(runEvents).where(eq(runEvents.runId, response.json().id))
     )[0];
@@ -1748,6 +2129,17 @@ describe("github platform lane", async () => {
       ({
         rest: {
           issues: {
+            get: async (input: { issue_number: number }) => ({
+              data: {
+                number: input.issue_number,
+                title: `Issue ${input.issue_number}`,
+                body: "Body",
+                user: { login: "author" },
+                labels: [],
+                html_url: `https://github.test/issues/${input.issue_number}`,
+              },
+            }),
+            listComments: async () => ({ data: [] }),
             addAssignees: async () => ({ data: { assignees: [] } }),
             createComment: async () => ({ data: { id: 2 } }),
           },
@@ -1782,6 +2174,17 @@ describe("github platform lane", async () => {
       ({
         rest: {
           issues: {
+            get: async (input: { issue_number: number }) => ({
+              data: {
+                number: input.issue_number,
+                title: `Issue ${input.issue_number}`,
+                body: "Body",
+                user: { login: "author" },
+                labels: [],
+                html_url: `https://github.test/issues/${input.issue_number}`,
+              },
+            }),
+            listComments: async () => ({ data: [] }),
             addAssignees: async () => {
               throw new Error("assignment permission denied");
             },
@@ -1839,6 +2242,55 @@ describe("github platform lane", async () => {
       login: null,
       reason: "missing_github_login",
     });
+
+    await insertIssue(repo.id, 48, "open", "2026-03-01T00:00:04Z");
+    await insertIssue(repo.id, 49, "open", "2026-03-01T00:00:05Z");
+    app.githubClientFactory = async () =>
+      ({
+        rest: {
+          issues: {
+            get: async (input: { issue_number: number }) => {
+              if (input.issue_number === 48) throw new Error("GitHub issue read failed");
+              return {
+                data: {
+                  number: input.issue_number,
+                  title: `Issue ${input.issue_number}`,
+                  body: "x".repeat(512 * 1024),
+                  user: { login: "author" },
+                  labels: [],
+                  html_url: `https://github.test/issues/${input.issue_number}`,
+                },
+              };
+            },
+            listComments: async () => ({ data: [] }),
+          },
+          repos: {},
+          git: {},
+          pulls: {},
+        },
+      }) as never;
+    const unavailableContext = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${projectId}/issues/48/trigger?repoId=${repo.id}`,
+      headers: { cookie },
+      payload: { agent: "builder" },
+    });
+    expect(unavailableContext.statusCode).toBe(500);
+    const oversizedContext = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${projectId}/issues/49/trigger?repoId=${repo.id}`,
+      headers: { cookie },
+      payload: { agent: "builder" },
+    });
+    expect(oversizedContext.statusCode).toBe(413);
+    expect(oversizedContext.json().error.code).toBe("issue_context_too_large");
+    const rejectedContextRuns = await db
+      .select()
+      .from(runs)
+      .where(
+        and(eq(runs.projectId, projectId), sql`(${runs.gh}->>'issueNumber')::int in (48, 49)`),
+      );
+    expect(rejectedContextRuns).toHaveLength(0);
 
     const missing = await app.inject({
       method: "POST",
@@ -2130,6 +2582,7 @@ describe("github platform lane", async () => {
         head: "feature/agent-owned-delivery",
         title: "feat: deliver agent-owned metadata",
         body: "## Summary\n\n- Preserve the builder's exact PR metadata.",
+        draft: true,
       }),
     );
     const [stored] = await db.select().from(runs).where(eq(runs.id, run.id));

--- a/services/api/test/github.test.ts
+++ b/services/api/test/github.test.ts
@@ -22,7 +22,12 @@ import { buildApp } from "../src/app.js";
 import { FacilityGithubClient } from "../src/github/client.js";
 import { parseFacilityRepoManifest, syncRepoFacilityConfig } from "../src/github/kickstart.js";
 import { githubEventMatches, processGithubWebhook } from "../src/github/processor.js";
-import { githubRequestContext, resolveSlashCommand, routeTrigger } from "../src/github/router.js";
+import {
+  assertGithubRequestContextSize,
+  githubRequestContext,
+  resolveSlashCommand,
+  routeTrigger,
+} from "../src/github/router.js";
 import { createPreviewRecord } from "../src/previews.js";
 import type { AppConfig } from "../src/types.js";
 
@@ -90,6 +95,124 @@ describe("FacilityGithubClient", () => {
     );
     await client.updateIssueComment(77, "completed");
     expect(args).toEqual({ owner: "octo", repo: "repo", comment_id: 77, body: "completed" });
+  });
+
+  it("creates draft pull requests explicitly", async () => {
+    let args: Record<string, unknown> | undefined;
+    const client = new FacilityGithubClient(
+      {
+        rest: {
+          pulls: {
+            create: async (input: Record<string, unknown>) => {
+              args = input;
+              return { data: { number: 8, html_url: "https://github.test/octo/repo/pull/8" } };
+            },
+          },
+        },
+      } as never,
+      { owner: "octo", repo: "repo", defaultBranch: "main" },
+    );
+    await client.createPullRequest({
+      title: "feat: retain delivery",
+      body: "Body",
+      head: "feature/retain-delivery",
+      draft: true,
+    });
+    expect(args).toMatchObject({ head: "feature/retain-delivery", base: "main", draft: true });
+  });
+
+  it("marks only the expected draft head ready for review", async () => {
+    const mutations: Record<string, unknown>[] = [];
+    const client = new FacilityGithubClient(
+      {
+        graphql: async (_query: string, variables: Record<string, unknown>) => {
+          mutations.push(variables);
+          return {};
+        },
+        rest: {
+          pulls: {
+            get: async () => ({
+              data: {
+                number: 8,
+                title: "feat: retain delivery",
+                state: "open",
+                draft: true,
+                html_url: "https://github.test/octo/repo/pull/8",
+                node_id: "PR_node",
+                head: { sha: "current-sha" },
+              },
+            }),
+          },
+        },
+      } as never,
+      { owner: "octo", repo: "repo", defaultBranch: "main" },
+    );
+    await expect(client.markPullRequestReadyForReview(8, "stale-sha")).resolves.toBe(false);
+    await expect(client.markPullRequestReadyForReview(8, "current-sha")).resolves.toBe(true);
+    expect(mutations).toEqual([{ pullRequestId: "PR_node" }]);
+  });
+
+  it("collects bounded failed workflow details and paginates issue comments", async () => {
+    const pages: number[] = [];
+    const client = new FacilityGithubClient(
+      {
+        rest: {
+          actions: {
+            listJobsForWorkflowRun: async () => ({
+              data: {
+                jobs: [
+                  {
+                    id: 9,
+                    name: "build",
+                    conclusion: "failure",
+                    html_url: "https://github.test/actions/jobs/9",
+                    steps: [
+                      { number: 1, name: "checkout", conclusion: "success" },
+                      { number: 2, name: "test", conclusion: "failure" },
+                    ],
+                  },
+                ],
+              },
+            }),
+            downloadJobLogsForWorkflowRunJob: async () => ({ data: Buffer.from("test failed") }),
+          },
+          issues: {
+            listComments: async (input: Record<string, unknown>) => {
+              const page = Number(input.page);
+              pages.push(page);
+              const count = page === 1 ? 100 : 1;
+              return {
+                data: Array.from({ length: count }, (_, index) => ({
+                  id: (page - 1) * 100 + index + 1,
+                  user: { login: "octocat", type: "User" },
+                  body: `comment ${index + 1}`,
+                  created_at: "2026-08-01T00:00:00Z",
+                  html_url: `https://github.test/comments/${index + 1}`,
+                })),
+              };
+            },
+          },
+        },
+      } as never,
+      { owner: "octo", repo: "repo", defaultBranch: "main" },
+    );
+    await expect(client.getWorkflowFailureContext(99)).resolves.toEqual({
+      jobs: [
+        {
+          id: 9,
+          name: "build",
+          conclusion: "failure",
+          url: "https://github.test/actions/jobs/9",
+          failedSteps: [{ number: 2, name: "test", conclusion: "failure" }],
+          logTail: "test failed",
+        },
+      ],
+    });
+    await expect(client.listIssueComments(42)).resolves.toHaveLength(101);
+    expect(pages).toEqual([1, 2]);
+    await expect(client.listIssueComments(42, 100)).rejects.toThrow(
+      "GitHub issue comments exceed the governed context limit",
+    );
   });
 });
 
@@ -773,15 +896,50 @@ describe("github integration", async () => {
 
   it("preserves the end-user GitHub request for the platform agent", () => {
     expect(
-      githubRequestContext({
-        issue: { number: 42, title: "Add subtraction", body: "Support negative results." },
-        comment: { id: 7, body: "/codex-architect\nKeep the public API stable." },
-      }),
+      githubRequestContext(
+        {
+          issue: {
+            number: 42,
+            title: "Add subtraction",
+            body: "Support negative results.",
+            user: { login: "ada" },
+            labels: [{ name: "delivery" }, "platform"],
+            html_url: "https://github.test/octo/repo/issues/42",
+          },
+          comment: { id: 7, body: "/codex-architect\nKeep the public API stable." },
+        },
+        [
+          {
+            id: 6,
+            author: "grace",
+            authorType: "User",
+            body: "Preserve compatibility.",
+            createdAt: "2026-08-01T00:00:00Z",
+            url: "https://github.test/comments/6",
+          },
+        ],
+      ),
     ).toEqual({
       title: "Add subtraction",
       body: "Support negative results.",
       comment: "/codex-architect\nKeep the public API stable.",
+      author: "ada",
+      url: "https://github.test/octo/repo/issues/42",
+      labels: ["delivery", "platform"],
+      comments: [
+        {
+          id: 6,
+          author: "grace",
+          authorType: "User",
+          body: "Preserve compatibility.",
+          createdAt: "2026-08-01T00:00:00Z",
+          url: "https://github.test/comments/6",
+        },
+      ],
     });
+    expect(() => assertGithubRequestContextSize({ body: "x".repeat(512 * 1024) })).toThrow(
+      "complete GitHub issue context is too large",
+    );
   });
 
   it("treats an opened non-draft PR as ready for review but leaves drafts alone", () => {


### PR DESCRIPTION
## What changes

Platform builder and repair runs now publish signed work as draft pull requests before exhaustive repository checks. GitHub Actions owns acceptance, failed workflows can dispatch a bounded CI-doctor on the same Facility-owned branch, duplicate SHA deliveries are ignored, and a draft becomes ready only when the current head aggregate rollup succeeds.

Direct control-plane issue triggers now fetch the canonical GitHub issue and every comment before dispatch, with a 512 KiB fail-closed context budget. This fixes builders receiving only the issue number instead of the requested scope.

## Why

Running the complete suite inside the builder sandbox could consume the run, discard otherwise reviewable work, and leave no PR for iteration. Persisting the draft first makes GitHub CI and subsequent repair the durable delivery loop while preserving repository and SHA boundaries.

## Verification

- [x] `COMPOSE_DISABLE_ENV_FILE=1 pnpm verify` passes locally
- [x] Behaviour verified beyond the baseline with deterministic GitHub fakes covering draft creation, current-SHA readiness, unrelated and cross-repository denial, duplicate workflow delivery, attempt exhaustion, failed job log context, complete issue hydration, pagination, unavailable context, and oversized context
- [x] Documentation updated with the platform delivery lifecycle and `ci_repair_max_attempts` setting

The final independent review found no high-severity defects. Its three actionable findings (exhaustion-notice idempotency, per-PR promotion isolation, and incremental comment budget enforcement) were fixed and covered before publication.