### PR TITLE
feat(sandbox): fast-path read-only agent setup

### DIFF
--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -16,6 +16,27 @@ runner image with your project's provision command. The provisioned-site rule
 is enforced: if provisioning fails, the agent never starts — a partial
 environment produces hedging, not work.
 
+Facility also seeds an **Analysis runner** profile for agents that never ship
+repository changes (`architect`, `codex-architect`, `review`, and
+`security-sweep`). It keeps the repository's dependency-install phase so tools
+can resolve imports and types, but skips service/database/browser provisioning
+and disables nested Docker. Builder and repair agents stay on the full default
+profile. These are ordinary profile assignments: operators can replace them
+without changing agent or runner code. The deploy seed moves unchanged legacy
+analysis agents from the managed Default profile once; later operator
+assignments are preserved.
+
+The optional `setup.provisioning` capability controls repository setup depth:
+
+- `full` runs dependency installation and provisioning (also the legacy default
+  when the key is absent or invalid in persisted data).
+- `deps_only` installs dependencies but skips the repository provision command.
+- `none` skips both phases.
+
+Command overrides remain strings (`package_install_cmd` and `provision_cmd`). A
+profile write is rejected when it configures a command for a phase its
+`provisioning` depth disables.
+
 :::note The runner image & driver
 A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
 **driver matches the deployment** and that can run the Facility runner:

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -48,8 +48,14 @@ const BUNDLED_ACTION_TYPES = [
   { name: "mcp_tool_call", required: ["toolName", "args", "requestedBy"] },
 ];
 
-function defaultSandboxProfileId(orgId: string): string {
+const ANALYSIS_AGENT_NAMES = ["architect", "codex-architect", "review", "security-sweep"] as const;
+
+export function defaultSandboxProfileId(orgId: string): string {
   return orgId === "org_dev_the_agile_monkeys" ? "sbx_dev_default" : `sbx_default_${orgId}`;
+}
+
+export function analysisSandboxProfileId(orgId: string): string {
+  return orgId === "org_dev_the_agile_monkeys" ? "sbx_dev_analysis" : `sbx_analysis_${orgId}`;
 }
 
 // The default sandbox profile must run the Facility runner (its ENTRYPOINT), or
@@ -314,6 +320,28 @@ async function seedOrgEssentialsSql(sql: postgres.Sql, orgId: string): Promise<v
       updated_at = now()
   `;
 
+  await sql`
+    INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
+    VALUES (
+      ${analysisSandboxProfileId(orgId)},
+      ${orgId},
+      'Analysis runner',
+      ${defaultSandboxDriver()},
+      ${defaultRunnerImage()},
+      '{"deps":[],"nested_docker":false,"provisioning":"deps_only"}'::jsonb,
+      ${defaultSandboxResources()}::jsonb,
+      '{"egress":"restricted"}'::jsonb
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      name = EXCLUDED.name,
+      driver = EXCLUDED.driver,
+      image = EXCLUDED.image,
+      setup = EXCLUDED.setup,
+      resources = EXCLUDED.resources,
+      network = EXCLUDED.network,
+      updated_at = now()
+  `;
+
   for (const actionType of BUNDLED_ACTION_TYPES) {
     await sql`
       INSERT INTO action_types (id, org_id, name, payload_schema, resolver, executor, default_ttl_hours)
@@ -346,6 +374,7 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
   const orgInputs = orgIds.map((orgId) => ({
     org_id: orgId,
     profile_id: defaultSandboxProfileId(orgId),
+    analysis_profile_id: analysisSandboxProfileId(orgId),
   }));
   await sql`
     WITH inputs AS (
@@ -372,6 +401,53 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
       resources = EXCLUDED.resources,
       network = EXCLUDED.network,
       updated_at = now()
+  `;
+  await sql`
+    WITH inputs AS (
+      SELECT *
+      FROM jsonb_to_recordset(${sql.json(orgInputs)}::jsonb)
+        AS value(org_id text, profile_id text, analysis_profile_id text)
+    )
+    INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
+    SELECT
+      inputs.analysis_profile_id,
+      inputs.org_id,
+      'Analysis runner',
+      ${defaultSandboxDriver()},
+      ${defaultRunnerImage()},
+      '{"deps":[],"nested_docker":false,"provisioning":"deps_only"}'::jsonb,
+      ${defaultSandboxResources()}::jsonb,
+      '{"egress":"restricted"}'::jsonb
+    FROM inputs
+    ON CONFLICT (id) DO UPDATE SET
+      name = EXCLUDED.name,
+      driver = EXCLUDED.driver,
+      image = EXCLUDED.image,
+      setup = EXCLUDED.setup,
+      resources = EXCLUDED.resources,
+      network = EXCLUDED.network,
+      updated_at = now()
+  `;
+  // One-time activation for legacy agents that still point at Facility's
+  // canonical default. The timestamp guard makes a later operator assignment
+  // back to the full profile durable; custom and NULL assignments also remain
+  // untouched. The org join prevents cross-tenant profile references.
+  await sql`
+    WITH inputs AS (
+      SELECT *
+      FROM jsonb_to_recordset(${sql.json(orgInputs)}::jsonb)
+        AS value(org_id text, profile_id text, analysis_profile_id text)
+    )
+    UPDATE agent_defs AS agents
+    SET sandbox_profile_id = inputs.analysis_profile_id, updated_at = now()
+    FROM inputs
+    INNER JOIN sandbox_profiles AS analysis_profiles
+      ON analysis_profiles.id = inputs.analysis_profile_id
+      AND analysis_profiles.org_id = inputs.org_id
+    WHERE agents.org_id = inputs.org_id
+      AND agents.sandbox_profile_id = inputs.profile_id
+      AND agents.name = ANY(${[...ANALYSIS_AGENT_NAMES]})
+      AND agents.updated_at < analysis_profiles.created_at
   `;
   const actionInputs = BUNDLED_ACTION_TYPES.map((actionType) => ({
     name: actionType.name,
@@ -416,6 +492,8 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
 }
 
 async function seedOrgEssentialsDb(db: RegistryDb, orgId: string): Promise<void> {
+  // New-org onboarding has no legacy agents to reassign. Existing-tenant
+  // activation intentionally remains in the set-wise deploy seed above.
   await db.execute(drizzleSql`
     INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
     VALUES (
@@ -425,6 +503,28 @@ async function seedOrgEssentialsDb(db: RegistryDb, orgId: string): Promise<void>
       ${defaultSandboxDriver()},
       ${defaultRunnerImage()},
       '{"deps":[]}'::jsonb,
+      ${defaultSandboxResources()}::jsonb,
+      '{"egress":"restricted"}'::jsonb
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      name = EXCLUDED.name,
+      driver = EXCLUDED.driver,
+      image = EXCLUDED.image,
+      setup = EXCLUDED.setup,
+      resources = EXCLUDED.resources,
+      network = EXCLUDED.network,
+      updated_at = now()
+  `);
+
+  await db.execute(drizzleSql`
+    INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
+    VALUES (
+      ${analysisSandboxProfileId(orgId)},
+      ${orgId},
+      'Analysis runner',
+      ${defaultSandboxDriver()},
+      ${defaultRunnerImage()},
+      '{"deps":[],"nested_docker":false,"provisioning":"deps_only"}'::jsonb,
       ${defaultSandboxResources()}::jsonb,
       '{"egress":"restricted"}'::jsonb
     )

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -2,7 +2,15 @@ import { hashChain, newId } from "@facility/core";
 import { count, eq, inArray, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { createDb, insertAuditEvent, migrate, seed, withOrg } from "../src/index.js";
+import {
+  analysisSandboxProfileId,
+  createDb,
+  defaultSandboxProfileId,
+  insertAuditEvent,
+  migrate,
+  seed,
+  withOrg,
+} from "../src/index.js";
 import * as schema from "../src/schema.js";
 
 const databaseUrl =
@@ -187,7 +195,10 @@ describe("db", async () => {
       "skill_proposal",
       "task_creation",
     ]);
-    expect(seededProfiles.map((profile) => profile.name)).toEqual(["Default runner"]);
+    expect(seededProfiles.map((profile) => profile.name).sort()).toEqual([
+      "Analysis runner",
+      "Default runner",
+    ]);
     expect(seededActionTypes.find((action) => action.name === "plan_acceptance")?.executor).toEqual(
       {
         type: "internal",
@@ -243,6 +254,140 @@ describe("db", async () => {
           .limit(1)
       )[0]?.executor,
     ).toEqual({ type: "webhook", config: { url: "https://hooks.invalid/plan" } });
+  });
+
+  it("moves only managed analysis agents to their tenant's analysis profile", async () => {
+    const orgA = newId("org");
+    const orgB = newId("org");
+    const projectA = newId("proj");
+    const projectB = newId("proj");
+    await db.insert(schema.orgs).values([
+      { id: orgA, name: "Analysis A", slug: `analysis-a-${orgA}`, settings: {} },
+      { id: orgB, name: "Analysis B", slug: `analysis-b-${orgB}`, settings: {} },
+    ]);
+    await db.insert(schema.projects).values([
+      { id: projectA, orgId: orgA, name: "Analysis A", slug: "analysis", settings: {} },
+      { id: projectB, orgId: orgB, name: "Analysis B", slug: "analysis", settings: {} },
+    ]);
+    await seed(databaseUrl, { includeDemoData: false });
+
+    const contractA = (
+      await db
+        .select({ id: schema.registryItems.id })
+        .from(schema.registryItems)
+        .where(eq(schema.registryItems.orgId, orgA))
+        .limit(1)
+    )[0];
+    const contractB = (
+      await db
+        .select({ id: schema.registryItems.id })
+        .from(schema.registryItems)
+        .where(eq(schema.registryItems.orgId, orgB))
+        .limit(1)
+    )[0];
+    if (!contractA || !contractB) throw new Error("analysis migration contract fixtures missing");
+
+    const customProfileId = newId("sbx");
+    await db.insert(schema.sandboxProfiles).values({
+      id: customProfileId,
+      orgId: orgA,
+      name: "Custom analysis",
+      driver: "docker",
+      image: "custom-runner:test",
+      setup: {},
+      resources: {},
+      network: {},
+    });
+    const fixtures = [
+      {
+        id: newId("agent"),
+        orgId: orgA,
+        projectId: projectA,
+        name: "architect",
+        contractItemId: contractA.id,
+        sandboxProfileId: defaultSandboxProfileId(orgA),
+      },
+      {
+        id: newId("agent"),
+        orgId: orgA,
+        projectId: projectA,
+        name: "review",
+        contractItemId: contractA.id,
+        sandboxProfileId: customProfileId,
+      },
+      {
+        id: newId("agent"),
+        orgId: orgA,
+        projectId: projectA,
+        name: "security-sweep",
+        contractItemId: contractA.id,
+        sandboxProfileId: null,
+      },
+      {
+        id: newId("agent"),
+        orgId: orgA,
+        projectId: projectA,
+        name: "builder",
+        contractItemId: contractA.id,
+        sandboxProfileId: defaultSandboxProfileId(orgA),
+      },
+      {
+        id: newId("agent"),
+        orgId: orgB,
+        projectId: projectB,
+        name: "codex-architect",
+        contractItemId: contractB.id,
+        sandboxProfileId: defaultSandboxProfileId(orgB),
+      },
+    ].map((fixture) => ({
+      ...fixture,
+      engine: "codex",
+      model: {},
+      triggers: [],
+      permissions: [],
+      enabled: true,
+      // These rows model agents created before the managed Analysis profile was
+      // introduced. Later API edits advance updatedAt and are not migrated.
+      createdAt: new Date("2020-01-01T00:00:00Z"),
+      updatedAt: new Date("2020-01-01T00:00:00Z"),
+    }));
+    await db.insert(schema.agentDefs).values(fixtures);
+
+    await seed(databaseUrl, { includeDemoData: false });
+    const assignments = new Map(
+      (
+        await db
+          .select({ id: schema.agentDefs.id, sandboxProfileId: schema.agentDefs.sandboxProfileId })
+          .from(schema.agentDefs)
+          .where(
+            inArray(
+              schema.agentDefs.id,
+              fixtures.map((fixture) => fixture.id),
+            ),
+          )
+      ).map((agent) => [agent.id, agent.sandboxProfileId]),
+    );
+    expect(assignments.get(fixtures[0]?.id ?? "")).toBe(analysisSandboxProfileId(orgA));
+    expect(assignments.get(fixtures[1]?.id ?? "")).toBe(customProfileId);
+    expect(assignments.get(fixtures[2]?.id ?? "")).toBeNull();
+    expect(assignments.get(fixtures[3]?.id ?? "")).toBe(defaultSandboxProfileId(orgA));
+    expect(assignments.get(fixtures[4]?.id ?? "")).toBe(analysisSandboxProfileId(orgB));
+    expect(assignments.get(fixtures[4]?.id ?? "")).not.toBe(analysisSandboxProfileId(orgA));
+
+    await db
+      .update(schema.agentDefs)
+      .set({ sandboxProfileId: defaultSandboxProfileId(orgA), updatedAt: new Date() })
+      .where(eq(schema.agentDefs.id, fixtures[0]?.id ?? ""));
+    await seed(databaseUrl, { includeDemoData: false });
+    expect(
+      (
+        await db
+          .select({ sandboxProfileId: schema.agentDefs.sandboxProfileId })
+          .from(schema.agentDefs)
+          .where(eq(schema.agentDefs.id, fixtures[0]?.id ?? ""))
+          .limit(1)
+      )[0]?.sandboxProfileId,
+    ).toBe(defaultSandboxProfileId(orgA));
   });
 
   it("allows only one plan-acceptance builder run per architect plan under a race", async () => {

--- a/services/api/src/routes/v1/agents-sandboxes.ts
+++ b/services/api/src/routes/v1/agents-sandboxes.ts
@@ -4,7 +4,11 @@ import { and, asc, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { ApiError } from "../../errors.js";
-import { nestedDockerSettingIsValid } from "../../sandbox/capabilities.js";
+import {
+  nestedDockerSettingIsValid,
+  provisioningCommandsAreCoherent,
+  provisioningSettingIsValid,
+} from "../../sandbox/capabilities.js";
 import { validateScheduleTrigger } from "../../schedules.js";
 import type { Principal } from "../../types.js";
 import {
@@ -29,8 +33,28 @@ export async function registerAgentsSandboxesRoutes(
   registerCrud(app, "/v1/sandbox-profiles", "sandboxes", sandboxProfiles, "sbx");
 }
 
-const SandboxSetup = AnyObject.refine(nestedDockerSettingIsValid, {
-  message: "setup.nested_docker must be a boolean",
+const SandboxSetup = AnyObject.superRefine((setup, context) => {
+  if (!nestedDockerSettingIsValid(setup)) {
+    context.addIssue({
+      code: "custom",
+      message: "setup.nested_docker must be a boolean",
+      path: ["nested_docker"],
+    });
+  }
+  if (!provisioningSettingIsValid(setup)) {
+    context.addIssue({
+      code: "custom",
+      message: "setup.provisioning must be full, deps_only, or none",
+      path: ["provisioning"],
+    });
+  }
+  if (!provisioningCommandsAreCoherent(setup)) {
+    context.addIssue({
+      code: "custom",
+      message: "setup command overrides cannot target phases disabled by setup.provisioning",
+      path: ["provisioning"],
+    });
+  }
 });
 
 function _objectOrEmpty(value: unknown): Record<string, unknown> {

--- a/services/api/src/routes/v1/projects-repos.ts
+++ b/services/api/src/routes/v1/projects-repos.ts
@@ -1,6 +1,8 @@
 import { newId } from "@facility/core";
 import {
   agentDefs,
+  analysisSandboxProfileId,
+  defaultSandboxProfileId,
   githubInstallations,
   projects,
   registryItems,
@@ -403,14 +405,17 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       .from(registryItems)
       .where(and(eq(registryItems.orgId, orgId), eq(registryItems.scope, "bundled")));
     const byName = new Map(items.map((item) => [item.name, item]));
-    const sandbox = (
-      await db
-        .select()
-        .from(sandboxProfiles)
-        .where(eq(sandboxProfiles.orgId, orgId))
-        .orderBy(asc(sandboxProfiles.createdAt))
-        .limit(1)
-    )[0];
+    const availableSandboxes = await db
+      .select()
+      .from(sandboxProfiles)
+      .where(and(eq(sandboxProfiles.orgId, orgId), isNull(sandboxProfiles.projectId)))
+      .orderBy(asc(sandboxProfiles.createdAt));
+    const defaultSandbox =
+      availableSandboxes.find((profile) => profile.id === defaultSandboxProfileId(orgId)) ??
+      availableSandboxes[0];
+    const analysisSandbox =
+      availableSandboxes.find((profile) => profile.id === analysisSandboxProfileId(orgId)) ??
+      defaultSandbox;
     const productChain = byName.get("product-chain");
     const poContract = byName.get("po-agent");
     const learningContract = byName.get("learning-agent");
@@ -428,6 +433,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
     const crew = [
       {
         name: "architect",
+        sandbox: "analysis",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/architect",
@@ -438,6 +444,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "builder",
+        sandbox: "full",
         engine: "claude_code",
         model: { model: "claude-fable-5" },
         contract: "prompts/builder",
@@ -448,6 +455,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "codex-architect",
+        sandbox: "analysis",
         engine: "codex",
         model: { primary: "gpt-5.6-sol", reasoning_effort: "high" },
         contract: "prompts/architect",
@@ -458,6 +466,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "codex-builder",
+        sandbox: "full",
         engine: "codex",
         model: { primary: "gpt-5.6-sol", reasoning_effort: "high" },
         contract: "prompts/builder",
@@ -468,6 +477,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "review",
+        sandbox: "analysis",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/review",
@@ -475,6 +485,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "address-review",
+        sandbox: "full",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/address-review",
@@ -482,6 +493,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "ci-doctor",
+        sandbox: "full",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/doctor",
@@ -489,6 +501,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "security-sweep",
+        sandbox: "analysis",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/sweep",
@@ -511,7 +524,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
             { type: "schedule", config: { cron: "0 6 * * *", timezone: "UTC" } },
             { type: "manual", config: {} },
           ],
-          sandboxProfileId: sandbox?.id,
+          sandboxProfileId: defaultSandbox?.id,
           // Read grants are explicit (write does not imply read in can()): the
           // PO reads its KB, the pipeline, and delegated runs, and may
           // dispatch a read-only architect consult.
@@ -541,7 +554,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
           contractItemId: learningContract.id,
           harnessItemId: productChain?.id,
           triggers: [{ type: "schedule", config: { cron: "0 3 * * *", timezone: "UTC" } }],
-          sandboxProfileId: sandbox?.id,
+          sandboxProfileId: defaultSandbox?.id,
           permissions: ["runs:read", "hitl:write", "kb:read"],
           enabled: true,
         })
@@ -559,7 +572,10 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
         model: spec.model,
         contractItemId: contract.id,
         triggers: [...spec.triggers],
-        sandboxProfileId: sandbox?.id,
+        // This is a seed-time assignment, not run-time mode inference. Operators
+        // can replace it through the existing agent/profile APIs. Keep the
+        // analysis set aligned with the runner's read-only repository modes.
+        sandboxProfileId: spec.sandbox === "analysis" ? analysisSandbox?.id : defaultSandbox?.id,
         permissions: ["runs:read"],
         enabled: true,
       });

--- a/services/api/src/sandbox/capabilities.ts
+++ b/services/api/src/sandbox/capabilities.ts
@@ -1,4 +1,8 @@
 export const NESTED_DOCKER_SETUP_KEY = "nested_docker";
+export const PROVISIONING_SETUP_KEY = "provisioning";
+export const PROVISIONING_DEPTHS = ["full", "deps_only", "none"] as const;
+
+export type ProvisioningDepth = (typeof PROVISIONING_DEPTHS)[number];
 
 /**
  * Existing profiles predate capability flags and ran with nested Docker on AWS.
@@ -18,4 +22,37 @@ export function nestedDockerSettingIsValid(setup: Record<string, unknown>): bool
     !Object.hasOwn(setup, NESTED_DOCKER_SETUP_KEY) ||
     typeof setup[NESTED_DOCKER_SETUP_KEY] === "boolean"
   );
+}
+
+/**
+ * Provisioning depth is ordered: none skips all repository setup, deps_only
+ * keeps dependency installation but skips service/database provisioning, and
+ * full preserves the legacy lifecycle. Invalid persisted values retain full
+ * setup; trusted writes reject them.
+ */
+export function provisioningDepth(setup: unknown): ProvisioningDepth {
+  if (!setup || typeof setup !== "object" || Array.isArray(setup)) return "full";
+  const value = (setup as Record<string, unknown>)[PROVISIONING_SETUP_KEY];
+  return typeof value === "string" && PROVISIONING_DEPTHS.includes(value as ProvisioningDepth)
+    ? (value as ProvisioningDepth)
+    : "full";
+}
+
+export function provisioningSettingIsValid(setup: Record<string, unknown>): boolean {
+  return (
+    !Object.hasOwn(setup, PROVISIONING_SETUP_KEY) ||
+    PROVISIONING_DEPTHS.includes(setup[PROVISIONING_SETUP_KEY] as ProvisioningDepth)
+  );
+}
+
+export function provisioningCommandsAreCoherent(setup: Record<string, unknown>): boolean {
+  const depth = provisioningDepth(setup);
+  const provisionOverride = commandConfigured(setup, ["provision_cmd", "provisionCmd"]);
+  const installOverride = commandConfigured(setup, ["package_install_cmd", "packageInstallCmd"]);
+  if (depth !== "full" && provisionOverride) return false;
+  return depth !== "none" || !installOverride;
+}
+
+function commandConfigured(setup: Record<string, unknown>, keys: string[]): boolean {
+  return keys.some((key) => typeof setup[key] === "string" && setup[key].trim().length > 0);
 }

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -56,7 +56,7 @@ import { harnessFragmentForBundle, validateProjectKb } from "../harness.js";
 import { assertPreviewProvisioningAvailable, createPreviewRecord } from "../previews.js";
 import type { AppConfig } from "../types.js";
 import { raisePlatformIssue } from "../watchtower/issues.js";
-import { nestedDockerEnabled } from "./capabilities.js";
+import { nestedDockerEnabled, provisioningDepth } from "./capabilities.js";
 import { DockerSandboxDriver } from "./docker.js";
 import type { LaunchSpec, SandboxDriver, SandboxDriverName } from "./driver.js";
 import { sandboxDriver } from "./driver.js";
@@ -148,6 +148,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
     const runnerToken = `frt_${crypto.randomUUID().replaceAll("-", "")}${crypto.randomUUID().replaceAll("-", "")}`;
     const driverName = normalizeDriver(profile.driver);
     const nestedDocker = nestedDockerEnabled(profile.setup);
+    const provisioning = provisioningDepth(profile.setup);
     const driver = await (deps.sandboxDriver ?? sandboxDriver)(driverName);
     const launchSpec: LaunchSpec = {
       runId: run.id,
@@ -202,6 +203,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
         data: {
           driver: driver.name,
           ref: launched.ref,
+          provisioning,
           ...(driverName === "aws" ? { nested_docker: nestedDocker } : {}),
         },
       },
@@ -1397,8 +1399,10 @@ async function buildRunBundle(
       .limit(1)
   )[0];
   const timeoutMin = resourceNumber(profile.resources, "timeout_min", 60);
-  const packageInstallCmd = resolvePackageInstallCmd(profile, repo?.renderAnswers);
-  const provisionCmd = resolveProvisionCmd(profile, repo?.renderAnswers);
+  const { packageInstallCmd, provisionCmd } = resolveProvisioningCommands(
+    profile,
+    repo?.renderAnswers,
+  );
   const checkCmds = resolveCheckCmds(profile, repo?.renderAnswers, project?.settings);
   const provisionSummary = [packageInstallCmd, provisionCmd].filter(Boolean).join(" && ") || null;
   const contract = renderRunContract(rawContract, provisionSummary, checkCmds);
@@ -2108,6 +2112,17 @@ export function resolvePackageInstallCmd(profile: { setup: unknown }, renderAnsw
     stringField(renderAnswers, "packageInstallCmd") ??
     stringField(renderAnswers, "package_install_cmd")
   );
+}
+
+export function resolveProvisioningCommands(
+  profile: { setup: unknown },
+  renderAnswers: unknown,
+): { packageInstallCmd: string | null; provisionCmd: string | null } {
+  const depth = provisioningDepth(profile.setup);
+  return {
+    packageInstallCmd: depth === "none" ? null : resolvePackageInstallCmd(profile, renderAnswers),
+    provisionCmd: depth === "full" ? resolveProvisionCmd(profile, renderAnswers) : null,
+  };
 }
 
 // Seed contracts are also used by the repository lane, where these placeholders

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -7,11 +7,13 @@ import { hashKey, newId, seal } from "@facility/core";
 import {
   actionTypes,
   agentDefs,
+  analysisSandboxProfileId,
   auditEvents,
   budgets,
   conversationMessages,
   conversations,
   createDb,
+  defaultSandboxProfileId,
   ghIssues,
   githubInstallations,
   inboundEvents,
@@ -620,6 +622,37 @@ describe("api", async () => {
     expect(await validateProjectKb(db, orgId, projectId)).toMatchObject({
       ok: true,
       errors: [],
+    });
+    const projectAgents = await db
+      .select({ name: agentDefs.name, sandboxProfileId: agentDefs.sandboxProfileId })
+      .from(agentDefs)
+      .where(and(eq(agentDefs.orgId, orgId), eq(agentDefs.projectId, projectId)));
+    const profileByAgent = new Map(
+      projectAgents.map((agent) => [agent.name, agent.sandboxProfileId]),
+    );
+    for (const name of ["architect", "codex-architect", "review", "security-sweep"]) {
+      expect(profileByAgent.get(name), name).toBe(analysisSandboxProfileId(orgId));
+    }
+    for (const name of [
+      "builder",
+      "codex-builder",
+      "address-review",
+      "ci-doctor",
+      "project-owner",
+      "learning",
+    ]) {
+      expect(profileByAgent.get(name), name).toBe(defaultSandboxProfileId(orgId));
+    }
+    const analysisProfile = (
+      await db
+        .select()
+        .from(sandboxProfiles)
+        .where(eq(sandboxProfiles.id, analysisSandboxProfileId(orgId)))
+        .limit(1)
+    )[0];
+    expect(analysisProfile?.setup).toMatchObject({
+      nested_docker: false,
+      provisioning: "deps_only",
     });
     let listedProject = false;
     for (let offset = 0; !listedProject; offset += 100) {

--- a/services/api/test/orchestrator-checks.test.ts
+++ b/services/api/test/orchestrator-checks.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCheckCmds,
   resolvePackageInstallCmd,
   resolveProvisionCmd,
+  resolveProvisioningCommands,
   resolveRepoEngineConfig,
   runSafePermissions,
 } from "../src/sandbox/orchestrator.js";
@@ -116,6 +117,38 @@ describe("platform run repository setup", () => {
         { provisionCmd: "pnpm install" },
       ),
     ).toBe("make bootstrap");
+  });
+
+  it("gates repository setup with an explicit provisioning depth", () => {
+    const answers = {
+      packageInstallCmd: "pnpm install --frozen-lockfile",
+      provisionCmd: "pnpm run local:setup:ui",
+    };
+    expect(resolveProvisioningCommands({ setup: {} }, answers)).toEqual({
+      packageInstallCmd: "pnpm install --frozen-lockfile",
+      provisionCmd: "pnpm run local:setup:ui",
+    });
+    expect(resolveProvisioningCommands({ setup: { provisioning: "full" } }, answers)).toEqual({
+      packageInstallCmd: "pnpm install --frozen-lockfile",
+      provisionCmd: "pnpm run local:setup:ui",
+    });
+    expect(resolveProvisioningCommands({ setup: { provisioning: "deps_only" } }, answers)).toEqual({
+      packageInstallCmd: "pnpm install --frozen-lockfile",
+      provisionCmd: null,
+    });
+    expect(resolveProvisioningCommands({ setup: { provisioning: "deps_only" } }, {})).toEqual({
+      packageInstallCmd: null,
+      provisionCmd: null,
+    });
+    expect(resolveProvisioningCommands({ setup: { provisioning: "none" } }, answers)).toEqual({
+      packageInstallCmd: null,
+      provisionCmd: null,
+    });
+    // Invalid persisted state stays on the legacy full lifecycle.
+    expect(resolveProvisioningCommands({ setup: { provisioning: "skip" } }, answers)).toEqual({
+      packageInstallCmd: "pnpm install --frozen-lockfile",
+      provisionCmd: "pnpm run local:setup:ui",
+    });
   });
 
   it("renders repository setup and gates into platform contracts", () => {

--- a/services/api/test/sandbox-capabilities.test.ts
+++ b/services/api/test/sandbox-capabilities.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { nestedDockerEnabled, nestedDockerSettingIsValid } from "../src/sandbox/capabilities.js";
+import {
+  nestedDockerEnabled,
+  nestedDockerSettingIsValid,
+  provisioningCommandsAreCoherent,
+  provisioningDepth,
+  provisioningSettingIsValid,
+} from "../src/sandbox/capabilities.js";
 
 describe("sandbox capabilities", () => {
   it.each([
@@ -17,5 +23,55 @@ describe("sandbox capabilities", () => {
     expect(nestedDockerSettingIsValid({ provision_cmd: "pnpm setup" })).toBe(true);
     expect(nestedDockerSettingIsValid({ nested_docker: false, deps: [] })).toBe(true);
     expect(nestedDockerSettingIsValid({ nested_docker: 0 })).toBe(false);
+  });
+
+  it.each([
+    [{ provisioning: "full" }, "full"],
+    [{ provisioning: "deps_only" }, "deps_only"],
+    [{ provisioning: "none" }, "none"],
+    [{}, "full"],
+    [null, "full"],
+    [["none"], "full"],
+    [{ provisioning: "skip" }, "full"],
+    [{ provisioning: false }, "full"],
+  ] as const)("normalizes %j to provisioning depth %s", (setup, expected) => {
+    expect(provisioningDepth(setup)).toBe(expected);
+  });
+
+  it("accepts only the closed provisioning-depth enum", () => {
+    expect(provisioningSettingIsValid({ deps: [] })).toBe(true);
+    expect(provisioningSettingIsValid({ provisioning: "full" })).toBe(true);
+    expect(provisioningSettingIsValid({ provisioning: "deps_only" })).toBe(true);
+    expect(provisioningSettingIsValid({ provisioning: "none" })).toBe(true);
+    expect(provisioningSettingIsValid({ provisioning: "skip" })).toBe(false);
+    expect(provisioningSettingIsValid({ provisioning: false })).toBe(false);
+  });
+
+  it("rejects command overrides for phases the profile disables", () => {
+    expect(
+      provisioningCommandsAreCoherent({
+        provisioning: "full",
+        provision_cmd: "pnpm setup",
+        package_install_cmd: "pnpm install",
+      }),
+    ).toBe(true);
+    expect(
+      provisioningCommandsAreCoherent({
+        provisioning: "deps_only",
+        package_install_cmd: "pnpm install",
+      }),
+    ).toBe(true);
+    expect(
+      provisioningCommandsAreCoherent({
+        provisioning: "deps_only",
+        provisionCmd: "pnpm setup",
+      }),
+    ).toBe(false);
+    expect(
+      provisioningCommandsAreCoherent({
+        provisioning: "none",
+        packageInstallCmd: "pnpm install",
+      }),
+    ).toBe(false);
   });
 });

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -318,6 +318,18 @@ describe("sandbox api", async () => {
         .returning()
     )[0];
     if (!agent) throw new Error("nested-Docker agent fixture missing");
+    await db.insert(repos).values({
+      id: newId("repo"),
+      orgId,
+      projectId,
+      owner: `sandbox-capabilities-${suffix}`,
+      name: "repo",
+      defaultBranch: "main",
+      renderAnswers: {
+        packageInstallCmd: "pnpm install --frozen-lockfile",
+        provisionCmd: "pnpm run local:setup:ui",
+      },
+    });
 
     const launched: Array<Parameters<SandboxDriver["launch"]>[0]> = [];
     const driver: SandboxDriver = {
@@ -332,10 +344,28 @@ describe("sandbox api", async () => {
       destroy: async () => undefined,
     };
     for (const fixture of [
-      { setup: { nested_docker: false }, expected: "0" },
-      { setup: { nested_docker: true }, expected: "1" },
+      {
+        setup: { nested_docker: false, provisioning: "deps_only" },
+        expected: "0",
+        provisioning: "deps_only",
+        packageInstallCmd: "pnpm install --frozen-lockfile",
+        provisionCmd: null,
+      },
+      {
+        setup: { nested_docker: true, provisioning: "none" },
+        expected: "1",
+        provisioning: "none",
+        packageInstallCmd: null,
+        provisionCmd: null,
+      },
       // Profiles created before this capability keep their legacy full boundary.
-      { setup: {}, expected: "1" },
+      {
+        setup: {},
+        expected: "1",
+        provisioning: "full",
+        packageInstallCmd: "pnpm install --frozen-lockfile",
+        provisionCmd: "pnpm run local:setup:ui",
+      },
     ] as const) {
       await db
         .update(sandboxProfiles)
@@ -361,12 +391,22 @@ describe("sandbox api", async () => {
       await dispatchRun(config, { runId: run.id, orgId }, { sandboxDriver: async () => driver });
 
       expect(launched.at(-1)?.env.FACILITY_SANDBOX_NESTED_DOCKER).toBe(fixture.expected);
+      const persistedRun = (
+        await db.select({ sandbox: runs.sandbox }).from(runs).where(eq(runs.id, run.id)).limit(1)
+      )[0];
+      expect(
+        (persistedRun?.sandbox as { bundle?: Record<string, unknown> } | null)?.bundle,
+      ).toMatchObject({
+        packageInstallCmd: fixture.packageInstallCmd,
+        provisionCmd: fixture.provisionCmd,
+      });
       const sandboxEvent = (
         await db.select({ data: runEvents.data }).from(runEvents).where(eq(runEvents.runId, run.id))
       ).find((event) => (event.data as Record<string, unknown>).nested_docker !== undefined);
       expect(sandboxEvent?.data).toMatchObject({
         driver: "aws",
         nested_docker: fixture.expected === "1",
+        provisioning: fixture.provisioning,
       });
     }
 
@@ -406,9 +446,10 @@ describe("sandbox api", async () => {
         .where(eq(runEvents.runId, dockerRun.id))
     ).find((event) => (event.data as Record<string, unknown>).driver === "docker");
     expect(dockerSandboxEvent?.data).not.toHaveProperty("nested_docker");
+    expect(dockerSandboxEvent?.data).toMatchObject({ provisioning: "full" });
   });
 
-  it("accepts only boolean nested-Docker profile settings", async () => {
+  it("accepts only coherent sandbox capability settings", async () => {
     const valid = await app.inject({
       method: "POST",
       url: "/v1/sandbox-profiles",
@@ -417,25 +458,59 @@ describe("sandbox api", async () => {
         name: `no-nested-docker-${Date.now()}`,
         driver: "aws",
         image: "facility-runner:test",
-        setup: { nested_docker: false },
+        setup: { nested_docker: false, provisioning: "deps_only" },
       },
     });
     expect(valid.statusCode).toBe(200);
-    expect(valid.json().setup).toMatchObject({ nested_docker: false });
-
-    const invalid = await app.inject({
-      method: "POST",
-      url: "/v1/sandbox-profiles",
-      headers: { cookie },
-      payload: {
-        name: `invalid-nested-docker-${Date.now()}`,
-        driver: "aws",
-        image: "facility-runner:test",
-        setup: { nested_docker: "false" },
-      },
+    expect(valid.json().setup).toMatchObject({
+      nested_docker: false,
+      provisioning: "deps_only",
     });
-    expect(invalid.statusCode).toBe(400);
-    expect(invalid.body).toContain("setup.nested_docker must be a boolean");
+
+    for (const [setup, message] of [
+      [{ nested_docker: "false" }, "setup.nested_docker must be a boolean"],
+      [{ provisioning: "skip" }, "setup.provisioning must be full, deps_only, or none"],
+      [
+        { provisioning: "deps_only", provision_cmd: "pnpm setup" },
+        "setup command overrides cannot target phases disabled by setup.provisioning",
+      ],
+      [
+        { provisioning: "none", package_install_cmd: "pnpm install" },
+        "setup command overrides cannot target phases disabled by setup.provisioning",
+      ],
+    ] as const) {
+      const invalid = await app.inject({
+        method: "POST",
+        url: "/v1/sandbox-profiles",
+        headers: { cookie },
+        payload: {
+          name: `invalid-capability-${Date.now()}`,
+          driver: "aws",
+          image: "facility-runner:test",
+          setup,
+        },
+      });
+      expect(invalid.statusCode).toBe(400);
+      expect(invalid.body).toContain(message);
+    }
+
+    const invalidPatch = await app.inject({
+      method: "PATCH",
+      url: `/v1/sandbox-profiles/${valid.json().id}`,
+      headers: { cookie },
+      payload: { setup: { provisioning: false } },
+    });
+    expect(invalidPatch.statusCode).toBe(400);
+    expect(invalidPatch.body).toContain("setup.provisioning must be full, deps_only, or none");
+
+    const validPatch = await app.inject({
+      method: "PATCH",
+      url: `/v1/sandbox-profiles/${valid.json().id}`,
+      headers: { cookie },
+      payload: { setup: { nested_docker: false, provisioning: "none" } },
+    });
+    expect(validPatch.statusCode).toBe(200);
+    expect(validPatch.json().setup).toEqual({ nested_docker: false, provisioning: "none" });
   });
 
   it("appendRunEvents allocates contiguous seqs under concurrent appends", async () => {


### PR DESCRIPTION
## What changes

- Adds setup.provisioning with full, deps_only, and none execution depths. Runtime command resolution remains authoritative even for legacy persisted data.
- Seeds one managed Analysis runner profile and assigns it explicitly to architect, codex-architect, review, and security-sweep for new projects.
- Moves eligible legacy analysis agents once, while preserving custom, null, cross-tenant, builder, and later operator assignments.
- Reports the selected provisioning depth in sandbox runtime events and documents the two-profile topology.

This is intentionally stacked on #84. It must be rebased onto main and receive fresh current-SHA CI after #83 and #84 merge.

## Why

Read-only agents currently pay for project provisioning such as database resets and browser-service setup that they do not use. This keeps the existing full runner for builders while providing one simpler, explicit analysis path without runtime inference from agent names or additional services.

## Verification

- COMPOSE_ENV_FILES=.env.example pnpm verify passed against clean disposable test databases: DB 9, CLI 67, API 326, gateway 37, runner 122, all remaining package tests, repository guards, and dependency audit.
- Targeted API tests exercise valid and invalid POST/PATCH setup contracts and prove disabled commands cannot execute.
- Database integration tests cover idempotence, two organizations, cross-tenant isolation, custom/null/builder preservation, and a newer operator override surviving a later seed.
- Claude Opus high independently audited source and tests for alias bypasses, runtime gating, migration durability, and tenant safety; final verdict APPROVE with no blocking findings.

- [x] pnpm verify passes locally
- [x] Behaviour verified beyond the test suite: independent runtime/source audit confirmed every command alias read by the orchestrator is guarded and inert at disabled depths
- [x] Documentation updated, or no user-facing change