### PR TITLE
fix(deploy): detect completed enhanced ECR scans

### DIFF
--- a/scripts/deploy-aws.mjs
+++ b/scripts/deploy-aws.mjs
@@ -947,8 +947,12 @@ export function createAwsCliAdapter({
           );
         }
 
+        // ECR used to expose enhanced scans as ACTIVE, but now also returns
+        // COMPLETE. The enhancedFindings collection is the stable response
+        // discriminator; status alone would misclassify the same Inspector
+        // result as a basic scan and block non-fixable distribution CVEs.
         enforceEcrScanPolicy(findings, {
-          enhanced: status === "ACTIVE",
+          enhanced: Array.isArray(findings?.enhancedFindings),
           repository: `${repository}@${digest}`,
         });
         return { done: true };

--- a/scripts/deploy-aws.test.mjs
+++ b/scripts/deploy-aws.test.mjs
@@ -971,7 +971,7 @@ if (service === "ecr" && operation === "describe-images") {
   );
 });
 
-test("AWS CLI adapter admits only non-fixable enhanced findings", async (t) => {
+test("AWS CLI adapter detects COMPLETE enhanced scans and admits only non-fixable findings", async (t) => {
   const directory = await mkdtemp(join(tmpdir(), "facility-aws-enhanced-image-scan-"));
   t.after(() => rm(directory, { force: true, recursive: true }));
   const command = join(directory, "aws");
@@ -988,7 +988,7 @@ if (service === "ecr" && operation === "describe-images") {
 } else if (service === "ecr" && operation === "describe-image-scan-findings") {
   const fixAvailable = repository.endsWith("/api") ? "NO" : repository.endsWith("/gateway") ? "YES" : undefined;
   process.stdout.write(JSON.stringify({
-    imageScanStatus: { status: "ACTIVE" },
+    imageScanStatus: { status: "COMPLETE" },
     imageScanFindings: {
       imageScanCompletedAt: "2026-08-07T00:00:00Z",
       findingSeverityCounts: { HIGH: 1 },


### PR DESCRIPTION
## Summary

- detect enhanced ECR scans from the `enhancedFindings` response shape instead of assuming only `ACTIVE` can be enhanced
- retain fail-closed basic scanning and the fix-availability gate for enhanced scans
- cover the live AWS `COMPLETE + enhancedFindings` response with the credential-free AWS CLI adapter integration test

## Production evidence

AWS ECR returned `imageScanStatus.status = COMPLETE` together with `enhancedFindings` for the production web digest. The former status-only check misclassified that enhanced result as basic and rejected 4 Critical / 8 High Debian findings even though every finding reported `fixAvailable = NO`.

## Acceptance commands

```text
$ node --test scripts/deploy-aws.test.mjs
# tests 26
# suites 0
# pass 26
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 3662.633916

$ pnpm exec biome check scripts/deploy-aws.mjs scripts/deploy-aws.test.mjs
Checked 2 files in 18ms. No fixes applied.

$ git diff --check
```

## Open questions

None.
