### PR TITLE
perf(preview): detect runnable tasks during launch

### DIFF
--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -81,6 +81,9 @@ AWS preview environments are the deliberate exception to the execution backend:
 they need a private inbound service endpoint, which CodeBuild does not expose.
 The AWS module therefore registers an immutable, unprivileged ECS Fargate task
 definition for each preview image while agent runs remain on privileged CodeBuild.
+Endpoint discovery and the ECS `RUNNING` check share one bounded launch window;
+unusually slow tasks remain `provisioning` and converge through the existing
+lifecycle reconciler instead of creating another scheduler or warm-pool service.
 
 ## What's inside (and what isn't)
 

--- a/services/api/src/previews.ts
+++ b/services/api/src/previews.ts
@@ -313,6 +313,7 @@ export async function provisionPreview(
   previewId: string,
   driverOverride?: SandboxDriver,
 ) {
+  const provisionStartedAt = Date.now();
   const { db, client } = createDb(config.databaseUrl);
   try {
     const preview = (
@@ -326,7 +327,10 @@ export async function provisionPreview(
       .set({ driver: driver.name, updatedAt: new Date() })
       .where(eq(previewSandboxes.id, preview.id));
     let launchedRef: string | undefined;
+    let launchStartedAt = provisionStartedAt;
+    let launchFinishedAt: number | undefined;
     try {
+      launchStartedAt = Date.now();
       const launched = await driver.launch({
         runId: `preview:${preview.id}`,
         image: spec.image,
@@ -338,6 +342,7 @@ export async function provisionPreview(
         network: { egress: "unrestricted" },
         servicePort: spec.port,
       });
+      launchFinishedAt = Date.now();
       launchedRef = launched.ref;
       await db
         .update(previewSandboxes)
@@ -367,6 +372,7 @@ export async function provisionPreview(
           ? await waitForPreviewReadiness(launched.endpoint, spec.readinessPath)
           : true);
       const status = ready ? "running" : "provisioning";
+      const provisionFinishedAt = Date.now();
       const updated = (
         await db
           .update(previewSandboxes)
@@ -387,10 +393,18 @@ export async function provisionPreview(
         actor: { type: "system", id: "preview.provisioner" },
         action: "preview.provisioned",
         target: { type: "preview", id: preview.id },
-        payload: { driver: driver.name, status, auth_mode: "facility_session" },
+        payload: {
+          driver: driver.name,
+          status,
+          auth_mode: "facility_session",
+          queue_delay_ms: elapsedMs(preview.createdAt.getTime(), provisionStartedAt),
+          launch_ms: elapsedMs(launchStartedAt, launchFinishedAt ?? provisionFinishedAt),
+          total_ms: elapsedMs(preview.createdAt.getTime(), provisionFinishedAt),
+        },
       });
       return updated;
     } catch (error) {
+      const failedAt = Date.now();
       const message = error instanceof Error ? error.message : String(error);
       const retryRef = error instanceof SandboxLaunchError ? error.ref : launchedRef;
       await db
@@ -408,13 +422,22 @@ export async function provisionPreview(
         actor: { type: "system", id: "preview.provisioner" },
         action: "preview.failed",
         target: { type: "preview", id: preview.id },
-        payload: { error: message },
+        payload: {
+          error: message,
+          queue_delay_ms: elapsedMs(preview.createdAt.getTime(), provisionStartedAt),
+          launch_ms: elapsedMs(launchStartedAt, launchFinishedAt ?? failedAt),
+          total_ms: elapsedMs(preview.createdAt.getTime(), failedAt),
+        },
       });
       throw error;
     }
   } finally {
     await client.end();
   }
+}
+
+function elapsedMs(startedAt: number, endedAt: number) {
+  return Math.max(0, endedAt - startedAt);
 }
 
 export async function destroyPreview(

--- a/services/api/src/sandbox/aws-preview.ts
+++ b/services/api/src/sandbox/aws-preview.ts
@@ -14,6 +14,7 @@ import {
   type RunTaskCommandOutput,
   StopTaskCommand,
   type StopTaskCommandOutput,
+  type Task,
 } from "@aws-sdk/client-ecs";
 import { type LaunchSpec, type SandboxDriver, SandboxLaunchError } from "./driver.js";
 
@@ -133,8 +134,11 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
       if (launched.failures?.length) throw new Error(formatFailures(launched.failures));
       taskArn = launched.tasks?.[0]?.taskArn;
       if (!taskArn) throw new Error("ECS RunTask did not return a preview task ARN");
-      const privateIp =
-        privateIpv4(launched.tasks?.[0]) ?? (await this.waitForPrivateIp(config.cluster, taskArn));
+      const privateIp = await this.waitForRunnableEndpoint(
+        config.cluster,
+        taskArn,
+        launched.tasks?.[0],
+      );
       return {
         ref: encodeRef({ taskArn, taskDefinitionArn }),
         ...(privateIp ? { endpoint: `http://${privateIp}:${spec.servicePort}` } : {}),
@@ -180,11 +184,7 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
       return "starting";
     }
     if (task.lastStatus === "RUNNING") return "running";
-    if (
-      ["DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED", "DELETED"].includes(
-        task.lastStatus ?? "",
-      )
-    ) {
+    if (terminalTaskStatus(task.lastStatus)) {
       return "exited";
     }
     return "lost";
@@ -256,15 +256,26 @@ export class AwsPreviewSandboxDriver implements SandboxDriver {
     if (failure) throw failure;
   }
 
-  private async waitForPrivateIp(cluster: string, taskArn: string) {
+  private async waitForRunnableEndpoint(cluster: string, taskArn: string, initialTask?: Task) {
+    let privateIp = privateIpv4(initialTask);
+    if (initialTask?.lastStatus === "RUNNING" && privateIp) return privateIp;
+    if (terminalTaskStatus(initialTask?.lastStatus)) {
+      throw new Error(`aws_preview_task_stopped_before_running:${initialTask?.lastStatus}`);
+    }
     for (let attempt = 0; attempt < 30; attempt += 1) {
       const task = await this.describe(cluster, taskArn);
-      const privateIp = privateIpv4(task);
-      if (privateIp) return privateIp;
-      if (!task || task.lastStatus === "STOPPED") return undefined;
-      await this.sleep(2_000);
+      privateIp ??= privateIpv4(task);
+      // RunTask is eventually consistent: an immediate DescribeTasks can
+      // temporarily omit the task, so keep the existing bounded poll alive.
+      if (task?.lastStatus === "RUNNING" && privateIp) return privateIp;
+      if (terminalTaskStatus(task?.lastStatus)) {
+        throw new Error(`aws_preview_task_stopped_before_running:${task?.lastStatus}`);
+      }
+      if (attempt < 29) await this.sleep(2_000);
     }
-    return undefined;
+    // Preserve the existing reconciliation fallback for unusually slow task
+    // activation. The endpoint is private even before ECS reports RUNNING.
+    return privateIp;
   }
 
   private async describe(cluster: string, taskArn: string) {
@@ -345,6 +356,12 @@ function privateIpv4(
   return task?.attachments
     ?.flatMap((attachment) => attachment.details ?? [])
     .find((detail) => detail.name === "privateIPv4Address")?.value;
+}
+
+function terminalTaskStatus(status: string | undefined) {
+  return ["DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED", "DELETED"].includes(
+    status ?? "",
+  );
 }
 
 function formatFailures(failures: { arn?: string; reason?: string; detail?: string }[]) {

--- a/services/api/test/aws-preview-sandbox.test.ts
+++ b/services/api/test/aws-preview-sandbox.test.ts
@@ -29,7 +29,6 @@ describe("AWS preview sandbox driver", () => {
           taskDefinitionArn: "arn:aws:ecs:eu-west-1:123:task-definition/facility-prod-preview:7",
         },
       },
-      { tasks: [{ taskArn: "arn:aws:ecs:eu-west-1:123:task/facility-prod/task-1" }] },
       {
         tasks: [
           {
@@ -39,6 +38,8 @@ describe("AWS preview sandbox driver", () => {
           },
         ],
       },
+      { tasks: [] },
+      { tasks: [{ lastStatus: "RUNNING" }] },
       { tasks: [{ lastStatus: "RUNNING" }] },
       {},
       {},
@@ -83,10 +84,103 @@ describe("AWS preview sandbox driver", () => {
     });
     expect(commands[1]).toBeInstanceOf(RunTaskCommand);
     expect(commands[2]).toBeInstanceOf(DescribeTasksCommand);
+    expect(commands[3]).toBeInstanceOf(DescribeTasksCommand);
     await expect(driver.status(launched.ref)).resolves.toBe("running");
+    expect(commands[4]).toBeInstanceOf(DescribeTasksCommand);
     await driver.destroy(launched.ref);
-    expect(commands[4]).toBeInstanceOf(StopTaskCommand);
-    expect(commands[5]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+    expect(commands[5]).toBeInstanceOf(StopTaskCommand);
+    expect(commands[6]).toBeInstanceOf(DeregisterTaskDefinitionCommand);
+  });
+
+  it("returns a private endpoint after the existing activation budget expires", async () => {
+    const commands: unknown[] = [];
+    let sleeps = 0;
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        if (command instanceof RegisterTaskDefinitionCommand) {
+          return { taskDefinition: { taskDefinitionArn: "arn:aws:ecs:task-definition/preview:8" } };
+        }
+        if (command instanceof RunTaskCommand) {
+          return { tasks: [{ taskArn: "arn:aws:ecs:task/facility-prod/slow" }] };
+        }
+        if (command instanceof DescribeTasksCommand) {
+          return {
+            tasks: [
+              {
+                lastStatus: "ACTIVATING",
+                attachments: [{ details: [{ name: "privateIPv4Address", value: "10.0.2.42" }] }],
+              },
+            ],
+          };
+        }
+        return {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+      async () => {
+        sleeps += 1;
+      },
+    );
+    const launched = await driver.launch({
+      runId: "preview:slow",
+      image: "example.invalid/preview:latest",
+      env: {},
+      cpu: 1,
+      memoryMb: 1024,
+      timeoutMin: 60,
+      servicePort: 3000,
+    });
+    expect(launched.endpoint).toBe("http://10.0.2.42:3000");
+    expect(commands.filter((command) => command instanceof DescribeTasksCommand)).toHaveLength(30);
+    expect(sleeps).toBe(29);
+  });
+
+  it("cleans up a preview task that stops after receiving a private IP", async () => {
+    const commands: unknown[] = [];
+    const responses = [
+      { taskDefinition: { taskDefinitionArn: "arn:aws:ecs:task-definition/preview:9" } },
+      { tasks: [{ taskArn: "arn:aws:ecs:task/facility-prod/stopped" }] },
+      {
+        tasks: [
+          {
+            lastStatus: "PENDING",
+            attachments: [{ details: [{ name: "privateIPv4Address", value: "10.0.2.43" }] }],
+          },
+        ],
+      },
+      { tasks: [{ lastStatus: "STOPPED", stoppedReason: "CannotPullContainerError" }] },
+      {},
+      {},
+    ];
+    const ecs = {
+      send: async (command: unknown) => {
+        commands.push(command);
+        return responses.shift() ?? {};
+      },
+    };
+    const driver = new AwsPreviewSandboxDriver(
+      ecs as never,
+      { send: async () => ({}) } as never,
+      previewEnv,
+      async () => undefined,
+    );
+    await expect(
+      driver.launch({
+        runId: "preview:stopped",
+        image: "example.invalid/preview:missing",
+        env: {},
+        cpu: 1,
+        memoryMb: 1024,
+        timeoutMin: 60,
+        servicePort: 3000,
+      }),
+    ).rejects.toThrow("aws_preview_task_stopped_before_running:STOPPED");
+    expect(commands.at(-2)).toBeInstanceOf(StopTaskCommand);
+    expect(commands.at(-1)).toBeInstanceOf(DeregisterTaskDefinitionCommand);
   });
 
   it("deregisters the per-preview definition when task launch is denied", async () => {

--- a/services/api/test/previews.test.ts
+++ b/services/api/test/previews.test.ts
@@ -249,6 +249,20 @@ describe("SSO-protected preview sandboxes", async () => {
         config: expect.objectContaining({ readinessPath: "/healthz" }),
         commitSha: "abc123def456",
       });
+      const provisionedAudit = (
+        await db
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.orgId, orgId), eq(auditEvents.action, "preview.provisioned")))
+      ).find((event) => (event.target as { id?: string }).id === preview.id);
+      expect(provisionedAudit?.payload).toMatchObject({
+        driver: "docker",
+        status: "running",
+        auth_mode: "facility_session",
+        queue_delay_ms: expect.any(Number),
+        launch_ms: expect.any(Number),
+        total_ms: expect.any(Number),
+      });
 
       const listed = await app.inject({
         method: "GET",
@@ -532,6 +546,18 @@ describe("SSO-protected preview sandboxes", async () => {
     await expect(provisionPreview(config, preview.id, leakingDriver)).rejects.toThrow(
       "launch_cleanup_failed",
     );
+    const failedAudit = (
+      await db
+        .select()
+        .from(auditEvents)
+        .where(and(eq(auditEvents.orgId, orgId), eq(auditEvents.action, "preview.failed")))
+    ).find((event) => (event.target as { id?: string }).id === preview.id);
+    expect(failedAudit?.payload).toMatchObject({
+      error: "launch_cleanup_failed",
+      queue_delay_ms: expect.any(Number),
+      launch_ms: expect.any(Number),
+      total_ms: expect.any(Number),
+    });
     const retained = (
       await db.select().from(previewSandboxes).where(eq(previewSandboxes.id, preview.id)).limit(1)
     )[0];


### PR DESCRIPTION
## Summary

- reuse the existing bounded ECS endpoint-discovery poll to wait for RUNNING before returning a preview endpoint
- preserve the reconciler fallback for slow activation and clean terminal tasks immediately
- record queue, launch, and total preview provisioning timings in existing audit events

## Verification

- full repository verifier passed: lint, typecheck, clean uncached build, critical integration suites, remaining tests, guards, and all-severity dependency audit
- focused preview suite passed: 2 files, 15 tests
- Claude Opus high implementation review: APPROVED

## Stack

Depends on #93.