### PR TITLE
fix(sandbox): make dependency setup reliable

### DIFF
--- a/apps/docs/test/aws-deployment-runbook.test.mjs
+++ b/apps/docs/test/aws-deployment-runbook.test.mjs
@@ -311,7 +311,8 @@ test("the CodeBuild role and lifecycle cannot escape the cache prefix", () => {
   assert.match(policy, /s3:GetObjectVersion/);
   assert.match(policy, /s3:PutObject/);
   assert.match(policy, /codebuild-cache\/\*/);
-  assert.doesNotMatch(policy, /s3:ListBucket/);
+  assert.match(policy, /s3:ListBucket/);
+  assert.match(policy, /"s3:prefix"\s*=\s*\["codebuild-cache\/\*"\]/);
   assert.match(policy, /kms:GenerateDataKey/);
   assert.match(policy, /kms:Decrypt/);
   assert.match(policy, /kms:ViaService/);

--- a/infra/terraform/aws/iam.tf
+++ b/infra/terraform/aws/iam.tf
@@ -344,6 +344,7 @@ resource "aws_iam_role_policy" "codebuild_runner" {
         ]
         Resource = "${aws_s3_bucket.objects.arn}/codebuild-cache/*"
       },
+      local.codebuild_cache_list_statement,
       {
         Sid    = "VerifyCacheBucket"
         Effect = "Allow"
@@ -397,4 +398,22 @@ resource "aws_iam_role_policy" "codebuild_runner" {
       }
     ]
   })
+}
+
+locals {
+  # CodeBuild's S3 cache client lists the configured prefix before it downloads
+  # an archive. Object-only permissions make every restore fail with
+  # AccessDenied. The bucket action remains confined to Facility's cache
+  # subtree, so the runner cannot enumerate unrelated object prefixes.
+  codebuild_cache_list_statement = {
+    Sid      = "ListProjectCachePrefix"
+    Effect   = "Allow"
+    Action   = "s3:ListBucket"
+    Resource = aws_s3_bucket.objects.arn
+    Condition = {
+      StringLike = {
+        "s3:prefix" = ["codebuild-cache/*"]
+      }
+    }
+  }
 }

--- a/infra/terraform/aws/tests/codebuild_cache.tftest.hcl
+++ b/infra/terraform/aws/tests/codebuild_cache.tftest.hcl
@@ -1,0 +1,87 @@
+mock_provider "aws" {
+  override_during = plan
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-east-1a", "us-east-1b"]
+    }
+  }
+
+  mock_data "aws_cloudfront_cache_policy" {
+    defaults = {
+      id = "managed-caching-disabled"
+    }
+  }
+
+  mock_data "aws_cloudfront_origin_request_policy" {
+    defaults = {
+      id = "managed-all-viewer-except-host"
+    }
+  }
+
+  mock_data "aws_ec2_managed_prefix_list" {
+    defaults = {
+      id = "pl-cloudfront-origin-facing"
+    }
+  }
+
+  mock_resource "aws_cloudfront_distribution" {
+    defaults = {
+      domain_name = "d111111abcdef8.cloudfront.net"
+    }
+  }
+
+  mock_resource "aws_lb" {
+    defaults = {
+      arn      = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/facility-test/0000000000000000"
+      dns_name = "facility-test.us-east-1.elb.amazonaws.com"
+      zone_id  = "Z35SXDOTRQ7X7K"
+    }
+  }
+
+  mock_resource "aws_db_instance" {
+    defaults = {
+      master_user_secret = [{
+        kms_key_id    = "mock-kms-key"
+        secret_arn    = "arn:aws:secretsmanager:us-east-1:123456789012:secret:facility-db"
+        secret_status = "active"
+      }]
+    }
+  }
+}
+
+mock_provider "random" {
+  override_during = plan
+
+  mock_resource "random_password" {
+    defaults = {
+      result = "preview-surface-token-0000000000000000000000000000000000000000"
+    }
+  }
+}
+
+run "codebuild_can_list_only_the_facility_cache_prefix" {
+  command = plan
+
+  variables {
+    app_hostname = "app.example.com"
+    api_hostname = "api.example.com"
+    mcp_hostname = "mcp.example.com"
+  }
+
+  assert {
+    condition     = local.codebuild_cache_list_statement.Action == "s3:ListBucket"
+    error_message = "CodeBuild cache restore requires s3:ListBucket."
+  }
+
+  assert {
+    condition     = local.codebuild_cache_list_statement.Condition.StringLike["s3:prefix"] == ["codebuild-cache/*"]
+    error_message = "The bucket listing permission must remain confined to Facility cache objects."
+  }
+}

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -138,7 +138,7 @@ RUN cd /opt/facility-agent-clis \
   && codex --version
 
 # Create the package-manager shims while the image is still writable. Runtime
-# sandboxes mount /work as a writable tmpfs and keep the image root read-only;
+# sandboxes mount /work as a writable, per-run volume and keep the image root read-only;
 # baking the shims makes a later `corepack enable` idempotent instead of trying
 # (and failing) to write /usr/local/bin. Package downloads still use $HOME in
 # writable /work.
@@ -146,7 +146,7 @@ RUN corepack enable
 
 # Seed the repository's pinned package-manager release into an immutable image
 # layer. The entrypoint copies this trusted seed into each sandbox's ephemeral
-# tmpfs; repositories pinning another release can still download it for that run,
+# workspace; repositories pinning another release can still download it for that run,
 # but no executable Corepack cache persists into the next run.
 COPY package.json /tmp/facility-root-package.json
 RUN package_manager="$(node -p "require('/tmp/facility-root-package.json').packageManager")" \

--- a/runner/runner-entrypoint.sh
+++ b/runner/runner-entrypoint.sh
@@ -10,7 +10,7 @@ export COREPACK_HOME="$XDG_CACHE_HOME/node/corepack"
 mkdir -p "$COREPACK_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
 
 # Corepack caches executable package-manager code. Start every sandbox from the
-# read-only image seed, but keep its runtime cache in this run's tmpfs so agent
+# read-only image seed, but keep its runtime cache in this run's workspace so agent
 # code cannot persist an executable into a later run. Unknown pinned versions
 # may be downloaded here without weakening that boundary.
 if [[ -d /opt/facility-corepack ]]; then

--- a/services/api/src/sandbox/docker.ts
+++ b/services/api/src/sandbox/docker.ts
@@ -56,6 +56,13 @@ export class DockerSandboxDriver implements SandboxDriver {
         [RUN_LABEL]: spec.runId,
       },
       ...(spec.servicePort ? { ExposedPorts: { [`${spec.servicePort}/tcp`]: {} } } : {}),
+      // Keep the repository workspace on an anonymous Docker volume instead
+      // of a RAM-backed tmpfs. Dependency trees for real repositories routinely
+      // exceed several GiB while package managers unpack them; charging that to
+      // the daemon's memory budget makes otherwise healthy runs OOM under local
+      // concurrency. The volume remains run-scoped and `destroy({ v: true })`
+      // removes it with the container, so no workspace or credential persists.
+      Volumes: { "/work": {} },
       HostConfig: {
         // Use Docker's built-in tiny init as PID 1. Agent tools may launch and
         // disown children; without an init those children become permanent
@@ -66,9 +73,6 @@ export class DockerSandboxDriver implements SandboxDriver {
         NanoCpus: Math.max(0.1, spec.cpu) * 1_000_000_000,
         ReadonlyRootfs: true,
         Tmpfs: {
-          // Owned by the non-root `node` user (uid 1000) the runner image runs
-          // as — a root-owned tmpfs over /work would be unwritable to the agent.
-          "/work": "rw,exec,nosuid,nodev,size=4g,uid=1000,gid=1000",
           "/tmp": "rw,exec,nosuid,nodev,size=512m",
           "/var/tmp": "rw,exec,nosuid,nodev,size=512m",
         },
@@ -222,6 +226,14 @@ function packageCacheMount(spec: LaunchSpec) {
       // volume, not another service, and never contains the repository working
       // tree.
       pnpm_config_store_dir: `${target}/pnpm-store`,
+      // Docker Desktop and small self-hosted daemons often share a finite VM
+      // with the control plane. pnpm otherwise derives aggressive concurrency
+      // from the host CPU count, which can overwhelm that shared daemon while
+      // extracting a large dependency graph. These remain package-manager
+      // settings, not a shell-command override, so private-registry command
+      // validation stays intact.
+      pnpm_config_network_concurrency: "4",
+      pnpm_config_child_concurrency: "2",
       PNPM_CONFIG_VERIFY_STORE_INTEGRITY: "true",
       NPM_CONFIG_CACHE: `${target}/npm`,
     },

--- a/services/api/test/docker-sandbox.test.ts
+++ b/services/api/test/docker-sandbox.test.ts
@@ -43,8 +43,11 @@ describe("Docker sandbox ownership and caches", () => {
     ]);
 
     expect(created[0]).toMatchObject({
+      Volumes: { "/work": {} },
       Env: [
         "pnpm_config_store_dir=/work/.facility-package-cache/pnpm-store",
+        "pnpm_config_network_concurrency=4",
+        "pnpm_config_child_concurrency=2",
         "PNPM_CONFIG_VERIFY_STORE_INTEGRITY=true",
         "NPM_CONFIG_CACHE=/work/.facility-package-cache/npm",
       ],
@@ -55,6 +58,10 @@ describe("Docker sandbox ownership and caches", () => {
       },
       HostConfig: {
         Init: true,
+        Tmpfs: {
+          "/tmp": "rw,exec,nosuid,nodev,size=512m",
+          "/var/tmp": "rw,exec,nosuid,nodev,size=512m",
+        },
         Mounts: [
           {
             Type: "volume",
@@ -65,6 +72,9 @@ describe("Docker sandbox ownership and caches", () => {
         ],
       },
     });
+    expect((created[0]?.HostConfig as { Tmpfs?: Record<string, string> }).Tmpfs).not.toHaveProperty(
+      "/work",
+    );
     expect(
       (created[0]?.Labels as Record<string, string> | undefined)?.["facility.run"],
     ).toBeUndefined();


### PR DESCRIPTION
## What changes

- Keep each Docker sandbox workspace on a disposable per-run volume instead of RAM-backed tmpfs.
- Bound pnpm extraction and network concurrency while retaining the tenant-partitioned package cache.
- Permit CodeBuild to list only the Facility S3 cache prefix so restores no longer fail with AccessDenied.

## Why

Real TAM-OS provisioning exceeded Docker Desktop's memory budget because the dependency tree was unpacked into a 4 GiB tmpfs. AWS cache restores also failed because CodeBuild checks the cache prefix before reading its object, but the role had object permissions only.

## Verification

- [ ] `pnpm verify` passes locally — lint, clean typecheck/build, 17 critical DB tests, and 409 API tests passed; 11 unrelated tests timed out at their unchanged 5s boundary on the shared 7.65 GiB Docker VM. The failing test names changed on rerun, confirming environmental contention. CI remains the clean full-suite gate.
- [x] Behaviour verified beyond the test suite: real Docker TAM-OS runs used the disk-backed workspace; a production Terraform plan showed exactly one in-place IAM policy update, and applying it changed 1 resource with 0 additions/0 deletions.
- [x] No user-facing documentation change; deployment contract tests were updated.

Focused passing evidence:

- `vitest run test/docker-sandbox.test.ts`: 2/2 passed.
- `node --test apps/docs/test/aws-deployment-runbook.test.mjs`: 10/10 passed.
- `terraform test -filter=tests/codebuild_cache.tftest.hcl`: 1/1 passed.
- `terraform validate -no-color` and `terraform fmt -check -recursive`: passed.
