### PR TITLE
perf(images): share runtime package builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,15 +49,19 @@ RUN pnpm install --frozen-lockfile --filter '@facility/core...' \
       --filter '@facility/harness...' \
       --filter '@facility/api...' --filter '@facility/gateway...'
 
-# --- API build: API + its workspace runtime dependencies ---
-FROM deps AS build-api
+# Build the workspace packages shared by the three service images once. Bake
+# requests API, gateway, and MCP concurrently; keeping this as one graph vertex
+# prevents three Core builds and two DB builds from competing for memory.
+FROM deps AS build-service-packages
 COPY packages ./packages
-COPY services/api ./services/api
 COPY tsconfig.base.json ./
-# @facility/harness is a runtime dependency of the API (KB validation, the
-# Project Owner / learning harness) — it must be built into the image.
 RUN pnpm --filter '@facility/core' --filter '@facility/db' \
-      --filter '@facility/harness' --filter '@facility/api' run build
+      --filter '@facility/harness' --filter '@facility/sdk' run build:runtime
+
+# --- API build: API + its workspace runtime dependencies ---
+FROM build-service-packages AS build-api
+COPY services/api ./services/api
+RUN pnpm --filter '@facility/api' run build:runtime
 # Produce isolated production trees. `deploy --prod` keeps runtime workspace
 # dependencies and package assets (including DB migrations) while excluding
 # source workspaces, tests, build tools, and every devDependency.
@@ -70,20 +74,14 @@ RUN test -f /prod/api/node_modules/@facility/db/dist/seed-assets/packages/harnes
   && test -f /prod/api/node_modules/@facility/core/dist/render-assets/packages/cli/templates/workflows/facility-crew.yml
 
 # --- Gateway build: avoid compiling the much larger API for proxy-only fixes ---
-FROM deps AS build-gateway
-COPY packages ./packages
+FROM build-service-packages AS build-gateway
 COPY services/gateway ./services/gateway
-COPY tsconfig.base.json ./
-RUN pnpm --filter '@facility/core' --filter '@facility/db' \
-      --filter '@facility/gateway' run build
+RUN pnpm --filter '@facility/gateway' run build:runtime
 RUN pnpm --filter '@facility/gateway' deploy --prod --legacy /prod/gateway
 
 # --- MCP build: keep SDK/MCP changes independent from API and gateway ---
-FROM deps AS build-mcp
-COPY packages ./packages
-COPY tsconfig.base.json ./
-RUN pnpm --filter '@facility/core' --filter '@facility/sdk' \
-      --filter '@facility/mcp' run build
+FROM build-service-packages AS build-mcp
+RUN pnpm --filter '@facility/mcp' run build:runtime
 RUN pnpm --filter '@facility/mcp' deploy --prod --legacy /prod/mcp
 
 # --- api (also serves the worker via `node dist/worker.js`) ---

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -38,7 +38,7 @@ COPY tsconfig.base.json ./
 ENV NEXT_TELEMETRY_DISABLED=1
 # The web imports the SDK's published workspace entrypoint (`dist/index.js`). A
 # clean image has no SDK artifact, so build it before Next consumes the output.
-RUN pnpm --filter '@facility/sdk...' run build && pnpm --filter '@facility/web' build
+RUN pnpm --filter '@facility/sdk...' run build:runtime && pnpm --filter '@facility/web' build
 
 FROM runtime AS web
 ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 PORT=3400 HOSTNAME=0.0.0.0

--- a/infra/docker-bake.hcl
+++ b/infra/docker-bake.hcl
@@ -28,21 +28,32 @@ target "service" {
   attest = ["type=provenance,disabled=true"]
 }
 
+# Make the shared package build a real dependency edge. Without the named
+# context, concurrent target solves may each start the same cold RUN before a
+# sibling has populated BuildKit's cache.
+target "service-packages" {
+  inherits = ["service"]
+  target   = "build-service-packages"
+}
+
 target "api" {
   inherits = ["service"]
   target   = "api"
+  contexts = { build-service-packages = "target:service-packages" }
   tags     = ["${ECR_REGISTRY}/${ECR_PREFIX}/api:${IMAGE_TAG}"]
 }
 
 target "gateway" {
   inherits = ["service"]
   target   = "gateway"
+  contexts = { build-service-packages = "target:service-packages" }
   tags     = ["${ECR_REGISTRY}/${ECR_PREFIX}/gateway:${IMAGE_TAG}"]
 }
 
 target "mcp" {
   inherits = ["service"]
   target   = "mcp"
+  contexts = { build-service-packages = "target:service-packages" }
   tags     = ["${ECR_REGISTRY}/${ECR_PREFIX}/mcp:${IMAGE_TAG}"]
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts src/audit.ts src/crypto.ts src/detect.ts src/fingerprints.ts src/ids.ts src/permissions.ts src/pricing.ts src/provider-url.ts src/render.ts src/receipts.ts src/roles.ts --format esm --dts && node scripts/copy-render-assets.mjs",
+    "build:runtime": "tsup src/index.ts src/audit.ts src/crypto.ts src/detect.ts src/fingerprints.ts src/ids.ts src/permissions.ts src/pricing.ts src/provider-url.ts src/render.ts src/receipts.ts src/roles.ts --format esm && node scripts/copy-render-assets.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts src/audit.ts src/schema.ts src/deploy.ts src/migrate.ts src/seed.ts src/bin/deploy.ts src/bin/migrate.ts src/bin/seed.ts --format esm --dts && node scripts/copy-seed-assets.mjs",
+    "build:runtime": "tsup src/index.ts src/audit.ts src/schema.ts src/deploy.ts src/migrate.ts src/seed.ts src/bin/deploy.ts src/bin/migrate.ts src/bin/seed.ts --format esm && node scripts/copy-seed-assets.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "migrate": "tsx src/bin/migrate.ts",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -14,6 +14,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts src/chain.ts src/provenance.ts src/session.ts src/validate.ts src/wsjf.ts --format esm --dts",
+    "build:runtime": "tsup src/index.ts src/chain.ts src/provenance.ts src/session.ts src/validate.ts src/wsjf.ts --format esm",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,6 +12,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts src/bin/facility-mcp.ts --format esm --dts",
+    "build:runtime": "tsup src/index.ts src/bin/facility-mcp.ts --format esm",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,6 +12,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "build:runtime": "tsup src/index.ts --format esm",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "generate": "openapi-typescript openapi.json -o src/schema.d.ts"

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -183,6 +183,15 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   assert.doesNotMatch(bake, /target "worker"/);
   assert.match(bake, /target "gateway" \{[\s\S]*target\s+= "gateway"/);
   assert.match(bake, /target "mcp" \{[\s\S]*target\s+= "mcp"/);
+  assert.match(bake, /target "service-packages" \{[\s\S]*target\s+= "build-service-packages"/);
+  for (const image of ["api", "gateway", "mcp"]) {
+    assert.match(
+      bake,
+      new RegExp(
+        `target "${image}" \\{[\\s\\S]*?contexts = \\{ build-service-packages = "target:service-packages" \\}`,
+      ),
+    );
+  }
   assert.match(bake, /target "web" \{[\s\S]*dockerfile = "apps\/web\/Dockerfile"/);
   assert.match(bake, /target "runner" \{[\s\S]*dockerfile = "runner\/Dockerfile"/);
   assert.match(bake, /target "service" \{[\s\S]*?attest\s+= \["type=provenance,disabled=true"\]/);
@@ -217,6 +226,17 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   const agentCliLock = JSON.parse(
     await readFile(join(root, "runner", "agent-clis", "package-lock.json"), "utf8"),
   );
+  const runtimeBuildPackages = await Promise.all(
+    [
+      "packages/core/package.json",
+      "packages/db/package.json",
+      "packages/harness/package.json",
+      "packages/sdk/package.json",
+      "packages/mcp/package.json",
+      "services/api/package.json",
+      "services/gateway/package.json",
+    ].map(async (path) => JSON.parse(await readFile(join(root, path), "utf8"))),
+  );
   assert.doesNotMatch(webDockerfile, /^COPY \. \.$/m);
   assert.ok(
     webDockerfile.indexOf("COPY pnpm-lock.yaml") < webDockerfile.indexOf("RUN pnpm install"),
@@ -225,6 +245,47 @@ test("Bake keeps thin target boundaries and publishes every target through one g
     webDockerfile.indexOf("RUN pnpm install") < webDockerfile.indexOf("COPY apps/web apps/web"),
   );
   assert.equal(rootPackage.packageManager, "pnpm@11.20.0");
+  const sharedServiceBuild = controlDockerfile.match(
+    /FROM deps AS build-service-packages\n([\s\S]*?)(?=\nFROM )/,
+  )?.[1];
+  assert.ok(sharedServiceBuild, "service images must share one workspace-package build stage");
+  for (const packageName of ["core", "db", "harness", "sdk"]) {
+    assert.match(sharedServiceBuild, new RegExp(`@facility/${packageName}`));
+  }
+  for (const [stage, packageName] of [
+    ["build-api", "api"],
+    ["build-gateway", "gateway"],
+    ["build-mcp", "mcp"],
+  ]) {
+    const serviceBuild = controlDockerfile.match(
+      new RegExp(`FROM build-service-packages AS ${stage}\\n([\\s\\S]*?)(?=\\nFROM )`),
+    )?.[1];
+    assert.ok(serviceBuild, `${stage} must inherit the shared workspace build`);
+    assert.match(
+      serviceBuild,
+      new RegExp(`pnpm --filter '@facility/${packageName}' run build:runtime(?:\\s|$)`),
+    );
+    for (const sharedPackage of ["core", "db", "harness", "sdk"]) {
+      assert.doesNotMatch(serviceBuild, new RegExp(`--filter '@facility/${sharedPackage}'`));
+    }
+  }
+  assert.equal(
+    controlDockerfile.match(/run build:runtime/g)?.length,
+    4,
+    "the shared stage and three service stages must omit declaration-only work",
+  );
+  assert.match(
+    webDockerfile,
+    /pnpm --filter '@facility\/sdk\.\.\.' run build:runtime && pnpm --filter '@facility\/web' build/,
+  );
+  for (const packageJson of runtimeBuildPackages) {
+    assert.match(packageJson.scripts.build, / --dts(?: |$)/);
+    assert.equal(
+      packageJson.scripts["build:runtime"],
+      packageJson.scripts.build.replace(" --dts", ""),
+      `${packageJson.name} runtime build must differ only by declaration emission`,
+    );
+  }
   for (const [dockerfile, targets] of [
     [controlDockerfile, ["api", "gateway", "mcp"]],
     [webDockerfile, ["web"]],

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts src/dev.ts src/start.ts src/worker.ts src/openapi.ts --format esm --dts",
+    "build:runtime": "tsup src/index.ts src/dev.ts src/start.ts src/worker.ts src/openapi.ts --format esm",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --fileParallelism=false",
     "test:e2e-sandbox": "vitest run --fileParallelism=false test/sandbox.e2e.test.ts",

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts src/dev.ts src/start.ts --format esm --dts",
+    "build:runtime": "tsup src/index.ts src/dev.ts src/start.ts --format esm",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "dev": "tsx watch src/dev.ts",


### PR DESCRIPTION
## What changes

- Build Core, DB, harness, and SDK once as an explicit Bake dependency shared by API, gateway, and MCP.
- Add runtime-only package builds that preserve JavaScript entries and bundled assets while skipping declaration generation already covered by CI.
- Use the runtime SDK build in the web image.
- Guard the Bake dependency, runtime entry parity, asset-copy commands, and Dockerfile wiring with static regression tests.

## Why

A cold three-service build compiled Core three times and DB twice concurrently. Declaration generation dominated service build time and created avoidable CPU and memory pressure even though container runtimes consume only JavaScript. The previous API/gateway/MCP baseline was 341.19 seconds and a five-image cold build exhausted 47 GB of Docker storage before completion.

This keeps the same five published images and services. It changes only the build graph and removes redundant declaration work from container builds.

## Verification

- node --test scripts/images-build.test.mjs scripts/images.test.mjs: 14/14 passed.
- Clean runtime build plus JavaScript, asset, and no-declaration assertions: passed in 2.17 seconds.
- docker buildx bake --print: one cache-only service-packages dependency feeding API, gateway, and MCP; only those three requested outputs are published.
- Biome and git diff checks passed.
- Full local pnpm verify passed lint, typecheck, clean builds, DB integration, and 97 CLI tests. Its API phase hit unrelated fixed 5-10 second timeouts while Docker Desktop was consuming about 970% CPU and 30% memory; no test limit was changed. Isolated PR CI is the authoritative complete-suite check.

- [ ] pnpm verify passes locally
- [x] Behaviour verified beyond the test suite (clean runtime artifacts and Bake graph inspected)
- [x] Documentation updated, or no user-facing change