### PR TITLE
fix(images): make service deploy trees portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,13 @@ RUN pnpm --filter '@facility/core' --filter '@facility/db' \
 FROM build-service-packages AS build-api
 COPY services/api ./services/api
 RUN pnpm --filter '@facility/api' run build:runtime
-# Produce isolated production trees. `deploy --prod` keeps runtime workspace
-# dependencies and package assets (including DB migrations) while excluding
-# source workspaces, tests, build tools, and every devDependency.
-RUN pnpm --filter '@facility/api' deploy --prod --legacy /prod/api
+# Produce isolated production trees. Injected workspace packages keep the
+# deployed node_modules self-contained; legacy deploy leaves links back to the
+# build workspace, which break after /prod/* is copied into the runtime stage.
+# Production deploys retain package assets (including DB migrations) while
+# excluding source workspaces, tests, build tools, and every devDependency.
+RUN pnpm --config.inject-workspace-packages=true \
+      --filter '@facility/api' deploy --prod /prod/api
 # First-org seeding and repository kickstart both load bundled source assets at
 # runtime. Fail the image build if pnpm deployment ever omits either package's
 # payload instead of discovering it after a user begins onboarding.
@@ -81,17 +84,23 @@ RUN test -f /prod/api/node_modules/@facility/db/dist/seed-assets/packages/harnes
 FROM build-service-packages AS build-gateway
 COPY services/gateway ./services/gateway
 RUN pnpm --filter '@facility/gateway' run build:runtime
-RUN pnpm --filter '@facility/gateway' deploy --prod --legacy /prod/gateway
+RUN pnpm --config.inject-workspace-packages=true \
+      --filter '@facility/gateway' deploy --prod /prod/gateway
 
 # --- MCP build: keep SDK/MCP changes independent from API and gateway ---
 FROM build-service-packages AS build-mcp
 RUN pnpm --filter '@facility/mcp' run build:runtime
-RUN pnpm --filter '@facility/mcp' deploy --prod --legacy /prod/mcp
+RUN pnpm --config.inject-workspace-packages=true \
+      --filter '@facility/mcp' deploy --prod /prod/mcp
 
 # --- api (also serves the worker via `node dist/worker.js`) ---
 FROM runtime AS api
 ENV NODE_ENV=production
 COPY --from=build-api /prod/api /app
+# Validate the final runtime filesystem, after the build workspaces are gone.
+# This catches portable-deploy regressions that a build-stage file check cannot.
+RUN test -f /app/node_modules/@facility/db/dist/bin/deploy.js \
+  && node --input-type=module --eval 'await import("@facility/db/deploy")'
 # The CLI travels with the API image so operator commands can be run as one-shot
 # tasks inside the VPC. `facility instance bootstrap` needs the database, and in
 # a reference deployment the database accepts connections only from the service

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -280,7 +280,15 @@ test("Bake keeps thin target boundaries and publishes every target through one g
     for (const sharedPackage of ["core", "db", "harness", "sdk"]) {
       assert.doesNotMatch(serviceBuild, new RegExp(`--filter '@facility/${sharedPackage}'`));
     }
+    assert.match(serviceBuild, /--config\.inject-workspace-packages=true/);
+    assert.match(serviceBuild, new RegExp(`deploy --prod /prod/${packageName}`));
+    assert.doesNotMatch(serviceBuild, /deploy --prod --legacy/);
   }
+  assert.ok(
+    controlDockerfile.indexOf("COPY --from=build-api /prod/api /app") <
+      controlDockerfile.indexOf('await import("@facility/db/deploy")'),
+    "the final API stage must import the deployed DB package after build workspaces are gone",
+  );
   assert.equal(
     controlDockerfile.match(/run build:runtime/g)?.length,
     4,


### PR DESCRIPTION
## Summary

- replace pnpm's legacy deploy mode with injected workspace packages for the API, gateway, and MCP production trees
- verify the DB deploy entrypoint in the final API filesystem after build-stage workspaces are gone
- make the image contract reject legacy deploy and require the portable final-stage import guard

## Production evidence

The production migration task exited before rollout because `/app/node_modules/@facility/db` was a broken link to `/app/packages/db`. The legacy deploy check passed in the build stage only because `/app/packages/db` still existed there; the runtime stage copied `/prod/api` without that workspace.

An isolated non-legacy deploy now resolves `@facility/db` inside its own `.pnpm` tree and successfully runs:

```text
portable deploy import: ok
```

## Acceptance commands

```text
$ node --test scripts/images-build.test.mjs
# tests 6
# suites 0
# pass 6
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2091.645917

$ pnpm exec biome check scripts/images-build.test.mjs
Checked 1 file in 8ms. No fixes applied.

$ docker buildx build --check --target api .
Check complete, no warnings found.

$ git diff --check
```

## Open questions

None.
