### PR TITLE
fix(test): recreate critical test databases

### DIFF
--- a/scripts/verify-test-databases.mjs
+++ b/scripts/verify-test-databases.mjs
@@ -1,0 +1,45 @@
+export const DEV_COMPOSE = ["compose", "-f", "docker-compose.dev.yml"];
+export const TEST_DATABASES = ["facility_test", "facility_gw"];
+
+export function recreateTestDatabase(name, execute) {
+  if (!TEST_DATABASES.includes(name)) {
+    throw new Error(`Refusing to recreate non-test database: ${name}`);
+  }
+
+  execute("docker", [
+    ...DEV_COMPOSE,
+    "exec",
+    "-T",
+    "postgres",
+    "psql",
+    "-U",
+    "facility",
+    "-d",
+    "postgres",
+    "-v",
+    "ON_ERROR_STOP=1",
+    "-c",
+    `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${name}' AND pid <> pg_backend_pid()`,
+  ]);
+  execute("docker", [
+    ...DEV_COMPOSE,
+    "exec",
+    "-T",
+    "postgres",
+    "dropdb",
+    "-U",
+    "facility",
+    "--if-exists",
+    name,
+  ]);
+  execute("docker", [
+    ...DEV_COMPOSE,
+    "exec",
+    "-T",
+    "postgres",
+    "createdb",
+    "-U",
+    "facility",
+    name,
+  ]);
+}

--- a/scripts/verify-test-databases.test.mjs
+++ b/scripts/verify-test-databases.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { recreateTestDatabase, TEST_DATABASES } from "./verify-test-databases.mjs";
+
+test("verification recreates each allowlisted disposable database", () => {
+  for (const database of TEST_DATABASES) {
+    const calls = [];
+    recreateTestDatabase(database, (command, args) => calls.push([command, args]));
+
+    assert.equal(calls.length, 3);
+    assert.match(calls[0][1].at(-1), new RegExp(`datname = '${database}'`));
+    assert.deepEqual(calls[1][1].slice(-4), ["-U", "facility", "--if-exists", database]);
+    assert.deepEqual(calls[2][1].slice(-3), ["-U", "facility", database]);
+  }
+});
+
+test("verification refuses to recreate arbitrary databases", () => {
+  assert.throws(
+    () => recreateTestDatabase("facility", () => assert.fail("must fail before executing")),
+    /Refusing to recreate non-test database/,
+  );
+});

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import {
+  DEV_COMPOSE,
+  TEST_DATABASES,
+  recreateTestDatabase,
+} from "./verify-test-databases.mjs";
 
-const compose = ["compose", "-f", "docker-compose.dev.yml"];
-const wasRunning = output("docker", [...compose, "ps", "--status", "running", "-q", "postgres"]).trim();
+const wasRunning = output("docker", [
+  ...DEV_COMPOSE,
+  "ps",
+  "--status",
+  "running",
+  "-q",
+  "postgres",
+]).trim();
 let startedPostgres = false;
 
 try {
@@ -12,44 +23,28 @@ try {
   step("Clean workspace build (Turbo cache disabled)", "pnpm", ["build:clean"]);
 
   if (!wasRunning) {
-    step("Start isolated test Postgres", "docker", [...compose, "up", "-d", "--wait", "postgres"]);
+    step("Start isolated test Postgres", "docker", [
+      ...DEV_COMPOSE,
+      "up",
+      "-d",
+      "--wait",
+      "postgres",
+    ]);
     startedPostgres = true;
   }
-  for (const database of ["facility_test", "facility_gw"]) ensureDatabase(database);
+  for (const database of TEST_DATABASES) {
+    console.log(`\n==> Recreate isolated database ${database}`);
+    recreateTestDatabase(database, run);
+  }
 
   step("Critical integration tests (direct, uncached, skips forbidden)", "pnpm", ["test:critical"]);
   step("Remaining tests (Turbo cache disabled)", "pnpm", ["test:uncached"]);
   step("Repository guards", "pnpm", ["guards"]);
   step("All-severity dependency audit", "pnpm", ["audit", "--audit-level", "low"]);
 } finally {
-  if (startedPostgres) run("docker", [...compose, "stop", "postgres"], { allowFailure: true });
-}
-
-function ensureDatabase(name) {
-  const exists = output("docker", [
-    ...compose,
-    "exec",
-    "-T",
-    "postgres",
-    "psql",
-    "-U",
-    "facility",
-    "-d",
-    "postgres",
-    "-tAc",
-    `SELECT 1 FROM pg_database WHERE datname='${name}'`,
-  ]).trim();
-  if (exists === "1") return;
-  step(`Create isolated database ${name}`, "docker", [
-    ...compose,
-    "exec",
-    "-T",
-    "postgres",
-    "createdb",
-    "-U",
-    "facility",
-    name,
-  ]);
+  if (startedPostgres) {
+    run("docker", [...DEV_COMPOSE, "stop", "postgres"], { allowFailure: true });
+  }
 }
 
 function step(label, command, args) {


### PR DESCRIPTION
## What changes

- Recreates the two disposable integration databases, facility_test and facility_gw, before every repository verification run.
- Terminates only connections to the selected allowlisted database, then uses dropdb --if-exists and createdb with argument arrays.
- Refuses every database name outside the exact test allowlist and unit-tests both the command sequence and denial path.

Stacked on #86. Retarget to main and rerun current-SHA CI after the preceding stack merges.

## Why

The verifier previously reused an existing test database. A second run could collide with deterministic fixtures left by the first run, making local and CI acceptance non-repeatable and requiring manual cleanup.

## Verification

- [x] pnpm verify passes locally twice consecutively with no manual database cleanup between runs.
- [x] Behaviour verified beyond the test suite: each full run visibly recreated only facility_test and facility_gw; unit tests pass 2/2, including arbitrary-name rejection.
- [x] No user-facing documentation change.

Both consecutive gates reported 330 API tests, 37 gateway tests, 122 runner tests, all remaining suites, repository guards, and dependency audit green. Claude Opus high reviewed the final diff and returned APPROVE.