### PR TITLE
fix: unblock secure image publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,19 @@ jobs:
         if: steps.policy.outputs.required == 'true'
         run: docker build --pull -f runner/Dockerfile -t facility-runner:dev .
 
+      # Ubuntu 24.04 restricts unprivileged user namespaces through AppArmor,
+      # including inside this disposable nested-Docker test. RootlessKit needs
+      # that kernel primitive; AWS CodeBuild runs the image directly and does
+      # not use this CI-only outer container boundary.
+      - name: Permit nested rootless user namespaces
+        if: steps.policy.outputs.required == 'true'
+        shell: bash
+        run: |
+          key=kernel.apparmor_restrict_unprivileged_userns
+          if sudo sysctl "$key" >/dev/null 2>&1; then
+            sudo sysctl -w "$key=0"
+          fi
+
       - name: Exercise the privileged CodeBuild boundary
         if: steps.policy.outputs.required == 'true'
         run: |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -133,6 +133,8 @@ jobs:
       contents: read
       packages: read
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: facility-image-digests-${{ github.sha }}
@@ -194,7 +196,15 @@ jobs:
               }
               process.stdout.write(manifest.digest);
             ' "$DIGEST_DIRECTORY/$image.json" "$image")"
-            if ! "$GRYPE" "registry:$IMAGE_PREFIX/$image@$digest" --fail-on high --only-fixed; then
+            grype_config=()
+            if [[ "$image" == "runner" ]]; then
+              grype_config=(--config "$GITHUB_WORKSPACE/runner/grype.yaml")
+            fi
+            # Service scans run outside the checkout so a future repository
+            # config cannot silently weaken them. Only runner receives the
+            # explicit, path- and version-pinned upstream-binary policy.
+            if ! (cd "$RUNNER_TEMP" && "$GRYPE" "${grype_config[@]}" \
+              "registry:$IMAGE_PREFIX/$image@$digest" --fail-on high --only-fixed); then
               scan_failed=1
             fi
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 #   docker build --target api     -t facility/api .
 #   docker build --target gateway -t facility/gateway .
-FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS base
+FROM node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH=/pnpm:$PATH
 RUN apt-get update \
@@ -16,6 +16,21 @@ RUN apt-get update \
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/aws-rds-global.pem
 RUN corepack enable
 WORKDIR /app
+
+# Deployable services execute Node directly. Keep package managers in the build
+# stages, but delete their global dependency trees from the runtime rootfs so
+# unused npm/Corepack code cannot become a production CVE surface.
+FROM base AS runtime
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /pnpm \
+  && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm \
+    /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+    /usr/local/bin/corepack \
+  && for tool in npm npx pnpm corepack yarn; do \
+    if command -v "$tool" >/dev/null 2>&1; then \
+      echo "runtime package manager remains available: $tool" >&2; \
+      exit 1; \
+    fi; \
+  done
 
 # --- deps: install with the full workspace manifest set for cache reuse ---
 FROM base AS deps
@@ -72,7 +87,7 @@ RUN pnpm --filter '@facility/core' --filter '@facility/sdk' \
 RUN pnpm --filter '@facility/mcp' deploy --prod --legacy /prod/mcp
 
 # --- api (also serves the worker via `node dist/worker.js`) ---
-FROM base AS api
+FROM runtime AS api
 ENV NODE_ENV=production
 COPY --from=build-api /prod/api /app
 # The CLI travels with the API image so operator commands can be run as one-shot
@@ -108,14 +123,14 @@ EXPOSE 4400
 CMD ["node", "dist/start.js"]
 
 # --- gateway ---
-FROM base AS gateway
+FROM runtime AS gateway
 ENV NODE_ENV=production
 COPY --from=build-gateway /prod/gateway /app
 EXPOSE 4410
 CMD ["node", "dist/start.js"]
 
 # --- MCP streamable-HTTP gateway ---
-FROM base AS mcp
+FROM runtime AS mcp
 ENV NODE_ENV=production
 COPY --from=build-mcp /prod/mcp /app
 EXPOSE 4420

--- a/apps/docs/docs/concepts/sandboxes.md
+++ b/apps/docs/docs/concepts/sandboxes.md
@@ -44,7 +44,7 @@ A **platform-lane** run (Claude Code, Codex) needs a sandbox profile whose
 - **docker** (local/self-host) — the profile's image entrypoint must be the
   runner. Build it with `docker build -f runner/Dockerfile -t facility-runner:dev .` and set
   `FACILITY_RUNNER_IMAGE` (default `facility-runner:dev`). A bare base image like
-  `node:22-bookworm` only supports **BYO-command** runs.
+  `node:24-trixie` only supports **BYO-command** runs.
 - **aws** (CodeBuild) — each run starts a private CodeBuild job using the runner
   image fixed in the deployed CodeBuild project. Profile image overrides are
   deliberately ignored: an editable image cannot inherit the project's AWS

--- a/apps/docs/docs/reference/architecture.md
+++ b/apps/docs/docs/reference/architecture.md
@@ -64,7 +64,7 @@ infra/              # docker-compose (self-host), terraform/aws (reference deplo
 
 | # | decision | why (alternatives rejected) |
 |---|---|---|
-| 1 | TypeScript everywhere, Node 22, pnpm + Turborepo | one language across api/web/cli/mcp/runner; team fluency; turbo caching. Nx heavier, polyglot unnecessary. |
+| 1 | TypeScript everywhere, Node 22+ (Node 24 production images), pnpm + Turborepo | one language across api/web/cli/mcp/runner; team fluency; turbo caching. Nx heavier, polyglot unnecessary. |
 | 2 | Next.js 16 App Router + React 19 + Tailwind v4 for web | matches Facility's web stack; RSC for fast dashboards. |
 | 3 | Fastify 5 + Zod (type-provider) + OpenAPI for api & gateway | schema-first: the SDK's schema.d.ts is generated from the emitted OpenAPI doc and the ergonomic route contracts are hand-maintained on top, guarded against drift by a route-coverage test; mature plugin ecosystem (ws, sse, rate-limit); long-lived Node servers. tRPC rejected (CLI/MCP/GitHub are non-TS-web consumers; OpenAPI is the lingua franca). NestJS rejected (ceremony without payoff). |
 | 4 | Postgres 16 + Drizzle ORM | boring, portable, SQL-first migrations; JSONB for payloads; LISTEN/NOTIFY for cheap realtime. Supabase-compatible but not required. |

--- a/apps/docs/test/aws-deployment-runbook.test.mjs
+++ b/apps/docs/test/aws-deployment-runbook.test.mjs
@@ -40,8 +40,9 @@ function terraformResource(source, type, name) {
 }
 
 function apiStage(image) {
-  const start = image.indexOf("FROM base AS api\n");
-  assert.notEqual(start, -1, "the root Dockerfile must still build an api stage");
+  const declaration = image.match(/^FROM \S+ AS api$/m);
+  assert.ok(declaration, "the root Dockerfile must still build an api stage");
+  const start = declaration.index;
   const end = image.indexOf("\nFROM ", start + 1);
   return image.slice(start, end === -1 ? undefined : end);
 }

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,10 +1,25 @@
 # Facility web (Next.js standalone). Built once; FACILITY_API_URL is supplied
 # when the container starts so the same artifact works in every installation.
 #   docker build -f apps/web/Dockerfile -t facility/web .
-FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS base
+FROM node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d AS base
 ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH
 RUN corepack enable
 WORKDIR /app
+
+# The standalone server needs Node, not the package managers used to build it.
+# Removing their vendored dependencies keeps unused tooling out of the image
+# CVE inventory and makes a future base-layout change fail visibly at build time.
+FROM base AS runtime
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /pnpm \
+  && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm \
+    /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg \
+    /usr/local/bin/corepack \
+  && for tool in npm npx pnpm corepack yarn; do \
+    if command -v "$tool" >/dev/null 2>&1; then \
+      echo "runtime package manager remains available: $tool" >&2; \
+      exit 1; \
+    fi; \
+  done
 
 FROM base AS build
 # Keep dependency resolution keyed to the lockfile and relevant workspace
@@ -25,7 +40,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # clean image has no SDK artifact, so build it before Next consumes the output.
 RUN pnpm --filter '@facility/sdk...' run build && pnpm --filter '@facility/web' build
 
-FROM base AS web
+FROM runtime AS web
 ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 PORT=3400 HOSTNAME=0.0.0.0
 COPY --from=build /app/apps/web/.next/standalone ./
 COPY --from=build /app/apps/web/.next/static ./apps/web/.next/static

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@11.1.2",
+  "packageManager": "pnpm@11.20.0",
   "scripts": {
     "build": "turbo run build",
     "clean:outputs": "node scripts/clean-outputs.mjs",

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -60,7 +60,7 @@ export function analysisSandboxProfileId(orgId: string): string {
 }
 
 // The default sandbox profile must run the Facility runner (its ENTRYPOINT), or
-// platform-lane runs never start. A bare base image like node:22-bookworm only
+// platform-lane runs never start. A bare base image like node:24-trixie only
 // works for BYO-command runs. Keep this in sync with config.sandboxRunnerImage.
 function defaultRunnerImage(): string {
   return process.env.FACILITY_RUNNER_IMAGE ?? "facility-runner:dev";

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,22 +1,49 @@
-FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS bind-broker-build
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS bind-broker-build
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends gcc libc6-dev \
   && rm -rf /var/lib/apt/lists/*
+
 COPY runner/bind-broker.c /src/bind-broker.c
 RUN gcc -std=c11 -O2 -Wall -Wextra -Werror \
       -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE \
       /src/bind-broker.c -Wl,-z,relro,-z,now -pie \
       -o /facility-bind-broker
 
-FROM node:22-bookworm@sha256:0557ac14e0d45d02ed563067b82856ca5e7aa3437fa28d98d4350ea9c3d9494a
+# Docker's official rootless image publishes a coherent, multi-platform static
+# daemon/client/runtime set built with a current Go toolchain. Copying from one
+# digest-pinned source avoids Debian's lagging docker.io binaries and a second
+# architecture-specific download/checksum matrix.
+FROM docker:29-dind-rootless@sha256:7451e3dc398b11ba2d8183bb7915402683e3d32e5ec8cef835c215f314a65fef AS docker-tools
+
+# GitHub CLI has no official container image. Its immutable release archives
+# are verified per target architecture before the single binary crosses stages.
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS gh-build
+ARG TARGETARCH
+ARG GH_VERSION=2.97.0
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
+  && case "$TARGETARCH" in \
+    amd64) gh_sha256="a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112" ;; \
+    arm64) gh_sha256="73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5" ;; \
+    *) echo "unsupported GitHub CLI architecture: $TARGETARCH" >&2; exit 1 ;; \
+  esac \
+  && archive="gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" \
+    --output "/tmp/${archive}" \
+  && printf '%s  %s\n' "$gh_sha256" "/tmp/${archive}" | sha256sum --check --strict \
+  && tar -xzf "/tmp/${archive}" -C /tmp \
+  && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /gh
+
+FROM node:24-trixie@sha256:66bb8d36ae1ddd72199ed235a089904874ca4079ee517936ca3adb80506a75c1
 
 RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
     busybox-static \
     curl \
-    docker.io \
     fonts-noto-color-emoji \
     fonts-freefont-ttf \
     fonts-ipafont-gothic \
@@ -26,20 +53,19 @@ RUN apt-get update \
     fonts-wqy-zenhei \
     fuse-overlayfs \
     git \
-    gh \
     iproute2 \
     iptables \
     jq \
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libatspi2.0-0 \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libatspi2.0-0t64 \
     libcairo2 \
-    libcups2 \
+    libcups2t64 \
     libdbus-1-3 \
     libdrm2 \
     libgbm1 \
-    libglib2.0-0 \
+    libglib2.0-0t64 \
     libnspr4 \
     libnss3 \
     libpango-1.0-0 \
@@ -52,13 +78,44 @@ RUN apt-get update \
     libxkbcommon0 \
     libxrandr2 \
     ripgrep \
-    rootlesskit \
     slirp4netns \
     uidmap \
     util-linux \
     xfonts-scalable \
     xvfb \
   && rm -rf /var/lib/apt/lists/*
+
+# npm is a runtime capability for repositories that use package-lock.json, so
+# keep it rather than forcing every project through pnpm. The Node base can lag
+# fixes in npm's own dependency tree: install the current CLI, overlay its
+# same-major patched transitives, and remove the older nested copies that Node
+# would otherwise resolve first.
+ARG NPM_VERSION=12.0.2
+RUN npm install --global "npm@${NPM_VERSION}" \
+  && npm install --global --omit=dev --ignore-scripts \
+    brace-expansion@5.0.9 \
+    ip-address@10.3.1 \
+    tar@7.5.21 \
+    undici@6.28.0 \
+  && rm -rf \
+    /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
+    /usr/local/lib/node_modules/npm/node_modules/ip-address \
+    /usr/local/lib/node_modules/npm/node_modules/tar \
+    /usr/local/lib/node_modules/npm/node_modules/undici \
+  && test "$(npm --version)" = "$NPM_VERSION" \
+  && npm config get registry >/dev/null
+
+COPY --from=docker-tools /usr/local/bin/ /usr/local/bin/
+COPY --from=docker-tools /usr/local/libexec/docker/cli-plugins/ /usr/local/libexec/docker/cli-plugins/
+COPY --from=gh-build /gh /usr/local/bin/gh
+RUN docker --version \
+  && dockerd --version \
+  && rootlesskit --version \
+  && containerd --version \
+  && runc --version \
+  && docker compose version \
+  && docker buildx version \
+  && gh --version
 
 # Keep the Docker daemon and its socket proxy on identities that the untrusted
 # agent user cannot impersonate. The daemon itself is rootless; the proxy is the
@@ -103,7 +160,7 @@ COPY runner/package.json runner/package-lock.json runner/tsconfig.json ./
 COPY packages/run-objective/package.json /packages/run-objective/
 COPY packages/run-objective/src /packages/run-objective/src
 COPY runner/src ./src
-COPY runner/runner-entrypoint.sh runner/codebuild-runner.sh /app/
+COPY runner/runner-entrypoint.sh runner/codebuild-runner.sh runner/find-descendant.awk /app/
 RUN npm ci && npm run build && npm prune --omit=dev
 
 # Run non-root: agent CLIs (Claude Code) refuse bypass-permissions as root, and

--- a/runner/agent-clis/package.json
+++ b/runner/agent-clis/package.json
@@ -2,6 +2,9 @@
   "name": "@facility/agent-clis",
   "version": "0.1.0",
   "private": true,
+  "allowScripts": {
+    "@anthropic-ai/claude-code@2.1.215": true
+  },
   "dependencies": {
     "@anthropic-ai/claude-code": "2.1.215",
     "@openai/codex": "0.144.6"

--- a/runner/codebuild-runner.sh
+++ b/runner/codebuild-runner.sh
@@ -7,8 +7,11 @@ readonly untrusted_uid="${FACILITY_UNTRUSTED_UID:-1000}"
 readonly untrusted_gid="${FACILITY_UNTRUSTED_GID:-1000}"
 readonly docker_runtime="/run/facility-docker"
 readonly proxy_runtime="/run/facility-proxy"
-readonly bind_runtime="/run/facility-binds"
-readonly workspace_view="/run/facility-workspace"
+readonly bind_runtime="/var/lib/facility-binds"
+# The official RootlessKit launcher copy-ups /run inside dockerd's mount
+# namespace. Keep propagated bind aliases under /var/lib so the shared mount is
+# visible on both sides without placing privileged state inside /work.
+readonly workspace_view="/var/lib/facility-workspace"
 readonly npm_cache="/work/.npm"
 readonly raw_socket="${docker_runtime}/docker.sock"
 readonly public_socket="${proxy_runtime}/docker.sock"
@@ -47,6 +50,7 @@ proxy_secret_vars=(
 
 dockerd_env=()
 dockerd_pid=""
+docker_daemon_pid=""
 proxy_pid=""
 mounter_pid=""
 for name in "${proxy_secret_vars[@]}"; do dockerd_env+=(--unset="$name"); done
@@ -93,7 +97,7 @@ start_docker() {
     XDG_RUNTIME_DIR="$docker_runtime" \
     DOCKER_HOST="unix://${raw_socket}" \
     DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="--net=slirp4netns --disable-host-loopback" \
-    /usr/share/docker.io/contrib/dockerd-rootless.sh \
+    /usr/local/bin/dockerd-entrypoint.sh dockerd \
       --host="unix://${raw_socket}" \
       --storage-driver="$storage_driver" \
       --data-root="$data_root" \
@@ -134,18 +138,19 @@ start_proxy() {
 }
 
 start_mounter() {
-  local docker_uid docker_daemon_pid
+  local docker_uid
   docker_uid="$(id -u "$docker_user")"
-  docker_daemon_pid="$(
-    ps -eo pid=,pgid=,uid=,comm= | awk \
-      -v group="$dockerd_pid" -v uid="$docker_uid" \
-      '$2 == group && $3 == uid && $4 == "dockerd" { print $1 }'
-  )"
-  if [[ -z "$docker_daemon_pid" || "$docker_daemon_pid" == *$'\n'* ]]; then
+  if ! docker_daemon_pid="$(
+    ps -eo pid=,ppid=,uid=,comm= | awk \
+      -v root_pid="$dockerd_pid" \
+      -v target_uid="$docker_uid" \
+      -v target_command=dockerd \
+      -f /app/find-descendant.awk
+  )"; then
     echo "Facility could not identify the rootless Docker mount namespace" >&2
     return 1
   fi
-  setsid env -i \
+  setsid nsenter --mount="/proc/${docker_daemon_pid}/ns/mnt" -- env -i \
     /usr/local/bin/facility-bind-broker \
       "$bind_socket" "/work" "$workspace_view" \
       "$(id -u "$proxy_user")" "$(id -g "$proxy_user")" \
@@ -173,6 +178,11 @@ start_mounter() {
     sleep 1
   done
   return 1
+}
+
+docker_namespace_mounts() {
+  if [[ -z "$docker_daemon_pid" ]]; then return 1; fi
+  nsenter --mount="/proc/${docker_daemon_pid}/ns/mnt" -- findmnt "$@"
 }
 
 security_smoke() {
@@ -382,13 +392,13 @@ security_smoke() {
   local rollback_probe='const net=require("node:net"); const socket=net.createConnection(process.argv[1]); let response=""; const timer=setTimeout(()=>socket.destroy(new Error("timeout")),1000); socket.setEncoding("utf8"); socket.on("connect",()=>socket.end("BATCH 2\nOPEN .facility-security-partial/probe\nOPEN .facility-security-partial/missing\n")); socket.on("data",chunk=>response+=chunk); socket.on("end",()=>{clearTimeout(timer); process.exit(response==="ERR workspace_bind_source_denied\n"?0:1)}); socket.on("error",()=>{clearTimeout(timer); process.exit(1)});'
   echo "Facility smoke: checking transactional bind rollback"
   local aliases_before aliases_after
-  aliases_before="$(findmnt -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
+  aliases_before="$(docker_namespace_mounts -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
   if ! runuser --user "$proxy_user" -- env -i \
     /usr/local/bin/node -e "$rollback_probe" "$bind_socket"; then
     echo "Security smoke failed: the bind broker did not reject a partial batch" >&2
     return 1
   fi
-  aliases_after="$(findmnt -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
+  aliases_after="$(docker_namespace_mounts -rn -o TARGET | grep -c "^${workspace_view}/" || true)"
   if [[ "$aliases_after" != "$aliases_before" ]]; then
     echo "Security smoke failed: a rejected broker batch leaked a pinned alias" >&2
     return 1
@@ -440,7 +450,7 @@ security_smoke() {
   fi
   run_untrusted rm /work/.facility-security-create/dangling
   rmdir /work/.facility-security-create/created /work/.facility-security-create
-  if ! findmnt -rn -o TARGET | grep -q "^${workspace_view}/"; then
+  if ! docker_namespace_mounts -rn -o TARGET | grep -q "^${workspace_view}/"; then
     echo "Security smoke failed: workspace binds did not use pinned mount aliases" >&2
     return 1
   fi
@@ -457,7 +467,8 @@ security_smoke_without_docker() {
     echo "No-Docker smoke failed: storage driver was not reported as none" >&2
     return 1
   fi
-  if [[ -n "$dockerd_pid" || -n "$proxy_pid" || -n "$mounter_pid" ]]; then
+  if [[ -n "$dockerd_pid" || -n "$docker_daemon_pid" || -n "$proxy_pid" || \
+    -n "$mounter_pid" ]]; then
     echo "No-Docker smoke failed: a nested-Docker process was recorded" >&2
     return 1
   fi

--- a/runner/find-descendant.awk
+++ b/runner/find-descendant.awk
@@ -1,0 +1,29 @@
+# Find exactly one process with the expected UID and command beneath root_pid.
+# Print it only when the process tree is unambiguous; otherwise fail closed.
+{
+  parent[$1] = $2
+  owner[$1] = $3
+  process_command[$1] = $4
+}
+
+END {
+  match_count = 0
+  matched_pid = ""
+  for (pid in parent) {
+    if (owner[pid] != target_uid || process_command[pid] != target_command) continue
+
+    cursor = pid
+    depth = 0
+    while (cursor != root_pid && cursor > 1 && parent[cursor] != "" && depth < 4096) {
+      cursor = parent[cursor]
+      depth++
+    }
+    if (cursor == root_pid) {
+      matched_pid = pid
+      match_count++
+    }
+  }
+
+  if (match_count != 1) exit 1
+  print matched_pid
+}

--- a/runner/grype.yaml
+++ b/runner/grype.yaml
@@ -1,0 +1,107 @@
+# Runner-only risk acceptances for version-pinned upstream Docker binaries.
+#
+# This file is never auto-discovered: the image workflow passes it explicitly
+# only for the runner scan and scans service images from RUNNER_TEMP. Every rule
+# binds the advisory, embedded module version, package type, and exact binary
+# path. A Docker-tool digest or embedded-version change therefore fails closed
+# and requires this evidence to be reviewed again.
+#
+# Reviewed 2026-08-07 with Grype 0.110.0 and govulncheck 1.6.0. runc and
+# RootlessKit have no reachable vulnerable symbols. The containerd findings are
+# limited to its rootless, local-UNIX-socket runtime behind Facility's Docker
+# proxy; it does not use Docker AuthZ plugins or xDS RBAC. Remove these rules as
+# soon as the pinned upstream image contains the fixed module versions.
+ignore:
+  # Docker AuthZ request-body bypass. Facility configures no AuthZ plugin, and
+  # these files are client plugins rather than the rootless dockerd daemon.
+  - vulnerability: GHSA-x744-4wpc-v9h2
+    package:
+      name: github.com/docker/docker
+      version: v28.5.2+incompatible
+      type: go-module
+      location: /usr/local/libexec/docker/cli-plugins/docker-buildx
+  - vulnerability: GHSA-x744-4wpc-v9h2
+    package:
+      name: github.com/docker/docker
+      version: v28.5.2+incompatible
+      type: go-module
+      location: /usr/local/libexec/docker/cli-plugins/docker-compose
+
+  # Go's symbol-aware binary scanner reports no reachable vulnerable symbols
+  # for the x/net copies embedded in runc and RootlessKit.
+  - vulnerability: GO-2026-4918
+    package:
+      name: golang.org/x/net
+      version: v0.43.0
+      type: go-module
+      location: /usr/local/bin/runc
+  - vulnerability: GO-2026-5026
+    package:
+      name: golang.org/x/net
+      version: v0.43.0
+      type: go-module
+      location: /usr/local/bin/runc
+  - vulnerability: GO-2026-5942
+    package:
+      name: golang.org/x/net
+      version: v0.43.0
+      type: go-module
+      location: /usr/local/bin/runc
+  - vulnerability: GO-2026-5942
+    package:
+      name: golang.org/x/net
+      version: v0.55.0
+      type: go-module
+      location: /usr/local/bin/rootlesskit
+
+  # containerd is rootless and its Unix socket is reachable only through the
+  # restricted Facility proxy. The gRPC advisory's xDS RBAC path is unused;
+  # malformed DNS/UTF-8 inputs can at most terminate this disposable sandbox.
+  - vulnerability: GO-2026-5942
+    package:
+      name: golang.org/x/net
+      version: v0.55.0
+      type: go-module
+      location: /usr/local/bin/containerd
+  - vulnerability: GO-2026-5942
+    package:
+      name: golang.org/x/net
+      version: v0.55.0
+      type: go-module
+      location: /usr/local/bin/containerd-shim-runc-v2
+  - vulnerability: GO-2026-5942
+    package:
+      name: golang.org/x/net
+      version: v0.55.0
+      type: go-module
+      location: /usr/local/bin/ctr
+  - vulnerability: GO-2026-5970
+    package:
+      name: golang.org/x/text
+      version: v0.38.0
+      type: go-module
+      location: /usr/local/bin/containerd
+  - vulnerability: GO-2026-5970
+    package:
+      name: golang.org/x/text
+      version: v0.38.0
+      type: go-module
+      location: /usr/local/bin/ctr
+  - vulnerability: GHSA-hrxh-6v49-42gf
+    package:
+      name: google.golang.org/grpc
+      version: v1.80.0
+      type: go-module
+      location: /usr/local/bin/containerd
+  - vulnerability: GHSA-hrxh-6v49-42gf
+    package:
+      name: google.golang.org/grpc
+      version: v1.80.0
+      type: go-module
+      location: /usr/local/bin/containerd-shim-runc-v2
+  - vulnerability: GHSA-hrxh-6v49-42gf
+    package:
+      name: google.golang.org/grpc
+      version: v1.80.0
+      type: go-module
+      location: /usr/local/bin/ctr

--- a/runner/src/docker-proxy.ts
+++ b/runner/src/docker-proxy.ts
@@ -66,6 +66,14 @@ export function dockerRequestPolicy(method: string, rawUrl: string): PolicyDecis
   return { allowed: false, reason: `docker_api_denied:${method}:${pathname}` };
 }
 
+export function dockerUpgradeAllowed(method: string, rawUrl: string): boolean {
+  const pathname = dockerPath(rawUrl);
+  return (
+    method === "POST" &&
+    /^\/(?:grpc|session|exec\/[^/]+\/start|containers\/[^/]+\/attach)$/.test(pathname)
+  );
+}
+
 export function validateDockerBody(
   kind: "container" | "exec" | "volume",
   value: unknown,
@@ -348,8 +356,7 @@ function handleUpgrade(
 ) {
   const method = request.method ?? "GET";
   const url = request.url ?? "/";
-  const pathname = dockerPath(url);
-  if (method !== "POST" || !/^\/(?:exec\/[^/]+\/start|containers\/[^/]+\/attach)$/.test(pathname)) {
+  if (!dockerUpgradeAllowed(method, url)) {
     client.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 21\r\n\r\ndocker_upgrade_denied");
     return;
   }
@@ -362,9 +369,11 @@ function handleUpgrade(
       `${method} ${url} HTTP/${request.httpVersion}\r\n${headers.join("\r\n")}\r\n\r\n`,
     );
     if (head.length > 0) upstream.write(head);
-    client.pipe(upstream).pipe(client);
+    client.pipe(upstream);
+    upstream.pipe(client);
   });
   upstream.on("error", () => client.destroy());
+  client.on("error", () => upstream.destroy());
 }
 
 function dockerPath(rawUrl: string) {

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import {
   dockerRequestPolicy,
+  dockerUpgradeAllowed,
   secureDockerBindSources,
   startDockerProxy,
   validateDockerBody,
@@ -42,6 +43,71 @@ describe("restricted Docker API", () => {
     expect(script).toContain("export PNPM_CONFIG_VERIFY_STORE_INTEGRITY=true");
   });
 
+  test("keeps the official rootless launcher behind explicit host-loopback isolation", async () => {
+    const runnerRoot = fileURLToPath(new URL("..", import.meta.url));
+    const [dockerfile, script] = await Promise.all([
+      readFile(join(runnerRoot, "Dockerfile"), "utf8"),
+      readFile(join(runnerRoot, "codebuild-runner.sh"), "utf8"),
+    ]);
+    expect(dockerfile).toMatch(
+      /^FROM docker:29-dind-rootless@sha256:[0-9a-f]{64} AS docker-tools$/m,
+    );
+    expect(dockerfile).toContain("COPY --from=docker-tools /usr/local/bin/");
+    expect(dockerfile).not.toMatch(/^\s+docker\.io\s+\\$/m);
+    expect(dockerfile).not.toMatch(/^\s+rootlesskit\s+\\$/m);
+    expect(script).toContain(
+      'DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="--net=slirp4netns --disable-host-loopback"',
+    );
+    expect(script).toContain("/usr/local/bin/dockerd-entrypoint.sh dockerd");
+    expect(script).not.toContain("/usr/share/docker.io/contrib/dockerd-rootless.sh");
+    expect(script).toContain("-f /app/find-descendant.awk");
+    expect(script).not.toContain("ps -eo pid=,pgid=,uid=,comm=");
+    expect(script).toMatch(
+      /setsid nsenter --mount="\/proc\/\$\{docker_daemon_pid\}\/ns\/mnt" -- env -i/,
+    );
+  });
+
+  test("selects one descendant dockerd and denies ambiguous or spoofed process trees", () => {
+    const program = fileURLToPath(new URL("../find-descendant.awk", import.meta.url));
+    const find = (processes: string) =>
+      spawnSync(
+        "awk",
+        [
+          "-v",
+          "root_pid=244",
+          "-v",
+          "target_uid=1001",
+          "-v",
+          "target_command=dockerd",
+          "-f",
+          program,
+        ],
+        { encoding: "utf8", input: processes },
+      );
+
+    const valid = find(`
+244 1 0 runuser
+252 244 1001 rootlesskit
+316 252 1001 rootlesskit
+343 316 1001 docker-init
+348 343 1001 dockerd
+360 348 1001 containerd
+900 1 1001 dockerd
+`);
+    expect(valid.status).toBe(0);
+    expect(valid.stdout.trim()).toBe("348");
+
+    for (const denied of [
+      `244 1 0 runuser\n252 244 1001 rootlesskit\n348 252 1000 dockerd\n`,
+      `244 1 0 runuser\n348 1 1001 dockerd\n`,
+      `244 1 0 runuser\n348 244 1001 dockerd\n349 244 1001 dockerd\n`,
+    ]) {
+      const result = find(denied);
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toBe("");
+    }
+  });
+
   test("allows build and ordinary container lifecycle calls", () => {
     expect(dockerRequestPolicy("POST", "/v1.47/build?t=repo%2Fimage")).toEqual({
       allowed: true,
@@ -73,6 +139,26 @@ describe("restricted Docker API", () => {
     expect(
       validateDockerBody("container", { HostConfig: { SecurityOpt: ["label:disable"] } }),
     ).toBeNull();
+  });
+
+  test("allows only lifecycle and integrated rootless BuildKit upgrades", () => {
+    for (const path of [
+      "/grpc",
+      "/v1.55/session",
+      "/v1.55/exec/abc/start",
+      "/v1.55/containers/abc/attach",
+    ]) {
+      expect(dockerUpgradeAllowed("POST", path)).toBe(true);
+    }
+    const deniedUpgrades: Array<[string, string]> = [
+      ["GET", "/grpc"],
+      ["POST", "/plugins/pull"],
+      ["POST", "/containers/abc/update"],
+      ["POST", "/grpc/other"],
+    ];
+    for (const [method, path] of deniedUpgrades) {
+      expect(dockerUpgradeAllowed(method, path)).toBe(false);
+    }
   });
 
   test("denies daemon administration and runtime privilege escalation", () => {
@@ -477,6 +563,51 @@ describe("restricted Docker API", () => {
     await expect(upgrade(publicSocket, "/v1.47/exec/abc/start", execBody)).resolves.toBe("ready");
   });
 
+  test("keeps serving after a BuildKit probe closes its upgraded socket", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "facility-buildkit-upgrade-"));
+    const upstreamSocket = join(dir, "upstream.sock");
+    const publicSocket = join(dir, "public.sock");
+    const upstream = net.createServer((socket) => {
+      socket.once("data", (request) => {
+        const headers = request.toString();
+        if (headers.startsWith("POST /grpc ")) {
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: h2c\r\n\r\n",
+          );
+          setTimeout(() => socket.write(Buffer.from([0, 0, 0, 4])), 10);
+          return;
+        }
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK");
+      });
+      socket.on("error", () => {});
+    });
+    await listen(upstream, upstreamSocket);
+    const proxy = await startDockerProxy({ publicSocket, upstreamSocket });
+    cleanup.push(async () => {
+      await close(proxy);
+      await close(upstream);
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const client = net.createConnection(publicSocket, () => {
+        client.write(
+          "POST /grpc HTTP/1.1\r\nHost: docker\r\nConnection: Upgrade\r\nUpgrade: h2c\r\n\r\n",
+        );
+      });
+      client.once("data", () => {
+        client.destroy();
+        setTimeout(resolve, 30);
+      });
+      client.once("error", reject);
+    });
+
+    await expect(get(publicSocket, "/_ping")).resolves.toMatchObject({
+      status: 200,
+      body: "OK",
+    });
+  });
+
   test("flushes long-lived Docker response headers before the body", async () => {
     const dir = await mkdtemp(join(tmpdir(), "facility-docker-stream-"));
     const upstreamSocket = join(dir, "upstream.sock");
@@ -550,8 +681,10 @@ test("CodeBuild rejects malformed nested-Docker capability values before setup",
 
 test("CodeBuild keeps pinned bind aliases outside the recursively managed workspace", async () => {
   const script = await readFile(new URL("../codebuild-runner.sh", import.meta.url), "utf8");
-  expect(script).toContain('readonly workspace_view="/run/facility-workspace"');
+  expect(script).toContain('readonly workspace_view="/var/lib/facility-workspace"');
+  expect(script).toContain('readonly bind_runtime="/var/lib/facility-binds"');
   expect(script).not.toContain('readonly workspace_view="/work/');
+  expect(script).toContain("docker_namespace_mounts -rn -o TARGET");
   expect(script).toContain("if ! find /work -type d -print >/dev/null; then");
   expect(script).toContain('--mount "type=bind,src=/work,dst=/workspace,readonly"');
 });
@@ -611,6 +744,20 @@ function request(socketPath: string, path: string, body: Record<string, unknown>
     );
     req.on("error", reject);
     req.end(json);
+  });
+}
+
+function get(socketPath: string, path: string) {
+  return new Promise<{ status: number; body: string }>((resolve, reject) => {
+    const req = http.request({ socketPath, method: "GET", path }, (response) => {
+      let responseBody = "";
+      response.on("data", (chunk) => {
+        responseBody += chunk.toString();
+      });
+      response.on("end", () => resolve({ status: response.statusCode ?? 0, body: responseBody }));
+    });
+    req.on("error", reject);
+    req.end();
   });
 }
 

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -209,6 +209,8 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   const controlDockerfile = await readFile(join(root, "Dockerfile"), "utf8");
   const webDockerfile = await readFile(join(root, "apps/web/Dockerfile"), "utf8");
   const runnerDockerfile = await readFile(join(root, "runner/Dockerfile"), "utf8");
+  const runnerGrypePolicy = await readFile(join(root, "runner/grype.yaml"), "utf8");
+  const rootPackage = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
   const agentCliPackage = JSON.parse(
     await readFile(join(root, "runner", "agent-clis", "package.json"), "utf8"),
   );
@@ -222,15 +224,106 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   assert.ok(
     webDockerfile.indexOf("RUN pnpm install") < webDockerfile.indexOf("COPY apps/web apps/web"),
   );
-  assert.doesNotMatch(runnerDockerfile, /npm (?:i|install) -g/);
+  assert.equal(rootPackage.packageManager, "pnpm@11.20.0");
+  for (const [dockerfile, targets] of [
+    [controlDockerfile, ["api", "gateway", "mcp"]],
+    [webDockerfile, ["web"]],
+  ]) {
+    assert.match(dockerfile, /FROM base AS runtime[\s\S]*runtime package manager remains/);
+    assert.match(dockerfile, /rm -rf \/usr\/local\/lib\/node_modules\/npm/);
+    for (const target of targets) {
+      assert.match(dockerfile, new RegExp(`FROM runtime AS ${target}`));
+    }
+  }
+  assert.match(runnerDockerfile, /ARG NPM_VERSION=12\.0\.2/);
+  assert.ok(
+    runnerDockerfile.indexOf("FROM node:24-trixie@sha256:") <
+      runnerDockerfile.indexOf("ARG NPM_VERSION=12.0.2"),
+    "the patched npm runtime must be installed in the Node stage",
+  );
+  for (const patchedPackage of [
+    "brace-expansion@5.0.9",
+    "ip-address@10.3.1",
+    "tar@7.5.21",
+    "undici@6.28.0",
+  ]) {
+    assert.match(runnerDockerfile, new RegExp(patchedPackage.replace(".", "\\.")));
+  }
   assert.match(
     runnerDockerfile,
     /COPY runner\/agent-clis\/package\.json runner\/agent-clis\/package-lock\.json/,
   );
   assert.match(runnerDockerfile, /npm ci --omit=dev/);
+  assert.match(
+    runnerDockerfile,
+    /^FROM docker:29-dind-rootless@sha256:[0-9a-f]{64} AS docker-tools$/m,
+  );
+  assert.match(runnerDockerfile, /COPY --from=docker-tools \/usr\/local\/bin\//);
+  assert.doesNotMatch(runnerDockerfile, /^\s+docker\.io\s+\\$/m);
+  assert.doesNotMatch(runnerDockerfile, /^\s+rootlesskit\s+\\$/m);
+  assert.match(runnerDockerfile, /GH_VERSION=2\.97\.0/);
+  assert.match(
+    runnerDockerfile,
+    /a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112/,
+  );
+  assert.match(
+    runnerDockerfile,
+    /73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5/,
+  );
+  const riskRules = [
+    ...runnerGrypePolicy.matchAll(
+      /- vulnerability: ([^\n]+)\n\s+package:\n\s+name: ([^\n]+)\n\s+version: ([^\n]+)\n\s+type: ([^\n]+)\n\s+location: ([^\n]+)/g,
+    ),
+  ].map((match) => ({
+    vulnerability: match[1],
+    name: match[2],
+    version: match[3],
+    type: match[4],
+    location: match[5],
+  }));
+  assert.equal([...runnerGrypePolicy.matchAll(/^\s+- vulnerability:/gm)].length, 14);
+  assert.equal(riskRules.length, 14);
+  const allowedLocations = new Set([
+    "/usr/local/bin/containerd",
+    "/usr/local/bin/containerd-shim-runc-v2",
+    "/usr/local/bin/ctr",
+    "/usr/local/bin/rootlesskit",
+    "/usr/local/bin/runc",
+    "/usr/local/libexec/docker/cli-plugins/docker-buildx",
+    "/usr/local/libexec/docker/cli-plugins/docker-compose",
+  ]);
+  for (const rule of riskRules) {
+    assert.match(rule.vulnerability, /^(?:GHSA-[a-z0-9-]+|GO-\d{4}-\d+)$/);
+    assert.match(
+      rule.name,
+      /^(?:github\.com\/docker\/docker|golang\.org\/x\/(?:net|text)|google\.golang\.org\/grpc)$/,
+    );
+    assert.match(rule.version, /^v[^*\s]+$/);
+    assert.equal(rule.type, "go-module");
+    assert.ok(allowedLocations.has(rule.location));
+  }
+  for (const packageName of [
+    "libasound2t64",
+    "libatk-bridge2.0-0t64",
+    "libatk1.0-0t64",
+    "libatspi2.0-0t64",
+    "libcups2t64",
+    "libglib2.0-0t64",
+    "uidmap",
+    "fuse-overlayfs",
+    "iptables",
+  ]) {
+    assert.match(
+      runnerDockerfile,
+      new RegExp(`^\\s+${packageName.replaceAll(".", "\\.")}\\s+\\\\$`, "m"),
+    );
+  }
   assert.deepEqual(agentCliPackage.dependencies, {
     "@anthropic-ai/claude-code": "2.1.215",
     "@openai/codex": "0.144.6",
+  });
+  assert.deepEqual(agentCliPackage.allowScripts, {
+    "@anthropic-ai/claude-code@2.1.215": true,
   });
   assert.deepEqual(agentCliLock.packages[""].dependencies, agentCliPackage.dependencies);
   for (const packageName of Object.keys(agentCliPackage.dependencies)) {

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -195,9 +195,13 @@ test("CI gates release images and the reusable publisher stages digests before p
   assert.match(scanJob, /"\$GRYPE" db update/);
   assert.match(scanJob, /GRYPE_DB_AUTO_UPDATE: "false"/);
   assert.match(scanJob, /GRYPE_CHECK_FOR_APP_UPDATE: "false"/);
+  assert.match(scanJob, /actions\/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5/);
   assert.match(scanJob, /for image in api gateway mcp web runner/);
   assert.match(scanJob, /registry:\$IMAGE_PREFIX\/\$image@\$digest/);
   assert.match(scanJob, /--fail-on high --only-fixed/);
+  assert.match(scanJob, /\[\[ "\$image" == "runner" \]\]/);
+  assert.match(scanJob, /--config "\$GITHUB_WORKSPACE\/runner\/grype\.yaml"/);
+  assert.match(scanJob, /cd "\$RUNNER_TEMP"/);
   assert.match(scanJob, /scan_failed=1/);
   assert.match(scanJob, /exit "\$scan_failed"/);
   assert.doesNotMatch(scanJob, /matrix:/);
@@ -208,4 +212,18 @@ test("CI gates release images and the reusable publisher stages digests before p
     /publish-images:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
   );
   assert.match(ciWorkflow, /publish-images:[\s\S]*uses: \.\/\.github\/workflows\/images\.yml/);
+});
+
+test("sandbox CI explicitly admits RootlessKit user namespaces on Ubuntu 24.04", () => {
+  const sandboxJob = ciWorkflow.split("\n  publish-npm:")[0].split("\n  sandbox-e2e:")[1];
+  assert.ok(sandboxJob, "CI must contain the sandbox E2E job");
+  assert.match(sandboxJob, /- name: Permit nested rootless user namespaces/);
+  assert.match(sandboxJob, /key=kernel\.apparmor_restrict_unprivileged_userns/);
+  assert.match(sandboxJob, /if sudo sysctl "\$key" >\/dev\/null 2>&1; then/);
+  assert.match(sandboxJob, /sudo sysctl -w "\$key=0"/);
+  assert.ok(
+    sandboxJob.indexOf("Permit nested rootless user namespaces") <
+      sandboxJob.indexOf("Exercise the privileged CodeBuild boundary"),
+    "the host must admit unprivileged user namespaces before RootlessKit starts",
+  );
 });


### PR DESCRIPTION
## What changes

- upgrades digest-pinned Node service runtimes and removes unused package-manager trees
- sources the runner Docker stack from the digest-pinned official rootless image and pins external tools
- hardens dockerd process/namespace selection and the restricted Docker upgrade paths
- isolates service scans and applies an exact 14-rule runner-only upstream-binary risk policy
- adds regression coverage for the security boundary and image policy

## Why

The v0.6.0 image publication was blocked by fixable high CVEs in unused service toolchains and the previous Debian Docker stack. The rootless Docker upgrade also required correcting mount-namespace discovery and BuildKit upgraded connections.

## Verification

- [x] `COMPOSE_DISABLE_ENV_FILE=1 corepack pnpm verify` passes locally
- [x] all five `linux/amd64` images build
- [x] api, gateway, mcp, and web Grype scans report no vulnerabilities
- [x] final runner Grype `--fail-on high --only-fixed` exits 0 with only medium/low/unknown remaining
- [x] privileged boundary, no-Docker, and Docker-backed sandbox E2E checks pass
- [x] documentation updated

Claude Opus/high independently reviewed the complete diff. Codex tested and corrected one npm assessment; Claude accepted the evidence. Joint verdict: **Ship; no remaining blockers.**
