### PR TITLE
fix(aws): align image gate with actionable findings

### DIFF
--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -99,6 +99,14 @@ hostnames, and select `auth_identity_provider = "github"` for self-hosting. A
 tfvars filename does not set Terraform's `environment` variable, so do not
 leave the copied `playground` value behind.
 
+Set `enable_ecr_enhanced_scanning = true` only when this stack owns the ECR
+scanning policy for the AWS account and Region. This is a paid Amazon Inspector
+integration and changes the registry-wide scan type, although its on-push filter
+is limited to this stack's `${project}-${environment}/*` repositories. Leave it
+false in a shared account whose registry scanning policy is managed centrally.
+Applying the opt-in requires `ecr:PutRegistryScanningConfiguration` and may
+require `inspector2:Enable` when Inspector has not already been activated.
+
 To limit direct GitHub login to active members of one organization, set
 `github_oauth_allowed_organization` to its login. Leave it empty to preserve
 Facility's invitation and App-installation checks without an additional
@@ -359,8 +367,11 @@ print secret values or commit `.env`, tfvars, state, or private-key files.
 ## 5. Stage the digest-pinned release and database gate
 
 One command now replaces the manual register/run/wait/update sequence. It checks
-that every digest exists in this stack's ECR, waits for each ECR basic or enhanced
-scan to complete, and rejects any image with a HIGH or CRITICAL finding. It then verifies
+that every digest exists in this stack's ECR and waits for its cached scan-on-push
+result. Basic scanning rejects any HIGH or CRITICAL finding because it cannot
+report whether an update exists. Inspector-backed enhanced scanning rejects every
+HIGH or CRITICAL finding whose `fixAvailable` value is `YES` or `PARTIAL`; a
+missing or inconsistent enhanced result also fails closed. It then verifies
 architecture and the Terraform-owned runner, registers task revisions from the
 exact Terraform templates, and runs the database deploy task. The deploying AWS
 principal therefore needs `ecr:DescribeImages` and

--- a/apps/docs/test/aws-deployment-runbook.test.mjs
+++ b/apps/docs/test/aws-deployment-runbook.test.mjs
@@ -199,8 +199,18 @@ test("AWS guides require the build manifest and reserve overrides for the runner
     );
     assert.match(
       markdown,
-      /ECR basic or enhanced[\s\S]{0,120}HIGH or CRITICAL/,
-      `${guideName} must document the deployment vulnerability gate`,
+      /Basic scanning[\s\S]{0,120}(?:rejects|reject) any HIGH or CRITICAL/,
+      `${guideName} must document the fail-closed basic-scan gate`,
+    );
+    assert.match(
+      markdown,
+      /enhanced scanning[\s\S]{0,160}HIGH or CRITICAL[\s\S]{0,80}`fixAvailable`[\s\S]{0,80}`YES` or `PARTIAL`/i,
+      `${guideName} must document the actionable enhanced-scan gate`,
+    );
+    assert.match(
+      markdown,
+      /registry-wide[\s\S]{0,180}(?:shared AWS account|shared account)/i,
+      `${guideName} must disclose the enhanced scanner's account and Region blast radius`,
     );
     assert.match(
       markdown,

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -242,8 +242,20 @@ plaintext to the terminal.
 ## 5. Stage or deploy the release
 
 The release command validates every image against this stack's ECR repositories
-and architecture, waits for each ECR basic or enhanced scan to complete, and rejects any
-image with a HIGH or CRITICAL finding. The deploying AWS principal needs
+and architecture and waits for its cached ECR scan-on-push result. Basic scanning
+remains fail-closed and rejects any HIGH or CRITICAL finding because it cannot
+report whether an update exists. When `enable_ecr_enhanced_scanning = true`, the
+module opts this account and region into paid Amazon Inspector scanning for only
+`${project}-${environment}/*`. With enhanced scanning enabled, deployment rejects
+every HIGH or CRITICAL finding whose `fixAvailable` value is `YES` or `PARTIAL`.
+This matches the pinned Grype
+`--only-fixed` promotion policy without maintaining a drifting CVE allowlist.
+
+The enhanced setting is registry-wide even though its repository filter is narrow.
+Leave it disabled in a shared AWS account unless this stack owns the central ECR
+scanning policy. Applying the opt-in requires
+`ecr:PutRegistryScanningConfiguration` and may require `inspector2:Enable` when
+Inspector has not already been activated. The deploying AWS principal needs
 `ecr:DescribeImages` and `ecr:DescribeImageScanFindings`. It then verifies the
 Terraform-owned CodeBuild runner digest, copies the freshly rendered Terraform
 task templates, and replaces only their main container images. It runs the

--- a/infra/terraform/aws/storage.tf
+++ b/infra/terraform/aws/storage.tf
@@ -110,6 +110,25 @@ resource "aws_ecr_repository" "service" {
   }
 }
 
+# ECR exposes fix availability only through Inspector-backed enhanced findings.
+# Registry scanning is account-and-region scoped, so shared accounts must leave
+# this opt-in disabled and manage their single registry policy centrally.
+resource "aws_ecr_registry_scanning_configuration" "facility" {
+  count = var.enable_ecr_enhanced_scanning ? 1 : 0
+
+  # This registry policy supersedes each repository's basic scan_on_push setting.
+  scan_type = "ENHANCED"
+
+  rule {
+    scan_frequency = "SCAN_ON_PUSH"
+
+    repository_filter {
+      filter      = "${local.name_prefix}/*"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+
 resource "aws_ecr_lifecycle_policy" "service" {
   for_each = aws_ecr_repository.service
 

--- a/infra/terraform/aws/terraform.tfvars.example
+++ b/infra/terraform/aws/terraform.tfvars.example
@@ -45,6 +45,12 @@ database_backup_retention_days = 7
 enable_deletion_protection = true
 force_destroy_bucket       = false
 
+# Optional paid Amazon Inspector integration. This changes the ECR scan type
+# for the whole AWS account/region, while the filter below is limited to this
+# stack's repositories. Enable only in a dedicated registry or when this stack
+# is the declared owner of the shared registry scanning policy.
+enable_ecr_enhanced_scanning = false
+
 envelope_retention_days = 90
 
 container_image_tags = {

--- a/infra/terraform/aws/tests/ecr_scanning.tftest.hcl
+++ b/infra/terraform/aws/tests/ecr_scanning.tftest.hcl
@@ -1,0 +1,113 @@
+mock_provider "aws" {
+  override_during = plan
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-east-1a", "us-east-1b"]
+    }
+  }
+
+  mock_data "aws_cloudfront_cache_policy" {
+    defaults = {
+      id = "managed-caching-disabled"
+    }
+  }
+
+  mock_data "aws_cloudfront_origin_request_policy" {
+    defaults = {
+      id = "managed-all-viewer-except-host"
+    }
+  }
+
+  mock_data "aws_ec2_managed_prefix_list" {
+    defaults = {
+      id = "pl-cloudfront-origin-facing"
+    }
+  }
+
+  mock_resource "aws_cloudfront_distribution" {
+    defaults = {
+      domain_name = "d111111abcdef8.cloudfront.net"
+    }
+  }
+
+  mock_resource "aws_lb" {
+    defaults = {
+      arn      = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/facility-test/0000000000000000"
+      dns_name = "facility-test.us-east-1.elb.amazonaws.com"
+      zone_id  = "Z35SXDOTRQ7X7K"
+    }
+  }
+
+  mock_resource "aws_db_instance" {
+    defaults = {
+      master_user_secret = [{
+        kms_key_id    = "mock-kms-key"
+        secret_arn    = "arn:aws:secretsmanager:us-east-1:123456789012:secret:facility-db"
+        secret_status = "active"
+      }]
+    }
+  }
+}
+
+mock_provider "random" {
+  override_during = plan
+
+  mock_resource "random_password" {
+    defaults = {
+      result = "preview-surface-token-0000000000000000000000000000000000000000"
+    }
+  }
+}
+
+run "enhanced_scanning_is_an_explicit_scoped_opt_in" {
+  command = plan
+
+  variables {
+    app_hostname                 = "app.example.com"
+    api_hostname                 = "api.example.com"
+    mcp_hostname                 = "mcp.example.com"
+    enable_ecr_enhanced_scanning = true
+  }
+
+  assert {
+    condition     = length(aws_ecr_registry_scanning_configuration.facility) == 1
+    error_message = "The explicit opt-in must manage one regional ECR registry policy."
+  }
+
+  assert {
+    condition     = one(aws_ecr_registry_scanning_configuration.facility).scan_type == "ENHANCED"
+    error_message = "The managed policy must use Inspector-backed enhanced scanning."
+  }
+
+  assert {
+    condition     = one(one(aws_ecr_registry_scanning_configuration.facility).rule).scan_frequency == "SCAN_ON_PUSH"
+    error_message = "Facility images must be scanned once on push, not continuously rescanned."
+  }
+
+  assert {
+    condition     = one(one(one(aws_ecr_registry_scanning_configuration.facility).rule).repository_filter).filter == "facility-playground/*"
+    error_message = "The paid scan must be limited to this Facility stack's repository prefix."
+  }
+}
+
+run "enhanced_scanning_is_not_enabled_implicitly" {
+  command = plan
+
+  variables {
+    app_hostname = "app.example.com"
+    api_hostname = "api.example.com"
+    mcp_hostname = "mcp.example.com"
+  }
+
+  assert {
+    condition     = length(aws_ecr_registry_scanning_configuration.facility) == 0
+    error_message = "A stack must not take over the account-wide ECR policy without an explicit opt-in."
+  }
+}

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -159,6 +159,12 @@ variable "force_destroy_bucket" {
   default     = false
 }
 
+variable "enable_ecr_enhanced_scanning" {
+  description = "Manage the account-and-region ECR registry scan type with Amazon Inspector and scan only this Facility repository prefix on push. This is a paid, registry-wide setting; enable it only when this stack owns the registry scanning policy."
+  type        = bool
+  default     = false
+}
+
 variable "container_image_tags" {
   description = "Image tags used when image_overrides does not provide a full image URI. The worker tag is retained for tfvars compatibility; the AWS fallback runs worker from the API image."
   type = object({

--- a/scripts/deploy-aws.mjs
+++ b/scripts/deploy-aws.mjs
@@ -13,6 +13,7 @@ export const AWS_IMAGE_NAMES = Object.freeze(["api", "worker", "gateway", "web",
 
 const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
 const FULL_SHA_PATTERN = /^[0-9a-f]{40,64}$/;
+const ECR_FIX_AVAILABILITY = new Set(["YES", "NO", "PARTIAL"]);
 const ECR_REPOSITORY_PATTERN =
   /^\d{12}\.dkr\.ecr(?:-fips)?\.[a-z0-9-]+\.amazonaws\.com(?:\.cn)?\/[a-z0-9]+(?:[._/-][a-z0-9]+)*$/;
 const TASK_REGISTRATION_FIELDS = Object.freeze([
@@ -92,6 +93,75 @@ function expectedPlatform(cpuArchitecture) {
     "terraform_outputs_invalid",
     `task_cpu_architecture must be X86_64 or ARM64, received ${cpuArchitecture || "missing"}`,
   );
+}
+
+function vulnerabilityCounts(findings, repository) {
+  const counts = findings?.findingSeverityCounts;
+  const critical = Number(counts?.CRITICAL ?? 0);
+  const high = Number(counts?.HIGH ?? 0);
+  if (!Number.isSafeInteger(critical) || critical < 0 || !Number.isSafeInteger(high) || high < 0) {
+    throw new AwsDeployError(
+      "ecr_scan_invalid_response",
+      `ECR returned invalid vulnerability counts for ${repository}`,
+    );
+  }
+  return { critical, high };
+}
+
+export function enforceEcrScanPolicy(findings, { enhanced, repository }) {
+  const { critical, high } = vulnerabilityCounts(findings, repository);
+  if (!enhanced) {
+    // Basic scanning cannot distinguish a patchable vulnerability from one for
+    // which the distribution has no update. Preserve the original fail-closed
+    // behavior instead of silently guessing.
+    if (critical > 0 || high > 0) {
+      throw new AwsDeployError(
+        "ecr_scan_blocked",
+        `ECR blocked ${repository}: ${critical} critical and ${high} high vulnerabilities`,
+      );
+    }
+    return { critical, high, actionableCritical: 0, actionableHigh: 0, enhanced: false };
+  }
+
+  if (!Array.isArray(findings?.enhancedFindings)) {
+    throw new AwsDeployError(
+      "ecr_scan_invalid_response",
+      `ECR returned no enhanced findings for ${repository}`,
+    );
+  }
+
+  let actionableCritical = 0;
+  let actionableHigh = 0;
+  let observedCritical = 0;
+  let observedHigh = 0;
+  for (const finding of findings.enhancedFindings) {
+    if (finding?.severity !== "CRITICAL" && finding?.severity !== "HIGH") continue;
+    if (!ECR_FIX_AVAILABILITY.has(finding.fixAvailable)) {
+      throw new AwsDeployError(
+        "ecr_scan_invalid_response",
+        `ECR returned invalid fix availability for ${repository}`,
+      );
+    }
+    if (finding.severity === "CRITICAL") observedCritical += 1;
+    else observedHigh += 1;
+    if (finding.fixAvailable === "NO") continue;
+    if (finding.severity === "CRITICAL") actionableCritical += 1;
+    else actionableHigh += 1;
+  }
+
+  if (observedCritical !== critical || observedHigh !== high) {
+    throw new AwsDeployError(
+      "ecr_scan_invalid_response",
+      `ECR enhanced findings did not match vulnerability counts for ${repository}`,
+    );
+  }
+  if (actionableCritical > 0 || actionableHigh > 0) {
+    throw new AwsDeployError(
+      "ecr_scan_blocked",
+      `ECR blocked ${repository}: ${actionableCritical} critical and ${actionableHigh} high vulnerabilities have fixes available`,
+    );
+  }
+  return { critical, high, actionableCritical, actionableHigh, enhanced: true };
 }
 
 export function createAwsReleaseManifest({ metadata, repositoryPrefix, sourceSha, platform }) {
@@ -855,26 +925,10 @@ export function createAwsCliAdapter({
           );
         }
 
-        const counts = findings?.findingSeverityCounts;
-        const critical = Number(counts?.CRITICAL ?? 0);
-        const high = Number(counts?.HIGH ?? 0);
-        if (
-          !Number.isSafeInteger(critical) ||
-          critical < 0 ||
-          !Number.isSafeInteger(high) ||
-          high < 0
-        ) {
-          throw new AwsDeployError(
-            "ecr_scan_invalid_response",
-            `ECR returned invalid vulnerability counts for ${repository}@${digest}`,
-          );
-        }
-        if (critical > 0 || high > 0) {
-          throw new AwsDeployError(
-            "ecr_scan_blocked",
-            `ECR blocked ${repository}@${digest}: ${critical} critical and ${high} high vulnerabilities`,
-          );
-        }
+        enforceEcrScanPolicy(findings, {
+          enhanced: status === "ACTIVE",
+          repository: `${repository}@${digest}`,
+        });
         return { done: true };
       });
     },

--- a/scripts/deploy-aws.test.mjs
+++ b/scripts/deploy-aws.test.mjs
@@ -10,10 +10,79 @@ import {
   createAwsCliAdapter,
   createAwsReleaseManifest,
   deployAws,
+  enforceEcrScanPolicy,
   normalizeTerraformOutputs,
   taskDefinitionRegistration,
   validateAwsReleaseManifest,
 } from "./deploy-aws.mjs";
+
+test("ECR scan policy keeps basic scanning strict and gates enhanced actionable findings", () => {
+  assert.throws(
+    () =>
+      enforceEcrScanPolicy(
+        { findingSeverityCounts: { CRITICAL: 1, HIGH: 2 } },
+        { enhanced: false, repository: "repo@digest" },
+      ),
+    (error) => error.code === "ecr_scan_blocked" && /1 critical and 2 high/.test(error.message),
+  );
+
+  assert.deepEqual(
+    enforceEcrScanPolicy(
+      {
+        findingSeverityCounts: { CRITICAL: 1, HIGH: 1 },
+        enhancedFindings: [
+          { severity: "CRITICAL", fixAvailable: "NO" },
+          { severity: "HIGH", fixAvailable: "NO" },
+        ],
+      },
+      { enhanced: true, repository: "repo@digest" },
+    ),
+    {
+      critical: 1,
+      high: 1,
+      actionableCritical: 0,
+      actionableHigh: 0,
+      enhanced: true,
+    },
+  );
+
+  for (const fixAvailable of ["YES", "PARTIAL"]) {
+    assert.throws(
+      () =>
+        enforceEcrScanPolicy(
+          {
+            findingSeverityCounts: { HIGH: 1 },
+            enhancedFindings: [{ severity: "HIGH", fixAvailable }],
+          },
+          { enhanced: true, repository: "repo@digest" },
+        ),
+      (error) =>
+        error.code === "ecr_scan_blocked" &&
+        /0 critical and 1 high vulnerabilities have fixes available/.test(error.message),
+    );
+  }
+});
+
+test("ECR enhanced scan policy fails closed on malformed or incomplete findings", () => {
+  for (const findings of [
+    { findingSeverityCounts: { HIGH: 1 } },
+    { findingSeverityCounts: { HIGH: 1 }, enhancedFindings: [] },
+    {
+      findingSeverityCounts: { HIGH: 1 },
+      enhancedFindings: [{ severity: "HIGH", fixAvailable: undefined }],
+    },
+    { findingSeverityCounts: { HIGH: -1 }, enhancedFindings: [] },
+  ]) {
+    assert.throws(
+      () =>
+        enforceEcrScanPolicy(findings, {
+          enhanced: true,
+          repository: "repo@digest",
+        }),
+      (error) => error.code === "ecr_scan_invalid_response",
+    );
+  }
+});
 
 const account = "123456789012";
 const region = "eu-west-1";
@@ -805,7 +874,7 @@ if (service === "ecr" && operation === "describe-images") {
   const scanCalls = calls.filter((call) => call[3] === "ecr" && call[4] === "describe-image-scan-findings");
   const status = scanCalls.length === 1 ? "IN_PROGRESS" : "ACTIVE";
   const completed = scanCalls.length >= 3 ? { imageScanCompletedAt: "2026-08-07T00:00:00Z" } : {};
-  process.stdout.write(JSON.stringify({ imageScanStatus: { status }, imageScanFindings: { ...completed, findingSeverityCounts: {} } }));
+  process.stdout.write(JSON.stringify({ imageScanStatus: { status }, imageScanFindings: { ...completed, findingSeverityCounts: {}, enhancedFindings: [] } }));
 } else {
   process.stderr.write("unexpected adapter command " + service + " " + operation);
   process.exit(19);
@@ -844,6 +913,56 @@ if (service === "ecr" && operation === "describe-images") {
   await assert.rejects(
     aws.assertImage(`${prefix}/api`, digests.api),
     (error) => error.code === "ecr_scan_blocked" && /1 critical and 2 high/.test(error.message),
+  );
+});
+
+test("AWS CLI adapter admits only non-fixable enhanced findings", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "facility-aws-enhanced-image-scan-"));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const command = join(directory, "aws");
+  await writeFile(
+    command,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const service = args[3];
+const operation = args[4];
+const repository = args[args.indexOf("--repository-name") + 1];
+if (service === "ecr" && operation === "describe-images") {
+  const digest = args[args.findIndex((arg) => arg.startsWith("imageDigest="))].slice("imageDigest=".length);
+  process.stdout.write(JSON.stringify({ imageDetails: [{ imageDigest: digest }] }));
+} else if (service === "ecr" && operation === "describe-image-scan-findings") {
+  const fixAvailable = repository.endsWith("/api") ? "NO" : repository.endsWith("/gateway") ? "YES" : undefined;
+  process.stdout.write(JSON.stringify({
+    imageScanStatus: { status: "ACTIVE" },
+    imageScanFindings: {
+      imageScanCompletedAt: "2026-08-07T00:00:00Z",
+      findingSeverityCounts: { HIGH: 1 },
+      enhancedFindings: [{ severity: "HIGH", ...(fixAvailable ? { fixAvailable } : {}) }]
+    }
+  }));
+} else {
+  process.stderr.write("unexpected adapter command " + service + " " + operation);
+  process.exit(19);
+}
+`,
+  );
+  await chmod(command, 0o755);
+  const aws = createAwsCliAdapter({
+    awsCommand: command,
+    commandTimeoutMs: 1_000,
+    pollIntervalMs: 1,
+    region,
+  });
+
+  await aws.assertImage(`${prefix}/api`, digests.api);
+  await assert.rejects(
+    aws.assertImage(`${prefix}/gateway`, digests.gateway),
+    (error) =>
+      error.code === "ecr_scan_blocked" && /1 high vulnerabilities have fixes/.test(error.message),
+  );
+  await assert.rejects(
+    aws.assertImage(`${prefix}/mcp`, digests.mcp),
+    (error) => error.code === "ecr_scan_invalid_response",
   );
 });
 


### PR DESCRIPTION
## What changes

- Keep ECR Basic scanning fail-closed on every HIGH or CRITICAL finding.
- When explicitly opted into Inspector-backed enhanced scanning, reject HIGH or CRITICAL findings with `fixAvailable` equal to `YES` or `PARTIAL`, and reject malformed or inconsistent scan responses.
- Add a default-off, repository-prefix-scoped Terraform option for ECR enhanced scan-on-push.
- Document the paid account/Region registry-policy boundary and required IAM actions.

## Why

Production image admission was impossible with ECR Basic scanning because it reports raw Debian findings but cannot say whether a fix exists. Facility CI already promotes on the stricter actionable policy enforced by pinned Grype `--only-fixed`. The enhanced path makes the production gate express the same rule without a drifting CVE allowlist; Basic users retain the original zero-tolerance behavior.

The Inspector integration is deliberately disabled by default because ECR registry scanning configuration is account-and-Region scoped and paid.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (the production deploy gate rejected the exact digest set before migration or ECS mutation under Basic scanning; all five existing ECS services remained healthy)
- [x] Documentation updated, or no user-facing change

Additional focused evidence:

- `node --test scripts/deploy-aws.test.mjs` — 25/25 pass, including deterministic enhanced allow, deny, malformed-response, and CLI adapter coverage.
- `terraform fmt -check -recursive && terraform validate && terraform test` — valid; 5/5 Terraform tests pass, including explicit opt-in and default-off assertions.
- `node --test apps/docs/test/aws-deployment-runbook.test.mjs` — 10/10 pass.
- Independent Claude Opus high-reasoning review: SHIP; live Inspector count/finding consistency must still be checked before production activation.

Production Inspector activation is not part of this PR and has not been performed.
