### PR TITLE
feat(infra): make storage and web routing portable

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -82,30 +82,22 @@ jobs:
             dockerfile: Dockerfile
             target: api
             context: .
-            build_args: ""
           - image: gateway
             dockerfile: Dockerfile
             target: gateway
             context: .
-            build_args: ""
           - image: mcp
             dockerfile: Dockerfile
             target: mcp
             context: .
-            build_args: ""
           - image: web
             dockerfile: apps/web/Dockerfile
             target: web
             context: .
-            # The official image serves Facility's hosted control plane. AWS
-            # self-hosters with a different api_url must build their web image
-            # for that deployment, as documented in the runbook.
-            build_args: FACILITY_API_URL=https://api.facility.tam-os.com
           - image: runner
             dockerfile: runner/Dockerfile
             target: ""
             context: .
-            build_args: ""
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -132,7 +124,6 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
-          build-args: ${{ matrix.build_args }}
           platforms: linux/amd64
           outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ pnpm dev
 
 `pnpm dev` creates `.env` when needed, fills only blank required development
 values (including `SECRET_MASTER_KEY` and the MCP signing keys), starts
-Postgres and MinIO, installs dependencies, builds shared packages, migrates and
+Postgres plus MinIO when `S3_ENDPOINT` is local (or only Postgres for an external
+S3-compatible endpoint), installs dependencies, builds shared packages, migrates and
 seeds platform essentials, then launches the API (`:4400`), worker, gateway
 (`:4410`), web app (`:3400`), and documentation site. Existing `.env` values
 are never replaced, and the command refuses a non-local `DATABASE_URL`.

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -173,10 +173,10 @@ terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
 ## 3. Build and push images when needed
 
 If you configured and verified public `image_overrides` before the first apply,
-skip this step. The overridden `web` image must have been built with
-`FACILITY_API_URL` set to this deployment's `api_url`; its same-origin proxy
-destination is part of the compiled Next.js build. Otherwise build the images
-into the ECR repositories that the module created.
+skip this step. The web image reads `FACILITY_API_URL` at runtime, so the same
+published image works for every deployment. Set it to the deployment's bare
+HTTP(S) `api_url` origin, with no credentials, path, query, or fragment.
+Otherwise build the images into the ECR repositories that the module created.
 
 The build script defaults to a playground prefix, so `ECR_PREFIX` is mandatory:
 
@@ -184,7 +184,6 @@ The build script defaults to a playground prefix, so `ECR_PREFIX` is mandatory:
 AWS_REGION="$FACILITY_AWS_REGION" \
 ECR_PREFIX="$(terraform -chdir="$FACILITY_TF_DIR" output -raw ecs_cluster_name)" \
 IMAGE_TAG="$FACILITY_IMAGE_TAG" \
-FACILITY_API_URL="$(terraform -chdir="$FACILITY_TF_DIR" output -raw api_url)" \
 CPU_ARCHITECTURE=X86_64 \
 ./infra/build-images.sh
 ```
@@ -201,9 +200,8 @@ deployment lifecycles. Repeated runs reuse the local BuildKit cache and do not
 create an extra registry-cache artifact. Terraform provider and state files from
 the preceding apply are excluded from the Docker context.
 
-Rebuild and redeploy the `web` image whenever `api_url` changes. Changing only
-the runtime ECS environment variable does not alter the rewrite destination in
-an already-built image.
+When `api_url` changes, update the web task's runtime `FACILITY_API_URL` and
+redeploy the existing image; it does not need to be rebuilt.
 
 ## 4. Populate the secret containers
 

--- a/apps/docs/docs/self-host/production.md
+++ b/apps/docs/docs/self-host/production.md
@@ -39,9 +39,11 @@ with compose.
    (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`), or ECS/container
    credentials. For non-AWS S3-compatible stores, also set `S3_ENDPOINT` and
    use static `S3_ACCESS_KEY`/`S3_SECRET_KEY` unless that runtime supplies
-   AWS-compatible credentials. The development compose stack auto-creates its
-   MinIO bucket; external stores should be provisioned by your
-   infrastructure.
+   AWS-compatible credentials. The compose stack only runs the bundled MinIO and
+   auto-creates its bucket under the `local-storage` profile; a production
+   deployment points `S3_ENDPOINT` at an externally provisioned store and omits
+   the profile, so the API and gateway neither run MinIO nor wait on bucket
+   creation.
 3. Load secrets into the runtime: `SECRET_MASTER_KEY`, identity/OAuth variables, and
    the GitHub App variables when repo automation is enabled.
 4. Run the database deploy gate once, before app traffic. Set

--- a/apps/docs/docs/self-host/quickstart.md
+++ b/apps/docs/docs/self-host/quickstart.md
@@ -36,9 +36,19 @@ To delegate the whole setup to Claude Code or Codex, paste this prompt:
 > the services to be ready, then report their local URLs.
 
 To exercise the complete production-shaped stack instead of source-watch mode,
-run `SECRET_MASTER_KEY="$(openssl rand -base64 32)" docker compose up -d --wait`.
-That stack builds the runner image, migrates and seeds once, and starts the API,
-worker, gateway, MCP server, and optional web application together.
+run
+
+```bash
+SECRET_MASTER_KEY="$(openssl rand -base64 32)" \
+  docker compose --profile local-storage up -d --wait
+```
+
+The `local-storage` profile adds the bundled MinIO and its bucket setup. That
+stack builds the runner image, migrates and seeds once, and starts the API,
+worker, gateway, MCP server, and optional web application together. To run
+against an external S3-compatible store instead, set `S3_ENDPOINT` (plus the
+matching `S3_*`/`AWS_REGION` values) and omit the profile — the API and gateway
+start without MinIO and do not wait on bucket creation.
 
 Create a GitHub App for the local instance, configure its OAuth callback and
 credentials, and run `facility instance bootstrap` before opening
@@ -73,10 +83,11 @@ configuration, and audit hash-chain verification.
 | postgres | 5461 | internal only | database |
 | minio | 9000 | internal only | envelope/transcript storage |
 
-The compose stack uses MinIO for envelopes and auto-creates the configured
-bucket (`S3_BUCKET`, default `facility`) during startup. API and gateway sign
-object-store requests with AWS SigV4, so the same settings work with MinIO,
-AWS S3, R2, and other S3-compatible endpoints.
+The `local-storage` profile runs MinIO for envelopes and auto-creates the
+configured bucket (`S3_BUCKET`, default `facility`) during startup. API and
+gateway sign object-store requests with AWS SigV4, so the same settings work
+with MinIO, AWS S3, R2, and other S3-compatible endpoints. Point `S3_ENDPOINT`
+at an external store and leave the profile off to run without MinIO.
 
 ## First real steps
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,15 +1,12 @@
-# Facility web (Next.js standalone). Built from the repo root:
-#   docker build --build-arg FACILITY_API_URL=https://api.example.com \
-#     -f apps/web/Dockerfile -t facility/web .
+# Facility web (Next.js standalone). Built once; FACILITY_API_URL is supplied
+# when the container starts so the same artifact works in every installation.
+#   docker build -f apps/web/Dockerfile -t facility/web .
 FROM node:22-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH
 RUN corepack enable
 WORKDIR /app
 
 FROM base AS build
-ARG FACILITY_API_URL
-RUN test -n "$FACILITY_API_URL"
-ENV FACILITY_API_URL=$FACILITY_API_URL
 COPY . .
 RUN pnpm install --frozen-lockfile --filter '@facility/web...'
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/apps/web/app/api/[[...path]]/route.ts
+++ b/apps/web/app/api/[[...path]]/route.ts
@@ -1,0 +1,13 @@
+import { proxyApiRequest } from "@/lib/api-proxy";
+
+export const dynamic = "force-dynamic";
+
+const handler = (request: Request) => proxyApiRequest(request);
+
+export const GET = handler;
+export const HEAD = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;
+export const OPTIONS = handler;

--- a/apps/web/lib/api-proxy.ts
+++ b/apps/web/lib/api-proxy.ts
@@ -1,0 +1,111 @@
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const UNTRUSTED_FORWARDING_HEADERS = [
+  "forwarded",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-port",
+  "x-forwarded-proto",
+] as const;
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9a-z]+$/;
+
+type ApiProxyOptions = {
+  apiUrl?: string;
+  nodeEnv?: string;
+  fetchImpl?: typeof fetch;
+};
+
+export function apiTargetUrl(requestUrl: string, apiUrl: string) {
+  let request: URL;
+  let base: URL;
+  try {
+    request = new URL(requestUrl);
+    base = new URL(apiUrl);
+  } catch {
+    throw new Error("facility_api_proxy_url_invalid");
+  }
+  if (
+    !new Set(["http:", "https:"]).has(base.protocol) ||
+    base.username ||
+    base.password ||
+    base.pathname !== "/" ||
+    base.search ||
+    base.hash
+  ) {
+    throw new Error("facility_api_proxy_url_invalid");
+  }
+  if (request.pathname !== "/api" && !request.pathname.startsWith("/api/")) {
+    throw new Error("facility_api_proxy_path_invalid");
+  }
+
+  const target = new URL(base);
+  target.pathname = request.pathname.slice("/api".length) || "/";
+  target.search = request.search;
+  return target;
+}
+
+export function apiProxyRequestHeaders(input: Headers) {
+  const headers = new Headers(input);
+  const connectionTokens = (headers.get("connection") ?? "")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  for (const name of [...HOP_BY_HOP_HEADERS, ...connectionTokens]) {
+    if (HEADER_NAME.test(name)) headers.delete(name);
+  }
+  headers.delete("host");
+  headers.delete("content-length");
+  for (const name of UNTRUSTED_FORWARDING_HEADERS) headers.delete(name);
+  // Undici transparently decompresses upstream responses. Ask for identity so
+  // the forwarded content-encoding header can never describe different bytes;
+  // production compression belongs at the edge in front of this service.
+  headers.set("accept-encoding", "identity");
+  return headers;
+}
+
+export async function proxyApiRequest(request: Request, options: ApiProxyOptions = {}) {
+  const configuredApiUrl = options.apiUrl ?? process.env.FACILITY_API_URL;
+  const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+  const apiUrl =
+    configuredApiUrl || (nodeEnv === "production" ? undefined : "http://localhost:4400");
+  if (!apiUrl) return proxyError(503, "api_proxy_not_configured");
+
+  let target: URL;
+  try {
+    target = apiTargetUrl(request.url, apiUrl);
+  } catch {
+    return proxyError(503, "api_proxy_not_configured");
+  }
+
+  const init: RequestInit & { duplex?: "half" } = {
+    method: request.method,
+    headers: apiProxyRequestHeaders(request.headers),
+    redirect: "manual",
+    cache: "no-store",
+    signal: request.signal,
+  };
+  if (request.method !== "GET" && request.method !== "HEAD" && request.body) {
+    init.body = request.body;
+    // Node's fetch requires half-duplex when the body is a ReadableStream.
+    init.duplex = "half";
+  }
+
+  try {
+    return await (options.fetchImpl ?? fetch)(target, init);
+  } catch {
+    return proxyError(502, "api_proxy_unavailable");
+  }
+}
+
+function proxyError(status: number, error: string) {
+  return Response.json({ error }, { status, headers: { "cache-control": "no-store" } });
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -62,8 +62,13 @@ export type {
  * Next can forward the session cookie; domain contracts live in @facility/sdk.
  */
 
-const API_URL = process.env.FACILITY_API_URL ?? "http://localhost:4400";
 export const SESSION_COOKIE = "facility_session";
+
+function facilityApiUrl() {
+  // Called from request-time server code (after `cookies()`), so a promoted
+  // standalone image reads the deployment's runtime environment.
+  return process.env.FACILITY_API_URL ?? "http://localhost:4400";
+}
 
 export type ApiResult<T> =
   | { ok: true; data: T }
@@ -80,7 +85,7 @@ async function apiFetch<Method extends FacilityRouteMethod, Path extends Facilit
   const jar = await cookies();
   const session = jar.get(SESSION_COOKIE);
   const client = new FacilityClient({
-    baseUrl: API_URL,
+    baseUrl: facilityApiUrl(),
     fetch: (input, init) => {
       const headers = new Headers(init?.headers);
       if (session) headers.set("cookie", `${SESSION_COOKIE}=${session.value}`);
@@ -247,7 +252,7 @@ export async function untypedApi<T>(
   const jar = await cookies();
   const session = jar.get(SESSION_COOKIE);
   try {
-    const res = await fetch(`${API_URL}${path}`, {
+    const res = await fetch(`${facilityApiUrl()}${path}`, {
       method,
       cache: "no-store",
       headers: {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,6 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 
-const API_URL = process.env.FACILITY_API_URL ?? "http://localhost:4400";
 const DEV_ORIGINS = (process.env.FACILITY_DEV_ORIGINS ?? "")
   .split(",")
   .map((origin) => origin.trim())
@@ -19,11 +18,6 @@ const nextConfig: NextConfig = {
   turbopack: { root: monorepoRoot },
   outputFileTracingRoot: monorepoRoot,
   transpilePackages: ["@facility/ui"],
-  async rewrites() {
-    // Same-origin proxy to the control plane: session cookies flow without
-    // cross-origin ceremony, in dev and behind any reverse proxy in prod.
-    return [{ source: "/api/:path*", destination: `${API_URL}/:path*` }];
-  },
 };
 
 export default nextConfig;

--- a/apps/web/test/api-proxy.test.ts
+++ b/apps/web/test/api-proxy.test.ts
@@ -1,0 +1,202 @@
+import { createServer, type RequestListener } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { apiProxyRequestHeaders, apiTargetUrl, proxyApiRequest } from "../lib/api-proxy";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+});
+
+describe("runtime API proxy policy", () => {
+  it("maps only the same-origin /api surface to a fixed HTTP(S) API origin", () => {
+    expect(
+      apiTargetUrl("https://app.example/api/v1/runs?limit=10", "https://api.example").toString(),
+    ).toBe("https://api.example/v1/runs?limit=10");
+    expect(() => apiTargetUrl("https://app.example/admin", "https://api.example")).toThrow(
+      "facility_api_proxy_path_invalid",
+    );
+    for (const apiUrl of [
+      "file:///tmp/socket",
+      "https://user:secret@api.example",
+      "https://api.example/base",
+      "https://api.example?target=other",
+      "not a URL",
+    ]) {
+      expect(() => apiTargetUrl("https://app.example/api/v1/runs", apiUrl)).toThrow(
+        "facility_api_proxy_url_invalid",
+      );
+    }
+  });
+
+  it("preserves application headers but strips hop-by-hop and spoofed forwarding headers", () => {
+    const headers = apiProxyRequestHeaders(
+      new Headers({
+        authorization: "Bearer token",
+        cookie: "facility_session=signed",
+        connection: "keep-alive, x-remove-me",
+        "x-remove-me": "secret",
+        host: "evil.example",
+        "content-length": "99",
+        "x-forwarded-for": "127.0.0.1",
+      }),
+    );
+    expect(headers.get("authorization")).toBe("Bearer token");
+    expect(headers.get("cookie")).toBe("facility_session=signed");
+    expect(headers.get("accept-encoding")).toBe("identity");
+    for (const name of ["connection", "x-remove-me", "host", "content-length", "x-forwarded-for"]) {
+      expect(headers.has(name)).toBe(false);
+    }
+  });
+
+  it("fails closed when production runtime configuration is missing or invalid", async () => {
+    const request = new Request("https://app.example/api/v1/runs");
+    const missing = await proxyApiRequest(request, { apiUrl: "", nodeEnv: "production" });
+    expect(missing.status).toBe(503);
+    await expect(missing.json()).resolves.toEqual({ error: "api_proxy_not_configured" });
+
+    const invalid = await proxyApiRequest(request, {
+      apiUrl: "https://user:secret@api.example",
+      nodeEnv: "production",
+    });
+    expect(invalid.status).toBe(503);
+  });
+
+  it("returns a sanitized error when the configured API is unavailable", async () => {
+    const request = new Request("https://app.example/api/v1/runs");
+    const result = await proxyApiRequest(request, {
+      apiUrl: "https://api.example",
+      nodeEnv: "production",
+      fetchImpl: async () => {
+        throw new Error("connect ECONNREFUSED 127.0.0.1:4400");
+      },
+    });
+    expect(result.status).toBe(502);
+    expect(result.headers.get("cache-control")).toBe("no-store");
+    await expect(result.json()).resolves.toEqual({ error: "api_proxy_unavailable" });
+  });
+});
+
+describe("runtime API proxy integration", () => {
+  it("streams request and response bodies while preserving auth, cookies, status, and set-cookie", async () => {
+    const { origin } = await listen((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        expect(request.url).toBe("/v1/echo?mode=stream");
+        expect(request.headers.authorization).toBe("Bearer runtime-token");
+        expect(request.headers.cookie).toBe("facility_session=signed");
+        expect(request.headers.host).toBe(new URL(origin).host);
+        expect(request.headers["x-forwarded-for"]).toBeUndefined();
+        expect(Buffer.concat(chunks).toString("utf8")).toBe("first-second");
+        response.writeHead(207, {
+          "content-type": "text/plain",
+          "set-cookie": ["a=1; HttpOnly", "b=2; Secure"],
+          "x-facility-upstream": "api",
+        });
+        response.write("response-");
+        response.end("stream");
+      });
+    });
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("first-"));
+        controller.enqueue(new TextEncoder().encode("second"));
+        controller.close();
+      },
+    });
+    const request = new Request("https://app.example/api/v1/echo?mode=stream", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer runtime-token",
+        cookie: "facility_session=signed",
+        "content-type": "text/plain",
+        "x-forwarded-for": "203.0.113.10",
+      },
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const result = await proxyApiRequest(request, { apiUrl: origin, nodeEnv: "production" });
+    expect(result.status).toBe(207);
+    expect(result.headers.get("x-facility-upstream")).toBe("api");
+    expect(result.headers.getSetCookie()).toEqual(["a=1; HttpOnly", "b=2; Secure"]);
+    await expect(result.text()).resolves.toBe("response-stream");
+  });
+
+  it("returns upstream redirects without following them", async () => {
+    let requests = 0;
+    const { origin } = await listen((_request, response) => {
+      requests += 1;
+      response.writeHead(302, { location: "/should-not-be-followed" });
+      response.end();
+    });
+    const result = await proxyApiRequest(new Request("https://app.example/api/auth/callback"), {
+      apiUrl: origin,
+      nodeEnv: "production",
+    });
+    expect(result.status).toBe(302);
+    expect(result.headers.get("location")).toBe("/should-not-be-followed");
+    expect(requests).toBe(1);
+  });
+
+  it("delivers an event-stream chunk before the upstream response completes", async () => {
+    let releaseSecondChunk = () => {};
+    let secondChunkSent = false;
+    const secondChunkAllowed = new Promise<void>((resolve) => {
+      releaseSecondChunk = resolve;
+    });
+    const { origin } = await listen((_request, response) => {
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      response.write("data: first\n\n");
+      void secondChunkAllowed.then(() => {
+        secondChunkSent = true;
+        response.end("data: second\n\n");
+      });
+    });
+    const fallback = setTimeout(releaseSecondChunk, 2_000);
+
+    try {
+      const result = await proxyApiRequest(
+        new Request("https://app.example/api/v1/runs/1/stream"),
+        {
+          apiUrl: origin,
+          nodeEnv: "production",
+        },
+      );
+      const reader = result.body?.getReader();
+      if (!reader) throw new Error("proxied event stream has no response body");
+
+      const first = await reader.read();
+      expect(new TextDecoder().decode(first.value)).toBe("data: first\n\n");
+      expect(secondChunkSent).toBe(false);
+
+      releaseSecondChunk();
+      const second = await reader.read();
+      expect(new TextDecoder().decode(second.value)).toBe("data: second\n\n");
+      await expect(reader.read()).resolves.toMatchObject({ done: true });
+    } finally {
+      clearTimeout(fallback);
+      releaseSecondChunk();
+    }
+  });
+});
+
+async function listen(handler: RequestListener): Promise<{ origin: string }> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server address unavailable");
+  return { origin: `http://127.0.0.1:${address.port}` };
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,8 +21,12 @@ services:
       timeout: 3s
       retries: 10
 
+  # Bundled MinIO, behind the "local-storage" profile. `pnpm dev` enables the
+  # profile only when the effective S3 endpoint is local; point S3_ENDPOINT at an
+  # external store to develop against it and leave MinIO stopped.
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
+    profiles: ["local-storage"]
     command: server /data --console-address ":9001"
     ports:
       - "9000:9000"
@@ -39,7 +43,8 @@ services:
       retries: 10
 
   createbuckets:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z@sha256:aead63c77f9db9107f1696fb08ecb0faeda23729cde94b0f663edf4fe09728e3
+    profiles: ["local-storage"]
     depends_on:
       - minio
     entrypoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,8 +253,6 @@ services:
       context: .
       dockerfile: apps/web/Dockerfile
       target: web
-      args:
-        FACILITY_API_URL: http://api:4400
     restart: unless-stopped
     environment:
       FACILITY_API_URL: http://api:4400

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,12 @@ services:
       timeout: 3s
       retries: 10
 
+  # Bundled MinIO object store. Behind the "local-storage" profile so a
+  # deployment pointed at an external S3-compatible endpoint runs neither MinIO
+  # nor createbuckets. Enable it with `docker compose --profile local-storage up`.
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
+    profiles: ["local-storage"]
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
@@ -30,7 +34,8 @@ services:
       - minio:/data
 
   createbuckets:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z@sha256:aead63c77f9db9107f1696fb08ecb0faeda23729cde94b0f663edf4fe09728e3
+    profiles: ["local-storage"]
     depends_on:
       - minio
     # The script must be the third element of entrypoint (the -c arg), NOT a
@@ -82,7 +87,10 @@ services:
       PUBLIC_URL: ${PUBLIC_URL:-http://localhost:4400}
       WEB_URL: ${WEB_URL:-http://localhost:3400}
       FACILITY_PREVIEW_URL: ${FACILITY_PREVIEW_URL:-http://preview.localhost:4400}
-      S3_ENDPOINT: http://minio:9000
+      # Defaults to the in-network MinIO of the local-storage profile. Point it
+      # at an external S3-compatible endpoint (with matching S3_* credentials)
+      # to run without the bundled store.
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-facility}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-facility-dev-secret}
       S3_BUCKET: ${S3_BUCKET:-facility}
@@ -119,7 +127,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       migrate: { condition: service_completed_successfully }
-      createbuckets: { condition: service_completed_successfully }
+      # Only hard-wait for the bucket when the local-storage profile supplies it;
+      # an external S3 endpoint leaves createbuckets absent and must not block.
+      createbuckets:
+        condition: service_completed_successfully
+        required: false
       runner-image: { condition: service_completed_successfully }
     healthcheck:
       test:
@@ -177,7 +189,8 @@ services:
     environment:
       DATABASE_URL: postgres://facility:${POSTGRES_PASSWORD:-facility}@postgres:5432/facility
       SECRET_MASTER_KEY: ${SECRET_MASTER_KEY:?set SECRET_MASTER_KEY}
-      S3_ENDPOINT: http://minio:9000
+      # Mirror the api: in-network MinIO by default, external S3 when configured.
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-facility}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-facility-dev-secret}
       S3_BUCKET: ${S3_BUCKET:-facility}
@@ -185,7 +198,9 @@ services:
     ports: ["4410:4410"]
     depends_on:
       migrate: { condition: service_completed_successfully }
-      createbuckets: { condition: service_completed_successfully }
+      createbuckets:
+        condition: service_completed_successfully
+        required: false
     healthcheck:
       test:
         [

--- a/infra/build-images.sh
+++ b/infra/build-images.sh
@@ -31,8 +31,6 @@ login() {
     docker login --username AWS --password-stdin "$ECR_REGISTRY"
 }
 
-: "${FACILITY_API_URL:?FACILITY_API_URL is required to build the web image}"
-
 BAKE_FILE="$ROOT_DIR/infra/docker-bake.hcl"
 if [[ ! -f "$BAKE_FILE" ]]; then
   printf 'Missing Facility image build definition: %s\n' "$BAKE_FILE" >&2
@@ -43,7 +41,7 @@ if ! docker buildx version >/dev/null 2>&1; then
   exit 1
 fi
 
-export ECR_REGISTRY ECR_PREFIX IMAGE_TAG PLATFORM FACILITY_API_URL
+export ECR_REGISTRY ECR_PREFIX IMAGE_TAG PLATFORM
 
 login
 

--- a/infra/docker-bake.hcl
+++ b/infra/docker-bake.hcl
@@ -14,10 +14,6 @@ variable "PLATFORM" {
   default = "linux/amd64"
 }
 
-variable "FACILITY_API_URL" {
-  default = ""
-}
-
 group "default" {
   targets = ["api", "gateway", "mcp", "web", "runner"]
 }
@@ -54,9 +50,6 @@ target "web" {
   dockerfile = "apps/web/Dockerfile"
   target     = "web"
   platforms  = [PLATFORM]
-  args = {
-    FACILITY_API_URL = FACILITY_API_URL
-  }
   tags = ["${ECR_REGISTRY}/${ECR_PREFIX}/web:${IMAGE_TAG}"]
 }
 

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -123,18 +123,16 @@ Record these outputs:
 ## 3. Build and push images when needed
 
 If you configured and verified public `image_overrides` before the first apply,
-skip this step. The overridden `web` image must have been built with
-`FACILITY_API_URL` set to this deployment's `api_url`; unlike the other images,
-its same-origin proxy destination is compiled into the Next.js build. Otherwise,
-from the module directory used above, build from the repository root and return
-afterward:
+skip this step. The web image reads `FACILITY_API_URL` when it runs, so one
+published artifact works for every deployment. Set it to a bare HTTP(S) origin
+with no credentials, path, query, or fragment. Otherwise, from the module
+directory used above, build from the repository root and return afterward:
 
 ```bash
 cd ../../..
 AWS_REGION=us-east-1 \
 ECR_PREFIX="$(terraform -chdir=infra/terraform/aws output -raw ecs_cluster_name)" \
 IMAGE_TAG=$(git rev-parse --short HEAD) \
-FACILITY_API_URL="$(terraform -chdir=infra/terraform/aws output -raw api_url)" \
 ./infra/build-images.sh
 cd infra/terraform/aws
 ```
@@ -154,9 +152,8 @@ The graph builds `linux/amd64` by default, matching Terraform's default
 in Terraform. The build exits before registry login if Buildx is unavailable or
 an explicit `PLATFORM` conflicts with `CPU_ARCHITECTURE`.
 
-Rebuild and redeploy the `web` image whenever `api_url` changes. Supplying only
-the runtime ECS environment variable does not update Next.js rewrite rules that
-were compiled into an existing image.
+When `api_url` changes, update the web task's runtime `FACILITY_API_URL` and
+redeploy the existing image; it does not need to be rebuilt.
 
 If you changed `container_image_tags` after the first apply, apply again before
 running the migrate task. Keeping the tag stable avoids that extra apply.

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -73,6 +73,25 @@ export function assertLocalDatabaseUrl(value) {
   }
 }
 
+// The bundled MinIO uses port 9000 on loopback or the compose service name.
+// Any other host/port pair is an external S3-compatible endpoint the operator runs.
+const LOCAL_S3_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "minio"]);
+
+// Does the effective S3 endpoint resolve to the bundled local MinIO? A blank or
+// unset endpoint keeps the local default; an unparseable value is treated as
+// external so we never auto-start MinIO against an endpoint we cannot classify.
+export function usesLocalStorage(s3Endpoint) {
+  const value = s3Endpoint?.trim();
+  if (!value) return true;
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  return LOCAL_S3_HOSTS.has(url.hostname.toLowerCase()) && url.port === "9000";
+}
+
 export async function prepareDevEnv(
   root = repoRoot,
   {
@@ -115,6 +134,8 @@ export async function prepareDevEnv(
   const exportedDatabaseUrl = environment.DATABASE_URL?.trim();
   const effectiveDatabaseUrl = exportedDatabaseUrl || envValue(content, "DATABASE_URL");
   assertLocalDatabaseUrl(effectiveDatabaseUrl);
+  // Exported env overrides .env, consistent with DATABASE_URL above.
+  const s3Endpoint = environment.S3_ENDPOINT?.trim() || envValue(content, "S3_ENDPOINT");
   if (created || filled.length > 0) {
     await writeFile(envPath, content, { mode: 0o600 });
   }
@@ -125,6 +146,8 @@ export async function prepareDevEnv(
     created,
     filled,
     databaseUrl: effectiveDatabaseUrl,
+    s3Endpoint,
+    localStorage: usesLocalStorage(s3Endpoint),
     // Next reads this from its own process env: it is spawned from apps/web
     // and never loads the repository-root .env itself.
     devOrigins:
@@ -189,16 +212,25 @@ export async function startDevelopment(root = repoRoot) {
   if (!prepared.created && prepared.filled.length === 0)
     console.log("✓ Preserved the existing .env");
 
-  console.log("→ Starting Postgres and MinIO");
   const compose = ["compose", "-f", "docker-compose.dev.yml"];
-  await run("docker", [...compose, "up", "-d", "--wait", "postgres", "minio"], {
-    cwd: root,
-    label: "Docker development infrastructure",
-  });
-  await run("docker", [...compose, "run", "--rm", "--no-deps", "createbuckets"], {
-    cwd: root,
-    label: "MinIO bucket setup",
-  });
+  if (prepared.localStorage) {
+    console.log("→ Starting Postgres and MinIO (local-storage profile)");
+    const local = [...compose, "--profile", "local-storage"];
+    await run("docker", [...local, "up", "-d", "--wait", "postgres", "minio"], {
+      cwd: root,
+      label: "Docker development infrastructure",
+    });
+    await run("docker", [...local, "run", "--rm", "--no-deps", "createbuckets"], {
+      cwd: root,
+      label: "MinIO bucket setup",
+    });
+  } else {
+    console.log(`→ Starting Postgres (external S3 endpoint ${prepared.s3Endpoint})`);
+    await run("docker", [...compose, "up", "-d", "--wait", "postgres"], {
+      cwd: root,
+      label: "Docker development infrastructure",
+    });
+  }
 
   console.log("→ Installing workspace dependencies");
   await run(pnpm, ["install"], {

--- a/scripts/dev.test.mjs
+++ b/scripts/dev.test.mjs
@@ -8,6 +8,7 @@ import {
   assertSupportedNode,
   prepareDevEnv,
   setEnvIfBlank,
+  usesLocalStorage,
 } from "./dev.mjs";
 
 const example = [
@@ -40,6 +41,8 @@ test("creates a private dev env and fills its generated secret", async () => {
     created: true,
     filled: ["SECRET_MASTER_KEY", "FACILITY_OAUTH_JWKS"],
     databaseUrl: "postgres://facility:facility@localhost:5461/facility",
+    s3Endpoint: undefined,
+    localStorage: true,
     devOrigins: undefined,
   });
   assert.match(content, new RegExp(`^SECRET_MASTER_KEY=${secret}$`, "m"));
@@ -72,6 +75,8 @@ test("fills only missing required values and preserves existing values", async (
     created: false,
     filled: ["DATABASE_URL", "FACILITY_OAUTH_JWKS"],
     databaseUrl: "postgres://facility:facility@localhost:5461/facility",
+    s3Endpoint: undefined,
+    localStorage: true,
     devOrigins: undefined,
   });
   assert.match(content, /^SECRET_MASTER_KEY=already-configured$/m);
@@ -101,6 +106,8 @@ test("rerunning env preparation is byte-stable", async () => {
     created: false,
     filled: [],
     databaseUrl: "postgres://facility:facility@localhost:5461/facility",
+    s3Endpoint: undefined,
+    localStorage: true,
     devOrigins: undefined,
   });
   assert.equal(second, first);
@@ -151,6 +158,65 @@ test("falls back to the env file when the exported database is blank", async () 
   });
 
   assert.equal(result.databaseUrl, "postgres://facility:facility@localhost:5461/facility");
+});
+
+test("classifies local and MinIO endpoints as bundled storage", () => {
+  // Unset or blank keeps the local default.
+  assert.equal(usesLocalStorage(undefined), true);
+  assert.equal(usesLocalStorage(""), true);
+  assert.equal(usesLocalStorage("   "), true);
+  // Loopback and the compose service name are the bundled MinIO.
+  assert.equal(usesLocalStorage("http://localhost:9000"), true);
+  assert.equal(usesLocalStorage("http://127.0.0.1:9000"), true);
+  assert.equal(usesLocalStorage("https://[::1]:9000"), true);
+  assert.equal(usesLocalStorage("http://minio:9000"), true);
+  // A loopback hostname can also host LocalStack or another external store;
+  // only the bundled MinIO port selects the profile.
+  assert.equal(usesLocalStorage("http://localhost:4566"), false);
+});
+
+test("classifies external S3-compatible endpoints as external storage", () => {
+  assert.equal(usesLocalStorage("https://s3.us-east-1.amazonaws.com"), false);
+  assert.equal(usesLocalStorage("https://accountid.r2.cloudflarestorage.com"), false);
+  assert.equal(usesLocalStorage("https://minio.example.com:9000"), false);
+  // An unparseable value must not be treated as local; we cannot classify it.
+  assert.equal(usesLocalStorage("not a url"), false);
+});
+
+test("resolves the effective S3 endpoint from the env file", async () => {
+  const root = await fixture();
+  await writeFile(join(root, ".env"), `${example}S3_ENDPOINT=http://localhost:9000\n`);
+
+  const result = await prepareDevEnv(root, {
+    generateSecret: () => "local-secret",
+    generateOauthJwks: () => '{"keys":[{"kid":"test"}]}',
+    environment: {},
+  });
+
+  assert.equal(result.s3Endpoint, "http://localhost:9000");
+  assert.equal(result.localStorage, true);
+});
+
+test("an exported S3 endpoint overrides the env file and selects external storage", async () => {
+  const root = await fixture();
+  await writeFile(join(root, ".env"), `${example}S3_ENDPOINT=http://localhost:9000\n`);
+
+  const exported = await prepareDevEnv(root, {
+    generateSecret: () => "local-secret",
+    generateOauthJwks: () => '{"keys":[{"kid":"test"}]}',
+    environment: { S3_ENDPOINT: "https://s3.us-east-1.amazonaws.com" },
+  });
+  assert.equal(exported.s3Endpoint, "https://s3.us-east-1.amazonaws.com");
+  assert.equal(exported.localStorage, false);
+
+  // A blank exported endpoint falls back to the env file's local value.
+  const blank = await prepareDevEnv(root, {
+    generateSecret: () => "local-secret",
+    generateOauthJwks: () => '{"keys":[{"kid":"test"}]}',
+    environment: { S3_ENDPOINT: "   " },
+  });
+  assert.equal(blank.s3Endpoint, "http://localhost:9000");
+  assert.equal(blank.localStorage, true);
 });
 
 test("requires Node.js 22 or newer", () => {

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -22,7 +22,7 @@ const stdin = args[0] === "login" ? readFileSync(0, "utf8") : null;
 appendFileSync(process.env.FAKE_DOCKER_LOG, JSON.stringify({
   args,
   cwd: process.cwd(),
-  env: Object.fromEntries(["ECR_REGISTRY", "ECR_PREFIX", "IMAGE_TAG", "PLATFORM", "FACILITY_API_URL"].map((name) => [name, process.env[name] ?? null])),
+  env: Object.fromEntries(["ECR_REGISTRY", "ECR_PREFIX", "IMAGE_TAG", "PLATFORM"].map((name) => [name, process.env[name] ?? null])),
   stdin,
 }) + "\\n");
 if (args[0] === "buildx" && args[1] === "version" && process.env.FAKE_BUILDX_UNAVAILABLE === "1") process.exit(17);
@@ -56,7 +56,6 @@ function environment(fake, overrides = {}) {
     IMAGE_TAG: "abc123def456",
     CPU_ARCHITECTURE: "X86_64",
     PLATFORM: "linux/amd64",
-    FACILITY_API_URL: "https://api.facility.example",
     ...overrides,
   };
 }
@@ -111,7 +110,6 @@ test("AWS fallback builds the complete image set through one Bake graph", async 
     ECR_PREFIX: "facility-test",
     IMAGE_TAG: "abc123def456",
     PLATFORM: "linux/amd64",
-    FACILITY_API_URL: "https://api.facility.example",
   });
   assert.equal(docker[1].stdin, "registry-password\n");
   assert.deepEqual(await invocations(fake.awsLog), [
@@ -148,7 +146,6 @@ test("Bake aliases worker to the API result and keeps all target boundaries", as
 for (const [name, overrides, message] of [
   ["platform mismatch", { PLATFORM: "linux/arm64" }, /does not match CPU_ARCHITECTURE/],
   ["invalid architecture", { CPU_ARCHITECTURE: "MIPS64" }, /must be X86_64 or ARM64/],
-  ["missing web API URL", { FACILITY_API_URL: "" }, /FACILITY_API_URL is required/],
 ]) {
   test(`${name} fails before registry authentication`, async (t) => {
     const fake = await fakeCommands(t);

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -132,15 +132,10 @@ test("CI gates release images and the reusable publisher stages digests before p
     "the isolated build checkout must be stamped before Docker consumes it",
   );
   assert.match(imagesWorkflow, /push-by-digest=true,name-canonical=true,push=true/);
-  assert.match(
+  assert.doesNotMatch(
     buildJob,
-    /- image: web[\s\S]*?build_args: FACILITY_API_URL=https:\/\/api\.facility\.tam-os\.com/,
-    "the release web image must receive the API URL compiled into its rewrites",
-  );
-  assert.match(
-    buildJob,
-    /build-args: \$\{\{ matrix\.build_args \}\}/,
-    "the matrix build arguments must reach docker/build-push-action",
+    /build[_-]args|FACILITY_API_URL=/,
+    "the release web image must remain portable across runtime API origins",
   );
   assert.match(imagesWorkflow, /promote:\n {4}needs: \[plan, build\]/);
   assert.match(imagesWorkflow, /node scripts\/images\.mjs promote/);


### PR DESCRIPTION
## Summary

- start the bundled MinIO and bucket initializer only for local S3-compatible storage
- let external S3-compatible deployments omit both storage containers without weakening the local readiness gate
- read the web control-plane origin at container runtime so one immutable image can move between deployments
- preserve same-origin browser sessions through a hardened streaming Route Handler proxy
- remove the obsolete build argument from Compose, Bake, the AWS build fallback, and image publication

## Security and portability boundaries

- proxy destinations are fixed to a configured bare HTTP(S) origin; credentials, paths, queries, fragments, forwarding headers, hop-by-hop headers, and redirect following are rejected or stripped
- production fails closed when the API origin is missing or invalid
- request bodies, response bodies, session cookies, status, redirects, and multiple `Set-Cookie` values are preserved
- local MinIO still blocks API/gateway startup until bucket creation succeeds when its profile is active
- the internal Facility planning/review documents are deliberately excluded

## Evidence

- `env COMPOSE_DISABLE_ENV_FILE=true COMPOSE_ENV_FILES=.env.example corepack pnpm@11.1.2 verify`
  - 372 API tests, 37 gateway tests, 33 web tests, 124 runner tests
  - repository guards: 2 passed
  - dependency audit: no known vulnerabilities
- built-container runtime routing: POST returned upstream status 209, preserved cookie/body/`Set-Cookie`, and removed `/api` from the upstream path
- built-container SSE routing: first event visible at 75 ms; second event visible at 1,574 ms after the upstream delay
- Compose profile contract: 8 default services; 10 with `local-storage`; external S3 starts no MinIO services
- independently reviewed with Claude Opus at high reasoning; no P0/P1 findings
