### PR TITLE
fix(runner): refresh Debian security packages

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -38,7 +38,14 @@ RUN apt-get update \
 
 FROM node:24-trixie@sha256:66bb8d36ae1ddd72199ed235a089904874ca4079ee517936ca3adb80506a75c1 AS runner-base
 
-RUN apt-get update \
+# The digest-pinned Node base can lag Debian security uploads, while BuildKit
+# correctly caches an earlier apt upgrade against the unchanged base digest.
+# Bump this audited epoch only when a scanner identifies a distro fix that the
+# official image has not incorporated yet; using it in the command makes that
+# refresh explicit and reproducible instead of disabling the whole build cache.
+ARG DEBIAN_SECURITY_REFRESH=20260808
+RUN test -n "$DEBIAN_SECURITY_REFRESH" \
+  && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/runner/test/docker-proxy.test.ts
+++ b/runner/test/docker-proxy.test.ts
@@ -21,6 +21,16 @@ afterEach(async () => {
 });
 
 describe("restricted Docker API", () => {
+  test("keeps Debian security refreshes explicit in the cached runner graph", async () => {
+    const dockerfile = await readFile(
+      join(fileURLToPath(new URL("..", import.meta.url)), "Dockerfile"),
+      "utf8",
+    );
+    expect(dockerfile).toMatch(
+      /ARG DEBIAN_SECURITY_REFRESH=\d{8}\s+RUN test -n "\$DEBIAN_SECURITY_REFRESH" \\\s+&& apt-get update \\\s+&& DEBIAN_FRONTEND=noninteractive apt-get upgrade -y/,
+    );
+  });
+
   test("seeds Corepack into ephemeral run storage instead of the persistent package cache", async () => {
     const runnerRoot = fileURLToPath(new URL("..", import.meta.url));
     const [dockerfile, entrypoint] = await Promise.all([


### PR DESCRIPTION
## Summary

- invalidate only the runner's cached Debian package layer with an audited security-refresh epoch
- keep the official digest-pinned `node:24-trixie` base and install Debian's available `libheif` fixes
- preserve the shared BuildKit cache for every unaffected image and layer
- add a regression assertion for the explicit refresh boundary

## Evidence

The main release scan for `c22d6363b6e10a3c9b60e1c85efea9e5a499cb3e` passed `api`, `gateway`, `mcp`, and `web`, then blocked `runner` because its cached Debian layer still contained:

```text
libheif-plugin-dav1d      1.19.8-1  fixed in 1.19.8-1+deb13u1
libheif-plugin-libde265   1.19.8-1  fixed in 1.19.8-1+deb13u1
libheif1                  1.19.8-1  fixed in 1.19.8-1+deb13u1
```

The current official `node:24-trixie` digest is still the repository's pinned digest, so `--pull` cannot invalidate the prior `apt upgrade` layer by itself.

## Verification

```text
$ pnpm --filter @facility/runner test -- --run runner/test/docker-proxy.test.ts
Test Files  12 passed (12)
Tests  155 passed (155)

$ pnpm exec biome check runner/Dockerfile runner/test/docker-proxy.test.ts
Checked 1 file in 18ms. No fixes applied.

$ git diff --check
(no output)
```

The hosted image publication scan is the acceptance gate for the rebuilt runner filesystem; it must pass before promotion or deployment.
