### PR TITLE
fix(release): accept Bake cache dependency metadata

### DIFF
--- a/scripts/deploy-aws.mjs
+++ b/scripts/deploy-aws.mjs
@@ -11,6 +11,8 @@ export const AWS_SERVICE_NAMES = Object.freeze(["api", "worker", "gateway", "web
 export const AWS_ARTIFACT_NAMES = Object.freeze(["api", "gateway", "mcp", "web", "runner"]);
 export const AWS_IMAGE_NAMES = Object.freeze(["api", "worker", "gateway", "web", "mcp", "runner"]);
 
+const AWS_BAKE_AUXILIARY_TARGETS = new Set(["service-packages"]);
+
 const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
 const FULL_SHA_PATTERN = /^[0-9a-f]{40,64}$/;
 const ECR_FIX_AVAILABILITY = new Set(["YES", "NO", "PARTIAL"]);
@@ -165,7 +167,12 @@ export function enforceEcrScanPolicy(findings, { enhanced, repository }) {
 }
 
 export function createAwsReleaseManifest({ metadata, repositoryPrefix, sourceSha, platform }) {
-  assertExactKeys(metadata, AWS_ARTIFACT_NAMES, "Bake metadata");
+  const artifactMetadata = Object.fromEntries(
+    Object.entries(assertObject(metadata, "Bake metadata")).filter(
+      ([name]) => !AWS_BAKE_AUXILIARY_TARGETS.has(name),
+    ),
+  );
+  assertExactKeys(artifactMetadata, AWS_ARTIFACT_NAMES, "Bake metadata");
   const prefix = assertString(repositoryPrefix, "repository prefix").replace(/\/$/, "");
   if (!ECR_REPOSITORY_PATTERN.test(`${prefix}/api`)) {
     throw new AwsDeployError(
@@ -188,7 +195,7 @@ export function createAwsReleaseManifest({ metadata, repositoryPrefix, sourceSha
 
   const refs = {};
   for (const name of AWS_ARTIFACT_NAMES) {
-    const result = assertObject(metadata[name], `Bake metadata target ${name}`);
+    const result = assertObject(artifactMetadata[name], `Bake metadata target ${name}`);
     const digest = assertDigest(result["containerimage.digest"], `${name} digest`);
     const descriptorDigest = result["containerimage.descriptor"]?.digest;
     if (descriptorDigest !== digest) {

--- a/scripts/deploy-aws.test.mjs
+++ b/scripts/deploy-aws.test.mjs
@@ -296,6 +296,7 @@ test("Bake metadata becomes one deterministic six-role ECR digest manifest", () 
       },
     ]),
   );
+  metadata["service-packages"] = {};
   assert.deepEqual(
     createAwsReleaseManifest({
       metadata,
@@ -314,6 +315,16 @@ test("Bake metadata becomes one deterministic six-role ECR digest manifest", () 
         sourceSha,
       }),
     /descriptor for api does not match/,
+  );
+  assert.throws(
+    () =>
+      createAwsReleaseManifest({
+        metadata: { ...metadata, unexpected: {} },
+        platform: "linux/amd64",
+        repositoryPrefix: prefix,
+        sourceSha,
+      }),
+    /Bake metadata contains .*unexpected/,
   );
 });
 

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -32,6 +32,7 @@ if (args[0] === "buildx" && args[1] === "bake") {
     const digest = "sha256:" + String(index + 1).repeat(64);
     return [name, { "containerimage.digest": digest, "containerimage.descriptor": { digest } }];
   }));
+  metadata["service-packages"] = {};
   writeFileSync(metadataPath, JSON.stringify(metadata));
 }
 `,

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -10,6 +10,8 @@ export const BUILD_IMAGES = Object.freeze(["api", "gateway", "mcp", "web", "runn
 export const PUBLISHED_IMAGES = Object.freeze(["api", "worker", "gateway", "web", "mcp", "runner"]);
 export const GITHUB_API_URL = "https://api.github.com/";
 
+const BAKE_AUXILIARY_TARGETS = new Set(["service-packages"]);
+
 const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
 const DOCKER_TAG_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/;
 const GITHUB_SHA_PATTERN = /^[0-9a-f]{40,64}$/;
@@ -115,11 +117,12 @@ export function recordBakeDigests({ metadata, directory }) {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
     throw new Error("Bake metadata must be an object keyed by image target");
   }
-  const targets = Object.keys(metadata).sort();
+  const allTargets = Object.keys(metadata).sort();
+  const targets = allTargets.filter((target) => !BAKE_AUXILIARY_TARGETS.has(target));
   const expected = [...BUILD_IMAGES].sort();
   if (JSON.stringify(targets) !== JSON.stringify(expected)) {
     throw new Error(
-      `Bake metadata targets ${targets.join(",") || "none"}; expected ${expected.join(",")}`,
+      `Bake metadata targets ${allTargets.join(",") || "none"}; expected ${expected.join(",")} plus optional service-packages`,
     );
   }
 

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -127,6 +127,7 @@ test("one Bake result records an exact, internally consistent digest set", (t) =
       ];
     }),
   );
+  metadata["service-packages"] = {};
 
   assert.equal(recordBakeDigests({ metadata, directory }).length, BUILD_IMAGES.length);
   assert.deepEqual(
@@ -135,7 +136,7 @@ test("one Bake result records an exact, internally consistent digest set", (t) =
   );
   assert.throws(
     () => recordBakeDigests({ metadata: { ...metadata, unexpected: {} }, directory }),
-    /expected api,gateway,mcp,runner,web/,
+    /expected api,gateway,mcp,runner,web plus optional service-packages/,
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary

- accept the named `service-packages` dependency target in Bake metadata
- continue requiring the exact five publishable image targets and reject any unknown target
- cover both GHCR publication and AWS release-manifest generation with the observed metadata shape

## Evidence

- `node --test scripts/images.test.mjs scripts/deploy-aws.test.mjs scripts/images-build.test.mjs` — 39 passed
- `pnpm exec biome check scripts/images.mjs scripts/deploy-aws.mjs scripts/images.test.mjs scripts/deploy-aws.test.mjs scripts/images-build.test.mjs` — passed
- reproduces main run 31261707041, where all five images built and pushed before `record-bake-digests` rejected `service-packages`

## Notes

The broader local verify run reached the unchanged database/API suites but timed out under the shared Docker/Postgres environment. The PR's clean hosted `verify` check is the acceptance gate; no timeout or guard was changed.
