### PR TITLE
perf(infra): share image build and worker artifact

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -3,11 +3,11 @@
 # passes; a manual run publishes a commit-SHA tag and never a version tag. The
 # version comes from the commits on main, not from a tag someone pushed.
 #
-# Builds first push addressable digests without deployable tags. Only after all
-# five builds succeed does the promote job point the six service tags at those
-# digests (worker intentionally reuses api). Existing tags are inspected through
-# the GitHub Packages API: an exact digest is idempotent, while a conflicting
-# replay fails closed before promotion.
+# One Bake graph first pushes five addressable digests without deployable tags.
+# Only after the complete graph succeeds does the promote job point the six
+# service tags at those digests (worker intentionally reuses api). Existing
+# tags are inspected through the GitHub Packages API: an exact digest is
+# idempotent, while a conflicting replay fails closed before promotion.
 #
 # A package is created PRIVATE regardless of the repository's visibility: what
 # it inherits from the linked repository is access permissions, not visibility.
@@ -33,9 +33,6 @@ permissions:
 concurrency:
   group: images-${{ github.repository }}
   cancel-in-progress: false
-
-env:
-  REGISTRY: ghcr.io/${{ github.repository }}
 
 jobs:
   plan:
@@ -72,37 +69,11 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # api carries the worker and the migrate task as well: same bits, a
-          # different command. The worker tags are promoted from this digest.
-          - image: api
-            dockerfile: Dockerfile
-            target: api
-            context: .
-          - image: gateway
-            dockerfile: Dockerfile
-            target: gateway
-            context: .
-          - image: mcp
-            dockerfile: Dockerfile
-            target: mcp
-            context: .
-          - image: web
-            dockerfile: apps/web/Dockerfile
-            target: web
-            context: .
-          - image: runner
-            dockerfile: runner/Dockerfile
-            target: ""
-            context: .
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # The plan job's stamp cannot cross the job boundary. Stamp every matrix
-      # checkout so the built image contains the version on its promoted tag.
+      # The plan job's stamp cannot cross the job boundary. Stamp this isolated
+      # checkout so every target contains the version on its promoted tag.
       - name: Stamp the decided version
         if: inputs.version != ''
         run: node scripts/release.mjs stamp "${{ inputs.version }}"
@@ -115,31 +86,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Shell steps do not receive the cache runtime credentials that JavaScript
+      # actions receive. Export them before raw Buildx uses the type=gha cache.
+      - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
       # linux/amd64 only, matching the module's default task_cpu_architecture.
-      # Graviton deployments still build their own until arm64 is added here.
-      - name: Build and push the addressable digest
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
-          platforms: linux/amd64
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
-
-      - name: Record the built digest
+      # A single graph shares base, dependency, and workspace stages across the
+      # five thin security-boundary images. The overlay pushes only canonical
+      # digests; release tags remain gated by the promote job.
+      - name: Build and push the addressable image set
         env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-          IMAGE_NAME: ${{ matrix.image }}
-        run: node scripts/images.mjs record-digest "$IMAGE_NAME" "$IMAGE_DIGEST" "$RUNNER_TEMP/image-digests"
+          ECR_REGISTRY: ghcr.io
+          ECR_PREFIX: ${{ github.repository }}
+          IMAGE_TAG: unused-by-publish-overlay
+          PLATFORM: linux/amd64
+          PUBLISH_REGISTRY: ghcr.io
+          PUBLISH_PREFIX: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata="$RUNNER_TEMP/image-build-metadata.json"
+          (
+            cd infra
+            docker buildx bake \
+              --allow=fs.read=.. \
+              --file docker-bake.hcl \
+              --file docker-bake.publish.hcl \
+              --metadata-file "$metadata"
+          )
+          node scripts/images.mjs record-bake-digests \
+            "$metadata" "$RUNNER_TEMP/image-digests"
 
-      - name: Preserve the digest for promotion
+      - name: Preserve the complete digest set for promotion
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: facility-image-${{ matrix.image }}-${{ github.sha }}
-          path: ${{ runner.temp }}/image-digests/${{ matrix.image }}.json
+          name: facility-image-digests-${{ github.sha }}
+          path: ${{ runner.temp }}/image-digests/*.json
           if-no-files-found: error
           retention-days: 1
 
@@ -164,9 +146,8 @@ jobs:
       - name: Download every accepted digest
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          pattern: facility-image-*-${{ github.sha }}
+          name: facility-image-digests-${{ github.sha }}
           path: ${{ runner.temp }}/image-digests
-          merge-multiple: true
 
       - name: Promote the complete image set
         env:

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -143,6 +143,23 @@ before their secrets exist. On the build path it also creates the repositories
 that Step 3 populates. Starting services early produces a crash-loop that is
 slower to diagnose than it is to avoid.
 
+If this state predates API/worker image deduplication, preserve its non-empty
+`worker` ECR repository through a rollback window rather than letting Terraform
+try to destroy it during the upgrade. Before the first apply of this version:
+
+```bash
+terraform -chdir="$FACILITY_TF_DIR" state rm \
+  'aws_ecr_lifecycle_policy.service["worker"]'
+terraform -chdir="$FACILITY_TF_DIR" state rm \
+  'aws_ecr_repository.service["worker"]'
+```
+
+This removes only Terraform ownership; it does not delete the legacy repository
+or its images. Apply and verify worker on the API digest, then delete that orphaned
+repository manually after the rollback window. New stacks create five unique
+artifact repositories. The legacy `container_image_tags.worker` tfvars field stays
+accepted; only an explicit `image_overrides.worker` keeps worker on separate bytes.
+
 Without a public DNS zone, clear the example's fake certificate and hosted-zone
 values as well as enabling the AWS-managed HTTPS origin:
 
@@ -194,11 +211,11 @@ Terraform keeps the pushed repositories aligned with the selected project and
 environment.
 
 The script requires the Docker Buildx plugin and builds all five artifacts in one
-parallel Bake graph. API and worker receive separate ECR tags for the same build
-result; the ECS services still keep separate commands, roles, scaling, and
-deployment lifecycles. Repeated runs reuse the local BuildKit cache and do not
-create an extra registry-cache artifact. Terraform provider and state files from
-the preceding apply are excluded from the Docker context.
+parallel Bake graph. API and worker use the same API digest from one ECR repository;
+the ECS services still keep separate commands, roles, scaling, and deployment
+lifecycles. Repeated runs reuse the local BuildKit cache and do not create an extra
+registry-cache artifact. Terraform provider and state files from the preceding
+apply are excluded from the Docker context.
 
 When `api_url` changes, update the web task's runtime `FACILITY_API_URL` and
 redeploy the existing image; it does not need to be rebuilt.
@@ -473,7 +490,7 @@ same variables:
 ```bash
 terraform -chdir="$FACILITY_TF_DIR" apply -var-file="${FACILITY_ENV}.tfvars"
 
-# Terraform protects non-empty ECR repositories. Remove all six repositories
+# Terraform protects non-empty ECR repositories. Remove all five repositories
 # and their images explicitly; destroy will reconcile them out of state.
 while IFS= read -r FACILITY_ECR_URL; do
   FACILITY_ECR_REPOSITORY="${FACILITY_ECR_URL#*/}"

--- a/apps/docs/test/aws-deployment-runbook.test.mjs
+++ b/apps/docs/test/aws-deployment-runbook.test.mjs
@@ -135,6 +135,37 @@ test("AWS guides keep the release override and build-fallback paths synchronized
   }
 });
 
+test("AWS stores the shared API and worker artifact once without collapsing their services", () => {
+  assert.match(
+    localsTerraform,
+    /ecr_repositories = toset\(\["api", "gateway", "web", "mcp", "runner"\]\)/,
+  );
+  assert.doesNotMatch(localsTerraform, /ecr_repositories[^\n]+"worker"/);
+  assert.match(
+    localsTerraform,
+    /worker = coalesce\(lookup\(var\.image_overrides, "worker", null\), local\.artifact_images\.api\)/,
+  );
+  assert.match(localsTerraform, /worker = \{[\s\S]*image\s+= local\.images\.worker/);
+
+  for (const [guideName, markdown] of guides) {
+    assert.match(
+      markdown,
+      /state rm[\s\\\n]+\s*'aws_ecr_lifecycle_policy\.service\["worker"\]'/,
+      `${guideName} must preserve the legacy lifecycle policy through the transition`,
+    );
+    assert.match(
+      markdown,
+      /state rm[\s\\\n]+\s*'aws_ecr_repository\.service\["worker"\]'/,
+      `${guideName} must preserve the non-empty legacy worker repository`,
+    );
+    assert.match(
+      markdown,
+      /API and worker (?:run|use) the same API digest|API and worker run the same API digest/,
+      `${guideName} must explain the shared artifact`,
+    );
+  }
+});
+
 test("AWS agent caches fail closed and contain only isolated package stores", () => {
   const buildspec = codeBuildTerraform.match(/buildspec = <<-YAML\n([\s\S]*?)\n\s+YAML/)?.[1];
   assert.ok(buildspec, "the runner project must have an inline buildspec");

--- a/infra/build-images.sh
+++ b/infra/build-images.sh
@@ -46,8 +46,8 @@ export ECR_REGISTRY ECR_PREFIX IMAGE_TAG PLATFORM
 login
 
 # Bake runs independent targets concurrently and shares the root Dockerfile's
-# dependency graph. The API target has both api and worker tags because those
-# ECS services run the same bytes with different commands.
+# dependency graph. API and worker run the same digest from the API repository
+# with different ECS commands, so only one copy is pushed and scanned.
 (
   # Bake automatically reads a .env from its working directory. Run from the
   # env-free infra directory so application secrets are neither parsed nor
@@ -56,7 +56,11 @@ login
   docker buildx bake --allow=fs.read=.. --file "$BAKE_FILE" --push
 )
 
-# Preserve the script's stable machine-readable output contract.
-for name in api worker gateway mcp web runner; do
+# Preserve the script's stable machine-readable output contract while making
+# the worker alias explicit for callers that still expect all service roles.
+api_ref="$ECR_REGISTRY/$ECR_PREFIX/api:$IMAGE_TAG"
+printf 'api=%s\n' "$api_ref"
+printf 'worker=%s\n' "$api_ref"
+for name in gateway mcp web runner; do
   printf '%s=%s/%s/%s:%s\n' "$name" "$ECR_REGISTRY" "$ECR_PREFIX" "$name" "$IMAGE_TAG"
 done

--- a/infra/docker-bake.hcl
+++ b/infra/docker-bake.hcl
@@ -27,10 +27,7 @@ target "service" {
 target "api" {
   inherits = ["service"]
   target   = "api"
-  tags = [
-    "${ECR_REGISTRY}/${ECR_PREFIX}/api:${IMAGE_TAG}",
-    "${ECR_REGISTRY}/${ECR_PREFIX}/worker:${IMAGE_TAG}",
-  ]
+  tags     = ["${ECR_REGISTRY}/${ECR_PREFIX}/api:${IMAGE_TAG}"]
 }
 
 target "gateway" {

--- a/infra/docker-bake.publish.hcl
+++ b/infra/docker-bake.publish.hcl
@@ -1,6 +1,9 @@
 # GHCR publication overlay. Merge this after docker-bake.hcl so one BuildKit
 # graph pushes addressable digests without exposing release tags before every
-# target succeeds and promotion validates the complete set.
+# target succeeds and promotion validates the complete set. Default BuildKit
+# provenance embeds per-run timestamps in an unsigned wrapper index, making an
+# identical runtime image produce a different digest on replay. Disable that
+# wrapper here so immutable tags address the reproducible runtime manifest.
 variable "PUBLISH_REGISTRY" {
   default = "ghcr.io"
 }
@@ -10,6 +13,7 @@ variable "PUBLISH_PREFIX" {
 }
 
 target "api" {
+  attest     = ["type=provenance,disabled=true"]
   tags       = []
   output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/api,push-by-digest=true,name-canonical=true,push=true"]
   cache-from = ["type=gha,scope=facility-api"]
@@ -17,6 +21,7 @@ target "api" {
 }
 
 target "gateway" {
+  attest     = ["type=provenance,disabled=true"]
   tags       = []
   output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/gateway,push-by-digest=true,name-canonical=true,push=true"]
   cache-from = ["type=gha,scope=facility-gateway"]
@@ -24,6 +29,7 @@ target "gateway" {
 }
 
 target "mcp" {
+  attest     = ["type=provenance,disabled=true"]
   tags       = []
   output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/mcp,push-by-digest=true,name-canonical=true,push=true"]
   cache-from = ["type=gha,scope=facility-mcp"]
@@ -31,6 +37,7 @@ target "mcp" {
 }
 
 target "web" {
+  attest     = ["type=provenance,disabled=true"]
   tags       = []
   output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/web,push-by-digest=true,name-canonical=true,push=true"]
   cache-from = ["type=gha,scope=facility-web"]
@@ -38,6 +45,7 @@ target "web" {
 }
 
 target "runner" {
+  attest     = ["type=provenance,disabled=true"]
   tags       = []
   output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/runner,push-by-digest=true,name-canonical=true,push=true"]
   cache-from = ["type=gha,scope=facility-runner"]

--- a/infra/docker-bake.publish.hcl
+++ b/infra/docker-bake.publish.hcl
@@ -1,0 +1,45 @@
+# GHCR publication overlay. Merge this after docker-bake.hcl so one BuildKit
+# graph pushes addressable digests without exposing release tags before every
+# target succeeds and promotion validates the complete set.
+variable "PUBLISH_REGISTRY" {
+  default = "ghcr.io"
+}
+
+variable "PUBLISH_PREFIX" {
+  default = "theam/facility"
+}
+
+target "api" {
+  tags       = []
+  output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/api,push-by-digest=true,name-canonical=true,push=true"]
+  cache-from = ["type=gha,scope=facility-api"]
+  cache-to   = ["type=gha,mode=max,scope=facility-api"]
+}
+
+target "gateway" {
+  tags       = []
+  output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/gateway,push-by-digest=true,name-canonical=true,push=true"]
+  cache-from = ["type=gha,scope=facility-gateway"]
+  cache-to   = ["type=gha,mode=max,scope=facility-gateway"]
+}
+
+target "mcp" {
+  tags       = []
+  output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/mcp,push-by-digest=true,name-canonical=true,push=true"]
+  cache-from = ["type=gha,scope=facility-mcp"]
+  cache-to   = ["type=gha,mode=max,scope=facility-mcp"]
+}
+
+target "web" {
+  tags       = []
+  output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/web,push-by-digest=true,name-canonical=true,push=true"]
+  cache-from = ["type=gha,scope=facility-web"]
+  cache-to   = ["type=gha,mode=max,scope=facility-web"]
+}
+
+target "runner" {
+  tags       = []
+  output     = ["type=image,name=${PUBLISH_REGISTRY}/${PUBLISH_PREFIX}/runner,push-by-digest=true,name-canonical=true,push=true"]
+  cache-from = ["type=gha,scope=facility-runner"]
+  cache-to   = ["type=gha,mode=max,scope=facility-runner"]
+}

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -138,13 +138,13 @@ cd infra/terraform/aws
 ```
 
 The script requires the Docker Buildx plugin and runs one Bake graph. The five
-artifacts build concurrently; the API result is tagged into both the `api` and
-`worker` repositories because those services run the same bytes with different
-commands. API, gateway, and MCP also share the root Dockerfile dependency graph.
-No registry-cache artifact is created: repeated builds reuse the operator's local
-BuildKit cache, while ECR continues to scan only deployable image pushes. The
-repository Docker context excludes Terraform providers and state created by the
-preceding apply.
+artifacts build concurrently. API and worker run the same API digest with
+different commands, so the AWS fallback stores and scans those bytes once in the
+`api` repository. API, gateway, and MCP also share the root Dockerfile dependency
+graph. No registry-cache artifact is created: repeated builds reuse the operator's
+local BuildKit cache, while ECR continues to scan only deployable image pushes.
+The repository Docker context excludes Terraform providers and state created by
+the preceding apply.
 
 The graph builds `linux/amd64` by default, matching Terraform's default
 `task_cpu_architecture = "X86_64"`. To deploy on Graviton, set
@@ -157,6 +157,25 @@ redeploy the existing image; it does not need to be rebuilt.
 
 If you changed `container_image_tags` after the first apply, apply again before
 running the migrate task. Keeping the tag stable avoids that extra apply.
+
+### Upgrade note: retire the duplicate worker repository
+
+Stacks created before the API/worker deduplication have a non-empty `worker` ECR
+repository in Terraform state. Preserve it through one rollback window instead
+of asking Terraform to destroy stored images during an application upgrade. Before
+the first apply of this version, remove only these legacy addresses from state:
+
+```bash
+terraform state rm 'aws_ecr_lifecycle_policy.service["worker"]'
+terraform state rm 'aws_ecr_repository.service["worker"]'
+```
+
+This deliberately leaves the old AWS repository intact but unmanaged. Apply the
+new configuration, deploy and verify worker on the API digest, then delete the
+legacy repository manually after the rollback window. New stacks create only the
+five unique artifact repositories. The `container_image_tags.worker` input remains
+accepted for existing tfvars but is unused unless `image_overrides.worker` explicitly
+selects a separate image.
 
 ## 4. Populate Secrets Manager
 

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -13,7 +13,7 @@ locals {
     ManagedBy   = "terraform"
   }
 
-  ecr_repositories = toset(["api", "worker", "gateway", "web", "mcp", "runner"])
+  ecr_repositories = toset(["api", "gateway", "web", "mcp", "runner"])
 
   ports = {
     api     = 4400
@@ -25,13 +25,21 @@ locals {
     migrate = 0
   }
 
-  images = {
+  artifact_images = {
     for name in local.ecr_repositories :
     name => coalesce(
       lookup(var.image_overrides, name, null),
       "${aws_ecr_repository.service[name].repository_url}:${var.container_image_tags[name]}"
     )
   }
+
+  # Worker is a separate fault/scaling boundary that deliberately executes the
+  # API artifact with another command. A distinct override remains supported
+  # for existing operators, but the AWS fallback no longer stores or scans the
+  # same bytes in a second ECR repository.
+  images = merge(local.artifact_images, {
+    worker = coalesce(lookup(var.image_overrides, "worker", null), local.artifact_images.api)
+  })
 
   public_urls = {
     api     = var.enable_cloudfront_api_endpoint ? "https://${aws_cloudfront_distribution.api[0].domain_name}" : "${var.acm_certificate_arn == "" ? "http" : "https"}://${var.api_hostname}"

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -159,7 +159,7 @@ variable "force_destroy_bucket" {
 }
 
 variable "container_image_tags" {
-  description = "Image tags used when image_overrides does not provide a full image URI."
+  description = "Image tags used when image_overrides does not provide a full image URI. The worker tag is retained for tfvars compatibility; the AWS fallback runs worker from the API image."
   type = object({
     api     = string
     worker  = string
@@ -179,7 +179,7 @@ variable "container_image_tags" {
 }
 
 variable "image_overrides" {
-  description = "Optional full image URI overrides keyed by api, worker, gateway, web, runner."
+  description = "Optional full image URI overrides keyed by api, worker, gateway, web, mcp, or runner. A worker override may intentionally separate it from the default API artifact."
   type        = map(string)
   default     = {}
 }

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -141,6 +141,12 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   assert.match(bake, /target "runner" \{[\s\S]*dockerfile = "runner\/Dockerfile"/);
   for (const image of ["api", "gateway", "mcp", "web", "runner"]) {
     assert.match(publish, new RegExp(`target "${image}" \\{`));
+    assert.match(
+      publish,
+      new RegExp(
+        `target "${image}" \\{[\\s\\S]*?attest\\s+= \\["type=provenance,disabled=true"\\]`,
+      ),
+    );
     assert.match(publish, new RegExp(`/${image},push-by-digest=true`));
     assert.match(publish, new RegExp(`scope=facility-${image}`));
   }

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -117,7 +117,7 @@ test("AWS fallback builds the complete image set through one Bake graph", async 
   ]);
   assert.deepEqual(result.stdout.trim().split("\n"), [
     "api=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/api:abc123def456",
-    "worker=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/worker:abc123def456",
+    "worker=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/api:abc123def456",
     "gateway=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/gateway:abc123def456",
     "mcp=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/mcp:abc123def456",
     "web=123456789012.dkr.ecr.eu-west-1.amazonaws.com/facility-test/web:abc123def456",
@@ -125,18 +125,26 @@ test("AWS fallback builds the complete image set through one Bake graph", async 
   ]);
 });
 
-test("Bake aliases worker to the API result and keeps all target boundaries", async () => {
+test("Bake keeps thin target boundaries and publishes every target through one graph", async () => {
   const bake = await readFile(join(root, "infra", "docker-bake.hcl"), "utf8");
+  const publish = await readFile(join(root, "infra", "docker-bake.publish.hcl"), "utf8");
   assert.match(
     bake,
     /group "default" \{[\s\S]*targets = \["api", "gateway", "mcp", "web", "runner"\]/,
   );
-  assert.match(bake, /target "api" \{[\s\S]*\/api:\$\{IMAGE_TAG\}[\s\S]*\/worker:\$\{IMAGE_TAG\}/);
+  assert.match(bake, /target "api" \{[\s\S]*\/api:\$\{IMAGE_TAG\}/);
+  assert.doesNotMatch(bake, /\/worker:\$\{IMAGE_TAG\}/);
   assert.doesNotMatch(bake, /target "worker"/);
   assert.match(bake, /target "gateway" \{[\s\S]*target\s+= "gateway"/);
   assert.match(bake, /target "mcp" \{[\s\S]*target\s+= "mcp"/);
   assert.match(bake, /target "web" \{[\s\S]*dockerfile = "apps\/web\/Dockerfile"/);
   assert.match(bake, /target "runner" \{[\s\S]*dockerfile = "runner\/Dockerfile"/);
+  for (const image of ["api", "gateway", "mcp", "web", "runner"]) {
+    assert.match(publish, new RegExp(`target "${image}" \\{`));
+    assert.match(publish, new RegExp(`/${image},push-by-digest=true`));
+    assert.match(publish, new RegExp(`scope=facility-${image}`));
+  }
+  assert.doesNotMatch(publish, /target "control"|\/control,/);
 
   const dockerignore = await readFile(join(root, ".dockerignore"), "utf8");
   assert.match(dockerignore, /^\*\*\/\.terraform$/m);

--- a/scripts/images.integration.test.mjs
+++ b/scripts/images.integration.test.mjs
@@ -132,6 +132,10 @@ test("a fresh image set promotes six packages and aliases worker to the api dige
     calls.map(({ githubToken, ghToken }) => ({ githubToken, ghToken })),
     Array.from({ length: 6 }, () => ({ githubToken: null, ghToken: null })),
   );
+  assert.ok(
+    calls.every(({ args }) => args.includes("--prefer-index=false")),
+    "promotion must preserve each single-platform source manifest digest",
+  );
   const worker = calls.find(({ args }) => args.includes("ghcr.io/theam/facility/worker:0.3.0"));
   assert(worker);
   assert.equal(worker.args.at(-1), `ghcr.io/theam/facility/api@${imageDigests().get("api")}`);

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -111,6 +111,32 @@ export function loadDigests(directory) {
   return digests;
 }
 
+export function recordBakeDigests({ metadata, directory }) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error("Bake metadata must be an object keyed by image target");
+  }
+  const targets = Object.keys(metadata).sort();
+  const expected = [...BUILD_IMAGES].sort();
+  if (JSON.stringify(targets) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Bake metadata targets ${targets.join(",") || "none"}; expected ${expected.join(",")}`,
+    );
+  }
+
+  const paths = [];
+  for (const image of BUILD_IMAGES) {
+    const result = metadata[image];
+    const digest = result?.["containerimage.digest"];
+    const descriptorDigest = result?.["containerimage.descriptor"]?.digest;
+    assertDigest(digest);
+    if (descriptorDigest !== digest) {
+      throw new Error(`Bake metadata descriptor for ${image} does not match ${digest}`);
+    }
+    paths.push(recordDigest({ image, digest, directory }));
+  }
+  return paths;
+}
+
 export async function inspectPublication({
   repository,
   owner,
@@ -352,6 +378,20 @@ async function main([command, ...args]) {
     if (args.length !== 3) throw new Error("record-digest requires image, digest, and directory");
     const path = recordDigest({ image: args[0], digest: args[1], directory: args[2] });
     console.log(path);
+    return;
+  }
+
+  if (command === "record-bake-digests") {
+    if (args.length !== 2) {
+      throw new Error("record-bake-digests requires metadata file and digest-manifest directory");
+    }
+    let metadata;
+    try {
+      metadata = JSON.parse(readFileSync(resolve(args[0]), "utf8"));
+    } catch (error) {
+      throw new Error(`cannot read Bake metadata: ${error.message}`);
+    }
+    for (const path of recordBakeDigests({ metadata, directory: args[1] })) console.log(path);
     return;
   }
 

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -227,7 +227,10 @@ export async function publishImageSet({
 
   for (const image of plan.images) {
     if (image.missingTags.length === 0) continue;
-    const args = ["buildx", "imagetools", "create"];
+    // A single-platform source is already the exact deployable manifest.
+    // Buildx otherwise wraps it in a new index with a different digest, which
+    // makes an identical immutable-tag replay look like changed runtime bytes.
+    const args = ["buildx", "imagetools", "create", "--prefer-index=false"];
     for (const tag of image.missingTags) {
       args.push("--tag", `${registry}/${image.image}:${tag}`);
     }

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -8,6 +8,7 @@ import {
   loadDigests,
   parseTagsJson,
   publicationPlan,
+  recordBakeDigests,
   recordDigest,
   validateRepositoryIdentity,
 } from "./images.mjs";
@@ -111,6 +112,44 @@ test("digest manifests require the complete, expected five-image set", (t) => {
   assert.throws(() => loadDigests(directory), /names worker, expected api/);
 });
 
+test("one Bake result records an exact, internally consistent digest set", (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "facility-bake-digests-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const metadata = Object.fromEntries(
+    BUILD_IMAGES.map((image, index) => {
+      const imageDigest = `sha256:${String(index + 1).repeat(64)}`;
+      return [
+        image,
+        {
+          "containerimage.digest": imageDigest,
+          "containerimage.descriptor": { digest: imageDigest },
+        },
+      ];
+    }),
+  );
+
+  assert.equal(recordBakeDigests({ metadata, directory }).length, BUILD_IMAGES.length);
+  assert.deepEqual(
+    [...loadDigests(directory)],
+    BUILD_IMAGES.map((image, index) => [image, `sha256:${String(index + 1).repeat(64)}`]),
+  );
+  assert.throws(
+    () => recordBakeDigests({ metadata: { ...metadata, unexpected: {} }, directory }),
+    /expected api,gateway,mcp,runner,web/,
+  );
+  assert.throws(
+    () =>
+      recordBakeDigests({
+        metadata: {
+          ...metadata,
+          api: { ...metadata.api, "containerimage.descriptor": { digest } },
+        },
+        directory,
+      }),
+    /descriptor for api does not match/,
+  );
+});
+
 test("CI gates release images and the reusable publisher stages digests before promotion", () => {
   assert.match(imagesWorkflow, /on:\n {2}workflow_call:\n {4}inputs:\n {6}version:/);
   assert.match(imagesWorkflow, /\n {2}workflow_dispatch:\n/);
@@ -128,10 +167,19 @@ test("CI gates release images and the reusable publisher stages digests before p
   );
   assert.ok(
     buildJob.indexOf("Stamp the decided version") <
-      buildJob.indexOf("Build and push the addressable digest"),
+      buildJob.indexOf("Build and push the addressable image set"),
     "the isolated build checkout must be stamped before Docker consumes it",
   );
-  assert.match(imagesWorkflow, /push-by-digest=true,name-canonical=true,push=true/);
+  assert.doesNotMatch(buildJob, /strategy:|matrix:/);
+  assert.ok(
+    buildJob.indexOf("crazy-max/ghaction-github-runtime@") < buildJob.indexOf("docker buildx bake"),
+    "raw Buildx must receive the GitHub Actions cache runtime before Bake runs",
+  );
+  assert.match(buildJob, /docker buildx bake/);
+  assert.match(buildJob, /--file docker-bake\.publish\.hcl/);
+  assert.match(buildJob, /--metadata-file "\$metadata"/);
+  assert.match(buildJob, /node scripts\/images\.mjs record-bake-digests/);
+  assert.match(buildJob, /facility-image-digests-\$\{\{ github\.sha \}\}/);
   assert.doesNotMatch(
     buildJob,
     /build[_-]args|FACILITY_API_URL=/,


### PR DESCRIPTION
## Summary

- build and push the five thin images through one shared Bake graph with per-target GitHub Actions caches
- preserve digest-only staging and complete-set promotion
- store the shared API/worker bytes once in AWS while keeping the worker ECS service, command, IAM, scaling, and override boundary
- document the non-destructive Terraform state transition for existing worker repositories
- make immutable replays reproducible by publishing bare runtime manifests and preserving their digest during promotion

## Evidence

- full repository verify passed locally: clean builds, critical database integration tests, 101 script tests, 372 API tests, 37 gateway tests, package tests, guards, and all-severity dependency audit
- Terraform fmt and validate passed
- merged Bake print produced exactly api, gateway, mcp, runner, and web with no tags and digest-only outputs
- 21 deterministic image publication and denial-path tests passed
- Claude Opus high-reasoning reviews approved the implementation and both live fixes

## Live measurements

Previous observed five-job matrix workflow: 4m47 wall time.

- cold shared-graph cache seed: 5m20 wall time
- final-form first publication on warm layers: 2m31 wall time; all six promoted tag digests exactly matched their staged source digests
- identical-SHA replay: 57s wall time; build 18s; promotion 22s; promoted 0 with no registry mutation

The warm repeated path is about 80% faster than the observed matrix workflow. The cold path is 33s slower, so the benefit is explicitly cache-dependent.

## Security note

BuildKit default provenance is disabled only in the GHCR publication overlay because its unsigned timestamped wrapper makes identical runtime bytes produce a different immutable digest. Runtime content addressing, digest-only staging, CVE scanning, immutable SHA tags, complete-set validation, conflict denial, worker aliasing, and partial recovery remain intact.