### PR TITLE
fix(deploy): scope preflight to active sandbox provider

### DIFF
--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -262,6 +262,10 @@ module opts this account and region into paid Amazon Inspector scanning for only
 every HIGH or CRITICAL finding whose `fixAvailable` value is `YES` or `PARTIAL`.
 This matches the pinned Grype
 `--only-fixed` promotion policy without maintaining a drifting CVE allowlist.
+The preflight derives the active sandbox provider from Terraform. In `vercel`
+mode it scans the four control-plane images but deliberately does not inspect or
+compare the inactive CodeBuild runner: that image cannot execute in the release.
+In `aws` mode, the runner digest and its scan remain mandatory.
 
 The enhanced setting is registry-wide even though its repository filter is narrow.
 Leave it disabled in a shared AWS account unless this stack owns the central ECR

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -48,6 +48,11 @@ output "task_cpu_architecture" {
   value       = var.task_cpu_architecture
 }
 
+output "sandbox_driver" {
+  description = "Active sandbox provider; release preflight validates only provider assets that can execute."
+  value       = var.sandbox_driver
+}
+
 output "secret_arns" {
   description = "Secrets Manager ARNs to populate out-of-band. Values are intentionally not managed by Terraform."
   value       = { for name, secret in aws_secretsmanager_secret.app : name => secret.arn }

--- a/scripts/deploy-aws.mjs
+++ b/scripts/deploy-aws.mjs
@@ -253,6 +253,7 @@ export function normalizeTerraformOutputs(raw) {
       unwrapTerraformOutput(raw, "task_cpu_architecture"),
       "task_cpu_architecture",
     ),
+    sandboxDriver: assertString(unwrapTerraformOutput(raw, "sandbox_driver"), "sandbox_driver"),
     cluster: assertString(unwrapTerraformOutput(raw, "ecs_cluster_name"), "ecs_cluster_name"),
     runnerProject: assertString(
       unwrapTerraformOutput(raw, "codebuild_runner_project_name"),
@@ -272,6 +273,12 @@ export function normalizeTerraformOutputs(raw) {
   };
 
   expectedPlatform(outputs.architecture);
+  if (outputs.sandboxDriver !== "aws" && outputs.sandboxDriver !== "vercel") {
+    throw new AwsDeployError(
+      "terraform_outputs_invalid",
+      `sandbox_driver must be aws or vercel, received ${outputs.sandboxDriver}`,
+    );
+  }
   if (
     !Array.isArray(outputs.subnets) ||
     outputs.subnets.length < 2 ||
@@ -576,20 +583,28 @@ export async function deployAws({
   });
 
   deployEvent(log, "preflight", "started");
-  const uniqueImages = AWS_ARTIFACT_NAMES.map((name) => release.parsedImages[name]);
+  const usesAwsSandbox = outputs.sandboxDriver === "aws";
+  const uniqueImages = AWS_ARTIFACT_NAMES.filter((name) => usesAwsSandbox || name !== "runner").map(
+    (name) => release.parsedImages[name],
+  );
   const [runnerImage, services] = await Promise.all([
-    aws.getRunnerImage(outputs.runnerProject),
+    usesAwsSandbox ? aws.getRunnerImage(outputs.runnerProject) : Promise.resolve(null),
     aws.describeServices(outputs.cluster, AWS_SERVICE_NAMES),
     ...uniqueImages.map(({ repository, digest }) => aws.assertImage(repository, digest)),
   ]);
-  if (runnerImage !== release.images.runner) {
+  if (usesAwsSandbox && runnerImage !== release.images.runner) {
     throw new AwsDeployError(
       "runner_image_mismatch",
       `CodeBuild runner is ${runnerImage || "unset"}; apply Terraform with ${release.images.runner} before deploying this manifest`,
     );
   }
   const { bootstrap, prior } = inspectStableServices(services, { allowZeroDesired });
-  deployEvent(log, "preflight", "completed", { bootstrap, services: AWS_SERVICE_NAMES.length });
+  deployEvent(log, "preflight", "completed", {
+    bootstrap,
+    sandboxDriver: outputs.sandboxDriver,
+    services: AWS_SERVICE_NAMES.length,
+    validatedImages: uniqueImages.length,
+  });
 
   deployEvent(log, "register", "started");
   const roles = [...AWS_SERVICE_NAMES, "migrate"];

--- a/scripts/deploy-aws.test.mjs
+++ b/scripts/deploy-aws.test.mjs
@@ -117,6 +117,7 @@ function outputFixture() {
       "arn:aws:ecs:eu-west-1:123456789012:task-definition/facility-test-migrate:7",
     repositories: Object.fromEntries(AWS_ARTIFACT_NAMES.map((name) => [name, `${prefix}/${name}`])),
     runnerProject: "facility-test-runner",
+    sandboxDriver: "aws",
     securityGroup: "sg-123",
     serviceTaskDefinitions: Object.fromEntries(
       AWS_SERVICE_NAMES.map((name) => [
@@ -133,6 +134,7 @@ function rawOutputFixture() {
   return {
     aws_region: { value: outputs.awsRegion },
     task_cpu_architecture: { value: outputs.architecture },
+    sandbox_driver: { value: outputs.sandboxDriver },
     ecs_cluster_name: { value: outputs.cluster },
     codebuild_runner_project_name: { value: outputs.runnerProject },
     migrate_task_definition_arn: { value: outputs.migrateTaskDefinitionArn },
@@ -331,6 +333,13 @@ test("Bake metadata becomes one deterministic six-role ECR digest manifest", () 
 test("Terraform outputs and release manifest bind account, repositories, roles, and platform", () => {
   const outputs = normalizeTerraformOutputs(rawOutputFixture());
   assert.deepEqual(outputs, outputFixture());
+  const invalidDriver = rawOutputFixture();
+  invalidDriver.sandbox_driver.value = "local";
+  assert.throws(
+    () => normalizeTerraformOutputs(invalidDriver),
+    (error) =>
+      error.code === "terraform_outputs_invalid" && /must be aws or vercel/.test(error.message),
+  );
   assert.equal(
     validateAwsReleaseManifest(manifestFixture(), outputs).parsedImages.api.digest,
     digests.api,
@@ -412,6 +421,25 @@ test("successful deployment gates on migration and pins all five services in par
   const firstUpdate = aws.calls.findIndex(([name]) => name === "updateService");
   assert.ok(migrationCall > -1 && migrationCall < firstUpdate);
   assert.equal(events.at(-1).status, "completed");
+});
+
+test("Vercel deployments exclude the inactive CodeBuild runner from release preflight", async () => {
+  const aws = fakeAws({ runnerImage: "runner:must-not-be-read" });
+  const outputs = { ...outputFixture(), sandboxDriver: "vercel" };
+  await deployAws({ aws, manifest: manifestFixture(), outputs });
+
+  assert.equal(
+    aws.calls.some(([name]) => name === "getRunnerImage"),
+    false,
+  );
+  const assertedRepositories = aws.calls
+    .filter(([name]) => name === "assertImage")
+    .map(([, repository]) => repository);
+  assert.equal(assertedRepositories.length, 4);
+  assert.equal(
+    assertedRepositories.some((repository) => repository.endsWith("/runner")),
+    false,
+  );
 });
 
 for (const exitCode of [11, 12]) {
@@ -705,7 +733,7 @@ if (service === "ecr" && operation === "describe-images") {
   assert.match(await readFile(terraformLog, "utf8"), /output.*-json/);
 });
 
-test("CLI integration completes the real subprocess sequence without credentials or network", async (t) => {
+test("CLI integration deploys Vercel mode without reading inactive CodeBuild or runner ECR", async (t) => {
   const directory = await mkdtemp(join(tmpdir(), "facility-deploy-cli-success-"));
   t.after(() => rm(directory, { force: true, recursive: true }));
   const terraformLog = join(directory, "terraform.log");
@@ -777,6 +805,8 @@ if (service === "ecr" && operation === "describe-images") {
   await chmod(join(directory, "terraform"), 0o755);
   await chmod(join(directory, "aws"), 0o755);
 
+  const rawOutputs = rawOutputFixture();
+  rawOutputs.sandbox_driver.value = "vercel";
   const result = spawnSync(
     process.execPath,
     [
@@ -794,9 +824,8 @@ if (service === "ecr" && operation === "describe-images") {
         ...process.env,
         PATH: `${directory}:${process.env.PATH}`,
         FAKE_AWS_LOG: awsLog,
-        FAKE_RUNNER_IMAGE: manifestFixture().images.runner,
         FAKE_TERRAFORM_LOG: terraformLog,
-        FAKE_TERRAFORM_OUTPUTS: JSON.stringify(rawOutputFixture()),
+        FAKE_TERRAFORM_OUTPUTS: JSON.stringify(rawOutputs),
       },
     },
   );
@@ -806,6 +835,21 @@ if (service === "ecr" && operation === "describe-images") {
   const awsCalls = (await readFile(awsLog, "utf8")).trim().split("\n").map(JSON.parse);
   assert.equal(awsCalls.filter((args) => args.includes("register-task-definition")).length, 6);
   assert.equal(awsCalls.filter((args) => args.includes("update-service")).length, 5);
+  assert.equal(
+    awsCalls.filter((args) => args.includes("describe-images")).length,
+    4,
+    "only the four control-plane image digests execute in Vercel mode",
+  );
+  assert.equal(
+    awsCalls.some((args) => args.includes("batch-get-projects")),
+    false,
+    "inactive CodeBuild must not gate a Vercel release",
+  );
+  assert.equal(
+    awsCalls.some((args) => args.includes("facility-test/runner")),
+    false,
+    "inactive runner ECR findings must not gate a Vercel release",
+  );
   assert.ok(
     awsCalls.findIndex((args) => args.includes("run-task")) <
       awsCalls.findIndex((args) => args.includes("update-service")),


### PR DESCRIPTION
## Summary

- export the active sandbox driver from the AWS Terraform stack
- validate the four executable control-plane image digests in Vercel mode without reading dormant CodeBuild/ECR runner state
- preserve the exact runner digest and vulnerability gate in AWS sandbox mode
- fail closed on unknown provider output

## Why

Production uses Vercel Sandboxes and Vercel previews. The CodeBuild runner is a dormant development provider in that configuration, so its upstream Docker binary findings must not block an otherwise independent control-plane release. This keeps the provider boundary swappable: choosing `aws` restores the runner preflight automatically.

The live Docker registry also confirmed that Facility already pins the current official `docker:29-dind-rootless` digest. Selecting `docker:29.3.1` would have been a downgrade caused by confusing an embedded Go module fix version with the Docker image version, so that attempted change is not part of this PR.

## Verification

```text
$ node --test scripts/deploy-aws.test.mjs
# tests 26
# pass 26
# fail 0

$ terraform -chdir=infra/terraform/aws test
Success! 8 passed, 0 failed.

$ pnpm exec biome check scripts/deploy-aws.mjs scripts/deploy-aws.test.mjs
Checked 2 files in 16ms. No fixes applied.

$ git diff --check
(no output)
```

The test suite includes both unit coverage for the provider-specific preflight and a credential-free CLI integration test proving Vercel mode makes no CodeBuild or runner-ECR calls.