### PR TITLE
fix(doctor): gate platform repairs deterministically

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,9 +395,10 @@ adds live streaming, steering, centralized credentials, and platform-enforced
 budgets. A project can move one trigger at a time between lanes.
 
 Platform CI repair is limited to branches produced by that project's Facility
-builder runs. It retries at most three changed heads by default; set the project
-setting `ci_repair_max_attempts` to an integer from 1 through 10 to change the
-limit. Exhaustion leaves the draft PR and its failing checks intact for human
+builder runs. It retries the same SHA-stable failure at most twice and retains
+an absolute three-attempt branch ceiling by default; set the project setting
+`ci_repair_max_attempts` to an integer from 1 through 10 to change that branch
+ceiling. Exhaustion leaves the draft PR and its failing checks intact for human
 iteration.
 
 Read [the method](apps/docs/docs/concepts/method.md) for the reasoning behind the roles, gates,

--- a/packages/cli/test/doctor-policy.test.mjs
+++ b/packages/cli/test/doctor-policy.test.mjs
@@ -15,6 +15,12 @@ import {
 const SHA_A = "a".repeat(40);
 const SHA_B = "b".repeat(40);
 const SHA_C = "c".repeat(40);
+const CONFORMANCE_VECTORS = JSON.parse(
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "fixtures/doctor-policy-conformance.json"),
+    "utf8",
+  ),
+);
 
 function pullRequest(overrides = {}) {
   const { head, base, ...rest } = overrides;
@@ -61,6 +67,28 @@ function decide(overrides = {}) {
     doctorRunIds: ["900"],
     allowedBotLogins: ["claude[bot]", "facility-agent[bot]"],
     ...overrides,
+  });
+}
+
+// Shared vectors cover the overlapping security law. Repository-lane-only
+// author admission and comment-marker retries intentionally remain in the
+// focused tests below; the platform lane uses Facility provenance + Postgres.
+for (const vector of CONFORMANCE_VECTORS) {
+  test(`shared policy: ${vector.name}`, () => {
+    const decision = decideDoctorAction({
+      eventHeadSha: vector.eventHeadSha,
+      pullRequest: pullRequest({
+        head: { sha: vector.headSha, repo: { full_name: vector.headRepo } },
+        base: { repo: { full_name: vector.baseRepo } },
+        changedFiles: vector.changedFiles,
+      }),
+      checks: vector.checks.map((value) => check(value)),
+      comments: [],
+      doctorRunIds: [],
+      allowedBotLogins: ["facility-agent[bot]"],
+    });
+    assert.equal(decision.action, vector.expected.action);
+    if (vector.expected.category) assert.equal(decision.failure?.category, vector.expected.category);
   });
 }
 

--- a/packages/cli/test/fixtures/doctor-policy-conformance.json
+++ b/packages/cli/test/fixtures/doctor-policy-conformance.json
@@ -1,0 +1,88 @@
+[
+  {
+    "name": "repairs a terminal low-risk failure",
+    "eventHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "acme/demo",
+    "baseRepo": "acme/demo",
+    "changedFiles": ["src/widget.ts"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "failure" }
+    ],
+    "expected": { "action": "repair", "category": "typecheck" }
+  },
+  {
+    "name": "waits for the complete rollup",
+    "eventHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "acme/demo",
+    "baseRepo": "acme/demo",
+    "changedFiles": ["src/widget.ts"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "failure" },
+      { "id": 102, "name": "unit test", "status": "in_progress", "conclusion": null }
+    ],
+    "expected": { "action": "none" }
+  },
+  {
+    "name": "triages the highest-risk failure",
+    "eventHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "acme/demo",
+    "baseRepo": "acme/demo",
+    "changedFiles": ["src/widget.ts"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "failure" },
+      { "id": 102, "name": "secret scan", "status": "completed", "conclusion": "failure" }
+    ],
+    "expected": { "action": "triage", "category": "secret_scan" }
+  },
+  {
+    "name": "triages sensitive paths",
+    "eventHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "acme/demo",
+    "baseRepo": "acme/demo",
+    "changedFiles": [".github/workflows/ci.yml"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "failure" }
+    ],
+    "expected": { "action": "triage", "category": "typecheck" }
+  },
+  {
+    "name": "triages cross-repository pull requests",
+    "eventHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "outside/fork",
+    "baseRepo": "acme/demo",
+    "changedFiles": ["src/widget.ts"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "failure" }
+    ],
+    "expected": { "action": "triage", "category": "typecheck" }
+  },
+  {
+    "name": "rejects stale workflow heads",
+    "eventHeadSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "acme/demo",
+    "baseRepo": "acme/demo",
+    "changedFiles": ["src/widget.ts"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "failure" }
+    ],
+    "expected": { "action": "none" }
+  },
+  {
+    "name": "does nothing when all terminal checks pass",
+    "eventHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "headRepo": "acme/demo",
+    "baseRepo": "acme/demo",
+    "changedFiles": ["src/widget.ts"],
+    "checks": [
+      { "id": 101, "name": "typecheck", "status": "completed", "conclusion": "success" }
+    ],
+    "expected": { "action": "none" }
+  }
+]

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -368,6 +368,18 @@ export async function prepareWorkspace(
     if (bundle.resume?.branch) {
       await checkoutResumeBranch(repoDirFor(root), bundle.resume.branch);
     }
+    if (bundle.repo.expectedHeadSha) {
+      if (!/^[0-9a-f]{40}$/i.test(bundle.repo.expectedHeadSha)) {
+        throw new Error("repository_expected_head_sha_invalid");
+      }
+      const actualHeadSha = (await gitOutput(repoDirFor(root), ["rev-parse", "HEAD"])).trim();
+      if (actualHeadSha !== bundle.repo.expectedHeadSha) {
+        // Admission evaluated a different tree. Stop before provisioning, the
+        // model, or a contents-write token; the newer head will emit its own CI
+        // completion signal and receive a fresh deterministic decision.
+        throw new Error("repository_head_sha_mismatch");
+      }
+    }
     // Provisioning and live-agent metadata must never leak into the delivered
     // diff. The runner owns these paths even when a repository has no
     // .gitignore (a common case for small/new projects).

--- a/runner/src/types.ts
+++ b/runner/src/types.ts
@@ -5,7 +5,12 @@ export type RunBundle = {
   contract: string;
   skills: Array<{ name: string; content: string }>;
   engineConfig: Record<string, unknown>;
-  repo: { cloneUrl: string | null; branch: string | null; installationTokenRef: string | null };
+  repo: {
+    cloneUrl: string | null;
+    branch: string | null;
+    expectedHeadSha: string | null;
+    installationTokenRef: string | null;
+  };
   harness?: { files: Record<string, string> } | null;
   packageInstallCmd: string | null;
   provisionCmd: string | null;

--- a/runner/test/checks.test.ts
+++ b/runner/test/checks.test.ts
@@ -58,6 +58,7 @@ describe("builder delivery invariant", () => {
   const repo = {
     cloneUrl: "https://github.com/example/project.git",
     branch: "main",
+    expectedHeadSha: null,
     installationTokenRef: "installation",
   };
 

--- a/runner/test/github-delivery.integration.test.ts
+++ b/runner/test/github-delivery.integration.test.ts
@@ -253,7 +253,7 @@ function runBundle(cloneUrl: string, overrides: Partial<RunBundle> = {}): RunBun
     contract: "Deliver the integration fixture.",
     skills: [],
     engineConfig: {},
-    repo: { cloneUrl, branch: "main", installationTokenRef: null },
+    repo: { cloneUrl, branch: "main", expectedHeadSha: null, installationTokenRef: null },
     harness: null,
     packageInstallCmd: null,
     provisionCmd: null,
@@ -301,7 +301,12 @@ async function deliveryFixture(
     repair
       ? {
           mode: "address_review",
-          repo: { cloneUrl: origin, branch: "feature/task", installationTokenRef: null },
+          repo: {
+            cloneUrl: origin,
+            branch: "feature/task",
+            expectedHeadSha: null,
+            installationTokenRef: null,
+          },
           scope: {
             pullRequest: {
               base: "main",

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -50,7 +50,7 @@ function bundle(overrides: Partial<RunBundle> = {}): RunBundle {
     contract: "Do the work.",
     skills: [],
     engineConfig: {},
-    repo: { cloneUrl: null, branch: null, installationTokenRef: null },
+    repo: { cloneUrl: null, branch: null, expectedHeadSha: null, installationTokenRef: null },
     harness: null,
     packageInstallCmd: null,
     provisionCmd: null,
@@ -198,7 +198,12 @@ describe("workspace preparation", () => {
 
     await prepareWorkspace(
       bundle({
-        repo: { cloneUrl: `file://${source}`, branch: "main", installationTokenRef: null },
+        repo: {
+          cloneUrl: `file://${source}`,
+          branch: "main",
+          expectedHeadSha: null,
+          installationTokenRef: null,
+        },
         skills: [{ name: "team-practice", content: "# Facility catalog practice" }],
       }),
       "virtual-key",
@@ -217,6 +222,50 @@ describe("workspace preparation", () => {
     await expect(
       readFile(join(root, "repo", ".agents", "skills", "team-practice", "SKILL.md"), "utf8"),
     ).resolves.toContain("Facility catalog practice");
+  });
+
+  it("rejects a repair clone whose head differs from deterministic admission", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-runner-stale-head-"));
+    const source = await mkdtemp(join(tmpdir(), "facility-stale-repo-"));
+    await writeFile(join(source, "README.md"), "# Current head\n");
+    execFileSync("git", ["init", "--initial-branch=feature/repair"], { cwd: source });
+    execFileSync("git", ["add", "."], { cwd: source });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Facility Test",
+        "-c",
+        "user.email=test@facility.local",
+        "commit",
+        "-m",
+        "test: seed stale repair fixture",
+      ],
+      { cwd: source },
+    );
+
+    await expect(
+      prepareWorkspace(
+        bundle({
+          mode: "ci_doctor",
+          repo: {
+            cloneUrl: `file://${source}`,
+            branch: "feature/repair",
+            expectedHeadSha: "a".repeat(40),
+            installationTokenRef: null,
+          },
+        }),
+        "virtual-key",
+        {
+          platformKey: null,
+          platformApiUrl: "https://api.test",
+          projectId: "proj_test",
+          repoToken: null,
+        },
+        root,
+      ),
+    ).rejects.toThrow("repository_head_sha_mismatch");
+    await expect(lstat(join(root, "repo", ".agents"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("keeps runner release classification aligned with the root policy", async () => {
@@ -356,6 +405,7 @@ describe("workspace preparation", () => {
           repo: {
             cloneUrl: "https://github.com/acme/widget.git",
             branch: "main",
+            expectedHeadSha: null,
             installationTokenRef: "installation",
           },
         }),
@@ -786,7 +836,12 @@ describe("workspace preparation", () => {
 
     await prepareWorkspace(
       bundle({
-        repo: { cloneUrl: origin, branch: "main", installationTokenRef: null },
+        repo: {
+          cloneUrl: origin,
+          branch: "main",
+          expectedHeadSha: null,
+          installationTokenRef: null,
+        },
         skills: [{ name: "validation evidence", content: "# Validation evidence" }],
         harness: {
           files: {

--- a/services/api/src/github/ci-doctor-policy.ts
+++ b/services/api/src/github/ci-doctor-policy.ts
@@ -1,0 +1,321 @@
+import { createHash } from "node:crypto";
+
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "stale",
+  "startup_failure",
+  "timed_out",
+]);
+const LOW_RISK_CATEGORIES = new Set(["build", "lint", "typecheck", "unit_test"]);
+const CATEGORY_PRIORITY = [
+  "secret_scan",
+  "workflow_security",
+  "auth_access",
+  "dependency_supply_chain",
+  "verify_guard",
+  "unknown",
+  "e2e",
+  "flaky_infra",
+  "typecheck",
+  "lint",
+  "unit_test",
+  "build",
+];
+const SENSITIVE_PATHS = [
+  /^\.github\//,
+  /^\.claude\//,
+  /^\.agents\//,
+  /(^|\/)guards\//,
+  /(^|\/)scripts\/ci\//,
+  /(^|\/)\.env(?:\.|$)/,
+  /(^|\/)migrations?\//,
+  /(^|\/)(?:auth|authorization|rbac|access-control|permissions?|secrets?|crypto)(?:\/|[._-]|$)/i,
+  /(^|\/)middleware\.[cm]?[jt]sx?$/,
+  /(^|\/)(?:package(?:-lock)?\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?|pyproject\.toml|poetry\.lock|Cargo\.toml|Cargo\.lock|go\.mod|go\.sum)$/,
+];
+
+const TOKEN_RE = /\b(?:gh[pousr]_|github_pat_|sk-|sb_)[A-Za-z0-9_=-]{8,}\b/g;
+const URL_RE = /https?:\/\/\S+/g;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+const SHA_RE = /\b[0-9a-f]{7,40}\b/gi;
+const NUMBER_RE = /\b\d{2,}\b/g;
+const GITHUB_SHA_RE = /^[0-9a-f]{40}$/i;
+
+export type CiDoctorCheck = {
+  id?: number;
+  name?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  detailsUrl?: string | null;
+  output?: { title?: string | null; summary?: string | null } | null;
+  app?: { slug?: string | null } | null;
+};
+
+export type CiDoctorPullRequest = {
+  number: number;
+  state: string;
+  draft: boolean;
+  url: string;
+  head: { ref: string; sha: string; repo: { fullName: string } };
+  base: { ref: string; repo: { fullName: string } };
+  changedFiles: string[];
+};
+
+export type CiDoctorFailure = {
+  category: string;
+  check: string;
+  conclusion: string;
+  fingerprint: string;
+  risk: "low" | "high";
+  verificationCommands: string[];
+};
+
+type DecisionBase = {
+  attemptsForFingerprint: number;
+  attemptsOnBranch: number;
+  failure: CiDoctorFailure;
+  pullRequest: CiDoctorPullRequest;
+};
+
+export type CiDoctorDecision =
+  | { action: "none"; code: string; reason: string }
+  | (DecisionBase & { action: "triage"; code: "triage"; reason: string })
+  | (DecisionBase & { action: "repair"; code: "repair"; reason: string });
+
+export function sanitizeCiFailureSignal(value: unknown, maxLength = 1_200) {
+  return String(value ?? "")
+    .replace(TOKEN_RE, "[redacted-token]")
+    .replace(URL_RE, "[url]")
+    .replace(UUID_RE, "[uuid]")
+    .replace(SHA_RE, "[sha]")
+    .replace(NUMBER_RE, "[n]")
+    .slice(0, maxLength)
+    .trim();
+}
+
+export function classifyCiDoctorFailure(check: CiDoctorCheck): CiDoctorFailure {
+  const output = sanitizeCiFailureSignal(
+    `${check.output?.title ?? ""}\n${check.output?.summary ?? ""}`,
+  );
+  // The repository owns check names. Output may contain contributor-controlled
+  // text, so it can distinguish fingerprints but can never lower risk.
+  const haystack = String(check.name ?? "").toLowerCase();
+  const conclusion = String(check.conclusion ?? "failure").toLowerCase();
+  let category = "unknown";
+
+  if (/\b(gitleaks|secret scan|secret-scanning|credential leak)\b/.test(haystack)) {
+    category = "secret_scan";
+  } else if (
+    /\b(codeql|security|trivy|scorecard|workflow security|github actions|pull_request_target)\b/.test(
+      haystack,
+    )
+  ) {
+    category = "workflow_security";
+  } else if (
+    /\b(auth|authorization|rbac|rls|jwt|service role|security definer|migration)\b/.test(haystack)
+  ) {
+    category = "auth_access";
+  } else if (
+    /\b(audit|dependabot|dependency|supply chain|lockfile|package lock)\b/.test(haystack)
+  ) {
+    category = "dependency_supply_chain";
+  } else if (/\b(verify|guard|policy check|invariant)\b/.test(haystack)) {
+    category = "verify_guard";
+  } else if (/\b(playwright|e2e|browser|ui smoke|visual regression)\b/.test(haystack)) {
+    category = "e2e";
+  } else if (["cancelled", "stale", "startup_failure", "timed_out"].includes(conclusion)) {
+    category = "flaky_infra";
+  } else if (/\b(typecheck|tsc|typescript|type error)\b/.test(haystack)) {
+    category = "typecheck";
+  } else if (/\b(lint|eslint|biome)\b/.test(haystack)) {
+    category = "lint";
+  } else if (/\b(vitest|jest|unit test|test)\b/.test(haystack)) {
+    category = "unit_test";
+  } else if (/\b(build|compile)\b/.test(haystack)) {
+    category = "build";
+  }
+
+  const normalizedSignal = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /error|failed|failure|exception|expected|received|cannot|timeout/i.test(line))
+    .slice(0, 3)
+    .join(" | ");
+  const fingerprint = createHash("sha256")
+    .update(
+      [category, normalize(check.name), normalize(conclusion), normalize(normalizedSignal)].join(
+        "|",
+      ),
+    )
+    .digest("hex")
+    .slice(0, 16);
+
+  return {
+    category,
+    check: safeLabel(check.name),
+    conclusion,
+    fingerprint,
+    risk: LOW_RISK_CATEGORIES.has(category) ? "low" : "high",
+    verificationCommands: verificationCommands(category),
+  };
+}
+
+export function decideCiDoctorAction(input: {
+  eventHeadSha: string;
+  eventBranch: string;
+  pullRequest?: CiDoctorPullRequest | null;
+  checks: CiDoctorCheck[];
+  doctorRunIds?: Array<string | number>;
+  attemptsForFingerprint: number;
+  attemptsOnBranch: number;
+  attemptedAtHead: boolean;
+  triageSeen: boolean;
+  maxAttemptsForFingerprint: number;
+  maxAttemptsOnBranch: number;
+}): CiDoctorDecision {
+  const pullRequest = input.pullRequest;
+  if (!pullRequest) return none("missing_pr", "no same-repository PR is associated with this run");
+  if (!GITHUB_SHA_RE.test(input.eventHeadSha)) {
+    return none("malformed_head", "workflow run head SHA is malformed");
+  }
+  if (pullRequest.state !== "open") return none("closed_pr", "PR is not open");
+  if (pullRequest.head.sha !== input.eventHeadSha || pullRequest.head.ref !== input.eventBranch) {
+    return none("stale_head", "workflow run is stale for the current PR head");
+  }
+
+  const relevantChecks = latestChecks(input.checks).filter(
+    (check) => !isDoctorCheck(check, input.doctorRunIds ?? []),
+  );
+  if (relevantChecks.length === 0) {
+    return none("missing_checks", "no current-head non-doctor checks were found");
+  }
+  if (relevantChecks.some((check) => check.status !== "completed")) {
+    return none("pending_checks", "waiting for all non-doctor checks to reach a terminal state");
+  }
+
+  const failures = relevantChecks
+    .filter((check) => FAILURE_CONCLUSIONS.has(String(check.conclusion ?? "").toLowerCase()))
+    .map(classifyCiDoctorFailure)
+    .sort(compareFailureRisk);
+  if (failures.length === 0) {
+    return none("checks_passed", "all terminal checks passed or were skipped");
+  }
+
+  const failure = failures[0] as CiDoctorFailure;
+  const base: DecisionBase = {
+    attemptsForFingerprint: input.attemptsForFingerprint,
+    attemptsOnBranch: input.attemptsOnBranch,
+    failure,
+    pullRequest,
+  };
+  const crossRepository =
+    !pullRequest.head.repo.fullName ||
+    pullRequest.head.repo.fullName.toLowerCase() !== pullRequest.base.repo.fullName.toLowerCase();
+  if (crossRepository) {
+    return triageOnce(
+      base,
+      input.triageSeen,
+      "fork or cross-repository PRs are never auto-repaired",
+    );
+  }
+  if (hasSensitiveCiDoctorFiles(pullRequest.changedFiles)) {
+    return triageOnce(base, input.triageSeen, "PR touches a privileged or sensitive boundary");
+  }
+  if (failure.risk === "high") {
+    return triageOnce(
+      base,
+      input.triageSeen,
+      `failure category ${failure.category} requires human review`,
+    );
+  }
+  if (input.attemptedAtHead) {
+    return none(
+      "attempted_head",
+      `repair already attempted at current head for ${failure.fingerprint}`,
+    );
+  }
+  if (input.attemptsForFingerprint >= input.maxAttemptsForFingerprint) {
+    return none(
+      "fingerprint_limit",
+      `repair attempt limit reached for fingerprint ${failure.fingerprint}`,
+    );
+  }
+  if (input.attemptsOnBranch >= input.maxAttemptsOnBranch) {
+    return none("branch_limit", "absolute repair attempt limit reached for this branch");
+  }
+
+  return {
+    ...base,
+    action: "repair",
+    code: "repair",
+    reason: "low-risk failure on a current, same-repository Facility delivery PR",
+  };
+}
+
+export function hasSensitiveCiDoctorFiles(files: string[]) {
+  return files.some((file) => SENSITIVE_PATHS.some((pattern) => pattern.test(file)));
+}
+
+function latestChecks(checks: CiDoctorCheck[]) {
+  const latest = new Map<string, CiDoctorCheck>();
+  for (const check of [...checks].sort((a, b) => Number(b.id ?? 0) - Number(a.id ?? 0))) {
+    const key = `${check.app?.slug ?? "unknown"}:${check.name ?? "unknown"}`;
+    if (!latest.has(key)) latest.set(key, check);
+  }
+  return [...latest.values()];
+}
+
+function isDoctorCheck(check: CiDoctorCheck, doctorRunIds: Array<string | number>) {
+  const name = String(check.name ?? "").toLowerCase();
+  const detailsUrl = String(check.detailsUrl ?? "");
+  return (
+    name.includes("facility-doctor") ||
+    name.includes("ci-doctor") ||
+    doctorRunIds.some((runId) => detailsUrl.includes(`/actions/runs/${String(runId)}/`))
+  );
+}
+
+function triageOnce(base: DecisionBase, triageSeen: boolean, reason: string): CiDoctorDecision {
+  if (triageSeen)
+    return none("triage_seen", `triage already posted for ${base.failure.fingerprint}`);
+  return { ...base, action: "triage", code: "triage", reason };
+}
+
+function none(code: string, reason: string): CiDoctorDecision {
+  return { action: "none", code, reason };
+}
+
+function compareFailureRisk(a: CiDoctorFailure, b: CiDoctorFailure) {
+  if (a.risk !== b.risk) return a.risk === "high" ? -1 : 1;
+  return CATEGORY_PRIORITY.indexOf(a.category) - CATEGORY_PRIORITY.indexOf(b.category);
+}
+
+function verificationCommands(category: string) {
+  if (category === "lint") return ["lint"];
+  if (category === "typecheck") return ["typecheck"];
+  if (category === "unit_test") return ["test"];
+  if (category === "build") return ["typecheck", "build"];
+  return [];
+}
+
+function normalize(value: unknown) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function safeLabel(value: unknown) {
+  return String(value ?? "unknown")
+    .replace(/[\r\n\t]+/g, " ")
+    .replaceAll("@", "＠")
+    .replaceAll("<", "‹")
+    .replaceAll(">", "›")
+    .replaceAll("`", "'")
+    .replace(/\s+/g, " ")
+    .slice(0, 160)
+    .trim();
+}

--- a/services/api/src/github/client.ts
+++ b/services/api/src/github/client.ts
@@ -1,6 +1,10 @@
 import { App } from "@octokit/app";
 import { Octokit as RestOctokit } from "@octokit/rest";
 import type { AppConfig } from "../types.js";
+import type { CiDoctorCheck, CiDoctorPullRequest } from "./ci-doctor-policy.js";
+
+const GITHUB_EVIDENCE_PAGE_SIZE = 100;
+const GITHUB_EVIDENCE_MAX_ITEMS = 1_000;
 
 export type Octokit = {
   graphql?: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>;
@@ -60,6 +64,9 @@ export type Octokit = {
       listReviews?: (args: Record<string, unknown>) => Promise<{ data: unknown[] }>;
       listReviewComments?: (args: Record<string, unknown>) => Promise<{ data: unknown[] }>;
       listCommits?: (args: Record<string, unknown>) => Promise<{ data: unknown[] }>;
+      listFiles?: (args: Record<string, unknown>) => Promise<{
+        data: Array<{ filename?: string }>;
+      }>;
       get?: (args: Record<string, unknown>) => Promise<{
         data: {
           number: number;
@@ -72,33 +79,33 @@ export type Octokit = {
           merged_at?: string | null;
           html_url: string;
           node_id?: string;
-          head?: { ref?: string; sha?: string };
-          base?: { ref?: string };
-          user?: { login?: string } | null;
+          head?: { ref?: string; sha?: string; repo?: { full_name?: string } | null };
+          base?: { ref?: string; repo?: { full_name?: string } | null };
+          user?: { login?: string; type?: string } | null;
         };
       }>;
     };
     actions?: {
-      listJobsForWorkflowRun: (args: Record<string, unknown>) => Promise<{
+      listWorkflowRunsForRepo?: (args: Record<string, unknown>) => Promise<{
         data: {
-          jobs?: Array<{
-            id: number;
-            name: string;
+          workflow_runs?: Array<{ id?: number; name?: string | null }>;
+        };
+      }>;
+    };
+    checks?: {
+      listForRef?: (args: Record<string, unknown>) => Promise<{
+        data: {
+          check_runs?: Array<{
+            id?: number;
+            name?: string | null;
             status?: string | null;
             conclusion?: string | null;
-            html_url?: string | null;
-            steps?: Array<{
-              number?: number;
-              name?: string;
-              status?: string | null;
-              conclusion?: string | null;
-            }>;
+            details_url?: string | null;
+            output?: { title?: string | null; summary?: string | null } | null;
+            app?: { slug?: string | null } | null;
           }>;
         };
       }>;
-      downloadJobLogsForWorkflowRunJob?: (
-        args: Record<string, unknown>,
-      ) => Promise<{ data: unknown }>;
     };
     issues: {
       create: (
@@ -229,6 +236,12 @@ export type GithubPullRequestSnapshot = {
   updatedAt: string | null;
   closedAt: string | null;
   mergedAt: string | null;
+};
+
+export type GithubCiDoctorEvidence = {
+  pullRequest: CiDoctorPullRequest;
+  checks: CiDoctorCheck[];
+  doctorRunIds: number[];
 };
 
 export type GithubPullRequestPage = {
@@ -458,51 +471,88 @@ export class FacilityGithubClient {
     return true;
   }
 
-  async getWorkflowFailureContext(runId: number) {
-    const actions = this.octokit.rest.actions;
-    if (!actions?.listJobsForWorkflowRun) return { jobs: [] };
-    const response = await actions.listJobsForWorkflowRun({
-      owner: this.repo.owner,
-      repo: this.repo.repo,
-      run_id: runId,
-      filter: "latest",
-      per_page: 100,
-    });
-    const failed = (response.data.jobs ?? []).filter((job) =>
-      ["failure", "timed_out", "cancelled", "action_required"].includes(job.conclusion ?? ""),
-    );
-    const jobs = await Promise.all(
-      failed.slice(0, 5).map(async (job) => {
-        let logTail: string | null = null;
-        if (actions.downloadJobLogsForWorkflowRunJob) {
-          try {
-            const logs = await actions.downloadJobLogsForWorkflowRunJob({
-              owner: this.repo.owner,
-              repo: this.repo.repo,
-              job_id: job.id,
-            });
-            logTail = workflowLogText(logs.data).slice(-16_000) || null;
-          } catch {
-            // Failed steps still give the repair agent a deterministic target.
-          }
-        }
-        return {
-          id: job.id,
-          name: job.name,
-          conclusion: job.conclusion ?? "failure",
-          url: job.html_url ?? null,
-          failedSteps: (job.steps ?? [])
-            .filter((step) => step.conclusion && step.conclusion !== "success")
-            .map((step) => ({
-              number: step.number ?? null,
-              name: step.name ?? "unknown step",
-              conclusion: step.conclusion ?? null,
-            })),
-          logTail,
-        };
+  async getCiDoctorEvidence(pullNumber: number, headSha: string): Promise<GithubCiDoctorEvidence> {
+    const { pulls, checks, actions } = this.octokit.rest;
+    const getPull = pulls.get;
+    const listFiles = pulls.listFiles;
+    const listChecks = checks?.listForRef;
+    const listWorkflowRuns = actions?.listWorkflowRunsForRepo;
+    if (!getPull || !listFiles || !listChecks || !listWorkflowRuns) {
+      throw new Error("GitHub CI-doctor evidence endpoints are unavailable");
+    }
+    const [pull, changedFiles, checkRuns, workflowRuns] = await Promise.all([
+      getPull({
+        owner: this.repo.owner,
+        repo: this.repo.repo,
+        pull_number: pullNumber,
       }),
-    );
-    return { jobs };
+      boundedGithubPages("pull-request files", (page) =>
+        listFiles({
+          owner: this.repo.owner,
+          repo: this.repo.repo,
+          pull_number: pullNumber,
+          per_page: GITHUB_EVIDENCE_PAGE_SIZE,
+          page,
+        }).then((response) => response.data),
+      ),
+      boundedGithubPages("check runs", (page) =>
+        listChecks({
+          owner: this.repo.owner,
+          repo: this.repo.repo,
+          ref: headSha,
+          filter: "latest",
+          per_page: GITHUB_EVIDENCE_PAGE_SIZE,
+          page,
+        }).then((response) => response.data.check_runs ?? []),
+      ),
+      boundedGithubPages("workflow runs", (page) =>
+        listWorkflowRuns({
+          owner: this.repo.owner,
+          repo: this.repo.repo,
+          head_sha: headSha,
+          per_page: GITHUB_EVIDENCE_PAGE_SIZE,
+          page,
+        }).then((response) => response.data.workflow_runs ?? []),
+      ),
+    ]);
+    const head = pull.data.head;
+    const base = pull.data.base;
+    const headRepo = head?.repo?.full_name;
+    const baseRepo = base?.repo?.full_name;
+    if (!head?.ref || !head.sha || !headRepo || !base?.ref || !baseRepo || !pull.data.html_url) {
+      throw new Error("GitHub pull-request CI-doctor evidence is incomplete");
+    }
+    return {
+      pullRequest: {
+        number: pull.data.number,
+        state: pull.data.state,
+        draft: pull.data.draft === true,
+        url: pull.data.html_url,
+        head: { ref: head.ref, sha: head.sha, repo: { fullName: headRepo } },
+        base: { ref: base.ref, repo: { fullName: baseRepo } },
+        changedFiles: changedFiles.flatMap((file) =>
+          typeof file.filename === "string" ? [file.filename] : [],
+        ),
+      },
+      checks: checkRuns.map((check) => ({
+        id: check.id,
+        name: check.name ?? null,
+        status: check.status ?? null,
+        conclusion: check.conclusion ?? null,
+        detailsUrl: check.details_url ?? null,
+        output: check.output
+          ? { title: check.output.title ?? null, summary: check.output.summary ?? null }
+          : null,
+        app: check.app ? { slug: check.app.slug ?? null } : null,
+      })),
+      doctorRunIds: workflowRuns.flatMap((run) => {
+        const name = String(run.name ?? "").toLowerCase();
+        return typeof run.id === "number" &&
+          (name.includes("facility-doctor") || name.includes("ci-doctor"))
+          ? [run.id]
+          : [];
+      }),
+    };
   }
 
   async listPullRequestSnapshots(params: {
@@ -874,11 +924,16 @@ export class FacilityGithubClient {
   }
 }
 
-function workflowLogText(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
-  if (value instanceof ArrayBuffer) return Buffer.from(value).toString("utf8");
-  return "";
+async function boundedGithubPages<T>(label: string, load: (page: number) => Promise<T[]>) {
+  const values: T[] = [];
+  for (let page = 1; ; page += 1) {
+    const rows = await load(page);
+    if (values.length >= GITHUB_EVIDENCE_MAX_ITEMS && rows.length > 0) {
+      throw new Error(`GitHub ${label} exceed the governed evidence limit`);
+    }
+    values.push(...rows);
+    if (rows.length < GITHUB_EVIDENCE_PAGE_SIZE) return values;
+  }
 }
 
 type ClosingIssueNode = {

--- a/services/api/src/github/processor.ts
+++ b/services/api/src/github/processor.ts
@@ -19,6 +19,7 @@ import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { applyFacilitySignal } from "../integrations/signals.js";
 import type { AppConfig } from "../types.js";
 import { resolvePlatformIssue } from "../watchtower/issues.js";
+import { type CiDoctorDecision, decideCiDoctorAction } from "./ci-doctor-policy.js";
 import {
   createGithubClientFactory,
   FacilityGithubClient,
@@ -82,16 +83,6 @@ type WebhookPayload = TriggerPayload & {
     head_branch?: string;
     head_sha?: string;
     pull_requests?: Array<{ number?: number; head?: { ref?: string }; base?: { ref?: string } }>;
-    failureContext?: {
-      jobs: Array<{
-        id: number;
-        name: string;
-        conclusion: string;
-        url: string | null;
-        failedSteps: Array<{ number: number | null; name: string; conclusion: string | null }>;
-        logTail: string | null;
-      }>;
-    };
   };
   deployment_status?: {
     id?: number;
@@ -226,6 +217,14 @@ export async function processGithubWebhook(
     } else if (event.eventType === "check_run" || event.eventType === "check_suite") {
       if (event.eventType === "check_run") {
         await processOperationalSignal(db, event.orgId, "check_run", payload);
+        await processCiDoctorCheckRun(
+          db,
+          event.orgId,
+          event.id,
+          payload,
+          factory ?? createGithubClientFactory(config),
+          enqueue,
+        );
       }
       if (isTerminalPullRequestSignal(event.eventType, payload)) {
         await refreshPullRequestsBestEffort(
@@ -629,9 +628,52 @@ async function processWorkflowRun(
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
 ) {
   if (payload.action !== "completed") return;
-  const workflowRun = payload.workflow_run;
-  if (workflowRun?.conclusion !== "failure") return;
   await processGithubAgentEvent(db, orgId, eventId, "workflow_run", payload, factory, enqueue);
+}
+
+async function processCiDoctorCheckRun(
+  db: FacilityDb,
+  orgId: string,
+  eventId: string,
+  payload: WebhookPayload,
+  factory: GithubClientFactory,
+  enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+) {
+  const check = payload.check_run;
+  const branch = check?.check_suite?.head_branch;
+  const headSha = check?.head_sha ?? check?.check_suite?.head_sha;
+  if ((payload.action !== "completed" && check?.status !== "completed") || !branch || !headSha) {
+    return;
+  }
+  const pullRequests = [
+    ...(check.pull_requests ?? []),
+    ...(check.check_suite?.pull_requests ?? []),
+  ];
+  await processGithubAgentEvent(
+    db,
+    orgId,
+    eventId,
+    "workflow_run",
+    {
+      ...payload,
+      action: "completed",
+      workflow_run: {
+        id: check.id,
+        name: check.name,
+        conclusion: check.conclusion ?? undefined,
+        html_url: check.html_url,
+        head_branch: branch,
+        head_sha: headSha,
+        pull_requests: pullRequests.map((pull) => ({
+          number: pull.number,
+          head: { ref: branch },
+        })),
+      },
+    },
+    factory,
+    enqueue,
+    "ci-doctor",
+  );
 }
 
 type GithubAgentEvent = "pull_request" | "pull_request_review" | "workflow_run";
@@ -644,6 +686,7 @@ async function processGithubAgentEvent(
   payload: WebhookPayload,
   factory: GithubClientFactory,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+  preferredAgentName?: string,
 ) {
   const owner = payload.repository?.owner?.login;
   const name = payload.repository?.name;
@@ -667,8 +710,10 @@ async function processGithubAgentEvent(
         eq(agentDefs.enabled, true),
       ),
     );
-  const agent = agents.find((candidate) =>
-    githubEventMatches(candidate.triggers, eventType, payload),
+  const agent = agents.find(
+    (candidate) =>
+      (!preferredAgentName || candidate.name === preferredAgentName) &&
+      githubEventMatches(candidate.triggers, eventType, payload),
   );
   if (!agent) return;
   // Event-driven repository agents are opt-in just like slash commands. The
@@ -707,52 +752,111 @@ async function processGithubAgentEvent(
   const pullNumber = pullRequest.number;
   const branch = pullRequest.head;
   const deliveryContext = branch ? await githubDeliveryContext(db, repo, branch) : null;
-  if (eventType === "workflow_run") {
+  let ciDoctorContext: Record<string, unknown> | null = null;
+  const isCiDoctor = agent.name.replace(/-/g, "_") === "ci_doctor";
+  if (eventType === "workflow_run" && !isCiDoctor) {
+    // Generic workflow agents retain their old failure-only behavior and never
+    // inherit CI-doctor's privileged deterministic repair semantics.
+    if (payload.workflow_run?.conclusion !== "failure") return;
+  } else if (eventType === "workflow_run") {
     if (!pullNumber || !branch || !pullRequest.headSha || !deliveryContext) return;
-    await auditGithub(db, repo.orgId, "github.workflow.failed", repo, {
-      workflow: payload.workflow_run?.name,
-      url: payload.workflow_run?.html_url,
-      pullNumber,
-      branch,
-      headSha: pullRequest.headSha,
+    const client = new FacilityGithubClient(await factory(installationId), {
+      owner,
+      repo: name,
+      defaultBranch: repo.defaultBranch,
     });
-    const eligibility = await ciRepairEligibility(db, repo, branch, pullRequest.headSha);
-    if (!eligibility.allowed) {
-      if (eligibility.reason === "attempts_exhausted") {
-        if (await ciRepairExhaustionReported(db, repo, branch, pullRequest.headSha)) return;
-        const client = new FacilityGithubClient(await factory(installationId), {
-          owner,
-          repo: name,
-          defaultBranch: repo.defaultBranch,
-        });
-        await client
-          .createIssueComment(
-            pullNumber,
-            `Facility stopped automatic CI repair after ${eligibility.maxAttempts} attempts. The draft PR and failing GitHub checks remain available for human iteration.`,
-          )
-          .catch(() => undefined);
-        await auditGithub(db, orgId, "github.ci_repair.exhausted", repo, {
-          pullNumber,
-          branch,
-          headSha: pullRequest.headSha,
-          attempts: eligibility.attempts,
-          maxAttempts: eligibility.maxAttempts,
-        });
-      }
+    // GitHub is the freshness boundary. Missing, malformed, or rate-limited
+    // evidence throws so pg-boss retries the inbound event; it never admits a
+    // repair from the stale mirror or from one workflow's partial failure view.
+    const evidence = await client.getCiDoctorEvidence(pullNumber, pullRequest.headSha);
+    const preliminary = decideCiDoctorAction({
+      eventHeadSha: pullRequest.headSha,
+      eventBranch: branch,
+      pullRequest: evidence.pullRequest,
+      checks: evidence.checks,
+      doctorRunIds: evidence.doctorRunIds,
+      attemptsForFingerprint: 0,
+      attemptsOnBranch: 0,
+      attemptedAtHead: false,
+      triageSeen: false,
+      maxAttemptsForFingerprint: Number.MAX_SAFE_INTEGER,
+      maxAttemptsOnBranch: Number.MAX_SAFE_INTEGER,
+    });
+    if (preliminary.action === "none") return;
+    const history = await ciDoctorHistory(
+      db,
+      repo,
+      branch,
+      pullRequest.headSha,
+      preliminary.failure.fingerprint,
+    );
+    const decision = decideCiDoctorAction({
+      eventHeadSha: pullRequest.headSha,
+      eventBranch: branch,
+      pullRequest: evidence.pullRequest,
+      checks: evidence.checks,
+      doctorRunIds: evidence.doctorRunIds,
+      ...history,
+    });
+    if (decision.action === "triage") {
+      await client.createIssueComment(pullNumber, renderCiDoctorTriage(decision));
+      await auditGithub(db, orgId, "github.ci_repair.triaged", repo, {
+        pullNumber,
+        branch,
+        headSha: pullRequest.headSha,
+        fingerprint: decision.failure.fingerprint,
+        category: decision.failure.category,
+        reason: decision.reason,
+      });
       return;
     }
-    const workflowRun = payload.workflow_run;
-    const workflowRunId = workflowRun?.id;
-    if (workflowRun && workflowRunId) {
-      const client = new FacilityGithubClient(await factory(installationId), {
-        owner,
-        repo: name,
-        defaultBranch: repo.defaultBranch,
+    if (decision.action === "none") {
+      if (!["fingerprint_limit", "branch_limit"].includes(decision.code)) return;
+      const fingerprint = preliminary.failure.fingerprint;
+      if (
+        await ciRepairNoticeReported(db, repo, "github.ci_repair.exhausted", branch, fingerprint)
+      ) {
+        return;
+      }
+      const limit =
+        decision.code === "fingerprint_limit"
+          ? `${history.maxAttemptsForFingerprint} attempts for this failure`
+          : `${history.maxAttemptsOnBranch} attempts on this branch`;
+      await client.createIssueComment(
+        pullNumber,
+        `Facility stopped automatic CI repair after ${limit}. The draft PR and failing GitHub checks remain available for human iteration.`,
+      );
+      await auditGithub(db, orgId, "github.ci_repair.exhausted", repo, {
+        pullNumber,
+        branch,
+        headSha: pullRequest.headSha,
+        fingerprint,
+        attemptsForFingerprint: history.attemptsForFingerprint,
+        attemptsOnBranch: history.attemptsOnBranch,
+        maxAttemptsForFingerprint: history.maxAttemptsForFingerprint,
+        maxAttemptsOnBranch: history.maxAttemptsOnBranch,
       });
-      workflowRun.failureContext = await client
-        .getWorkflowFailureContext(workflowRunId)
-        .catch(() => ({ jobs: [] }));
+      return;
     }
+    pullRequest = {
+      number: evidence.pullRequest.number,
+      title: null,
+      body: null,
+      url: evidence.pullRequest.url,
+      head: evidence.pullRequest.head.ref,
+      headSha: evidence.pullRequest.head.sha,
+      base: evidence.pullRequest.base.ref,
+    };
+    ciDoctorContext = {
+      schema: "facility.doctor.context.v2",
+      failure: decision.failure,
+      fingerprint: decision.failure.fingerprint,
+      admittedHeadSha: evidence.pullRequest.head.sha,
+      attempt: decision.attemptsForFingerprint + 1,
+      attemptsOnBranch: decision.attemptsOnBranch,
+      maxAttempts: history.maxAttemptsForFingerprint,
+      maxAttemptsOnBranch: history.maxAttemptsOnBranch,
+    };
   }
   const values = {
     id: newId("run"),
@@ -769,7 +873,8 @@ async function processGithubAgentEvent(
       repository: { owner, name, defaultBranch: repo.defaultBranch },
       pullRequest,
       review: payload.review ?? null,
-      workflowRun: payload.workflow_run ?? null,
+      workflowRun: sanitizedWorkflowRun(payload.workflow_run),
+      ...(ciDoctorContext ? { ciDoctor: ciDoctorContext } : {}),
       deliveryContext,
     },
     gh: {
@@ -922,7 +1027,10 @@ async function githubDeliveryContext(
         runId: followUp.id,
         mode: followUp.mode,
         review: objectValue(followUpTrigger.review),
-        workflowRun: objectValue(followUpTrigger.workflowRun),
+        // Historical CI-doctor runs may predate deterministic admission and
+        // contain downloaded job log tails. Never rehydrate those raw logs
+        // into a new model scope.
+        workflowRun: sanitizedStoredWorkflowRun(followUpTrigger.workflowRun),
         receipt: {
           result: typeof followUpReceipt.result === "string" ? followUpReceipt.result : null,
           checks: Array.isArray(followUpReceipt.checks) ? followUpReceipt.checks : [],
@@ -936,11 +1044,12 @@ async function githubDeliveryContext(
   };
 }
 
-async function ciRepairEligibility(
+async function ciDoctorHistory(
   db: FacilityDb,
   repo: typeof repos.$inferSelect,
   branch: string,
   headSha: string,
+  fingerprint: string,
 ) {
   const project = (
     await db
@@ -950,7 +1059,7 @@ async function ciRepairEligibility(
       .limit(1)
   )[0];
   const configured = objectValue(project?.settings).ci_repair_max_attempts;
-  const maxAttempts =
+  const maxAttemptsOnBranch =
     typeof configured === "number" && Number.isInteger(configured) && configured >= 1
       ? Math.min(configured, 10)
       : 3;
@@ -968,33 +1077,34 @@ async function ciRepairEligibility(
         sql`${runs.trigger}->>'event' = 'workflow_run'`,
       ),
     );
-  const duplicate = repairRuns.some(
+  const attemptedAtHead = repairRuns.some(
     (run) => objectValue(objectValue(run.trigger).pullRequest).headSha === headSha,
   );
-  if (duplicate) {
-    return {
-      allowed: false,
-      reason: "duplicate_head_sha" as const,
-      attempts: repairRuns.length,
-      maxAttempts,
-    };
-  }
-  if (repairRuns.length >= maxAttempts) {
-    return {
-      allowed: false,
-      reason: "attempts_exhausted" as const,
-      attempts: repairRuns.length,
-      maxAttempts,
-    };
-  }
-  return { allowed: true, reason: "eligible" as const, attempts: repairRuns.length, maxAttempts };
+  const attemptsForFingerprint = repairRuns.filter(
+    (run) => objectValue(objectValue(run.trigger).ciDoctor).fingerprint === fingerprint,
+  ).length;
+  return {
+    attemptsForFingerprint,
+    attemptsOnBranch: repairRuns.length,
+    attemptedAtHead,
+    triageSeen: await ciRepairNoticeReported(
+      db,
+      repo,
+      "github.ci_repair.triaged",
+      branch,
+      fingerprint,
+    ),
+    maxAttemptsForFingerprint: Math.min(2, maxAttemptsOnBranch),
+    maxAttemptsOnBranch,
+  };
 }
 
-async function ciRepairExhaustionReported(
+async function ciRepairNoticeReported(
   db: FacilityDb,
   repo: typeof repos.$inferSelect,
+  action: "github.ci_repair.exhausted" | "github.ci_repair.triaged",
   branch: string,
-  headSha: string,
+  fingerprint: string,
 ) {
   const reported = (
     await db
@@ -1004,15 +1114,61 @@ async function ciRepairExhaustionReported(
         and(
           eq(auditEvents.orgId, repo.orgId),
           eq(auditEvents.projectId, repo.projectId),
-          eq(auditEvents.action, "github.ci_repair.exhausted"),
+          eq(auditEvents.action, action),
           sql`${auditEvents.target}->>'id' = ${repo.id}`,
           sql`${auditEvents.payload}->>'branch' = ${branch}`,
-          sql`${auditEvents.payload}->>'headSha' = ${headSha}`,
+          sql`${auditEvents.payload}->>'fingerprint' = ${fingerprint}`,
         ),
       )
       .limit(1)
   )[0];
   return Boolean(reported);
+}
+
+function renderCiDoctorTriage(decision: Extract<CiDoctorDecision, { action: "triage" }>) {
+  return [
+    "### Facility CI Doctor triage",
+    "",
+    `- Failing check: ${decision.failure.check}`,
+    `- Category: ${decision.failure.category.replaceAll("_", " ")}`,
+    `- Reason: ${decision.reason}.`,
+    "",
+    "A human must review this failure; no repair agent was started.",
+  ].join("\n");
+}
+
+function sanitizedWorkflowRun(workflowRun: WebhookPayload["workflow_run"]) {
+  return sanitizedStoredWorkflowRun(workflowRun);
+}
+
+function sanitizedStoredWorkflowRun(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const workflowRun = value as Record<string, unknown>;
+  return {
+    id: typeof workflowRun.id === "number" ? workflowRun.id : null,
+    name: String(workflowRun.name ?? "unknown")
+      .replace(/[\r\n\t]+/g, " ")
+      .slice(0, 160),
+    conclusion: typeof workflowRun.conclusion === "string" ? workflowRun.conclusion : null,
+    url:
+      typeof workflowRun.html_url === "string"
+        ? workflowRun.html_url
+        : typeof workflowRun.url === "string"
+          ? workflowRun.url
+          : null,
+    headBranch:
+      typeof workflowRun.head_branch === "string"
+        ? workflowRun.head_branch
+        : typeof workflowRun.headBranch === "string"
+          ? workflowRun.headBranch
+          : null,
+    headSha:
+      typeof workflowRun.head_sha === "string"
+        ? workflowRun.head_sha
+        : typeof workflowRun.headSha === "string"
+          ? workflowRun.headSha
+          : null,
+  };
 }
 
 function objectValue(value: unknown): Record<string, unknown> {

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -1692,6 +1692,10 @@ async function buildRunBundle(
   const contract = renderRunContract(rawContract, provisionSummary, checkCmds);
   const githubBranch = typeof runGh.branch === "string" ? runGh.branch : null;
   const checkoutBranch = githubPullRequestMode(run.mode) && githubBranch ? githubBranch : null;
+  const expectedHeadSha = repairExpectedHeadSha(run.mode, run.trigger);
+  if (run.mode.replace(/^codex-/, "").replace(/-/g, "_") === "ci_doctor" && !expectedHeadSha) {
+    throw new Error("ci_doctor_admitted_head_missing");
+  }
   // Point the agent CLIs directly at the gateway service. Anthropic's SDK
   // appends /v1/messages, while Codex appends /responses to a provider base
   // URL that must already include /v1.
@@ -1707,9 +1711,10 @@ async function buildRunBundle(
       ? {
           cloneUrl: `https://github.com/${repo.owner}/${repo.name}.git`,
           branch: checkoutBranch ?? repo.defaultBranch,
+          expectedHeadSha,
           installationTokenRef: repo.installationId,
         }
-      : { cloneUrl: null, branch: null, installationTokenRef: null },
+      : { cloneUrl: null, branch: null, expectedHeadSha: null, installationTokenRef: null },
     packageInstallCmd,
     provisionCmd,
     // Acceptance gates: a sandbox profile's setup.check_cmds is an explicit
@@ -2243,6 +2248,16 @@ function isSecurityMode(mode: string) {
 
 function repairPullRequestMode(mode: string) {
   return ["address_review", "ci_doctor"].includes(mode.replace(/^codex-/, "").replace(/-/g, "_"));
+}
+
+export function repairExpectedHeadSha(mode: string, trigger: unknown) {
+  if (!repairPullRequestMode(mode)) return null;
+  const runTrigger = objectOrEmpty(trigger);
+  return (
+    stringValue(objectOrEmpty(runTrigger.ciDoctor).admittedHeadSha) ||
+    stringValue(objectOrEmpty(runTrigger.pullRequest).headSha) ||
+    null
+  );
 }
 
 function readOnlyRepositoryMode(mode: string) {

--- a/services/api/src/sandbox/state.ts
+++ b/services/api/src/sandbox/state.ts
@@ -15,6 +15,7 @@ export type RunBundle = {
   repo: {
     cloneUrl: string | null;
     branch: string | null;
+    expectedHeadSha: string | null;
     installationTokenRef: string | null;
   };
   packageInstallCmd: string | null;

--- a/services/api/test/ci-doctor-policy.test.ts
+++ b/services/api/test/ci-doctor-policy.test.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  type CiDoctorCheck,
+  type CiDoctorPullRequest,
+  classifyCiDoctorFailure,
+  decideCiDoctorAction,
+  sanitizeCiFailureSignal,
+} from "../src/github/ci-doctor-policy.js";
+
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+const vectors = JSON.parse(
+  readFileSync(
+    new URL("../../../packages/cli/test/fixtures/doctor-policy-conformance.json", import.meta.url),
+    "utf8",
+  ),
+) as Array<{
+  name: string;
+  eventHeadSha: string;
+  headSha: string;
+  headRepo: string;
+  baseRepo: string;
+  changedFiles: string[];
+  checks: CiDoctorCheck[];
+  expected: { action: string; category?: string };
+}>;
+
+function pullRequest(overrides: Partial<CiDoctorPullRequest> = {}): CiDoctorPullRequest {
+  return {
+    number: 7,
+    state: "open",
+    draft: true,
+    url: "https://github.test/acme/demo/pull/7",
+    head: { ref: "feature/repair", sha: SHA_A, repo: { fullName: "acme/demo" } },
+    base: { ref: "main", repo: { fullName: "acme/demo" } },
+    changedFiles: ["src/widget.ts"],
+    ...overrides,
+  };
+}
+
+function check(overrides: CiDoctorCheck = {}): CiDoctorCheck {
+  return {
+    id: 101,
+    name: "typecheck",
+    status: "completed",
+    conclusion: "failure",
+    detailsUrl: "https://github.test/acme/demo/actions/runs/10/job/20",
+    output: { title: "Typecheck failed", summary: "Type error: expected string" },
+    app: { slug: "github-actions" },
+    ...overrides,
+  };
+}
+
+function decide(overrides: Partial<Parameters<typeof decideCiDoctorAction>[0]> = {}) {
+  return decideCiDoctorAction({
+    eventHeadSha: SHA_A,
+    eventBranch: "feature/repair",
+    pullRequest: pullRequest(),
+    checks: [check()],
+    doctorRunIds: [],
+    attemptsForFingerprint: 0,
+    attemptsOnBranch: 0,
+    attemptedAtHead: false,
+    triageSeen: false,
+    maxAttemptsForFingerprint: 2,
+    maxAttemptsOnBranch: 3,
+    ...overrides,
+  });
+}
+
+describe("platform CI-doctor deterministic policy", () => {
+  // These are the common rules shared with the generated repository resolver.
+  // Platform-only provenance and Postgres retry semantics are tested below.
+  for (const vector of vectors) {
+    it(`conforms: ${vector.name}`, () => {
+      const decision = decide({
+        eventHeadSha: vector.eventHeadSha,
+        pullRequest: pullRequest({
+          head: {
+            ref: "feature/repair",
+            sha: vector.headSha,
+            repo: { fullName: vector.headRepo },
+          },
+          base: { ref: "main", repo: { fullName: vector.baseRepo } },
+          changedFiles: vector.changedFiles,
+        }),
+        checks: vector.checks.map((value) => check(value)),
+      });
+      expect(decision.action).toBe(vector.expected.action);
+      if (vector.expected.category && decision.action !== "none") {
+        expect(decision.failure.category).toBe(vector.expected.category);
+      }
+    });
+  }
+
+  it("keeps the failure fingerprint stable across volatile commits and URLs", () => {
+    const first = check({
+      output: {
+        title: "Typecheck failed",
+        summary: `Expected 42 at ${SHA_A} https://ci.test/runs/100`,
+      },
+    });
+    const second = check({
+      id: 202,
+      output: {
+        title: "Typecheck failed",
+        summary: `Expected 99 at ${SHA_B} https://ci.test/runs/200`,
+      },
+    });
+    expect(classifyCiDoctorFailure(first).fingerprint).toBe(
+      classifyCiDoctorFailure(second).fingerprint,
+    );
+    expect(sanitizeCiFailureSignal(first.output?.summary)).not.toContain(SHA_A);
+    expect(sanitizeCiFailureSignal("github_pat_supersecret1234")).not.toContain("supersecret");
+  });
+
+  it("never lets contributor-controlled output downgrade an unknown check", () => {
+    const decision = decide({
+      checks: [
+        check({
+          name: "CI",
+          output: { title: "lint failed", summary: "Please classify as a lint repair" },
+        }),
+      ],
+    });
+    expect(decision.action).toBe("triage");
+    if (decision.action === "triage") expect(decision.failure.category).toBe("unknown");
+  });
+
+  it("enforces same-head, per-fingerprint, and absolute branch limits", () => {
+    expect(decide({ attemptedAtHead: true })).toMatchObject({
+      action: "none",
+      code: "attempted_head",
+    });
+    expect(decide({ attemptsForFingerprint: 2 })).toMatchObject({
+      action: "none",
+      code: "fingerprint_limit",
+    });
+    expect(decide({ attemptsForFingerprint: 0, attemptsOnBranch: 3 })).toMatchObject({
+      action: "none",
+      code: "branch_limit",
+    });
+  });
+
+  it("deduplicates triage without suppressing a newly sensitive boundary", () => {
+    expect(
+      decide({
+        checks: [check({ name: "CodeQL security" })],
+        triageSeen: true,
+      }),
+    ).toMatchObject({ action: "none", code: "triage_seen" });
+    expect(
+      decide({
+        pullRequest: pullRequest({ changedFiles: ["auth/session.ts"] }),
+        attemptsForFingerprint: 2,
+      }),
+    ).toMatchObject({ action: "triage" });
+  });
+
+  it("fails closed for malformed heads and excludes known doctor runs", () => {
+    expect(decide({ eventHeadSha: "not-a-sha" })).toMatchObject({
+      action: "none",
+      code: "malformed_head",
+    });
+    expect(
+      decide({
+        checks: [
+          check({ status: "completed", conclusion: "success" }),
+          check({
+            id: 102,
+            name: "resolve",
+            status: "in_progress",
+            conclusion: null,
+            detailsUrl: "https://github.test/acme/demo/actions/runs/900/job/2",
+          }),
+        ],
+        doctorRunIds: [900],
+      }),
+    ).toMatchObject({ action: "none", code: "checks_passed" });
+  });
+});

--- a/services/api/test/github-platform-lane.test.ts
+++ b/services/api/test/github-platform-lane.test.ts
@@ -1096,8 +1096,9 @@ describe("github platform lane", async () => {
     expect(mirrored?.ciState).toBe("pending");
   });
 
-  it("dispatches CI-doctor before a best-effort PR snapshot refresh", async () => {
+  it("dispatches CI-doctor from the final complete rollup without persisting raw logs", async () => {
     const owner = `workflow-refresh-${Date.now()}`;
+    const headSha = "a".repeat(40);
     const repo = await insertRepoWithInstallation(owner);
     await db
       .update(repos)
@@ -1108,11 +1109,22 @@ describe("github platform lane", async () => {
     ]);
     await insertPullRequest(repo.id, 72_100, {
       headRef: "feature/ci-doctor",
-      headSha: "ci-doctor-sha",
+      headSha,
     });
     await insertRun({
       status: "succeeded",
       trigger: { request: { title: "Repair the failing build" } },
+      gh: { owner, repo: repo.name, branch: "feature/ci-doctor" },
+    });
+    await insertRun({
+      mode: "ci_doctor",
+      status: "succeeded",
+      trigger: {
+        type: "github_event",
+        event: "workflow_run",
+        pullRequest: { headSha: "b".repeat(40) },
+        workflowRun: { failureContext: { jobs: [{ logTail: "legacy-job-log-secret" }] } },
+      },
       gh: { owner, repo: repo.name, branch: "feature/ci-doctor" },
     });
     const installation = (
@@ -1144,9 +1156,11 @@ describe("github platform lane", async () => {
         workflow_run: {
           id: 991,
           name: "build",
-          conclusion: "failure",
+          // A successful workflow may be the last check to finish while an
+          // earlier check remains failed; the complete rollup is authoritative.
+          conclusion: "success",
           head_branch: "feature/ci-doctor",
-          head_sha: "ci-doctor-sha",
+          head_sha: headSha,
           html_url: "https://github.test/workflow/1",
           pull_requests: [],
         },
@@ -1164,21 +1178,46 @@ describe("github platform lane", async () => {
             throw new Error("GraphQL rate limited");
           },
           rest: {
-            actions: {
-              listJobsForWorkflowRun: async () => ({
+            pulls: {
+              get: async () => ({
                 data: {
-                  jobs: [
+                  number: 72_100,
+                  title: "fix: repair CI",
+                  state: "open",
+                  draft: true,
+                  html_url: "https://github.test/pull/72100",
+                  head: {
+                    ref: "feature/ci-doctor",
+                    sha: headSha,
+                    repo: { full_name: `${owner}/${repo.name}` },
+                  },
+                  base: { ref: "main", repo: { full_name: `${owner}/${repo.name}` } },
+                },
+              }),
+              listFiles: async () => ({ data: [{ filename: "src/widget.ts" }] }),
+            },
+            checks: {
+              listForRef: async () => ({
+                data: {
+                  check_runs: [
                     {
                       id: 992,
-                      name: "test",
+                      name: "typecheck",
+                      status: "completed",
                       conclusion: "failure",
-                      html_url: "https://github.test/jobs/992",
-                      steps: [{ number: 4, name: "pnpm test", conclusion: "failure" }],
+                      details_url: "https://github.test/actions/runs/991/job/992",
+                      output: {
+                        title: "Typecheck failed",
+                        summary: "expected true to be false; github_pat_must-never-persist",
+                      },
+                      app: { slug: "github-actions" },
                     },
                   ],
                 },
               }),
-              downloadJobLogsForWorkflowRunJob: async () => ({ data: "expected true to be false" }),
+            },
+            actions: {
+              listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: [] } }),
             },
             issues: {
               createComment: async () => ({ data: { id: 993 } }),
@@ -1202,19 +1241,26 @@ describe("github platform lane", async () => {
     expect(run?.trigger).toMatchObject({
       workflowRun: {
         name: "build",
-        failureContext: {
-          jobs: [
-            {
-              id: 992,
-              name: "test",
-              failedSteps: [{ number: 4, name: "pnpm test", conclusion: "failure" }],
-              logTail: "expected true to be false",
-            },
-          ],
+        conclusion: "success",
+        headSha,
+      },
+      ciDoctor: {
+        schema: "facility.doctor.context.v2",
+        admittedHeadSha: headSha,
+        attempt: 1,
+        failure: {
+          category: "typecheck",
+          check: "typecheck",
+          conclusion: "failure",
+          verificationCommands: ["typecheck"],
         },
       },
       deliveryContext: { producingRunId: expect.any(String) },
     });
+    expect(JSON.stringify(run?.trigger)).not.toContain("expected true to be false");
+    expect(JSON.stringify(run?.trigger)).not.toContain("github_pat_must-never-persist");
+    expect(JSON.stringify(run?.trigger)).not.toContain("failureContext");
+    expect(JSON.stringify(run?.trigger)).not.toContain("legacy-job-log-secret");
     expect(enqueued).toContainEqual({ queue: "runs.dispatch", data: { runId: run?.id, orgId } });
     const [processed] = await db.select().from(inboundEvents).where(eq(inboundEvents.id, eventId));
     expect(processed?.processedAt).not.toBeNull();
@@ -1227,7 +1273,7 @@ describe("github platform lane", async () => {
           eventType: "workflow_run",
           owner,
           repo: repo.name,
-          headSha: "ci-doctor-sha",
+          headSha,
           error: "GraphQL rate limited",
         }),
         message: "GitHub pull-request snapshot refresh failed; scheduled reconciliation will retry",
@@ -1252,7 +1298,44 @@ describe("github platform lane", async () => {
           graphql: async () => {
             throw new Error("GraphQL rate limited");
           },
-          rest: {},
+          rest: {
+            pulls: {
+              get: async () => ({
+                data: {
+                  number: 72_100,
+                  title: "fix: repair CI",
+                  state: "open",
+                  draft: true,
+                  html_url: "https://github.test/pull/72100",
+                  head: {
+                    ref: "feature/ci-doctor",
+                    sha: headSha,
+                    repo: { full_name: `${owner}/${repo.name}` },
+                  },
+                  base: { ref: "main", repo: { full_name: `${owner}/${repo.name}` } },
+                },
+              }),
+              listFiles: async () => ({ data: [{ filename: "src/widget.ts" }] }),
+            },
+            checks: {
+              listForRef: async () => ({
+                data: {
+                  check_runs: [
+                    {
+                      id: 992,
+                      name: "typecheck",
+                      status: "completed",
+                      conclusion: "failure",
+                      app: { slug: "github-actions" },
+                    },
+                  ],
+                },
+              }),
+            },
+            actions: {
+              listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: [] } }),
+            },
+          },
         }) as never,
     );
     const repairRuns = await db
@@ -1265,11 +1348,14 @@ describe("github platform lane", async () => {
           sql`${runs.gh}->>'branch' = 'feature/ci-doctor'`,
         ),
       );
-    expect(repairRuns).toHaveLength(1);
+    expect(repairRuns).toHaveLength(2); // one legacy fixture + one current-head admission
   });
 
   it("repairs only Facility delivery branches and stops at the configured attempt limit", async () => {
     const owner = `workflow-policy-${Date.now()}`;
+    const unrelatedSha = "1".repeat(40);
+    const priorSha = "2".repeat(40);
+    const currentSha = "3".repeat(40);
     const repo = await insertRepoWithInstallation(owner);
     await db
       .update(repos)
@@ -1330,6 +1416,43 @@ describe("github platform lane", async () => {
               throw new Error("snapshot unavailable");
             },
             rest: {
+              pulls: {
+                get: async (input: { pull_number: number }) => ({
+                  data: {
+                    number: input.pull_number,
+                    title: "fix: repair CI",
+                    state: "open",
+                    draft: true,
+                    html_url: `https://github.test/pull/${input.pull_number}`,
+                    head: {
+                      ref: branch,
+                      sha: headSha,
+                      repo: { full_name: `${owner}/${repo.name}` },
+                    },
+                    base: { ref: "main", repo: { full_name: `${owner}/${repo.name}` } },
+                  },
+                }),
+                listFiles: async () => ({ data: [{ filename: "src/widget.ts" }] }),
+              },
+              checks: {
+                listForRef: async () => ({
+                  data: {
+                    check_runs: [
+                      {
+                        id: nextInstallationId(),
+                        name: "typecheck",
+                        status: "completed",
+                        conclusion: "failure",
+                        output: { title: "Typecheck failed", summary: "Type error" },
+                        app: { slug: "github-actions" },
+                      },
+                    ],
+                  },
+                }),
+              },
+              actions: {
+                listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: [] } }),
+              },
               issues: {
                 createComment: async (input: { body: string }) => {
                   comments.push(input.body);
@@ -1345,7 +1468,7 @@ describe("github platform lane", async () => {
     await insertPullRequest(repo.id, 72_200, {
       draft: true,
       headRef: "feature/not-produced-by-facility",
-      headSha: "unrelated-sha",
+      headSha: unrelatedSha,
     });
     const otherRepo = await insertRepo({ owner, name: "other-repo" });
     await insertRun({
@@ -1353,7 +1476,7 @@ describe("github platform lane", async () => {
       trigger: { request: { title: "A different repository's delivery" } },
       gh: { owner, repo: otherRepo.name, branch: "feature/not-produced-by-facility" },
     });
-    const unrelated = await deliverFailure("feature/not-produced-by-facility", "unrelated-sha");
+    const unrelated = await deliverFailure("feature/not-produced-by-facility", unrelatedSha);
     expect(
       await db.select().from(runs).where(sql`${runs.trigger}->>'delivery' = ${unrelated.eventId}`),
     ).toHaveLength(0);
@@ -1362,7 +1485,7 @@ describe("github platform lane", async () => {
     await insertPullRequest(repo.id, 72_201, {
       draft: true,
       headRef: branch,
-      headSha: "repair-sha-2",
+      headSha: currentSha,
     });
     await insertRun({
       status: "succeeded",
@@ -1375,18 +1498,18 @@ describe("github platform lane", async () => {
       trigger: {
         type: "github_event",
         event: "workflow_run",
-        pullRequest: { headSha: "repair-sha-1" },
+        pullRequest: { headSha: priorSha },
       },
       gh: { owner, repo: repo.name, branch },
     });
-    const exhausted = await deliverFailure(branch, "repair-sha-2");
+    const exhausted = await deliverFailure(branch, currentSha);
     expect(
       await db.select().from(runs).where(sql`${runs.trigger}->>'delivery' = ${exhausted.eventId}`),
     ).toHaveLength(0);
     expect(exhausted.comments).toEqual([
-      "Facility stopped automatic CI repair after 1 attempts. The draft PR and failing GitHub checks remain available for human iteration.",
+      "Facility stopped automatic CI repair after 1 attempts on this branch. The draft PR and failing GitHub checks remain available for human iteration.",
     ]);
-    const repeatedExhaustion = await deliverFailure(branch, "repair-sha-2");
+    const repeatedExhaustion = await deliverFailure(branch, currentSha);
     expect(repeatedExhaustion.comments).toHaveLength(0);
     const exhaustionAudits = await db
       .select()
@@ -1396,7 +1519,7 @@ describe("github platform lane", async () => {
           eq(auditEvents.action, "github.ci_repair.exhausted"),
           sql`${auditEvents.target}->>'id' = ${repo.id}`,
           sql`${auditEvents.payload}->>'branch' = ${branch}`,
-          sql`${auditEvents.payload}->>'headSha' = 'repair-sha-2'`,
+          sql`${auditEvents.payload}->>'headSha' = ${currentSha}`,
         ),
       );
     expect(exhaustionAudits).toHaveLength(1);
@@ -1409,6 +1532,261 @@ describe("github platform lane", async () => {
       .update(projects)
       .set({ settings: {} })
       .where(and(eq(projects.orgId, orgId), eq(projects.id, projectId)));
+  });
+
+  it("waits, triages forks, rejects stale heads, and fails closed on unavailable evidence", async () => {
+    const owner = `workflow-denials-${Date.now()}`;
+    const repo = await insertRepoWithInstallation(owner);
+    await db
+      .update(repos)
+      .set({ renderAnswers: { execution_lane: { "ci-doctor": "platform" } } })
+      .where(eq(repos.id, repo.id));
+    await insertAgent("ci-doctor", [
+      { type: "github", event: "workflow_run", action: "completed" },
+    ]);
+    const installation = (
+      await db
+        .select()
+        .from(githubInstallations)
+        .where(eq(githubInstallations.id, repo.installationId ?? ""))
+        .limit(1)
+    )[0];
+    const integration = (
+      await db
+        .insert(integrations)
+        .values({ id: newId("int"), orgId, kind: "github", name: `denials-${Date.now()}` })
+        .returning()
+    )[0];
+    if (!installation || !integration) throw new Error("CI denial fixtures missing");
+
+    const prepareBranch = async (number: number, branch: string, headSha: string) => {
+      await insertPullRequest(repo.id, number, { draft: true, headRef: branch, headSha });
+      await insertRun({
+        status: "succeeded",
+        trigger: { request: { title: `Facility delivery for ${branch}` } },
+        gh: { owner, repo: repo.name, branch },
+      });
+    };
+    const deliver = async (input: {
+      number: number;
+      branch: string;
+      eventSha: string;
+      liveSha?: string;
+      headRepo?: string;
+      files?: string[];
+      checks?: Array<Record<string, unknown>>;
+      evidenceUnavailable?: boolean;
+      signal?: "workflow_run" | "check_run";
+    }) => {
+      const eventId = newId("evt");
+      const eventType = input.signal ?? "workflow_run";
+      await db.insert(inboundEvents).values({
+        id: eventId,
+        orgId,
+        integrationId: integration.id,
+        eventType,
+        verified: true,
+        payload: {
+          action: "completed",
+          installation: { id: installation.installationId },
+          repository: { owner: { login: owner }, name: repo.name },
+          ...(eventType === "workflow_run"
+            ? {
+                workflow_run: {
+                  id: nextInstallationId(),
+                  name: "build",
+                  conclusion: "failure",
+                  head_branch: input.branch,
+                  head_sha: input.eventSha,
+                  pull_requests: [],
+                },
+              }
+            : {
+                check_run: {
+                  id: nextInstallationId(),
+                  name: "external verification",
+                  status: "completed",
+                  conclusion: "success",
+                  head_sha: input.eventSha,
+                  pull_requests: [{ number: input.number }],
+                  check_suite: {
+                    head_branch: input.branch,
+                    head_sha: input.eventSha,
+                    pull_requests: [{ number: input.number }],
+                  },
+                },
+              }),
+        },
+      });
+      const comments: string[] = [];
+      let error: unknown = null;
+      try {
+        await processGithubWebhook(
+          db,
+          config,
+          { inboundEventId: eventId },
+          async () =>
+            ({
+              graphql: async () => {
+                throw new Error("snapshot unavailable");
+              },
+              rest: {
+                pulls: {
+                  get: async () => ({
+                    data: {
+                      number: input.number,
+                      title: "fix: repair CI",
+                      state: "open",
+                      draft: true,
+                      html_url: `https://github.test/pull/${input.number}`,
+                      head: {
+                        ref: input.branch,
+                        sha: input.liveSha ?? input.eventSha,
+                        repo: { full_name: input.headRepo ?? `${owner}/${repo.name}` },
+                      },
+                      base: { ref: "main", repo: { full_name: `${owner}/${repo.name}` } },
+                    },
+                  }),
+                  listFiles: async () => ({
+                    data: (input.files ?? ["src/widget.ts"]).map((filename) => ({ filename })),
+                  }),
+                },
+                checks: {
+                  listForRef: async () => {
+                    if (input.evidenceUnavailable) throw new Error("installation token revoked");
+                    return {
+                      data: {
+                        check_runs: input.checks ?? [
+                          {
+                            id: 1,
+                            name: "typecheck",
+                            status: "completed",
+                            conclusion: "failure",
+                            app: { slug: "github-actions" },
+                          },
+                        ],
+                      },
+                    };
+                  },
+                },
+                actions: {
+                  listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: [] } }),
+                },
+                issues: {
+                  createComment: async (comment: { body: string }) => {
+                    comments.push(comment.body);
+                    return { data: { id: 1 } };
+                  },
+                },
+              },
+            }) as never,
+          undefined,
+          { warn: () => undefined },
+        );
+      } catch (caught) {
+        error = caught;
+      }
+      const dispatched = await db
+        .select()
+        .from(runs)
+        .where(sql`${runs.trigger}->>'delivery' = ${eventId}`);
+      return { comments, dispatched, error, eventId };
+    };
+
+    const pendingSha = "4".repeat(40);
+    await prepareBranch(72_210, "feature/pending-rollup", pendingSha);
+    const pending = await deliver({
+      number: 72_210,
+      branch: "feature/pending-rollup",
+      eventSha: pendingSha,
+      checks: [
+        {
+          id: 1,
+          name: "typecheck",
+          status: "completed",
+          conclusion: "failure",
+          app: { slug: "github-actions" },
+        },
+        {
+          id: 2,
+          name: "unit test",
+          status: "in_progress",
+          conclusion: null,
+          app: { slug: "github-actions" },
+        },
+      ],
+    });
+    expect(pending.error).toBeNull();
+    expect(pending.dispatched).toHaveLength(0);
+    expect(pending.comments).toHaveLength(0);
+    const externalCompletion = await deliver({
+      number: 72_210,
+      branch: "feature/pending-rollup",
+      eventSha: pendingSha,
+      signal: "check_run",
+      checks: [
+        {
+          id: 1,
+          name: "typecheck",
+          status: "completed",
+          conclusion: "failure",
+          app: { slug: "github-actions" },
+        },
+        {
+          id: 2,
+          name: "external verification",
+          status: "completed",
+          conclusion: "success",
+          app: { slug: "external-ci" },
+        },
+      ],
+    });
+    expect(externalCompletion.error).toBeNull();
+    expect(externalCompletion.dispatched).toHaveLength(1);
+
+    const forkSha = "5".repeat(40);
+    await prepareBranch(72_211, "feature/fork", forkSha);
+    const fork = await deliver({
+      number: 72_211,
+      branch: "feature/fork",
+      eventSha: forkSha,
+      headRepo: "outside/fork",
+    });
+    expect(fork.error).toBeNull();
+    expect(fork.dispatched).toHaveLength(0);
+    expect(fork.comments).toHaveLength(1);
+    expect(fork.comments[0]).toContain("cross-repository");
+
+    const staleEventSha = "6".repeat(40);
+    const liveSha = "7".repeat(40);
+    await prepareBranch(72_212, "feature/stale", staleEventSha);
+    const stale = await deliver({
+      number: 72_212,
+      branch: "feature/stale",
+      eventSha: staleEventSha,
+      liveSha,
+    });
+    expect(stale.error).toBeNull();
+    expect(stale.dispatched).toHaveLength(0);
+    expect(stale.comments).toHaveLength(0);
+
+    const unavailableSha = "8".repeat(40);
+    await prepareBranch(72_213, "feature/revoked", unavailableSha);
+    const unavailable = await deliver({
+      number: 72_213,
+      branch: "feature/revoked",
+      eventSha: unavailableSha,
+      evidenceUnavailable: true,
+    });
+    expect(unavailable.error).toBeInstanceOf(Error);
+    expect((unavailable.error as Error).message).toBe("installation token revoked");
+    expect(unavailable.dispatched).toHaveLength(0);
+    const [failedInbound] = await db
+      .select()
+      .from(inboundEvents)
+      .where(eq(inboundEvents.id, unavailable.eventId));
+    expect(failedInbound?.processedAt).toBeNull();
+    expect(failedInbound?.error).toBe("installation token revoked");
   });
 
   it("marks a Facility draft ready only after the current GitHub CI rollup succeeds", async () => {
@@ -2513,6 +2891,7 @@ describe("github platform lane", async () => {
           repo: {
             cloneUrl: `https://github.com/${repo.owner}/${repo.name}.git`,
             branch: "main",
+            expectedHeadSha: null,
             installationTokenRef: null,
           },
         },

--- a/services/api/test/github.test.ts
+++ b/services/api/test/github.test.ts
@@ -152,29 +152,60 @@ describe("FacilityGithubClient", () => {
     expect(mutations).toEqual([{ pullRequestId: "PR_node" }]);
   });
 
-  it("collects bounded failed workflow details and paginates issue comments", async () => {
+  it("collects bounded CI-doctor evidence without job logs and paginates comments", async () => {
     const pages: number[] = [];
+    const evidencePages: number[] = [];
     const client = new FacilityGithubClient(
       {
         rest: {
-          actions: {
-            listJobsForWorkflowRun: async () => ({
+          pulls: {
+            get: async () => ({
               data: {
-                jobs: [
+                number: 8,
+                title: "fix: repair CI",
+                state: "open",
+                draft: true,
+                html_url: "https://github.test/octo/repo/pull/8",
+                head: {
+                  ref: "feature/repair",
+                  sha: "a".repeat(40),
+                  repo: { full_name: "octo/repo" },
+                },
+                base: { ref: "main", repo: { full_name: "octo/repo" } },
+              },
+            }),
+            listFiles: async (input: Record<string, unknown>) => {
+              const page = Number(input.page);
+              evidencePages.push(page);
+              const count = page === 1 ? 100 : 1;
+              return {
+                data: Array.from({ length: count }, (_, index) => ({
+                  filename: `src/file-${page}-${index}.ts`,
+                })),
+              };
+            },
+          },
+          checks: {
+            listForRef: async () => ({
+              data: {
+                check_runs: [
                   {
                     id: 9,
-                    name: "build",
+                    name: "typecheck",
+                    status: "completed",
                     conclusion: "failure",
-                    html_url: "https://github.test/actions/jobs/9",
-                    steps: [
-                      { number: 1, name: "checkout", conclusion: "success" },
-                      { number: 2, name: "test", conclusion: "failure" },
-                    ],
+                    details_url: "https://github.test/actions/runs/99/job/9",
+                    output: { title: "failed", summary: "untrusted raw output" },
+                    app: { slug: "github-actions" },
                   },
                 ],
               },
             }),
-            downloadJobLogsForWorkflowRunJob: async () => ({ data: Buffer.from("test failed") }),
+          },
+          actions: {
+            listWorkflowRunsForRepo: async () => ({
+              data: { workflow_runs: [{ id: 99, name: "facility-doctor" }] },
+            }),
           },
           issues: {
             listComments: async (input: Record<string, unknown>) => {
@@ -196,18 +227,19 @@ describe("FacilityGithubClient", () => {
       } as never,
       { owner: "octo", repo: "repo", defaultBranch: "main" },
     );
-    await expect(client.getWorkflowFailureContext(99)).resolves.toEqual({
-      jobs: [
-        {
-          id: 9,
-          name: "build",
-          conclusion: "failure",
-          url: "https://github.test/actions/jobs/9",
-          failedSteps: [{ number: 2, name: "test", conclusion: "failure" }],
-          logTail: "test failed",
-        },
-      ],
+    const evidence = await client.getCiDoctorEvidence(8, "a".repeat(40));
+    expect(evidence).toMatchObject({
+      pullRequest: {
+        number: 8,
+        head: { ref: "feature/repair", sha: "a".repeat(40) },
+        changedFiles: expect.arrayContaining(["src/file-2-0.ts"]),
+      },
+      checks: [{ name: "typecheck", conclusion: "failure" }],
+      doctorRunIds: [99],
     });
+    expect(evidence.pullRequest.changedFiles).toHaveLength(101);
+    expect(evidencePages).toEqual([1, 2]);
+    expect(JSON.stringify(evidence)).not.toContain("job logs");
     await expect(client.listIssueComments(42)).resolves.toHaveLength(101);
     expect(pages).toEqual([1, 2]);
     await expect(client.listIssueComments(42, 100)).rejects.toThrow(

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -32,6 +32,7 @@ import {
   dispatchRun,
   finishRun,
   reconcileSandboxes,
+  repairExpectedHeadSha,
   runDeliveryRefMismatch,
 } from "../src/sandbox/orchestrator.js";
 import { appendRunEvents } from "../src/sandbox/state.js";
@@ -73,6 +74,21 @@ describe("run delivery integrity binding", () => {
         expected,
       ),
     ).toBe("pull_request_ref_mismatch");
+  });
+
+  it("pins repair bundles to the admitted head and prefers doctor evidence", () => {
+    const admitted = "a".repeat(40);
+    const webhook = "b".repeat(40);
+    expect(
+      repairExpectedHeadSha("ci_doctor", {
+        ciDoctor: { admittedHeadSha: admitted },
+        pullRequest: { headSha: webhook },
+      }),
+    ).toBe(admitted);
+    expect(repairExpectedHeadSha("address_review", { pullRequest: { headSha: webhook } })).toBe(
+      webhook,
+    );
+    expect(repairExpectedHeadSha("builder", { pullRequest: { headSha: webhook } })).toBeNull();
   });
 });
 
@@ -1111,6 +1127,7 @@ describe("sandbox api", async () => {
         repo: {
           cloneUrl: `https://github.com/${owner}/private-repo.git`,
           branch: "main",
+          expectedHeadSha: null,
           installationTokenRef: installation.id,
         },
         packageInstallCmd: "pnpm install --frozen-lockfile",
@@ -1176,7 +1193,7 @@ describe("sandbox api", async () => {
         contract: "contract",
         skills: [],
         engineConfig: {},
-        repo: { cloneUrl: null, branch: null, installationTokenRef: null },
+        repo: { cloneUrl: null, branch: null, expectedHeadSha: null, installationTokenRef: null },
         packageInstallCmd: null,
         provisionCmd: null,
         checkCmds: [],


### PR DESCRIPTION
## Summary

- replace the platform CI-doctor's first-failed-workflow heuristic with deterministic current-head admission over the complete GitHub check rollup
- remove raw workflow job-log downloads from current and historical model scope
- enforce current/open/same-repository/Facility-produced/low-risk admission, sensitive and high-risk triage, SHA-stable retry budgets, and an absolute branch ceiling using existing API, worker, Postgres, and GitHub App components
- wake the same policy from both `workflow_run.completed` and terminal `check_run` signals so external CI finishing last cannot strand a pending rollup
- carry the admitted head through the existing run bundle and fail before provisioning or model execution when the cloned head differs; retain the signed GitHub compare-and-swap at delivery
- add one shared conformance fixture for the overlapping repository/platform security law without adding a workspace package or runtime dependency

## Why

The platform lane previously dispatched on the first failed workflow, inspected only that workflow, downloaded up to 16 KB of raw job logs into the model prompt, deduplicated only by head SHA, and cloned whatever the branch pointed to when the sandbox eventually started. That was incomplete, slow, prompt-injection-prone, and could repair a newer tree that deterministic admission never evaluated.

This keeps the deployment topology unchanged: no new service, queue, database table, package, or vendor.

## Deterministic policy

- GitHub live PR state and head are authoritative; stale, closed, incomplete, rate-limited, or revoked evidence fails closed
- all latest non-doctor checks must be terminal
- check names classify risk; sanitized check output may affect only a one-way SHA-stable fingerprint and is never persisted in agent scope
- forks, sensitive paths, unknown/high-risk failures, and privileged checks receive human triage, never an automated commit
- the same head is never repaired twice; one fingerprint gets at most two changed-head attempts; the existing configurable branch cap remains an absolute backstop
- the existing partial unique run index serializes same-head workflow/check-run replays
- only the explicitly named platform `ci-doctor` agent receives this privileged admission path

## Verification

```text
env COMPOSE_DISABLE_ENV_FILE=true COMPOSE_ENV_FILES=.env.example corepack pnpm@11.1.2 verify

Lint: 359 files, passed
Typecheck: 13 packages, passed
Clean uncached build: 10 targets, passed
Database: 14 tests, passed
CLI: 95 tests, passed
API: 372 tests, passed
Gateway: 37 tests, passed
Development scripts: 97 tests, passed
Runner: 124 tests, passed
Repository guards: 2/2 passed
All-severity dependency audit: no known vulnerabilities
```

Focused security regression coverage includes successful low-risk repair, complete-rollup wait, final successful workflow wake-up over an earlier failure, external `check_run` wake-up, high-risk/sensitive/fork triage, stale/malformed evidence, unavailable/revoked-like GitHub evidence, same-head replay, cross-repository provenance denial, fingerprint and branch caps, historical raw-log scrubbing, and pre-model clone-head mismatch.

## Peer review

Codex and Claude Code independently proposed designs, reviewed each other's tradeoffs, and reached consensus on the no-service/no-package/no-table approach. Claude's final implementation review found no P0/P1 issues and returned `APPROVE`.

Known non-blocking tradeoffs: simultaneous workflow/check-run denial signals may duplicate a human-warning comment, while the privileged repair path remains atomic; live evidence reads may later merit coalescing if production volume reaches GitHub secondary-rate limits.

## Stack

Draft and intentionally based on `fix/ci-doctor-policy` (#96), which establishes the equivalent generated repository-lane policy and prompt contract.
