### PR TITLE
fix(preview)!: isolate preview applications by origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ SECRET_MASTER_KEY=
 PORT=4400
 PUBLIC_URL=http://localhost:4400
 WEB_URL=http://localhost:3400
+# Untrusted preview applications use a browser origin distinct from Facility.
+# *.localhost resolves to loopback in modern browsers without /etc/hosts.
+FACILITY_PREVIEW_URL=http://preview.localhost:4400
 # Extra hostnames allowed to reach the dev server cross-origin (tunnel, LAN).
 # Comma-separated, no scheme. Development only.
 FACILITY_DEV_ORIGINS=

--- a/apps/docs/docs/reference/security.md
+++ b/apps/docs/docs/reference/security.md
@@ -51,8 +51,19 @@ Security and privacy are first-class concerns; this page is the contract.
 - Production preview creation, listing, viewing, and deletion fail closed until
   interactive GitHub/OIDC login is configured. Machine keys can request a preview, but cannot view
   or delete it.
-- The public URL is an authenticated Facility proxy. It strips cookies and
-  authorization before forwarding only browser-safe `GET` and `HEAD` requests.
+- Preview HTML and JavaScript are served only from `FACILITY_PREVIEW_URL`, a
+  separately registered browser site that routes to the existing API tasks.
+  The preview host denies every control-plane route, and the control-plane
+  hosts deny preview content routes.
+- Opening a preview exchanges the Facility session for a single-use,
+  60-second handoff and then a short-lived HttpOnly cookie bound to one user,
+  organization, and preview. Every request rechecks active membership and
+  `runs:read`; the proxy strips cookies and authorization before forwarding
+  only browser-safe `GET` and `HEAD` requests.
+- Do not configure the preview hostname as a sibling of the app/API hostnames,
+  and never widen Facility cookies with a parent `Domain` attribute. A separate
+  registered site prevents untrusted preview JavaScript from tossing cookies
+  into the control-plane site.
 - No provider or production secrets are injected. Projects publish an immutable
   review image whose command prepares only non-production data.
 - Preview application containers currently have outbound network access. Place

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -148,6 +148,11 @@ For production, leave the CloudFront validation endpoint disabled, point
 `api_hostname` at the ALB with a real certificate, and set `route53_zone_id`
 only when Terraform should create the alias record.
 
+Protected previews also require `preview_hostname` on a separately registered
+site, covered by the same ACM certificate. Set `preview_route53_zone_id` when
+Terraform should create its alias; otherwise create the DNS record externally.
+Production tasks reject a missing, HTTP, or control-plane-hosted preview URL.
+
 No secret values belong in tfvars. The file is gitignored; keep it that way.
 
 ## 2. First apply

--- a/apps/docs/docs/self-host/local-development.md
+++ b/apps/docs/docs/self-host/local-development.md
@@ -102,6 +102,12 @@ FACILITY_DEV_ORIGINS=dev.example.com
 Leave `PUBLIC_URL` as `http://localhost:4400`: it is the control plane's own
 origin, not the browser-facing one.
 
+Preview applications never share that browser origin. The default
+`FACILITY_PREVIEW_URL=http://preview.localhost:4400` resolves to loopback in
+modern browsers without editing `/etc/hosts`. If a teammate must open previews
+through a tunnel, give the preview origin its own HTTPS hostname on a
+separately registered site; do not reuse `dev.example.com` or a sibling of it.
+
 In the GitHub App settings:
 
 - **Callback URL** → `https://dev.example.com/api/auth/callback` (byte for byte;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -22,10 +22,7 @@ const nextConfig: NextConfig = {
   async rewrites() {
     // Same-origin proxy to the control plane: session cookies flow without
     // cross-origin ceremony, in dev and behind any reverse proxy in prod.
-    return [
-      { source: "/api/:path*", destination: `${API_URL}/:path*` },
-      { source: "/preview/:path*", destination: `${API_URL}/preview/:path*` },
-    ];
+    return [{ source: "/api/:path*", destination: `${API_URL}/:path*` }];
   },
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       SECRET_MASTER_KEY: ${SECRET_MASTER_KEY:?set SECRET_MASTER_KEY}
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:4400}
       WEB_URL: ${WEB_URL:-http://localhost:3400}
+      FACILITY_PREVIEW_URL: ${FACILITY_PREVIEW_URL:-http://preview.localhost:4400}
       S3_ENDPOINT: http://minio:9000
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-facility}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-facility-dev-secret}
@@ -140,6 +141,7 @@ services:
     environment:
       DATABASE_URL: postgres://facility:${POSTGRES_PASSWORD:-facility}@postgres:5432/facility
       SECRET_MASTER_KEY: ${SECRET_MASTER_KEY:?set SECRET_MASTER_KEY}
+      FACILITY_PREVIEW_URL: ${FACILITY_PREVIEW_URL:-http://preview.localhost:4400}
       # The worker dispatches runs, so it mints repo clone credentials — it needs
       # the same GitHub App env as the api (installation-token minting + fallback).
       GITHUB_APP_ID: ${GITHUB_APP_ID:-}

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -11,6 +11,10 @@ Topology:
 - `app_hostname` routes to the `web` ECS service through the public ALB.
 - `api_hostname` routes to the `api` ECS service through the public ALB.
 - `mcp_hostname` routes to the audience-bound MCP resource server.
+- `preview_hostname` routes only protected preview content to the existing API
+  tasks. Use a separately registered domain and certificate SAN, not a sibling
+  of the app/API hostnames; set `preview_route53_zone_id` when Terraform should
+  create that zone's alias record.
 - `gateway` has no public ALB route. It is reachable only inside the VPC through
   Cloud Map at the `gateway_internal_url` output.
 - Postgres accepts `5432` only from the ECS service security group.
@@ -34,7 +38,8 @@ Edit `playground.tfvars`:
 
 - Set `aws_region` and change the copied `environment = "playground"` value if
   this is not a playground deployment; a filename does not set the variable.
-- Set `app_hostname`, `api_hostname`, and `mcp_hostname`.
+- Set `app_hostname`, `api_hostname`, `mcp_hostname`, and the separately
+  registered `preview_hostname`.
 - Set `acm_certificate_arn` for HTTPS, or leave it empty for HTTP-only testing.
 - Set `route53_zone_id` if Terraform should create alias records.
 - Set `enable_cloudfront_api_endpoint = true` to get an AWS-managed HTTPS API

--- a/infra/terraform/aws/alb.tf
+++ b/infra/terraform/aws/alb.tf
@@ -132,6 +132,18 @@ resource "aws_lb_listener_rule" "http_mcp" {
   }
 }
 
+resource "aws_lb_listener_rule" "http_preview" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 40
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.service["api"].arn
+  }
+  condition {
+    host_header { values = [var.preview_hostname] }
+  }
+}
+
 resource "aws_lb_listener_rule" "https_api" {
   count = var.acm_certificate_arn == "" ? 0 : 1
 
@@ -181,6 +193,19 @@ resource "aws_lb_listener_rule" "https_mcp" {
   }
 }
 
+resource "aws_lb_listener_rule" "https_preview" {
+  count        = var.acm_certificate_arn == "" ? 0 : 1
+  listener_arn = aws_lb_listener.https[0].arn
+  priority     = 40
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.service["api"].arn
+  }
+  condition {
+    host_header { values = [var.preview_hostname] }
+  }
+}
+
 resource "aws_route53_record" "app" {
   count = var.route53_zone_id == "" ? 0 : 1
 
@@ -213,6 +238,18 @@ resource "aws_route53_record" "mcp" {
   count   = var.route53_zone_id == "" ? 0 : 1
   zone_id = var.route53_zone_id
   name    = var.mcp_hostname
+  type    = "A"
+  alias {
+    name                   = aws_lb.public.dns_name
+    zone_id                = aws_lb.public.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "preview" {
+  count   = var.preview_route53_zone_id == "" ? 0 : 1
+  zone_id = var.preview_route53_zone_id
+  name    = var.preview_hostname
   type    = "A"
   alias {
     name                   = aws_lb.public.dns_name

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -34,9 +34,10 @@ locals {
   }
 
   public_urls = {
-    api = var.enable_cloudfront_api_endpoint ? "https://${aws_cloudfront_distribution.api[0].domain_name}" : "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.api_hostname}"
-    web = "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.app_hostname}"
-    mcp = "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.mcp_hostname}"
+    api     = var.enable_cloudfront_api_endpoint ? "https://${aws_cloudfront_distribution.api[0].domain_name}" : "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.api_hostname}"
+    web     = "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.app_hostname}"
+    mcp     = "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.mcp_hostname}"
+    preview = "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.preview_hostname}"
   }
 
   common_environment = [
@@ -68,6 +69,7 @@ locals {
     { name = "PORT", value = tostring(local.ports.api) },
     { name = "PUBLIC_URL", value = local.public_urls.api },
     { name = "WEB_URL", value = local.public_urls.web },
+    { name = "FACILITY_PREVIEW_URL", value = local.public_urls.preview },
     { name = "AUTH_IDENTITY_PROVIDER", value = var.auth_identity_provider },
     { name = "AUTH_CALLBACK_URL", value = "${local.public_urls.web}/api/auth/callback" },
     { name = "GITHUB_OAUTH_ALLOWED_ORGANIZATION", value = lower(trimspace(var.github_oauth_allowed_organization)) },
@@ -83,6 +85,7 @@ locals {
     { name = "PORT", value = tostring(local.ports.worker) },
     { name = "PUBLIC_URL", value = local.public_urls.api },
     { name = "WEB_URL", value = local.public_urls.web },
+    { name = "FACILITY_PREVIEW_URL", value = local.public_urls.preview },
     { name = "GATEWAY_URL", value = "http://${aws_service_discovery_service.gateway.name}.${aws_service_discovery_private_dns_namespace.facility.name}:${local.ports.gateway}" },
     { name = "SANDBOX_GATEWAY_URL", value = "http://${aws_service_discovery_service.gateway.name}.${aws_service_discovery_private_dns_namespace.facility.name}:${local.ports.gateway}" },
   ])

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -18,6 +18,11 @@ output "mcp_url" {
   value       = local.public_urls.mcp
 }
 
+output "preview_url" {
+  description = "Isolated browser origin for protected preview applications."
+  value       = local.public_urls.preview
+}
+
 output "github_webhook_url" {
   description = "Public GitHub App webhook URL."
   value       = "${local.public_urls.api}/webhooks/github"

--- a/infra/terraform/aws/terraform.tfvars.example
+++ b/infra/terraform/aws/terraform.tfvars.example
@@ -5,6 +5,9 @@ project     = "facility"
 app_hostname = "app.example.com"
 api_hostname = "api.example.com"
 mcp_hostname = "mcp.example.com"
+# Use a separately registered site so preview JavaScript cannot toss cookies
+# into the Facility control-plane domain.
+preview_hostname = "facility-previews.example.net"
 
 # Optional. Leave empty to create only HTTP listeners and print the ALB DNS name.
 acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/placeholder"

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -43,8 +43,19 @@ variable "mcp_hostname" {
   type        = string
 }
 
+variable "preview_hostname" {
+  description = "Dedicated hostname for untrusted preview application content. Use a separately registered domain, not a sibling of app_hostname."
+  type        = string
+}
+
 variable "route53_zone_id" {
   description = "Optional Route53 hosted zone ID. When set, app/api alias records are created."
+  type        = string
+  default     = ""
+}
+
+variable "preview_route53_zone_id" {
+  description = "Optional Route53 hosted zone ID for preview_hostname. Keep this separate from the control-plane zone."
   type        = string
   default     = ""
 }

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -11,6 +11,7 @@ export const ID_PREFIXES = {
   sess: "sess",
   agent: "agent",
   sbx: "sbx",
+  pvh: "pvh",
   key: "key",
   prov: "prov",
   vkey: "vkey",

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -83,6 +83,7 @@ describe("run-scoped model policy", () => {
 describe("ids", () => {
   it("creates prefixed uuidv7 ids", () => {
     expect(newId("proj")).toMatch(/^proj_[0-9a-f]{32}$/);
+    expect(newId("pvh")).toMatch(/^pvh_[0-9a-f]{32}$/);
   });
 });
 

--- a/packages/db/migrations/0032_preview_access_handoffs.sql
+++ b/packages/db/migrations/0032_preview_access_handoffs.sql
@@ -1,0 +1,16 @@
+CREATE TABLE preview_access_handoffs (
+  id text PRIMARY KEY,
+  org_id text NOT NULL REFERENCES orgs(id),
+  project_id text NOT NULL REFERENCES projects(id),
+  preview_id text NOT NULL REFERENCES preview_sandboxes(id) ON DELETE CASCADE,
+  user_id text NOT NULL REFERENCES users(id),
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX preview_access_handoffs_expiry_idx
+  ON preview_access_handoffs(expires_at);
+
+CREATE INDEX preview_access_handoffs_preview_user_idx
+  ON preview_access_handoffs(preview_id, user_id);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1013,6 +1013,32 @@ export const previewSandboxes = pgTable(
   ],
 );
 
+export const previewAccessHandoffs = pgTable(
+  "preview_access_handoffs",
+  {
+    id: text("id").primaryKey(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => orgs.id),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id),
+    previewId: text("preview_id")
+      .notNull()
+      .references(() => previewSandboxes.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("preview_access_handoffs_expiry_idx").on(table.expiresAt),
+    index("preview_access_handoffs_preview_user_idx").on(table.previewId, table.userId),
+  ],
+);
+
 export const analyticsDaily = pgTable(
   "analytics_daily",
   {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16006,6 +16006,241 @@
         "x-facility-permission": "runs:write"
       }
     },
+    "/v1/projects/{projectId}/previews/{previewId}/open": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "previewId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          },
+          "400": {
+            "description": "The request is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The authenticated principal lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource was not found or is outside the principal scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The request conflicts with current resource state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The request rate limit was exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server error occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "A required service is unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getProjectsByProjectIdPreviewsByPreviewIdOpen",
+        "summary": "List open",
+        "tags": [
+          "Projects"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "x-facility-permission": "runs:read"
+      }
+    },
+    "/preview-auth/{previewId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "query",
+            "name": "handoff",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "previewId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          },
+          "400": {
+            "description": "The request is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The authenticated principal lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource was not found or is outside the principal scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The request conflicts with current resource state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The request rate limit was exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server error occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "A required service is unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getPreviewAuthByPreviewId",
+        "summary": "Get preview auth",
+        "tags": [
+          "Facility"
+        ],
+        "security": []
+      }
+    },
     "/preview/{previewId}": {
       "get": {
         "operationId": "getProtectedPreviewRoot",
@@ -16108,15 +16343,7 @@
         "tags": [
           "Facility"
         ],
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "sessionCookie": []
-          }
-        ],
-        "x-facility-permission": "runs:read"
+        "security": []
       }
     },
     "/preview/{previewId}/{*}": {

--- a/packages/sdk/src/routes.ts
+++ b/packages/sdk/src/routes.ts
@@ -64,6 +64,7 @@ export const FACILITY_V1_ROUTES = [
   "GET /v1/projects/:projectId/kickstart/preview",
   "GET /v1/projects/:projectId/pipeline",
   "GET /v1/projects/:projectId/previews",
+  "GET /v1/projects/:projectId/previews/:previewId/open",
   "GET /v1/projects/:projectId/repos",
   "GET /v1/projects/:projectId/runs",
   "GET /v1/projects/:projectId/stories/:number",

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -1026,6 +1026,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{projectId}/previews/{previewId}/open": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List open */
+        get: operations["getProjectsByProjectIdPreviewsByPreviewIdOpen"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/preview-auth/{previewId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get preview auth */
+        get: operations["getPreviewAuthByPreviewId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/preview/{previewId}": {
         parameters: {
             query?: never;
@@ -11035,6 +11069,193 @@ export interface operations {
                         url: string;
                     };
                 };
+            };
+            /** @description The request is invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Authentication is required or invalid. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The authenticated principal lacks the required permission. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The requested resource was not found or is outside the principal scope. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The request conflicts with current resource state. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The request rate limit was exceeded. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description An unexpected server error occurred. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description A required service is unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getProjectsByProjectIdPreviewsByPreviewIdOpen: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                projectId: string;
+                previewId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Default Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The request is invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Authentication is required or invalid. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The authenticated principal lacks the required permission. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The requested resource was not found or is outside the principal scope. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The request conflicts with current resource state. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The request rate limit was exceeded. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description An unexpected server error occurred. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description A required service is unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getPreviewAuthByPreviewId: {
+        parameters: {
+            query: {
+                handoff: string;
+            };
+            header?: never;
+            path: {
+                previewId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Default Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description The request is invalid. */
             400: {

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -37,6 +37,7 @@ import {
   type OpenApiDocument,
   type OpenApiRouteRecord,
 } from "./openapi-contract.js";
+import { assertPreviewOriginSurface } from "./previews.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerGithubRoutes } from "./routes/github.js";
 import { registerInternalRoutes } from "./routes/internal.js";
@@ -201,6 +202,14 @@ export async function buildApp(
       });
     },
   );
+
+  // The preview hostname reaches the existing API tasks to avoid another
+  // service, but it is not an API origin. Enforce that boundary before any
+  // Facility session is resolved so untrusted preview JavaScript cannot use
+  // the host as an alternate control-plane entrypoint.
+  app.addHook("onRequest", async (request) => {
+    assertPreviewOriginSurface(config, request.headers.host, request.raw.url ?? request.url);
+  });
 
   app.addHook("onRequest", async (request, reply) => {
     reply.header("x-request-id", request.id);

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -29,6 +29,7 @@ const EnvSchema = z
     PORT: z.coerce.number().int().positive().default(4400),
     PUBLIC_URL: z.string().url().default("http://localhost:4400"),
     WEB_URL: z.string().url().optional(),
+    FACILITY_PREVIEW_URL: OptionalUrl,
     SANDBOX_API_URL: z.string().url().optional(),
     GATEWAY_URL: z.string().url().default("http://localhost:4410"),
     SANDBOX_GATEWAY_URL: z.string().url().optional(),
@@ -89,6 +90,51 @@ const EnvSchema = z
         message: "FACILITY_INSECURE_DEV is refused in production",
       });
     }
+    if (env.FACILITY_PREVIEW_URL) {
+      const preview = new URL(env.FACILITY_PREVIEW_URL);
+      if (
+        preview.username ||
+        preview.password ||
+        preview.pathname !== "/" ||
+        preview.search ||
+        preview.hash
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["FACILITY_PREVIEW_URL"],
+          message:
+            "FACILITY_PREVIEW_URL must be an origin without credentials, path, query, or fragment",
+        });
+      }
+    }
+    if (env.NODE_ENV === "production") {
+      if (!env.FACILITY_PREVIEW_URL) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["FACILITY_PREVIEW_URL"],
+          message: "FACILITY_PREVIEW_URL is required in production",
+        });
+      } else {
+        const preview = new URL(env.FACILITY_PREVIEW_URL);
+        const controlHosts = [env.PUBLIC_URL, env.WEB_URL ?? env.PUBLIC_URL, env.MCP_PUBLIC_URL]
+          .filter((value): value is string => Boolean(value))
+          .map((value) => new URL(value).hostname);
+        if (preview.protocol !== "https:") {
+          ctx.addIssue({
+            code: "custom",
+            path: ["FACILITY_PREVIEW_URL"],
+            message: "FACILITY_PREVIEW_URL must use HTTPS in production",
+          });
+        }
+        if (controlHosts.includes(preview.hostname)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["FACILITY_PREVIEW_URL"],
+            message: "FACILITY_PREVIEW_URL must use a host separate from other Facility origins",
+          });
+        }
+      }
+    }
     if (
       env.AUTH_IDENTITY_PROVIDER === "github" &&
       Boolean(env.GITHUB_OAUTH_CLIENT_ID) !== Boolean(env.GITHUB_OAUTH_CLIENT_SECRET)
@@ -132,6 +178,7 @@ export function readConfig(env = process.env): AppConfig {
     port: parsed.PORT,
     publicUrl: parsed.PUBLIC_URL,
     webUrl,
+    previewUrl: parsed.FACILITY_PREVIEW_URL?.replace(/\/$/, ""),
     sandboxApiUrl: parsed.SANDBOX_API_URL ?? parsed.PUBLIC_URL,
     sandboxGatewayUrl: parsed.SANDBOX_GATEWAY_URL ?? parsed.GATEWAY_URL,
     gatewayUrl: parsed.GATEWAY_URL,

--- a/services/api/src/previews.ts
+++ b/services/api/src/previews.ts
@@ -1,12 +1,43 @@
-import { newId } from "@facility/core";
-import { createDb, insertAuditEvent, previewSandboxes } from "@facility/db";
-import { and, eq, inArray, lt } from "drizzle-orm";
+import { newId, open, seal } from "@facility/core";
+import { createDb, insertAuditEvent, previewAccessHandoffs, previewSandboxes } from "@facility/db";
+import { and, eq, gt, inArray, isNull, lt } from "drizzle-orm";
 import { request as upstreamRequest } from "undici";
+import { z } from "zod";
+import { ApiError } from "./errors.js";
 import { previewSandboxDriver, type SandboxDriver, SandboxLaunchError } from "./sandbox/driver.js";
 import type { AppConfig, Principal } from "./types.js";
 
 type Db = ReturnType<typeof createDb>["db"];
 type Preview = typeof previewSandboxes.$inferSelect;
+
+const HandoffTtlMs = 60_000;
+const PreviewSessionTtlMs = 60 * 60_000;
+const PreviewAccessToken = z.discriminatedUnion("kind", [
+  z.object({
+    version: z.literal(1),
+    kind: z.literal("handoff"),
+    handoffId: z.string(),
+    userId: z.string(),
+    orgId: z.string(),
+    projectId: z.string(),
+    previewId: z.string(),
+    expiresAt: z.number().int(),
+  }),
+  z.object({
+    version: z.literal(1),
+    kind: z.literal("preview_session"),
+    userId: z.string(),
+    orgId: z.string(),
+    previewId: z.string(),
+    expiresAt: z.number().int(),
+  }),
+]);
+
+export type PreviewHandoffClaims = Extract<z.infer<typeof PreviewAccessToken>, { kind: "handoff" }>;
+export type PreviewSessionClaims = Extract<
+  z.infer<typeof PreviewAccessToken>,
+  { kind: "preview_session" }
+>;
 
 export type PreviewCreateInput = {
   orgId: string;
@@ -54,6 +85,179 @@ export function assertPreviewProvisioningAvailable(config: AppConfig) {
       "preview_auth_unavailable",
       "Preview provisioning is disabled until interactive authentication is configured",
     );
+  }
+  if (!config.facilityInsecureDev && !isolatedPreviewOrigin(config)) {
+    throw previewError(
+      503,
+      "preview_origin_unavailable",
+      "Preview provisioning is disabled until an isolated preview origin is configured",
+    );
+  }
+}
+
+export function isolatedPreviewOrigin(config: AppConfig) {
+  if (!config.previewUrl) return false;
+  const preview = new URL(config.previewUrl);
+  return [config.publicUrl, config.webUrl ?? config.publicUrl, config.mcpPublicUrl]
+    .filter((value): value is string => Boolean(value))
+    .every((value) => new URL(value).hostname !== preview.hostname);
+}
+
+export function assertPreviewOriginSurface(
+  config: AppConfig,
+  rawHost: string | undefined,
+  rawPath: string,
+) {
+  if (!isolatedPreviewOrigin(config) || !config.previewUrl) return;
+  const requestHost = hostname(rawHost);
+  const previewHost = new URL(config.previewUrl).hostname.toLowerCase();
+  const path = rawPath.split("?", 1)[0] ?? "/";
+  const servesPreview = /^\/(?:preview|preview-auth)\//.test(path);
+  if (requestHost === previewHost ? !servesPreview : servesPreview) {
+    throw previewError(404, "not_found", "Route not found");
+  }
+}
+
+export async function mintPreviewHandoff(
+  db: Db,
+  config: AppConfig,
+  input: { userId: string; orgId: string; projectId: string; previewId: string },
+  now = Date.now(),
+) {
+  const claims: PreviewHandoffClaims = {
+    version: 1,
+    kind: "handoff",
+    handoffId: newId("pvh"),
+    ...input,
+    expiresAt: now + HandoffTtlMs,
+  };
+  await db.insert(previewAccessHandoffs).values({
+    id: claims.handoffId,
+    orgId: claims.orgId,
+    projectId: claims.projectId,
+    previewId: claims.previewId,
+    userId: claims.userId,
+    expiresAt: new Date(claims.expiresAt),
+  });
+  return seal(JSON.stringify(claims), config.secretMasterKey);
+}
+
+export async function readPreviewHandoff(
+  config: AppConfig,
+  token: string,
+  previewId: string,
+  now = Date.now(),
+) {
+  const claims = await readPreviewToken(config, token, now);
+  if (claims.kind !== "handoff" || claims.previewId !== previewId) {
+    throw invalidPreviewAccess();
+  }
+  return claims;
+}
+
+export async function consumePreviewHandoff(
+  db: Db,
+  claims: PreviewHandoffClaims,
+  now = new Date(),
+) {
+  const consumed = (
+    await db
+      .update(previewAccessHandoffs)
+      .set({ consumedAt: now })
+      .where(
+        and(
+          eq(previewAccessHandoffs.id, claims.handoffId),
+          eq(previewAccessHandoffs.orgId, claims.orgId),
+          eq(previewAccessHandoffs.projectId, claims.projectId),
+          eq(previewAccessHandoffs.previewId, claims.previewId),
+          eq(previewAccessHandoffs.userId, claims.userId),
+          isNull(previewAccessHandoffs.consumedAt),
+          gt(previewAccessHandoffs.expiresAt, now),
+        ),
+      )
+      .returning({ id: previewAccessHandoffs.id })
+  )[0];
+  if (!consumed) throw invalidPreviewAccess();
+}
+
+export async function mintPreviewSession(
+  config: AppConfig,
+  input: { userId: string; orgId: string; previewId: string },
+  now = Date.now(),
+) {
+  const claims: PreviewSessionClaims = {
+    version: 1,
+    kind: "preview_session",
+    ...input,
+    expiresAt: now + PreviewSessionTtlMs,
+  };
+  return seal(JSON.stringify(claims), config.secretMasterKey);
+}
+
+export async function readPreviewSession(
+  config: AppConfig,
+  token: string,
+  previewId: string,
+  now = Date.now(),
+) {
+  const claims = await readPreviewToken(config, token, now);
+  if (claims.kind !== "preview_session" || claims.previewId !== previewId) {
+    throw invalidPreviewAccess();
+  }
+  return claims;
+}
+
+export function previewCookieName(previewId: string) {
+  if (!/^[A-Za-z0-9_-]+$/.test(previewId)) throw invalidPreviewAccess();
+  return `facility_preview_${previewId}`;
+}
+
+export function previewCookieOptions(config: AppConfig, previewId: string) {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: config.previewUrl?.startsWith("https://") ?? false,
+    path: `/preview/${encodeURIComponent(previewId)}`,
+    maxAge: PreviewSessionTtlMs / 1000,
+  };
+}
+
+export function previewAccessUrl(config: AppConfig, projectId: string, previewId: string) {
+  const controlUrl = new URL(config.webUrl ?? config.publicUrl);
+  const apiUrl = new URL(config.publicUrl);
+  const throughWebProxy = controlUrl.origin !== apiUrl.origin;
+  controlUrl.pathname = `${throughWebProxy ? "/api" : ""}/v1/projects/${encodeURIComponent(
+    projectId,
+  )}/previews/${encodeURIComponent(previewId)}/open`;
+  controlUrl.search = "";
+  controlUrl.hash = "";
+  return controlUrl.toString();
+}
+
+async function readPreviewToken(config: AppConfig, token: string, now: number) {
+  try {
+    if (!token || Buffer.from(token, "base64").toString("base64") !== token) {
+      throw invalidPreviewAccess();
+    }
+    const claims = PreviewAccessToken.parse(JSON.parse(await open(token, config.secretMasterKey)));
+    if (claims.expiresAt <= now) throw invalidPreviewAccess();
+    return claims;
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    throw invalidPreviewAccess();
+  }
+}
+
+function invalidPreviewAccess() {
+  return previewError(401, "preview_access_invalid", "Preview access is invalid or expired");
+}
+
+function hostname(rawHost: string | undefined) {
+  if (!rawHost) return "";
+  try {
+    return new URL(`http://${rawHost}`).hostname.toLowerCase();
+  } catch {
+    return "";
   }
 }
 
@@ -260,6 +464,7 @@ export async function reconcilePreviews(config: AppConfig, driverOverride?: Sand
   const { db, client } = createDb(config.databaseUrl);
   const changed: string[] = [];
   try {
+    await db.delete(previewAccessHandoffs).where(lt(previewAccessHandoffs.expiresAt, new Date()));
     const expired = await db
       .select()
       .from(previewSandboxes)
@@ -474,5 +679,5 @@ function record(value: unknown): Record<string, unknown> {
 }
 
 function previewError(statusCode: number, code: string, message: string) {
-  return Object.assign(new Error(message), { statusCode, code });
+  return new ApiError(statusCode, code, message);
 }

--- a/services/api/src/routes/v1/previews.ts
+++ b/services/api/src/routes/v1/previews.ts
@@ -1,4 +1,5 @@
-import { previewSandboxes, repos, runs } from "@facility/db";
+import { can } from "@facility/core";
+import { orgMembers, previewSandboxes, repos, roles, runs, users } from "@facility/db";
 import { and, desc, eq } from "drizzle-orm";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
@@ -6,15 +7,25 @@ import { ApiError, notFound } from "../../errors.js";
 import {
   assertPreviewProvisioningAvailable,
   assertPreviewSession,
+  consumePreviewHandoff,
   createPreviewRecord,
   destroyPreview,
+  mintPreviewHandoff,
+  mintPreviewSession,
+  previewAccessUrl,
+  previewCookieName,
+  previewCookieOptions,
   proxyPreviewRequest,
+  readPreviewHandoff,
+  readPreviewSession,
   rewritePreviewHtml,
 } from "../../previews.js";
+import type { AppConfig } from "../../types.js";
 import type { V1RouteContext } from "./shared.js";
 
 const PreviewParams = z.object({ projectId: z.string(), previewId: z.string().optional() });
 const PublicPreviewParams = z.object({ previewId: z.string(), "*": z.string().optional() });
+const PreviewHandoffQuery = z.object({ handoff: z.string().min(1) });
 const PreviewCreate = z.object({
   repoId: z.string().optional(),
   runId: z.string().optional(),
@@ -80,7 +91,7 @@ export async function registerPreviewRoutes(
           ),
         )
         .orderBy(desc(previewSandboxes.createdAt));
-      return rows.map((row) => present(row, config.publicUrl));
+      return rows.map((row) => present(row, config));
     },
   );
 
@@ -153,7 +164,7 @@ export async function registerPreviewRoutes(
       });
       if (!preview) throw new ApiError(500, "preview_create_failed", "Preview was not created");
       await app.enqueue("previews.provision", { previewId: preview.id });
-      return reply.status(202).send(present(preview, config.publicUrl));
+      return reply.status(202).send(present(preview, config));
     },
   );
 
@@ -184,26 +195,87 @@ export async function registerPreviewRoutes(
       const destroyed = await destroyPreview(db, preview);
       if (!destroyed)
         throw new ApiError(500, "preview_destroy_failed", "Preview was not destroyed");
-      return present(destroyed, config.publicUrl);
+      return present(destroyed, config);
+    },
+  );
+
+  app.get(
+    "/v1/projects/:projectId/previews/:previewId/open",
+    {
+      config: { permission: "runs:read" },
+      schema: { params: PreviewParams },
+    },
+    async (request, reply) => {
+      assertPreviewSession(config, request.principal);
+      const principal = request.principal;
+      if (!principal?.userId) throw new ApiError(401, "unauthorized", "Authentication required");
+      const { projectId, previewId } = request.params as z.infer<typeof PreviewParams>;
+      const preview = (
+        await db
+          .select()
+          .from(previewSandboxes)
+          .where(
+            and(
+              eq(previewSandboxes.orgId, principal.orgId),
+              eq(previewSandboxes.projectId, projectId),
+              eq(previewSandboxes.id, previewId ?? ""),
+            ),
+          )
+          .limit(1)
+      )[0];
+      if (!preview) throw notFound("Preview");
+      if (preview.status !== "running") {
+        throw new ApiError(409, "preview_not_running", "Preview environment is not running");
+      }
+      const handoff = await mintPreviewHandoff(db, config, {
+        userId: principal.userId,
+        orgId: principal.orgId,
+        projectId,
+        previewId: preview.id,
+      });
+      await request.audit("preview.opened", { type: "preview", id: preview.id });
+      const previewUrl = new URL(config.previewUrl ?? config.publicUrl);
+      previewUrl.pathname = `/preview-auth/${encodeURIComponent(preview.id)}`;
+      previewUrl.search = new URLSearchParams({ handoff }).toString();
+      reply.header("cache-control", "no-store");
+      reply.header("referrer-policy", "no-referrer");
+      return reply.redirect(previewUrl.toString());
+    },
+  );
+
+  app.get(
+    "/preview-auth/:previewId",
+    {
+      config: { public: true },
+      schema: { params: PublicPreviewParams, querystring: PreviewHandoffQuery },
+    },
+    async (request, reply) => {
+      const { previewId } = request.params as z.infer<typeof PublicPreviewParams>;
+      const { handoff } = request.query as z.infer<typeof PreviewHandoffQuery>;
+      const claims = await readPreviewHandoff(config, handoff, previewId);
+      await loadAuthorizedPreview(db, claims, previewId, claims.projectId);
+      await consumePreviewHandoff(db, claims);
+      const previewSession = await mintPreviewSession(config, {
+        userId: claims.userId,
+        orgId: claims.orgId,
+        previewId,
+      });
+      reply.setCookie(
+        previewCookieName(previewId),
+        previewSession,
+        previewCookieOptions(config, previewId),
+      );
+      reply.header("cache-control", "no-store");
+      reply.header("referrer-policy", "no-referrer");
+      return reply.redirect(`/preview/${encodeURIComponent(previewId)}/`);
     },
   );
 
   const proxy = async (request: FastifyRequest, reply: FastifyReply) => {
-    assertPreviewSession(config, request.principal);
     const { previewId } = request.params as { previewId: string; "*"?: string };
-    const preview = (
-      await db
-        .select()
-        .from(previewSandboxes)
-        .where(
-          and(
-            eq(previewSandboxes.orgId, request.principal?.orgId ?? ""),
-            eq(previewSandboxes.id, previewId),
-          ),
-        )
-        .limit(1)
-    )[0];
-    if (!preview) throw notFound("Preview");
+    const token = request.cookies[previewCookieName(previewId)] ?? "";
+    const claims = await readPreviewSession(config, token, previewId);
+    const preview = await loadAuthorizedPreview(db, claims, previewId);
     const upstream = await proxyPreviewRequest(
       preview,
       (request.params as { "*"?: string })["*"] ?? "",
@@ -211,6 +283,8 @@ export async function registerPreviewRoutes(
       request.headers,
     );
     reply.status(upstream.statusCode);
+    reply.header("referrer-policy", "no-referrer");
+    reply.header("x-content-type-options", "nosniff");
     for (const name of ["content-type", "cache-control", "etag", "last-modified"]) {
       const value = upstream.headers[name];
       if (value) reply.header(name, value);
@@ -236,7 +310,7 @@ export async function registerPreviewRoutes(
         method,
         url,
         exposeHeadRoute: false,
-        config: { permission: "runs:read" },
+        config: { public: true },
         schema: {
           params: PublicPreviewParams,
           operationId: `${method.toLowerCase()}ProtectedPreview${suffix}`,
@@ -262,12 +336,56 @@ function rewritePreviewLocation(location: string, preview: typeof previewSandbox
   return location;
 }
 
-function present(preview: typeof previewSandboxes.$inferSelect, publicUrl: string) {
+async function loadAuthorizedPreview(
+  db: V1RouteContext["db"],
+  claims: { userId: string; orgId: string },
+  previewId: string,
+  projectId?: string,
+) {
+  const preview = (
+    await db
+      .select()
+      .from(previewSandboxes)
+      .where(
+        and(
+          eq(previewSandboxes.id, previewId),
+          eq(previewSandboxes.orgId, claims.orgId),
+          ...(projectId ? [eq(previewSandboxes.projectId, projectId)] : []),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (!preview) throw notFound("Preview");
+  const membership = (
+    await db
+      .select({ permissions: roles.permissions })
+      .from(orgMembers)
+      .innerJoin(roles, eq(orgMembers.roleId, roles.id))
+      .innerJoin(users, eq(orgMembers.userId, users.id))
+      .where(
+        and(
+          eq(orgMembers.orgId, claims.orgId),
+          eq(orgMembers.userId, claims.userId),
+          eq(users.status, "active"),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (!membership || !can(membership.permissions, "runs:read")) {
+    throw new ApiError(403, "preview_access_revoked", "Preview access has been revoked");
+  }
+  if (preview.status !== "running") {
+    throw new ApiError(409, "preview_not_running", "Preview environment is not running");
+  }
+  return preview;
+}
+
+function present(preview: typeof previewSandboxes.$inferSelect, config: AppConfig) {
   return {
     ...preview,
     originUrl: undefined,
     authMode: "facility_session" as const,
     config: (preview.config ?? {}) as Record<string, unknown>,
-    url: `${publicUrl.replace(/\/$/, "")}/preview/${encodeURIComponent(preview.id)}/`,
+    url: previewAccessUrl(config, preview.projectId, preview.id),
   };
 }

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -53,7 +53,11 @@ import {
   syncSecurityFindings,
 } from "../github/security-findings.js";
 import { harnessFragmentForBundle, validateProjectKb } from "../harness.js";
-import { assertPreviewProvisioningAvailable, createPreviewRecord } from "../previews.js";
+import {
+  assertPreviewProvisioningAvailable,
+  createPreviewRecord,
+  previewAccessUrl,
+} from "../previews.js";
 import type { AppConfig } from "../types.js";
 import { raisePlatformIssue } from "../watchtower/issues.js";
 import { nestedDockerEnabled, provisioningDepth } from "./capabilities.js";
@@ -1085,7 +1089,7 @@ async function requestConfiguredPreview(
   });
   if (!created) throw new Error("preview_record_create_failed");
   await deps.enqueue("previews.provision", { previewId: created.id });
-  const previewUrl = `${config.publicUrl.replace(/\/$/, "")}/preview/${created.id}/`;
+  const previewUrl = previewAccessUrl(config, created.projectId, created.id);
   await github
     .createIssueComment(
       prNumber,

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -20,6 +20,10 @@ export type AppConfig = {
   port: number;
   publicUrl: string;
   webUrl?: string;
+  // Browser origin used only for proxied preview application content. In
+  // production this must be HTTPS on a host separate from every control-plane
+  // hostname so untrusted preview JavaScript never receives Facility cookies.
+  previewUrl?: string;
   // URLs a sandbox uses to reach back — distinct from publicUrl because a
   // container cannot resolve the host's "localhost". Default to the public
   // URLs; override (e.g. host.docker.internal) for the local docker driver.

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -291,7 +291,7 @@ describe("api", async () => {
             : 0),
         0,
       ),
-    ).toBe(135);
+    ).toBe(136);
     expect(document.paths["/v1/projects"]?.get?.security).toEqual([
       { bearerAuth: [] },
       { sessionCookie: [] },
@@ -308,6 +308,12 @@ describe("api", async () => {
       expect.objectContaining({ name: "Idempotency-Key", in: "header" }),
     );
     expect(document.paths["/health"]?.get?.security).toEqual([]);
+    expect(
+      document.paths["/v1/projects/{projectId}/previews/{previewId}/open"]?.get?.[
+        "x-facility-permission"
+      ],
+    ).toBe("runs:read");
+    expect(document.paths["/preview-auth/{previewId}"]?.get?.security).toEqual([]);
     expect(document.paths["/v1/runs/{runId}/kb-checkpoint"]?.post?.security).toEqual([
       { runnerToken: [] },
     ]);

--- a/services/api/test/config.test.ts
+++ b/services/api/test/config.test.ts
@@ -29,6 +29,54 @@ describe("API configuration", () => {
     ).toThrow("FACILITY_INSECURE_DEV is refused in production");
   });
 
+  it("requires an isolated HTTPS preview origin in production", () => {
+    expect(() => readConfig({ ...validEnv, NODE_ENV: "production" })).toThrow(
+      "FACILITY_PREVIEW_URL is required in production",
+    );
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        NODE_ENV: "production",
+        FACILITY_PREVIEW_URL: "http://previews.example.net",
+      }),
+    ).toThrow("FACILITY_PREVIEW_URL must use HTTPS in production");
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        NODE_ENV: "production",
+        PUBLIC_URL: "https://api.example.com",
+        WEB_URL: "https://app.example.com",
+        FACILITY_PREVIEW_URL: "https://app.example.com/previews",
+      }),
+    ).toThrow("FACILITY_PREVIEW_URL must use a host separate from other Facility origins");
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        NODE_ENV: "production",
+        PUBLIC_URL: "https://api.example.com",
+        MCP_PUBLIC_URL: "https://facility-previews.example.net",
+        FACILITY_PREVIEW_URL: "https://facility-previews.example.net",
+      }),
+    ).toThrow("FACILITY_PREVIEW_URL must use a host separate from other Facility origins");
+    expect(
+      readConfig({
+        ...validEnv,
+        NODE_ENV: "production",
+        PUBLIC_URL: "https://api.example.com",
+        WEB_URL: "https://app.example.com",
+        FACILITY_PREVIEW_URL: "https://facility-previews.example.net/",
+      }),
+    ).toMatchObject({ previewUrl: "https://facility-previews.example.net" });
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        FACILITY_PREVIEW_URL: "https://user:secret@facility-previews.example.net/base?x=1",
+      }),
+    ).toThrow(
+      "FACILITY_PREVIEW_URL must be an origin without credentials, path, query, or fragment",
+    );
+  });
+
   it("requires direct GitHub client credentials as a pair", () => {
     expect(() => readConfig({ ...validEnv, GITHUB_OAUTH_CLIENT_ID: "client" })).toThrow(
       "GitHub OAuth client id and secret must be configured together",

--- a/services/api/test/github-platform-lane.test.ts
+++ b/services/api/test/github-platform-lane.test.ts
@@ -2892,7 +2892,7 @@ describe("github platform lane", async () => {
       queue: "previews.provision",
       data: { previewId: preview?.id },
     });
-    expect(comments.some((body) => body.includes(`/preview/${preview?.id}/`))).toBe(true);
+    expect(comments.some((body) => body.includes(`/previews/${preview?.id}/open`))).toBe(true);
     expect(comments.some((body) => body.includes("organization SSO"))).toBe(true);
   });
 

--- a/services/api/test/preview-access.test.ts
+++ b/services/api/test/preview-access.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertPreviewOriginSurface,
+  mintPreviewSession,
+  previewCookieName,
+  previewCookieOptions,
+  readPreviewSession,
+} from "../src/previews.js";
+import type { AppConfig } from "../src/types.js";
+
+const config: AppConfig = {
+  databaseUrl: "postgres://facility:facility@localhost:5432/facility",
+  secretMasterKey: Buffer.alloc(32, 19).toString("base64"),
+  port: 4400,
+  publicUrl: "https://api.example.com",
+  webUrl: "https://app.example.com",
+  previewUrl: "https://facility-previews.example.net",
+  sandboxApiUrl: "https://api.example.com",
+  sandboxGatewayUrl: "https://gateway.example.com",
+  gatewayUrl: "https://gateway.example.com",
+  sandboxRunnerImage: "facility-runner:dev",
+  sandboxDriver: "docker",
+  facilityInsecureDev: false,
+  logLevel: "silent",
+};
+
+describe("isolated preview access", () => {
+  it("binds preview sessions to one preview and rejects expiry, tampering, and another key", async () => {
+    const now = Date.now();
+    const token = await mintPreviewSession(
+      config,
+      { userId: "user_1", orgId: "org_1", previewId: "sbx_1" },
+      now,
+    );
+    await expect(readPreviewSession(config, token, "sbx_1", now)).resolves.toMatchObject({
+      userId: "user_1",
+      orgId: "org_1",
+      previewId: "sbx_1",
+    });
+    await expect(readPreviewSession(config, token, "sbx_2", now)).rejects.toMatchObject({
+      code: "preview_access_invalid",
+      statusCode: 401,
+    });
+    await expect(
+      readPreviewSession(config, token, "sbx_1", now + 60 * 60_000),
+    ).rejects.toMatchObject({ code: "preview_access_invalid", statusCode: 401 });
+    await expect(readPreviewSession(config, `${token}x`, "sbx_1", now)).rejects.toMatchObject({
+      code: "preview_access_invalid",
+      statusCode: 401,
+    });
+    await expect(
+      readPreviewSession(
+        { ...config, secretMasterKey: Buffer.alloc(32, 20).toString("base64") },
+        token,
+        "sbx_1",
+        now,
+      ),
+    ).rejects.toMatchObject({ code: "preview_access_invalid", statusCode: 401 });
+  });
+
+  it("uses a host-only, HttpOnly, per-preview cookie", () => {
+    expect(previewCookieName("sbx_abc")).toBe("facility_preview_sbx_abc");
+    expect(previewCookieOptions(config, "sbx_abc")).toEqual({
+      httpOnly: true,
+      sameSite: "lax",
+      secure: true,
+      path: "/preview/sbx_abc",
+      maxAge: 3600,
+    });
+    expect(
+      previewCookieOptions({ ...config, previewUrl: "http://preview.localhost:4400" }, "sbx_abc"),
+    ).toMatchObject({ secure: false });
+    expect(() => previewCookieName("../control")).toThrow("Preview access is invalid or expired");
+  });
+
+  it("enforces the two-sided host boundary before authentication", () => {
+    expect(() =>
+      assertPreviewOriginSurface(config, "facility-previews.example.net", "/preview/sbx_1/"),
+    ).not.toThrow();
+    expect(() =>
+      assertPreviewOriginSurface(
+        config,
+        "facility-previews.example.net:443",
+        "/preview-auth/sbx_1?handoff=sealed",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertPreviewOriginSurface(config, "facility-previews.example.net", "/v1/me"),
+    ).toThrowError(expect.objectContaining({ code: "not_found", statusCode: 404 }));
+    expect(() =>
+      assertPreviewOriginSurface(config, "app.example.com", "/preview/sbx_1/"),
+    ).toThrowError(expect.objectContaining({ code: "not_found", statusCode: 404 }));
+    expect(() =>
+      assertPreviewOriginSurface(config, "internal-api", "/preview/sbx_1/"),
+    ).toThrowError(expect.objectContaining({ code: "not_found", statusCode: 404 }));
+    expect(() => assertPreviewOriginSurface(config, "internal-api", "/health")).not.toThrow();
+  });
+});

--- a/services/api/test/previews.test.ts
+++ b/services/api/test/previews.test.ts
@@ -1,7 +1,17 @@
 import { createServer } from "node:http";
 import { newId } from "@facility/core";
-import { createDb, migrate, previewSandboxes, projects, seed } from "@facility/db";
-import { eq } from "drizzle-orm";
+import {
+  auditEvents,
+  createDb,
+  migrate,
+  orgMembers,
+  previewSandboxes,
+  projects,
+  roles,
+  seed,
+  users,
+} from "@facility/db";
+import { and, eq } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../src/app.js";
@@ -9,6 +19,9 @@ import {
   assertPreviewSession,
   createPreviewRecord,
   destroyPreview,
+  mintPreviewHandoff,
+  mintPreviewSession,
+  previewCookieName,
   provisionPreview,
   proxyPreviewRequest,
   reconcilePreviews,
@@ -44,6 +57,8 @@ describe("SSO-protected preview sandboxes", async () => {
     secretMasterKey: Buffer.alloc(32, 15).toString("base64"),
     port: 4416,
     publicUrl: "http://facility.test",
+    webUrl: "http://app.test",
+    previewUrl: "http://facility-previews.test",
     sandboxApiUrl: "http://127.0.0.1:0",
     sandboxGatewayUrl: "http://127.0.0.1:0",
     gatewayUrl: "http://localhost:4410",
@@ -57,6 +72,7 @@ describe("SSO-protected preview sandboxes", async () => {
   let orgId = "";
   let projectId = "";
   let cookie = "";
+  let userId = "";
 
   beforeAll(async () => {
     await migrate(databaseUrl);
@@ -68,6 +84,7 @@ describe("SSO-protected preview sandboxes", async () => {
       payload: { email: `preview-${Date.now()}@example.com` },
     });
     orgId = login.json().orgId;
+    userId = login.json().userId;
     cookie = login.cookies.map((item) => `${item.name}=${item.value}`).join("; ");
     projectId =
       (
@@ -169,25 +186,104 @@ describe("SSO-protected preview sandboxes", async () => {
       expect(row).toMatchObject({
         status: "running",
         authMode: "facility_session",
-        url: `http://facility.test/preview/${preview.id}/`,
+        url: `http://app.test/api/v1/projects/${projectId}/previews/${preview.id}/open`,
       });
       expect(row).not.toHaveProperty("originUrl");
-      const anonymous = await app.inject({
+      const anonymousOpen = await app.inject({
+        method: "GET",
+        url: `/v1/projects/${projectId}/previews/${preview.id}/open`,
+        headers: { host: "facility.test" },
+      });
+      expect(anonymousOpen.statusCode).toBe(401);
+      const controlOrigin = await app.inject({
         method: "GET",
         url: `/preview/${preview.id}/`,
+        headers: { host: "facility.test", cookie },
       });
-      expect(anonymous.statusCode).toBe(401);
+      expect(controlOrigin.statusCode).toBe(404);
+      const opened = await app.inject({
+        method: "GET",
+        url: `/v1/projects/${projectId}/previews/${preview.id}/open`,
+        headers: { host: "facility.test", cookie },
+      });
+      expect(opened.statusCode).toBe(302);
+      expect(opened.headers["cache-control"]).toBe("no-store");
+      expect(opened.headers["referrer-policy"]).toBe("no-referrer");
+      const handoffUrl = new URL(String(opened.headers.location));
+      expect(handoffUrl.origin).toBe("http://facility-previews.test");
+      const consumed = await app.inject({
+        method: "GET",
+        url: `${handoffUrl.pathname}${handoffUrl.search}`,
+        headers: { host: "facility-previews.test" },
+      });
+      expect(consumed.statusCode).toBe(302);
+      expect(consumed.headers.location).toBe(`/preview/${preview.id}/`);
+      const previewCookie = consumed.cookies.map((item) => `${item.name}=${item.value}`).join("; ");
+      expect(consumed.cookies[0]).toMatchObject({
+        name: previewCookieName(preview.id),
+        httpOnly: true,
+        sameSite: "Lax",
+        path: `/preview/${preview.id}`,
+      });
+      const replayed = await app.inject({
+        method: "GET",
+        url: `${handoffUrl.pathname}${handoffUrl.search}`,
+        headers: { host: "facility-previews.test" },
+      });
+      expect(replayed.statusCode).toBe(401);
+      const facilitySessionOnly = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: { host: "facility-previews.test", cookie },
+      });
+      expect(facilitySessionOnly.statusCode).toBe(401);
+      const malformedPreviewSession = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: {
+          host: "facility-previews.test",
+          cookie: `${previewCookieName(preview.id)}=not-a-sealed-token`,
+        },
+      });
+      expect(malformedPreviewSession.statusCode).toBe(401);
+      const expiredPreviewToken = await mintPreviewSession(
+        config,
+        { userId, orgId, previewId: preview.id },
+        Date.now() - 60 * 60_000,
+      );
+      const expiredPreviewSession = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: {
+          host: "facility-previews.test",
+          cookie: `${previewCookieName(preview.id)}=${expiredPreviewToken}`,
+        },
+      });
+      expect(expiredPreviewSession.statusCode).toBe(401);
+      const expiredHandoff = await mintPreviewHandoff(
+        db,
+        config,
+        { userId, orgId, projectId, previewId: preview.id },
+        Date.now() - 60_001,
+      );
+      const expiredConsume = await app.inject({
+        method: "GET",
+        url: `/preview-auth/${preview.id}?${new URLSearchParams({ handoff: expiredHandoff })}`,
+        headers: { host: "facility-previews.test" },
+      });
+      expect(expiredConsume.statusCode).toBe(401);
       const authenticated = await app.inject({
         method: "GET",
         url: `/preview/${preview.id}/`,
-        headers: { cookie },
+        headers: { host: "facility-previews.test", cookie: previewCookie },
       });
       expect(authenticated.statusCode).toBe(200);
       expect(authenticated.body).toContain(`/preview/${preview.id}/docs`);
+      expect(authenticated.headers["referrer-policy"]).toBe("no-referrer");
       const redirected = await app.inject({
         method: "GET",
         url: `/preview/${preview.id}/redirect`,
-        headers: { cookie },
+        headers: { host: "facility-previews.test", cookie: previewCookie },
       });
       expect(redirected.statusCode).toBe(302);
       expect(redirected.headers.location).toBe(`/preview/${preview.id}/docs`);
@@ -209,11 +305,90 @@ describe("SSO-protected preview sandboxes", async () => {
       await absolutePath.body.dump();
       expect(requestedPath).toBe("/http://203.0.113.1/should-stay-on-preview-origin");
 
+      const crossTenantToken = await mintPreviewSession(config, {
+        userId,
+        orgId: "org_not_the_preview_owner",
+        previewId: preview.id,
+      });
+      const crossTenant = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: {
+          host: "facility-previews.test",
+          cookie: `${previewCookieName(preview.id)}=${crossTenantToken}`,
+        },
+      });
+      expect(crossTenant.statusCode).toBe(404);
+
+      await db.update(users).set({ status: "inactive" }).where(eq(users.id, userId));
+      const deactivated = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: { host: "facility-previews.test", cookie: previewCookie },
+      });
+      expect(deactivated.statusCode).toBe(403);
+      await db.update(users).set({ status: "active" }).where(eq(users.id, userId));
+
+      const member = (
+        await db
+          .select({ roleId: orgMembers.roleId })
+          .from(orgMembers)
+          .where(and(eq(orgMembers.orgId, orgId), eq(orgMembers.userId, userId)))
+          .limit(1)
+      )[0];
+      if (!member) throw new Error("preview member missing");
+      const originalRole = (
+        await db
+          .select({ permissions: roles.permissions })
+          .from(roles)
+          .where(eq(roles.id, member.roleId))
+      )[0];
+      await db
+        .update(roles)
+        .set({ permissions: ["projects:read"] })
+        .where(eq(roles.id, member.roleId));
+      const permissionRevoked = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: { host: "facility-previews.test", cookie: previewCookie },
+      });
+      expect(permissionRevoked.statusCode).toBe(403);
+      await db
+        .update(roles)
+        .set({ permissions: originalRole?.permissions ?? ["*"] })
+        .where(eq(roles.id, member.roleId));
+
+      const openedAudit = (
+        await db
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.orgId, orgId), eq(auditEvents.action, "preview.opened")))
+          .limit(1)
+      )[0];
+      expect(openedAudit?.target).toEqual({ type: "preview", id: preview.id });
+
+      const corsProbe = await app.inject({
+        method: "OPTIONS",
+        url: "/v1/me",
+        headers: {
+          host: "facility.test",
+          origin: "http://facility-previews.test",
+          "access-control-request-method": "GET",
+        },
+      });
+      expect(corsProbe.headers["access-control-allow-origin"]).toBeUndefined();
+
       const destroyed = await destroyPreview(db, stored, "destroyed", driver);
       expect(destroyed?.status).toBe("destroyed");
       expect(destroyed?.ref).toBeNull();
       expect(destroyed?.originUrl).toBeNull();
       expect(destroyedRef).toBe("preview-container");
+      const destroyedAccess = await app.inject({
+        method: "GET",
+        url: `/preview/${preview.id}/`,
+        headers: { host: "facility-previews.test", cookie: previewCookie },
+      });
+      expect(destroyedAccess.statusCode).toBe(409);
 
       const retryable = await createPreviewRecord(db, {
         orgId,


### PR DESCRIPTION
## What changes

- Serves untrusted preview applications from a dedicated preview origin while reusing the existing API ECS service and target group; no new runtime service is added.
- Adds a 60-second, single-use sealed access handoff that becomes a host-only, HttpOnly, per-preview cookie. Every proxied request rechecks the user, organisation membership, runs:read permission, tenant, and preview status.
- Rejects preview routes on control-plane hosts and control routes on the preview host before principal resolution. The Facility session cookie is never accepted as preview-host authentication.
- Adds AWS ALB/DNS inputs for preview_hostname, Docker/local defaults, generated OpenAPI and SDK contracts, migration cleanup, documentation, and regression coverage.

Stacked on #85. Retarget to main and rerun current-SHA CI after #83, #84, and #85 merge.

BREAKING CHANGE: Production deployments must configure FACILITY_PREVIEW_URL on a separate HTTPS host. AWS Terraform users must set preview_hostname with matching DNS and certificate coverage.

## Why

Preview HTML and JavaScript previously shared the Facility control-plane origin, allowing untrusted application code to run in the same browser origin as authenticated Facility UI/API traffic. The dedicated origin creates the required browser security boundary without increasing the number of services.

## Verification

- [x] pnpm verify passes locally: lint 349 files; typecheck 16/16; clean build 10/10; DB 9; CLI 67; API 330; gateway 37; repository scripts 89; SDK 23; runner 122; remaining suites, guards 2/2, and dependency audit all pass.
- [x] Behaviour verified beyond the test suite: deterministic integration tests cover successful exchange, replay, malformed, expired, revoked, unauthenticated, forbidden, and cross-tenant access; Terraform fmt -check and validate pass.
- [x] Documentation updated for local and AWS deployment, hostname isolation, TLS, DNS, cookies, and CORS.

Claude Opus high independently reviewed the design and final authored diff, then reviewed the verifier-discovered SDK manifest correction. Final verdict: unconditional APPROVE.