### PR TITLE
perf(infra): build AWS images in parallel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,11 @@
 **/.turbo
 **/.docusaurus
 **/build
+# Terraform providers are hundreds of megabytes after `terraform init`, and
+# state can contain secrets. Neither belongs in any application image context.
+**/.terraform
+**/*.tfstate
+**/*.tfstate.*
 .claude
 .git
 **/.pnpm-store

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -194,6 +194,13 @@ that what is deployed is identifiable from a commit. Deriving `ECR_PREFIX` from
 Terraform keeps the pushed repositories aligned with the selected project and
 environment.
 
+The script requires the Docker Buildx plugin and builds all five artifacts in one
+parallel Bake graph. API and worker receive separate ECR tags for the same build
+result; the ECS services still keep separate commands, roles, scaling, and
+deployment lifecycles. Repeated runs reuse the local BuildKit cache and do not
+create an extra registry-cache artifact. Terraform provider and state files from
+the preceding apply are excluded from the Docker context.
+
 Rebuild and redeploy the `web` image whenever `api_url` changes. Changing only
 the runtime ECS environment variable does not alter the rewrite destination in
 an already-built image.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,7 +2,7 @@
 #   docker build --build-arg FACILITY_API_URL=https://api.example.com \
 #     -f apps/web/Dockerfile -t facility/web .
 FROM node:22-bookworm-slim AS base
-ENV PNPM_HOME=/pnpm PATH=$PNPM_HOME:$PATH
+ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH
 RUN corepack enable
 WORKDIR /app
 

--- a/infra/build-images.sh
+++ b/infra/build-images.sh
@@ -31,46 +31,34 @@ login() {
     docker login --username AWS --password-stdin "$ECR_REGISTRY"
 }
 
-# The api, gateway, and mcp images are stages of the root multi-stage Dockerfile;
-# web and runner have their own. api and worker share one image (the worker is
-# just `node services/api/dist/worker.js` at runtime).
-build_and_push() {
-  local name="$1" dockerfile="$2" target="$3"
-  local context="${4:-$ROOT_DIR}"
-  local image="${ECR_REGISTRY}/${ECR_PREFIX}/${name}:${IMAGE_TAG}"
-  local target_arg=()
-  local build_args=()
-  [[ -n "$target" ]] && target_arg=(--target "$target")
-  if [[ "$name" == "web" ]]; then
-    : "${FACILITY_API_URL:?FACILITY_API_URL is required to build the web image}"
-    build_args=(--build-arg "FACILITY_API_URL=$FACILITY_API_URL")
-  fi
+: "${FACILITY_API_URL:?FACILITY_API_URL is required to build the web image}"
 
-  if [[ ! -f "$ROOT_DIR/$dockerfile" ]]; then
-    printf 'Missing Dockerfile for %s: %s\n' "$name" "$dockerfile" >&2
-    exit 1
-  fi
-  docker build --platform "$PLATFORM" "${target_arg[@]}" "${build_args[@]}" \
-    -f "$ROOT_DIR/$dockerfile" -t "$image" "$context"
-  docker push "$image"
-  printf '%s=%s\n' "$name" "$image"
-}
+BAKE_FILE="$ROOT_DIR/infra/docker-bake.hcl"
+if [[ ! -f "$BAKE_FILE" ]]; then
+  printf 'Missing Facility image build definition: %s\n' "$BAKE_FILE" >&2
+  exit 1
+fi
+if ! docker buildx version >/dev/null 2>&1; then
+  printf '%s\n' 'Docker Buildx is required. Install the buildx plugin and retry.' >&2
+  exit 1
+fi
 
-# Retag an already-built local image into another ECR repo (no rebuild).
-retag_and_push() {
-  local from="$1" to="$2"
-  local src="${ECR_REGISTRY}/${ECR_PREFIX}/${from}:${IMAGE_TAG}"
-  local dst="${ECR_REGISTRY}/${ECR_PREFIX}/${to}:${IMAGE_TAG}"
-  docker tag "$src" "$dst"
-  docker push "$dst"
-  printf '%s=%s\n' "$to" "$dst"
-}
+export ECR_REGISTRY ECR_PREFIX IMAGE_TAG PLATFORM FACILITY_API_URL
 
 login
-build_and_push api Dockerfile api
-# The worker runs the api image with a different command — same bits, own repo.
-retag_and_push api worker
-build_and_push gateway Dockerfile gateway
-build_and_push mcp Dockerfile mcp
-build_and_push web apps/web/Dockerfile web
-build_and_push runner runner/Dockerfile "" "$ROOT_DIR"
+
+# Bake runs independent targets concurrently and shares the root Dockerfile's
+# dependency graph. The API target has both api and worker tags because those
+# ECS services run the same bytes with different commands.
+(
+  # Bake automatically reads a .env from its working directory. Run from the
+  # env-free infra directory so application secrets are neither parsed nor
+  # forwarded into the build definition.
+  cd "$ROOT_DIR/infra"
+  docker buildx bake --allow=fs.read=.. --file "$BAKE_FILE" --push
+)
+
+# Preserve the script's stable machine-readable output contract.
+for name in api worker gateway mcp web runner; do
+  printf '%s=%s/%s/%s:%s\n' "$name" "$ECR_REGISTRY" "$ECR_PREFIX" "$name" "$IMAGE_TAG"
+done

--- a/infra/docker-bake.hcl
+++ b/infra/docker-bake.hcl
@@ -1,0 +1,68 @@
+variable "ECR_REGISTRY" {
+  default = ""
+}
+
+variable "ECR_PREFIX" {
+  default = "facility-playground"
+}
+
+variable "IMAGE_TAG" {
+  default = "latest"
+}
+
+variable "PLATFORM" {
+  default = "linux/amd64"
+}
+
+variable "FACILITY_API_URL" {
+  default = ""
+}
+
+group "default" {
+  targets = ["api", "gateway", "mcp", "web", "runner"]
+}
+
+target "service" {
+  context    = ".."
+  dockerfile = "Dockerfile"
+  platforms  = [PLATFORM]
+}
+
+target "api" {
+  inherits = ["service"]
+  target   = "api"
+  tags = [
+    "${ECR_REGISTRY}/${ECR_PREFIX}/api:${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${ECR_PREFIX}/worker:${IMAGE_TAG}",
+  ]
+}
+
+target "gateway" {
+  inherits = ["service"]
+  target   = "gateway"
+  tags     = ["${ECR_REGISTRY}/${ECR_PREFIX}/gateway:${IMAGE_TAG}"]
+}
+
+target "mcp" {
+  inherits = ["service"]
+  target   = "mcp"
+  tags     = ["${ECR_REGISTRY}/${ECR_PREFIX}/mcp:${IMAGE_TAG}"]
+}
+
+target "web" {
+  context    = ".."
+  dockerfile = "apps/web/Dockerfile"
+  target     = "web"
+  platforms  = [PLATFORM]
+  args = {
+    FACILITY_API_URL = FACILITY_API_URL
+  }
+  tags = ["${ECR_REGISTRY}/${ECR_PREFIX}/web:${IMAGE_TAG}"]
+}
+
+target "runner" {
+  context    = ".."
+  dockerfile = "runner/Dockerfile"
+  platforms  = [PLATFORM]
+  tags       = ["${ECR_REGISTRY}/${ECR_PREFIX}/runner:${IMAGE_TAG}"]
+}

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -139,13 +139,20 @@ FACILITY_API_URL="$(terraform -chdir=infra/terraform/aws output -raw api_url)" \
 cd infra/terraform/aws
 ```
 
-The script expects Dockerfiles for `api`, `worker`, `gateway`, `web`, `mcp`, and
-`runner`. Override paths or image URIs with environment variables documented in
-the script when a service image is built elsewhere. It builds `linux/amd64` by
-default, matching Terraform's default `task_cpu_architecture = "X86_64"`. To
-deploy on Graviton, set `CPU_ARCHITECTURE=ARM64` while building and set
-`task_cpu_architecture = "ARM64"` in Terraform. The build exits early if an
-explicit `PLATFORM` conflicts with `CPU_ARCHITECTURE`.
+The script requires the Docker Buildx plugin and runs one Bake graph. The five
+artifacts build concurrently; the API result is tagged into both the `api` and
+`worker` repositories because those services run the same bytes with different
+commands. API, gateway, and MCP also share the root Dockerfile dependency graph.
+No registry-cache artifact is created: repeated builds reuse the operator's local
+BuildKit cache, while ECR continues to scan only deployable image pushes. The
+repository Docker context excludes Terraform providers and state created by the
+preceding apply.
+
+The graph builds `linux/amd64` by default, matching Terraform's default
+`task_cpu_architecture = "X86_64"`. To deploy on Graviton, set
+`CPU_ARCHITECTURE=ARM64` while building and set `task_cpu_architecture = "ARM64"`
+in Terraform. The build exits before registry login if Buildx is unavailable or
+an explicit `PLATFORM` conflicts with `CPU_ARCHITECTURE`.
 
 Rebuild and redeploy the `web` image whenever `api_url` changes. Supplying only
 the runtime ECS environment variable does not update Next.js rewrite rules that

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const script = join(root, "infra", "build-images.sh");
+
+async function fakeCommands(t) {
+  const directory = await mkdtemp(join(tmpdir(), "facility-build-images-"));
+  const dockerLog = join(directory, "docker.jsonl");
+  const awsLog = join(directory, "aws.jsonl");
+  await writeFile(
+    join(directory, "docker"),
+    `#!/usr/bin/env node
+const { appendFileSync, readFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+const stdin = args[0] === "login" ? readFileSync(0, "utf8") : null;
+appendFileSync(process.env.FAKE_DOCKER_LOG, JSON.stringify({
+  args,
+  cwd: process.cwd(),
+  env: Object.fromEntries(["ECR_REGISTRY", "ECR_PREFIX", "IMAGE_TAG", "PLATFORM", "FACILITY_API_URL"].map((name) => [name, process.env[name] ?? null])),
+  stdin,
+}) + "\\n");
+if (args[0] === "buildx" && args[1] === "version" && process.env.FAKE_BUILDX_UNAVAILABLE === "1") process.exit(17);
+`,
+  );
+  await writeFile(
+    join(directory, "aws"),
+    `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+appendFileSync(process.env.FAKE_AWS_LOG, JSON.stringify({ args }) + "\\n");
+if (args[0] === "ecr" && args[1] === "get-login-password") process.stdout.write("registry-password\\n");
+`,
+  );
+  await chmod(join(directory, "docker"), 0o755);
+  await chmod(join(directory, "aws"), 0o755);
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  return { directory, dockerLog, awsLog };
+}
+
+function environment(fake, overrides = {}) {
+  return {
+    ...process.env,
+    PATH: `${fake.directory}:${process.env.PATH}`,
+    FAKE_DOCKER_LOG: fake.dockerLog,
+    FAKE_AWS_LOG: fake.awsLog,
+    AWS_ACCOUNT_ID: "123456789012",
+    AWS_REGION: "eu-west-1",
+    ECR_REGISTRY: "123456789012.dkr.ecr.eu-west-1.amazonaws.com",
+    ECR_PREFIX: "facility-test",
+    IMAGE_TAG: "abc123def456",
+    CPU_ARCHITECTURE: "X86_64",
+    PLATFORM: "linux/amd64",
+    FACILITY_API_URL: "https://api.facility.example",
+    ...overrides,
+  };
+}
+
+function run(fake, overrides = {}) {
+  return spawnSync("bash", [script], {
+    cwd: root,
+    encoding: "utf8",
+    env: environment(fake, overrides),
+  });
+}
+
+async function invocations(path) {
+  try {
+    return (await readFile(path, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+test("AWS fallback builds the complete image set through one Bake graph", async (t) => {
+  const fake = await fakeCommands(t);
+  const result = run(fake);
+  assert.equal(result.status, 0, result.stderr);
+
+  const docker = await invocations(fake.dockerLog);
+  assert.deepEqual(
+    docker.map(({ args }) => args.slice(0, 2)),
+    [
+      ["buildx", "version"],
+      ["login", "--username"],
+      ["buildx", "bake"],
+    ],
+  );
+  const bake = docker[2];
+  assert.deepEqual(bake.args, [
+    "buildx",
+    "bake",
+    "--allow=fs.read=..",
+    "--file",
+    join(root, "infra", "docker-bake.hcl"),
+    "--push",
+  ]);
+  assert.equal(bake.cwd, join(root, "infra"));
+  assert.deepEqual(bake.env, {
+    ECR_REGISTRY: "123456789012.dkr.ecr.eu-west-1.amazonaws.com",
+    ECR_PREFIX: "facility-test",
+    IMAGE_TAG: "abc123def456",
+    PLATFORM: "linux/amd64",
+    FACILITY_API_URL: "https://api.facility.example",
+  });
+  assert.equal(docker[1].stdin, "registry-password\n");
+  assert.deepEqual(await invocations(fake.awsLog), [
+    { args: ["ecr", "get-login-password", "--region", "eu-west-1"] },
+  ]);
+  assert.deepEqual(result.stdout.trim().split("\n"), [
+    "api=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/api:abc123def456",
+    "worker=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/worker:abc123def456",
+    "gateway=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/gateway:abc123def456",
+    "mcp=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/mcp:abc123def456",
+    "web=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/web:abc123def456",
+    "runner=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/runner:abc123def456",
+  ]);
+});
+
+test("Bake aliases worker to the API result and keeps all target boundaries", async () => {
+  const bake = await readFile(join(root, "infra", "docker-bake.hcl"), "utf8");
+  assert.match(
+    bake,
+    /group "default" \{[\s\S]*targets = \["api", "gateway", "mcp", "web", "runner"\]/,
+  );
+  assert.match(bake, /target "api" \{[\s\S]*\/api:\$\{IMAGE_TAG\}[\s\S]*\/worker:\$\{IMAGE_TAG\}/);
+  assert.doesNotMatch(bake, /target "worker"/);
+  assert.match(bake, /target "gateway" \{[\s\S]*target\s+= "gateway"/);
+  assert.match(bake, /target "mcp" \{[\s\S]*target\s+= "mcp"/);
+  assert.match(bake, /target "web" \{[\s\S]*dockerfile = "apps\/web\/Dockerfile"/);
+  assert.match(bake, /target "runner" \{[\s\S]*dockerfile = "runner\/Dockerfile"/);
+
+  const dockerignore = await readFile(join(root, ".dockerignore"), "utf8");
+  assert.match(dockerignore, /^\*\*\/\.terraform$/m);
+  assert.match(dockerignore, /^\*\*\/\*\.tfstate\.\*$/m);
+});
+
+for (const [name, overrides, message] of [
+  ["platform mismatch", { PLATFORM: "linux/arm64" }, /does not match CPU_ARCHITECTURE/],
+  ["invalid architecture", { CPU_ARCHITECTURE: "MIPS64" }, /must be X86_64 or ARM64/],
+  ["missing web API URL", { FACILITY_API_URL: "" }, /FACILITY_API_URL is required/],
+]) {
+  test(`${name} fails before registry authentication`, async (t) => {
+    const fake = await fakeCommands(t);
+    const result = run(fake, overrides);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, message);
+    assert.deepEqual(await invocations(fake.awsLog), []);
+    assert.deepEqual(await invocations(fake.dockerLog), []);
+  });
+}
+
+test("missing Buildx fails actionably before registry authentication", async (t) => {
+  const fake = await fakeCommands(t);
+  const result = run(fake, { FAKE_BUILDX_UNAVAILABLE: "1" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Docker Buildx is required/);
+  assert.deepEqual(await invocations(fake.awsLog), []);
+  assert.deepEqual(
+    (await invocations(fake.dockerLog)).map(({ args }) => args),
+    [["buildx", "version"]],
+  );
+});


### PR DESCRIPTION
## Summary
- replace the sequential AWS fallback image build with one Docker Buildx Bake graph
- build API, gateway, MCP, web, and runner concurrently while tagging the API result for the worker repository
- keep local BuildKit caching, exclude Terraform providers/state from image contexts, and document the unchanged six-image deployment contract

## Verification
- `env COMPOSE_DISABLE_ENV_FILE=true COMPOSE_ENV_FILES=.env.example corepack pnpm@11.1.2 verify`
- `docker buildx bake --allow=fs.read=.. --file infra/docker-bake.hcl --check`
- `node --test scripts/images-build.test.mjs`
- `git diff --check`

Claude Opus high reviewed the design and implementation and approved it with no blocking findings.

Depends on #94.