### PR TITLE
perf(db): unify the deployment gate

### DIFF
--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -296,9 +296,10 @@ print secret values or commit `.env`, tfvars, state, or private-key files.
 
 ## 5. Migrate and seed, before any service starts
 
-The `migrate` task applies migrations **and** seeds the bundled roles, action
-types and default sandbox profile that the next step and `facility doctor`
-depend on. It is idempotent.
+The `migrate` task is one database deploy gate: one bounded advisory-lock
+session applies checksum-verified migrations and reconciles the bundled roles,
+action types, registry, and sandbox profiles that the next step and
+`facility doctor` depend on. Re-running it is safe.
 
 ```bash
 FACILITY_CLUSTER="$(terraform -chdir="$FACILITY_TF_DIR" output -raw ecs_cluster_name)"
@@ -331,7 +332,11 @@ facility_wait_for_task "$FACILITY_TASK"
 ```
 
 If the helper returns nonzero, do not continue. Read the named CloudWatch log
-group before retrying, and do not start any service.
+group before retrying, and do not start any service. Exit `10` is a lock timeout
+and can be retried; exit `11` identifies a changed applied migration; exit `12`
+identifies migration SQL that rolled back. Successful logs contain JSON
+`facility.db.deploy` events with lock, migration, reconciliation, and total
+durations.
 
 ## 6. Bind the instance to your GitHub organization
 

--- a/apps/docs/docs/self-host/production.md
+++ b/apps/docs/docs/self-host/production.md
@@ -13,7 +13,7 @@ with compose.
 ## Requirements
 
 - **Postgres 16+** (managed recommended). One database; the platform runs its
-  own migrations at deploy (`@facility/db migrate`). The gateway holds a
+  own schema and system-data reconciliation at deploy (`@facility/db deploy`). The gateway holds a
   `LISTEN` connection for cache invalidation — the api `NOTIFY`s
   `facility_key_revoked` (revoked keys) and `facility_provider_changed` (rotated
   provider credentials) so the gateway evicts immediately instead of waiting out
@@ -44,25 +44,29 @@ with compose.
    infrastructure.
 3. Load secrets into the runtime: `SECRET_MASTER_KEY`, identity/OAuth variables, and
    the GitHub App variables when repo automation is enabled.
-4. Run migrations once, before app traffic:
+4. Run the database deploy gate once, before app traffic. Set
+   `FACILITY_RUNNER_IMAGE` first (build/push the runner image from `runner/`) so
+   the reconciled default profile can run platform-lane agents. The command
+   holds one bounded advisory-lock session across migrations and bundled roles,
+   action types, registry essentials, and sandbox profiles:
 
    ```bash
-   pnpm --filter @facility/db migrate
+   FACILITY_RUNNER_IMAGE=<your-runner-image> FACILITY_SEED_DEMO=0 pnpm --filter @facility/db deploy
    ```
 
-5. Seed bundled roles, action types, registry essentials, and the default
-   sandbox profile. Set `FACILITY_RUNNER_IMAGE` first (build/push the runner
-   image from `runner/`) so the default profile can run platform-lane agents —
-   otherwise `facility doctor` flags `sandbox_runner` and platform-lane runs
-   never start:
+   In a production image the equivalent entry point is
+   `node node_modules/@facility/db/dist/bin/deploy.js`. The task emits JSON phase
+   timings. Exit `10` means lock timeout and is safe to retry; `11` means an
+   already-applied migration changed and requires operator correction; `12`
+   means a migration failed and its transaction was rolled back. Existing
+   filename-only ledgers adopt SHA-256 checksums on their first upgraded run.
+   Checksums cover the migration's exact UTF-8 bytes, including whitespace and
+   line endings; correct drift by restoring the shipped file, never by editing
+   the ledger.
 
-   ```bash
-   FACILITY_RUNNER_IMAGE=<your-runner-image> FACILITY_SEED_DEMO=0 pnpm --filter @facility/db seed
-   ```
-
-6. Start or roll the services in this order: `api`, `worker`, `gateway`, `mcp`,
+5. Start or roll the services in this order: `api`, `worker`, `gateway`, `mcp`,
    then optional `web`.
-7. Bootstrap the first owner and issue an API key. On an empty installation,
+6. Bootstrap the first owner and issue an API key. On an empty installation,
    run `facility instance bootstrap`, then open `https://<web-host>/api/auth/login`; the configured GitHub user
    signs into the organization already created by bootstrap. With the optional web
    app, issue the key in settings. Without it, reopen

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       [
         "sh",
         "-c",
-        "node node_modules/@facility/db/dist/bin/migrate.js && FACILITY_SEED_DEMO=0 node node_modules/@facility/db/dist/bin/seed.js",
+        "FACILITY_SEED_DEMO=0 node node_modules/@facility/db/dist/bin/deploy.js",
       ]
     environment:
       DATABASE_URL: postgres://facility:${POSTGRES_PASSWORD:-facility}@postgres:5432/facility

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -196,10 +196,11 @@ plaintext to the terminal.
 
 ## 5. Run the migrate + seed task once
 
-The `migrate` task runs database migrations **and** seeds the bundled essentials
-(roles, action types, default sandbox profile) that administrative bootstrap and
-`facility doctor` require — seeding is idempotent. Run it only after the
-`database_url` secret and images are populated:
+The `migrate` task is one database deploy gate. It holds one bounded lock while
+it applies checksum-verified migrations and reconciles the bundled essentials
+(roles, action types, registry, and sandbox profiles) that administrative
+bootstrap and `facility doctor` require. Re-running it is safe. Run it only
+after the `database_url` secret and images are populated:
 
 ```bash
 aws ecs run-task \
@@ -209,9 +210,11 @@ aws ecs run-task \
   --network-configuration "awsvpcConfiguration={subnets=$(terraform output -json private_subnet_ids),securityGroups=[$(terraform output -raw service_security_group_id)],assignPublicIp=DISABLED}"
 ```
 
-Watch `/facility/<environment>/migrate` in CloudWatch Logs for
-`applied 0001_control_plane.sql` (or `already applied`) followed by the seed
-summary. `facility doctor` will flag `seed_essentials` if this task did not run.
+Watch `/facility/<environment>/migrate` in CloudWatch Logs for JSON
+`facility.db.deploy` events ending with `phase=deploy,status=completed`. Exit
+`10` is a retryable lock timeout; exit `11` identifies an applied migration
+whose SHA-256 changed; exit `12` identifies migration SQL that rolled back.
+`facility doctor` will flag `seed_essentials` if this task did not run.
 
 ## 6. Bind the instance
 

--- a/infra/terraform/aws/ecs.tf
+++ b/infra/terraform/aws/ecs.tf
@@ -104,13 +104,12 @@ resource "aws_ecs_task_definition" "migrate" {
       name      = "migrate"
       image     = local.images.api
       essential = true
-      # Migrate AND seed: bundled roles/action-types/default sandbox profile must
-      # exist before administrative instance bootstrap and before `facility doctor`
-      # passes. Seed is idempotent (ON CONFLICT) so re-running each deploy is safe.
+      # One lock session covers both schema migrations and idempotent system-data
+      # reconciliation before instance bootstrap or `facility doctor` can run.
       command = [
         "sh",
         "-c",
-        "node node_modules/@facility/db/dist/bin/migrate.js && node node_modules/@facility/db/dist/bin/seed.js",
+        "node node_modules/@facility/db/dist/bin/deploy.js",
       ]
       environment = concat(local.common_environment, [{ name = "FACILITY_SEED_DEMO", value = "0" }])
       secrets     = local.common_secrets

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,15 +5,17 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
+    "./deploy": "./dist/deploy.js",
     "./schema": "./dist/schema.js",
     "./seed": "./dist/seed.js"
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.ts src/audit.ts src/schema.ts src/migrate.ts src/seed.ts src/bin/migrate.ts src/bin/seed.ts --format esm --dts && node scripts/copy-seed-assets.mjs",
+    "build": "tsup src/index.ts src/audit.ts src/schema.ts src/deploy.ts src/migrate.ts src/seed.ts src/bin/deploy.ts src/bin/migrate.ts src/bin/seed.ts --format esm --dts && node scripts/copy-seed-assets.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "migrate": "tsx src/bin/migrate.ts",
+    "deploy": "tsx src/bin/deploy.ts",
     "seed": "tsx src/bin/seed.ts"
   },
   "dependencies": {

--- a/packages/db/src/bin/deploy.ts
+++ b/packages/db/src/bin/deploy.ts
@@ -1,0 +1,19 @@
+import { databaseDeployExitCode, deployDatabase } from "../deploy.js";
+
+try {
+  await deployDatabase();
+} catch (error) {
+  const exitCode = databaseDeployExitCode(error);
+  console.error(
+    JSON.stringify({
+      event: "facility.db.deploy.exit",
+      exitCode,
+      errorCode:
+        error && typeof error === "object" && "code" in error
+          ? String(error.code)
+          : "database_deploy_failed",
+      message: error instanceof Error ? error.message : String(error),
+    }),
+  );
+  process.exitCode = exitCode;
+}

--- a/packages/db/src/deploy.ts
+++ b/packages/db/src/deploy.ts
@@ -1,0 +1,177 @@
+import postgres from "postgres";
+import {
+  acquireMigrationLock,
+  applyMigrations,
+  DEFAULT_MIGRATION_LOCK_TIMEOUT_MS,
+  MAX_MIGRATION_LOCK_TIMEOUT_MS,
+} from "./migrate.js";
+import { seedWithClient } from "./seed.js";
+
+export type DatabaseDeployPhase = "deploy" | "lock" | "migrations" | "reconciliation";
+
+export type DatabaseDeployEvent = {
+  event: "facility.db.deploy";
+  phase: DatabaseDeployPhase;
+  status: "started" | "completed" | "failed";
+  durationMs?: number;
+  errorCode?: string;
+  message?: string;
+  migrationsApplied?: number;
+  migrationsBackfilled?: number;
+  migrationsSkipped?: number;
+};
+
+export type DatabaseDeployOptions = {
+  includeDemoData?: boolean;
+  lockPollMs?: number;
+  lockTimeoutMs?: number;
+  log?: (event: DatabaseDeployEvent) => void;
+};
+
+export class DatabaseDeployConfigError extends Error {
+  readonly code = "database_deploy_config_invalid";
+  readonly exitCode = 2;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DatabaseDeployConfigError";
+  }
+}
+
+function defaultLogger(event: DatabaseDeployEvent): void {
+  console.log(JSON.stringify(event));
+}
+
+function durationMs(startedAt: number): number {
+  return Math.round(performance.now() - startedAt);
+}
+
+function errorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  return "database_deploy_failed";
+}
+
+export function databaseDeployExitCode(error: unknown): number {
+  if (
+    error &&
+    typeof error === "object" &&
+    "exitCode" in error &&
+    typeof error.exitCode === "number"
+  ) {
+    return error.exitCode;
+  }
+  return 1;
+}
+
+export function databaseDeployLockTimeout(
+  value = process.env.FACILITY_DB_DEPLOY_LOCK_TIMEOUT_MS,
+): number {
+  if (value === undefined || value === "") return DEFAULT_MIGRATION_LOCK_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > MAX_MIGRATION_LOCK_TIMEOUT_MS) {
+    throw new DatabaseDeployConfigError(
+      `FACILITY_DB_DEPLOY_LOCK_TIMEOUT_MS must be an integer between 0 and ${MAX_MIGRATION_LOCK_TIMEOUT_MS}`,
+    );
+  }
+  return parsed;
+}
+
+export async function deployDatabase(
+  connectionString = process.env.DATABASE_URL,
+  options: DatabaseDeployOptions = {},
+): Promise<void> {
+  if (!connectionString) throw new DatabaseDeployConfigError("DATABASE_URL is required");
+  // The entry point emits newline-delimited JSON only; expected IF NOT EXISTS
+  // notices would otherwise inject non-JSON objects into deployment logs.
+  const client = postgres(connectionString, { max: 1, onnotice: () => undefined });
+  try {
+    await deployDatabaseWithClient(client, options);
+  } finally {
+    await client.end();
+  }
+}
+
+export async function deployDatabaseWithClient(
+  client: postgres.Sql,
+  options: DatabaseDeployOptions = {},
+): Promise<void> {
+  const log = options.log ?? defaultLogger;
+  const deployStartedAt = performance.now();
+  let phase: DatabaseDeployPhase = "lock";
+  let phaseStartedAt = deployStartedAt;
+  let release: (() => Promise<void>) | undefined;
+  log({ event: "facility.db.deploy", phase: "deploy", status: "started" });
+  log({ event: "facility.db.deploy", phase, status: "started" });
+
+  try {
+    const lockTimeoutMs = options.lockTimeoutMs ?? databaseDeployLockTimeout();
+    release = await acquireMigrationLock(client, {
+      pollMs: options.lockPollMs,
+      timeoutMs: lockTimeoutMs,
+    });
+    log({
+      event: "facility.db.deploy",
+      phase,
+      status: "completed",
+      durationMs: durationMs(phaseStartedAt),
+    });
+
+    phase = "migrations";
+    phaseStartedAt = performance.now();
+    log({ event: "facility.db.deploy", phase, status: "started" });
+    const migrationResult = await applyMigrations(client, { log: () => undefined });
+    log({
+      event: "facility.db.deploy",
+      phase,
+      status: "completed",
+      durationMs: durationMs(phaseStartedAt),
+      migrationsApplied: migrationResult.applied.length,
+      migrationsBackfilled: migrationResult.backfilled.length,
+      migrationsSkipped: migrationResult.skipped.length,
+    });
+
+    phase = "reconciliation";
+    phaseStartedAt = performance.now();
+    log({ event: "facility.db.deploy", phase, status: "started" });
+    await seedWithClient(client, {
+      includeDemoData: options.includeDemoData,
+      log: () => undefined,
+    });
+    log({
+      event: "facility.db.deploy",
+      phase,
+      status: "completed",
+      durationMs: durationMs(phaseStartedAt),
+    });
+    log({
+      event: "facility.db.deploy",
+      phase: "deploy",
+      status: "completed",
+      durationMs: durationMs(deployStartedAt),
+    });
+  } catch (error) {
+    log({
+      event: "facility.db.deploy",
+      phase,
+      status: "failed",
+      durationMs: durationMs(phaseStartedAt),
+      errorCode: errorCode(error),
+      message: error instanceof Error ? error.message : String(error),
+    });
+    log({
+      event: "facility.db.deploy",
+      phase: "deploy",
+      status: "failed",
+      durationMs: durationMs(deployStartedAt),
+      errorCode: errorCode(error),
+    });
+    throw error;
+  } finally {
+    // deployDatabase() closes its max:1 client immediately afterwards, which
+    // also releases the session lock. Do not replace a useful 10/11/12 result
+    // with a generic unlock error if that connection has already gone away.
+    await release?.().catch(() => undefined);
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@ import * as schema from "./schema.js";
 import { withOrg } from "./scoped.js";
 
 export * from "./audit.js";
+export * from "./deploy.js";
 export * from "./migrate.js";
 export * from "./schema.js";
 export * from "./scoped.js";

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,7 +7,66 @@ import postgres from "postgres";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "../../..");
+const lockName = "facility:migrations";
 loadDotenv({ path: join(repoRoot, ".env"), quiet: true });
+
+export const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 60_000;
+export const MAX_MIGRATION_LOCK_TIMEOUT_MS = 15 * 60_000;
+
+type MigrationOptions = {
+  migrationsDir?: string;
+  log?: (message: string) => void;
+};
+
+type MigrationLockOptions = {
+  pollMs?: number;
+  timeoutMs?: number;
+};
+
+export type MigrationResult = {
+  applied: string[];
+  backfilled: string[];
+  skipped: string[];
+};
+
+export class MigrationLockTimeoutError extends Error {
+  readonly code = "migration_lock_timeout";
+  readonly exitCode = 10;
+
+  constructor(readonly timeoutMs: number) {
+    super(`timed out after ${timeoutMs}ms waiting for the Facility database deployment lock`);
+    this.name = "MigrationLockTimeoutError";
+  }
+}
+
+export class MigrationChecksumError extends Error {
+  readonly code = "migration_checksum_mismatch";
+  readonly exitCode = 11;
+
+  constructor(
+    readonly file: string,
+    readonly storedChecksum: string,
+    readonly currentChecksum: string,
+  ) {
+    super(
+      `applied migration ${file} changed: stored sha256 ${storedChecksum}, current sha256 ${currentChecksum}`,
+    );
+    this.name = "MigrationChecksumError";
+  }
+}
+
+export class MigrationExecutionError extends Error {
+  readonly code = "migration_execution_failed";
+  readonly exitCode = 12;
+
+  constructor(
+    readonly file: string,
+    cause: unknown,
+  ) {
+    super(`migration ${file} failed`, { cause });
+    this.name = "MigrationExecutionError";
+  }
+}
 
 export async function migrate(connectionString = process.env.DATABASE_URL): Promise<void> {
   if (!connectionString) {
@@ -14,34 +74,121 @@ export async function migrate(connectionString = process.env.DATABASE_URL): Prom
   }
   const client = postgres(connectionString, { max: 1 });
   try {
-    // Deploys commonly start API, gateway, worker, and a migration job together.
-    // Serialize the entire lexical scan on one session so two processes cannot
-    // both observe a migration as missing and execute it concurrently.
-    await client`SELECT pg_advisory_lock(hashtext('facility:migrations'))`;
-    await client`CREATE TABLE IF NOT EXISTS _facility_migrations (
-      name text PRIMARY KEY,
-      applied_at timestamptz NOT NULL DEFAULT now()
-    )`;
-    const migrationsDir = join(here, "..", "migrations");
-    // Apply every *.sql file in lexical order, each once, in its own tx.
-    const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
-    for (const file of files) {
-      const existing = await client<
-        { name: string }[]
-      >`SELECT name FROM _facility_migrations WHERE name = ${file}`;
-      if (existing.length > 0) {
-        console.log(`${file} already applied`);
-        continue;
-      }
-      const sql = await readFile(join(migrationsDir, file), "utf8");
-      await client.begin(async (tx) => {
-        await tx.unsafe(sql);
-        await tx`INSERT INTO _facility_migrations (name) VALUES (${file})`;
-      });
-      console.log(`applied ${file}`);
+    const release = await acquireMigrationLock(client);
+    try {
+      await applyMigrations(client);
+    } finally {
+      // Closing the max:1 client below also releases session locks. Preserve the
+      // migration's real outcome if the explicit unlock loses its connection.
+      await release().catch(() => undefined);
     }
   } finally {
-    await client`SELECT pg_advisory_unlock(hashtext('facility:migrations'))`.catch(() => undefined);
     await client.end();
   }
+}
+
+export async function acquireMigrationLock(
+  client: postgres.Sql,
+  options: MigrationLockOptions = {},
+): Promise<() => Promise<void>> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS;
+  const pollMs = Math.max(1, options.pollMs ?? 250);
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < 0 ||
+    timeoutMs > MAX_MIGRATION_LOCK_TIMEOUT_MS
+  ) {
+    throw new RangeError(
+      `migration lock timeout must be an integer between 0 and ${MAX_MIGRATION_LOCK_TIMEOUT_MS}ms`,
+    );
+  }
+
+  const startedAt = performance.now();
+  while (true) {
+    const rows = await client<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext(${lockName})) AS acquired
+    `;
+    if (rows[0]?.acquired) {
+      let released = false;
+      return async () => {
+        if (released) return;
+        await client`SELECT pg_advisory_unlock(hashtext(${lockName}))`;
+        released = true;
+      };
+    }
+
+    const elapsedMs = performance.now() - startedAt;
+    if (elapsedMs >= timeoutMs) throw new MigrationLockTimeoutError(timeoutMs);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, timeoutMs - elapsedMs)));
+  }
+}
+
+export async function applyMigrations(
+  client: postgres.Sql,
+  options: MigrationOptions = {},
+): Promise<MigrationResult> {
+  const log = options.log ?? console.log;
+  const migrationsDir = options.migrationsDir ?? join(here, "..", "migrations");
+  await client`CREATE TABLE IF NOT EXISTS _facility_migrations (
+    name text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+  )`;
+  // The metadata ledger is intentionally self-upgrading: adding a migration to
+  // add this column would require verifying that migration before the column exists.
+  await client`ALTER TABLE _facility_migrations ADD COLUMN IF NOT EXISTS checksum text`;
+
+  const files = (await readdir(migrationsDir)).filter((file) => file.endsWith(".sql")).sort();
+  const migrations = await Promise.all(
+    files.map(async (file) => {
+      const sql = await readFile(join(migrationsDir, file), "utf8");
+      return { file, sql, checksum: createHash("sha256").update(sql).digest("hex") };
+    }),
+  );
+  const appliedRows = await client<{ checksum: string | null; name: string }[]>`
+    SELECT name, checksum FROM _facility_migrations
+  `;
+  const appliedByName = new Map(appliedRows.map((row) => [row.name, row.checksum]));
+
+  // Validate every established checksum before applying or backfilling anything.
+  // Legacy NULL rows are trusted once, because no historical digest exists to compare.
+  for (const migration of migrations) {
+    const storedChecksum = appliedByName.get(migration.file);
+    if (storedChecksum && storedChecksum !== migration.checksum) {
+      throw new MigrationChecksumError(migration.file, storedChecksum, migration.checksum);
+    }
+  }
+
+  const result: MigrationResult = { applied: [], backfilled: [], skipped: [] };
+  for (const migration of migrations) {
+    if (appliedByName.has(migration.file)) {
+      if (appliedByName.get(migration.file) === null) {
+        await client`
+          UPDATE _facility_migrations
+          SET checksum = ${migration.checksum}
+          WHERE name = ${migration.file} AND checksum IS NULL
+        `;
+        result.backfilled.push(migration.file);
+        log(`${migration.file} checksum recorded`);
+      } else {
+        result.skipped.push(migration.file);
+        log(`${migration.file} already applied`);
+      }
+      continue;
+    }
+
+    try {
+      await client.begin(async (tx) => {
+        await tx.unsafe(migration.sql);
+        await tx`
+          INSERT INTO _facility_migrations (name, checksum)
+          VALUES (${migration.file}, ${migration.checksum})
+        `;
+      });
+    } catch (error) {
+      throw new MigrationExecutionError(migration.file, error);
+    }
+    result.applied.push(migration.file);
+    log(`applied ${migration.file}`);
+  }
+  return result;
 }

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -19,8 +19,9 @@ const repoRoot = existsSync(join(packagedAssetsRoot, "packages/harness/contracts
   : workspaceRoot;
 loadDotenv({ path: join(workspaceRoot, ".env"), quiet: true });
 
-type SeedOptions = {
+export type SeedOptions = {
   includeDemoData?: boolean;
+  log?: (message: string) => void;
 };
 
 type RegistryDb = {
@@ -135,35 +136,43 @@ export async function seed(
   if (!connectionString) {
     throw new Error("DATABASE_URL is required");
   }
-  const includeDemoData = options.includeDemoData ?? process.env.FACILITY_SEED_DEMO !== "0";
   const sql = postgres(connectionString, { max: 1 });
   try {
-    for (const role of BUNDLED_ROLES) {
-      await sql`
+    await seedWithClient(sql, options);
+  } finally {
+    await sql.end();
+  }
+}
+
+export async function seedWithClient(sql: postgres.Sql, options: SeedOptions = {}): Promise<void> {
+  const includeDemoData = options.includeDemoData ?? process.env.FACILITY_SEED_DEMO !== "0";
+  const log = options.log ?? console.log;
+  for (const role of BUNDLED_ROLES) {
+    await sql`
         INSERT INTO roles (id, org_id, name, description, permissions)
         VALUES (${`role_bundled_${role.name}`}, NULL, ${role.name}, ${role.description}, ${role.permissions})
         ON CONFLICT (coalesce(org_id, '__bundled__'), name)
         DO UPDATE SET description = EXCLUDED.description, permissions = EXCLUDED.permissions, updated_at = now()
       `;
-    }
-    const seededOrgs = await sql<{ id: string }[]>`SELECT id FROM orgs`;
-    await seedOrgEssentialsForOrgsSql(
+  }
+  const seededOrgs = await sql<{ id: string }[]>`SELECT id FROM orgs`;
+  await seedOrgEssentialsForOrgsSql(
+    sql,
+    seededOrgs.map((org) => org.id),
+  );
+  if (!includeDemoData) {
+    // Deploy-time seeds refresh bundled contracts and templates for existing
+    // tenants too. Do this set-wise so an upgrade is not one database round
+    // trip per file per tenant.
+    await seedBundledRegistryForOrgsSql(
       sql,
       seededOrgs.map((org) => org.id),
     );
-    if (!includeDemoData) {
-      // Deploy-time seeds refresh bundled contracts and templates for existing
-      // tenants too. Do this set-wise so an upgrade is not one database round
-      // trip per file per tenant.
-      await seedBundledRegistryForOrgsSql(
-        sql,
-        seededOrgs.map((org) => org.id),
-      );
-      console.log("seed complete");
-      return;
-    }
+    log("seed complete");
+    return;
+  }
 
-    await sql`
+  await sql`
       INSERT INTO orgs (id, name, slug, settings)
       VALUES (
         'org_dev_the_agile_monkeys',
@@ -173,19 +182,19 @@ export async function seed(
       )
       ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name, updated_at = now()
     `;
-    await sql`
+  await sql`
       INSERT INTO users (id, email, name, status)
       VALUES ('user_dev_admin', 'admin@theagilemonkeys.com', 'Dev Admin', 'active')
       ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name, updated_at = now()
     `;
-    await sql`
+  await sql`
       INSERT INTO org_members (id, org_id, user_id, role_id)
       VALUES ('member_dev_admin', 'org_dev_the_agile_monkeys', 'user_dev_admin', 'role_bundled_owner')
       ON CONFLICT (org_id, user_id) DO UPDATE SET role_id = EXCLUDED.role_id, updated_at = now()
     `;
 
-    await seedOrgEssentialsSql(sql, "org_dev_the_agile_monkeys");
-    const devProjects = await sql<{ id: string }[]>`
+  await seedOrgEssentialsSql(sql, "org_dev_the_agile_monkeys");
+  const devProjects = await sql<{ id: string }[]>`
       INSERT INTO projects (id, org_id, name, slug, description, settings)
       VALUES (
         'proj_dev_facility',
@@ -201,11 +210,11 @@ export async function seed(
         updated_at = now()
       RETURNING id
     `;
-    const devProjectId = devProjects[0]?.id;
-    if (!devProjectId) throw new Error("failed to seed dev project");
+  const devProjectId = devProjects[0]?.id;
+  if (!devProjectId) throw new Error("failed to seed dev project");
 
-    const bundled = await seedBundledRegistrySql(sql, "org_dev_the_agile_monkeys");
-    await sql`
+  const bundled = await seedBundledRegistrySql(sql, "org_dev_the_agile_monkeys");
+  await sql`
       INSERT INTO agent_defs (
         id,
         org_id,
@@ -246,7 +255,7 @@ export async function seed(
         enabled = true,
         updated_at = now()
     `;
-    await sql`
+  await sql`
       INSERT INTO agent_defs (
         id,
         org_id,
@@ -286,10 +295,7 @@ export async function seed(
         enabled = true,
         updated_at = now()
     `;
-    console.log("seed complete");
-  } finally {
-    await sql.end();
-  }
+  log("seed complete");
 }
 
 export async function seedBundledRegistryForOrg(db: RegistryDb, orgId: string): Promise<void> {

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -1,12 +1,21 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { hashChain, newId } from "@facility/core";
 import { count, eq, inArray, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   analysisSandboxProfileId,
+  applyMigrations,
   createDb,
   defaultSandboxProfileId,
+  deployDatabase,
   insertAuditEvent,
+  MigrationChecksumError,
+  MigrationExecutionError,
+  MigrationLockTimeoutError,
   migrate,
   seed,
   withOrg,
@@ -47,6 +56,130 @@ describe("db", async () => {
 
   afterAll(async () => {
     await client.end();
+  });
+
+  it("stores migration checksums and rejects edits to applied SQL before applying more", async () => {
+    const migrationsDir = await mkdtemp(join(tmpdir(), "facility-migrations-"));
+    const schemaName = `migration_test_${randomUUID().replaceAll("-", "_")}`;
+    const isolated = postgres(databaseUrl, { max: 1 });
+    try {
+      await isolated.unsafe(`CREATE SCHEMA "${schemaName}"`);
+      await isolated.unsafe(`SET search_path TO "${schemaName}"`);
+      await writeFile(join(migrationsDir, "0001_first.sql"), "CREATE TABLE first (id text);\n");
+
+      const first = await applyMigrations(isolated, { migrationsDir, log: () => undefined });
+      expect(first.applied).toEqual(["0001_first.sql"]);
+      const checksumRows = await isolated<{ checksum: string | null }[]>`
+        SELECT checksum FROM _facility_migrations WHERE name = '0001_first.sql'
+      `;
+      expect(checksumRows[0]?.checksum).toMatch(/^[a-f0-9]{64}$/);
+
+      const second = await applyMigrations(isolated, { migrationsDir, log: () => undefined });
+      expect(second.skipped).toEqual(["0001_first.sql"]);
+      await isolated`UPDATE _facility_migrations SET checksum = NULL WHERE name = '0001_first.sql'`;
+      const legacy = await applyMigrations(isolated, { migrationsDir, log: () => undefined });
+      expect(legacy.backfilled).toEqual(["0001_first.sql"]);
+
+      await writeFile(join(migrationsDir, "0001_first.sql"), "CREATE TABLE first (id text);\n\n");
+      await writeFile(join(migrationsDir, "0002_second.sql"), "CREATE TABLE second (id text);\n");
+      await expect(
+        applyMigrations(isolated, { migrationsDir, log: () => undefined }),
+      ).rejects.toBeInstanceOf(MigrationChecksumError);
+      const secondTable = await isolated<{ name: string | null }[]>`
+        SELECT to_regclass('second')::text AS name
+      `;
+      expect(secondTable[0]?.name).toBeNull();
+
+      await writeFile(join(migrationsDir, "0001_first.sql"), "CREATE TABLE first (id text);\n");
+      await writeFile(
+        join(migrationsDir, "0002_second.sql"),
+        "CREATE TABLE rolled_back (id text); SELECT * FROM table_that_does_not_exist;\n",
+      );
+      await expect(
+        applyMigrations(isolated, { migrationsDir, log: () => undefined }),
+      ).rejects.toBeInstanceOf(MigrationExecutionError);
+      const rollbackRows = await isolated<{ ledger: number; table_name: string | null }[]>`
+        SELECT
+          (SELECT count(*)::int FROM _facility_migrations WHERE name = '0002_second.sql') AS ledger,
+          to_regclass('rolled_back')::text AS table_name
+      `;
+      expect(rollbackRows[0]).toEqual({ ledger: 0, table_name: null });
+    } finally {
+      await isolated.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch(() => undefined);
+      await isolated.end();
+      await rm(migrationsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("times out cleanly when another deploy holds the database lock", async () => {
+    const blocker = postgres(databaseUrl, { max: 1 });
+    const events: Array<{ phase: string; status: string }> = [];
+    try {
+      await blocker`SELECT pg_advisory_lock(hashtext('facility:migrations'))`;
+      await expect(
+        deployDatabase(databaseUrl, {
+          includeDemoData: false,
+          lockPollMs: 5,
+          lockTimeoutMs: 20,
+          log: (event) => events.push(event),
+        }),
+      ).rejects.toBeInstanceOf(MigrationLockTimeoutError);
+      expect(events).toContainEqual(expect.objectContaining({ phase: "lock", status: "failed" }));
+      expect(events).not.toContainEqual(
+        expect.objectContaining({ phase: "migrations", status: "started" }),
+      );
+    } finally {
+      await blocker`SELECT pg_advisory_unlock(hashtext('facility:migrations'))`.catch(
+        () => undefined,
+      );
+      await blocker.end();
+    }
+  });
+
+  it("runs schema and system-data reconciliation behind one deploy entry point", async () => {
+    const observer = postgres(databaseUrl, { max: 1 });
+    // Open the observer before the very short empty-database reconciliation;
+    // otherwise connection startup can finish only after the deploy unlocks.
+    await observer`SELECT 1`;
+    const events: Array<{
+      migrationsApplied?: number;
+      migrationsSkipped?: number;
+      phase: string;
+      status: string;
+    }> = [];
+    const observeLock = () => observer<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext('facility:migrations')) AS acquired
+    `;
+    let reconciliationLock: Promise<Awaited<ReturnType<typeof observeLock>>> | undefined;
+    try {
+      await deployDatabase(databaseUrl, {
+        includeDemoData: false,
+        log: (event) => {
+          events.push(event);
+          if (event.phase === "reconciliation" && event.status === "started") {
+            // postgres.js queries are lazy; attaching then() here makes this
+            // observation race reconciliation, not the post-deploy assertion.
+            reconciliationLock = observeLock().then((rows) => rows);
+          }
+        },
+      });
+      expect((await reconciliationLock)?.[0]?.acquired).toBe(false);
+    } finally {
+      await observer.end();
+    }
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ phase: "lock", status: "completed" }),
+        expect.objectContaining({ phase: "migrations", status: "completed" }),
+        expect.objectContaining({ phase: "reconciliation", status: "completed" }),
+        expect.objectContaining({ phase: "deploy", status: "completed" }),
+      ]),
+    );
+    const migrationEvent = events.find(
+      (event) => event.phase === "migrations" && event.status === "completed",
+    );
+    expect(migrationEvent?.migrationsApplied).toBe(0);
+    expect(migrationEvent?.migrationsSkipped).toBeGreaterThan(0);
   });
 
   it("round-trips typed rows across core tables", async () => {

--- a/packages/db/test/deploy.test.ts
+++ b/packages/db/test/deploy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  DatabaseDeployConfigError,
+  databaseDeployExitCode,
+  databaseDeployLockTimeout,
+  MigrationChecksumError,
+  MigrationExecutionError,
+  MigrationLockTimeoutError,
+} from "../src/index.js";
+
+describe("database deploy configuration", () => {
+  it("accepts only bounded integer lock timeouts", () => {
+    expect(databaseDeployLockTimeout(undefined)).toBe(60_000);
+    expect(databaseDeployLockTimeout("0")).toBe(0);
+    expect(databaseDeployLockTimeout("900000")).toBe(900_000);
+    for (const value of ["-1", "1.5", "900001", "not-a-number"]) {
+      expect(() => databaseDeployLockTimeout(value)).toThrow(DatabaseDeployConfigError);
+    }
+  });
+
+  it("maps actionable deploy failures to stable process exit codes", () => {
+    expect(databaseDeployExitCode(new DatabaseDeployConfigError("bad config"))).toBe(2);
+    expect(databaseDeployExitCode(new MigrationLockTimeoutError(10))).toBe(10);
+    expect(databaseDeployExitCode(new MigrationChecksumError("0001.sql", "old", "new"))).toBe(11);
+    expect(databaseDeployExitCode(new MigrationExecutionError("0001.sql", new Error("bad")))).toBe(
+      12,
+    );
+    expect(databaseDeployExitCode(new Error("unknown"))).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace separate production migrate and seed commands with one private database deployment entrypoint
- keep the existing Compose migrate service and AWS one-shot ECS task; no service or component is added
- hold one bounded PostgreSQL advisory lock across migration validation, migration application, and idempotent system-data reconciliation
- add immutable SHA-256 migration checksums with safe legacy backfill and fail-closed mismatch handling
- emit structured phase timing and outcome events with distinct operational exit codes

## Why
The existing migrate task ran two independent Node processes. That meant two database connections, two coordination boundaries, and no protection against concurrent migration plus seed reconciliation. The new private package entrypoint makes database deployment one atomic operational gate while preserving the current topology.

This is intentionally not exposed as a public Facility CLI command: it is an image-internal deployment primitive that requires direct database credentials. The public CLI should not normalize operator database access.

A global seed fingerprint was considered and rejected. Registry reconciliation is tenant-aware and repairs drift; skipping it globally could omit new tenants or changed runner and driver data. Existing content hashes already avoid unchanged writes, and measured warm reconciliation is 209 ms.

## Operational contract
- default lock timeout: 60 seconds
- configurable timeout ceiling: 15 minutes
- exit 2: invalid configuration
- exit 10: deployment lock timeout
- exit 11: migration checksum mismatch
- exit 12: migration execution failure

## Validation
- full repository verifier: passed
- database tests: 14 of 14 passed
- API tests: 350 of 350 passed
- gateway tests: 37 of 37 passed
- critical CLI and security tests: 67 of 67 passed
- repository script tests: 91 of 91 passed
- runner tests: 122 of 122 passed
- repository guards: 2 of 2 passed
- all-severity dependency audit: no known vulnerabilities
- built deployment smoke test: 242 ms total; lock 28 ms; migrations 5 ms; reconciliation 209 ms
- missing database configuration: structured failure with exit 2
- Codex review: approved
- Claude Opus high-reasoning design and implementation review: approved