### PR TITLE
fix(audit): hash persisted JSON representation

### DIFF
--- a/packages/core/src/audit.ts
+++ b/packages/core/src/audit.ts
@@ -61,6 +61,14 @@ export const AuditEventSchema = z.object({
   ts: z.string().optional(),
 });
 
+function persistedJson(value: unknown): unknown {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new TypeError("Hash-chain events must be JSON-serializable");
+  }
+  return JSON.parse(encoded);
+}
+
 function stableStringify(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map(stableStringify).join(",")}]`;
@@ -71,11 +79,15 @@ function stableStringify(value: unknown): string {
       .map(([key, inner]) => `${JSON.stringify(key)}:${stableStringify(inner)}`)
       .join(",")}}`;
   }
-  return JSON.stringify(value);
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new TypeError("Hash-chain events must be JSON-serializable");
+  }
+  return encoded;
 }
 
 export function hashChain(prevHash: string | null, event: unknown): string {
   return createHash("sha256")
-    .update(`${prevHash ?? ""}:${stableStringify(event)}`)
+    .update(`${prevHash ?? ""}:${stableStringify(persistedJson(event))}`)
     .digest("hex");
 }

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -359,6 +359,15 @@ describe("audit", () => {
       "5347c7c917380c15ab8fbf413dccbddcca3bdfc3df03905c0e54cfe788c83289",
     );
   });
+
+  it("hashes the JSON value that persistence retains", () => {
+    expect(hashChain(null, { status: "succeeded", error: undefined })).toBe(
+      hashChain(null, { status: "succeeded" }),
+    );
+    expect(hashChain(null, { values: [undefined, "kept"] })).toBe(
+      hashChain(null, { values: [null, "kept"] }),
+    );
+  });
 });
 
 describe("receipts", () => {

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -18,6 +18,7 @@ import {
   MigrationLockTimeoutError,
   migrate,
   seed,
+  verifyAuditChain,
   withOrg,
 } from "../src/index.js";
 import * as schema from "../src/schema.js";
@@ -361,6 +362,27 @@ describe("db", async () => {
       }),
     );
     expect(second?.prevHash).toBe(first?.hash);
+  });
+
+  it("keeps the audit chain valid when JSON persistence omits undefined fields", async () => {
+    const orgId = newId("org");
+    await db
+      .insert(schema.orgs)
+      .values({ id: orgId, name: "Audit JSON", slug: `audit-json-${orgId}`, settings: {} });
+
+    const event = await insertAuditEvent(db, {
+      orgId,
+      actor: { type: "agent", id: "run_success" },
+      action: "run.finished",
+      target: { type: "run", id: "run_success" },
+      payload: { status: "succeeded", error: undefined, values: [undefined, "kept"] },
+    });
+
+    expect(event?.payload).toEqual({ status: "succeeded", values: [null, "kept"] });
+    await expect(verifyAuditChain(db, orgId)).resolves.toEqual({
+      ok: true,
+      firstBreakSeq: null,
+    });
   });
 
   it("seeds idempotently", async () => {


### PR DESCRIPTION
## What changes

- Canonicalize audit event bodies through JSON serialization before hashing.
- Reject non-JSON-serializable top-level hash inputs explicitly.
- Add unit coverage for omitted object fields and null-normalized array entries.
- Add a PostgreSQL integration regression matching successful run.finished events with error: undefined.

## Why

Successful runs pass error: undefined into the run.finished audit payload. The hash previously included that JavaScript field, but PostgreSQL JSON serialization omitted it. The persisted row therefore failed audit verification immediately even though it had not been tampered with.

This hashes exactly the representation persistence retains, so newly written audit evidence verifies after a database round trip.

Existing broken chains are intentionally not rewritten automatically: mutating historical audit evidence requires an explicit operator decision.

## Verification

- @facility/core tests: 28/28 passed, including JSON persistence semantics.
- Core and DB typechecks passed.
- Biome passed for all changed files.
- Direct PostgreSQL regression through insertAuditEvent and verifyAuditChain passed; persisted error was omitted, undefined array entry became null, and the chain verified.
- The full local DB file was affected by unrelated Docker Desktop saturation and its 10-second connectivity probe skipped after several fixed-timeout failures. Isolated PR CI is the authoritative complete-suite check.

- [ ] pnpm verify passes locally
- [x] Behaviour verified beyond the test suite (real PostgreSQL round trip and chain verification)
- [x] Documentation updated, or no user-facing change