### PR TITLE
fix(receipts): report truncated check evidence

### DIFF
--- a/packages/cli/templates/receipts/collect.mjs
+++ b/packages/cli/templates/receipts/collect.mjs
@@ -18,6 +18,7 @@ const MODES = new Set([
   "custom",
 ]);
 const PROVIDERS = new Set(["claude_code", "codex_cli", "byo"]);
+const MAX_RECEIPT_CHECKS = 200;
 
 export function collectReceipt(env = process.env, now = new Date()) {
   const provider = requiredChoice(env.FACILITY_RECEIPT_PROVIDER, PROVIDERS, "provider");
@@ -25,7 +26,7 @@ export function collectReceipt(env = process.env, now = new Date()) {
   const result = normalizeResult(env.FACILITY_RECEIPT_RESULT);
   const startedAt = validDate(env.FACILITY_RECEIPT_STARTED_AT) ?? now;
   const engine = parseEngineEvidence(env.FACILITY_RECEIPT_ENGINE_JSONL);
-  const checks = parseChecks(env.FACILITY_RECEIPT_CHECKS_FILE);
+  const checkEvidence = parseChecks(env.FACILITY_RECEIPT_CHECKS_FILE);
   const target = githubTarget(env.GITHUB_EVENT_PATH);
   const git = gitActivity(env.FACILITY_RECEIPT_BASE_SHA, env.GITHUB_WORKSPACE);
   const actor = env.GITHUB_ACTOR;
@@ -65,9 +66,9 @@ export function collectReceipt(env = process.env, now = new Date()) {
       ended_at: now.toISOString(),
       duration_ms: Math.max(0, now.getTime() - startedAt.getTime()),
     },
-    events: { count: engine.eventCount, checks: checks.length },
-    checks,
-    checks_truncated: false,
+    events: { count: engine.eventCount, checks: checkEvidence.total },
+    checks: checkEvidence.items,
+    checks_truncated: checkEvidence.total > checkEvidence.items.length,
   };
   const integrity = {
     algorithm: "sha256",
@@ -198,7 +199,7 @@ function mergeUsage(usage, value) {
 }
 
 function parseChecks(path) {
-  if (!path || !existsSync(path)) return [];
+  if (!path || !existsSync(path)) return { items: [], total: 0 };
   const checks = [];
   for (const line of readFileSync(path, "utf8").split(/\r?\n/).filter(Boolean)) {
     try {
@@ -214,7 +215,7 @@ function parseChecks(path) {
       });
     } catch {}
   }
-  return checks.slice(0, 200);
+  return { items: checks.slice(0, MAX_RECEIPT_CHECKS), total: checks.length };
 }
 
 function gitActivity(baseSha, worktree) {

--- a/packages/cli/test/receipts.test.mjs
+++ b/packages/cli/test/receipts.test.mjs
@@ -43,6 +43,8 @@ test("collects a privacy-preserving, tamper-evident agent receipt", async () => 
   assert.equal(receipt.usage.input_tokens, 10);
   assert.equal(receipt.activity.turns, 1);
   assert.equal(receipt.activity.shell_commands, 1);
+  assert.equal(receipt.events.checks, 0);
+  assert.equal(receipt.checks_truncated, false);
   assert.equal(receipt.github.actor, undefined);
   assert.match(receipt.github.actor_sha256, /^[0-9a-f]{64}$/);
   assert.equal(verifyReceipt(receipt), true);
@@ -52,4 +54,35 @@ test("collects a privacy-preserving, tamper-evident agent receipt", async () => 
     false,
   );
   assert.equal(writeReceipt(receipt, env), outputPath);
+});
+
+test("reports the full check count when receipt details are bounded", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "facility-receipt-checks-"));
+  const checksPath = join(dir, "checks.jsonl");
+  writeFileSync(
+    checksPath,
+    Array.from({ length: 205 }, (_, index) =>
+      JSON.stringify({ name: `check-${index + 1}`, status: "passed", self_reported: false }),
+    ).join("\n"),
+  );
+
+  const receipt = collectReceipt(
+    {
+      FACILITY_RECEIPT_PROVIDER: "claude_code",
+      FACILITY_RECEIPT_MODE: "builder",
+      FACILITY_RECEIPT_RESULT: "success",
+      FACILITY_RECEIPT_CHECKS_FILE: checksPath,
+      GITHUB_RUN_ID: "456",
+      GITHUB_RUN_ATTEMPT: "1",
+      GITHUB_JOB: "builder",
+    },
+    new Date("2026-08-07T00:00:00.000Z"),
+  );
+
+  assert.equal(receipt.events.checks, 205);
+  assert.equal(receipt.checks.length, 200);
+  assert.equal(receipt.checks_truncated, true);
+  assert.equal(receipt.checks[0].name, "check-1");
+  assert.equal(receipt.checks.at(-1).name, "check-200");
+  assert.equal(verifyReceipt(receipt), true);
 });


### PR DESCRIPTION
## Summary

- report the total number of valid repository-lane checks even when receipt details are capped
- set `checks_truncated` honestly when more than 200 check records exist
- align repository receipts with the existing platform-run receipt contract

## Evidence

- focused receipt regression: 2/2 passed
- complete CLI suite: 96/96 passed
- 205-check receipt: total 205, 200 retained details, truncation true, integrity valid
- independently reviewed with Claude Opus at high reasoning; no blockers

The two internal Facility planning/review documents remain untracked and are not part of this PR.
