### PR TITLE
fix(runner): enforce read-only architect sessions

### DIFF
--- a/packages/cli/templates/prompts/architect.md
+++ b/packages/cli/templates/prompts/architect.md
@@ -1,9 +1,9 @@
 # /architect operating contract
 
 Binding contract for the planning agent in this repository's CI. /architect
-has the same provisioned environment and permissions as /builder so it can
-validate plans with real evidence, but its delivery mode is planning and
-validation only.
+can inspect the provisioned repository and validate plans with real evidence,
+but its engine is read-only and its delivery mode is planning and validation
+only.
 
 <delivery_mode>
 Plan and validate; do not implement. Your job is to collaborate in the GitHub
@@ -13,10 +13,10 @@ implement, summarize the approved plan and tell them to invoke /builder.
 </delivery_mode>
 
 <environment>
-You are NOT on a bare checkout. A prior CI step already installed dependencies
-and ran the provision command (`{{PROVISION_CMD}}`), and you run with full
-bypass permissions on an isolated, ephemeral runner. Use that power to
-validate assumptions: read code, run targeted commands and checks
+You are NOT on a bare checkout. A prior CI step prepared the configured
+environment (`{{PROVISION_CMD}}`) in an isolated, ephemeral runner. Your engine
+cannot change the repository. Use the available environment to validate
+assumptions: read code, run targeted read-only commands and checks
 ({{CHECKS_INLINE}}), and gather real evidence when behavior matters. Do not
 claim the environment is unavailable without checking.
 </environment>
@@ -28,7 +28,8 @@ claim the environment is unavailable without checking.
   maintainable changes over broad rewrites.
 - Validate risky assumptions with real commands or code reads when useful.
 - Ask focused questions only when the answer materially changes the plan.
-- If you run local experiments, keep them temporary and leave the repo clean.
+- Keep experiments read-only. If a command needs scratch output, write it under
+  `/tmp`, never in the repository.
 </how_you_work>
 
 <output_contract>

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -174,6 +174,12 @@ async function main() {
       );
     }
     await writeFile(transcriptFile, "");
+    const managedProgress = readOnlyEngineMode(activeBundle.mode)
+      ? readOnlyEngineProgress(false)
+      : null;
+    if (managedProgress) {
+      await emit([{ type: "agent_progress", data: { markdown: managedProgress } }]);
+    }
     progressStop = startAgentProgressPoll(cwdFor(bundle));
     const stopProgress = progressStop;
     const engineCode = await phases.measure(
@@ -184,8 +190,17 @@ async function main() {
       }),
     );
     const captured = await phases.measure("result_capture", async () => {
-      const progressPublished = await stopProgress();
+      const agentProgressPublished = await stopProgress();
       progressStop = undefined;
+      if (managedProgress) {
+        await emit([
+          {
+            type: "agent_progress",
+            data: { markdown: readOnlyEngineProgress(engineCode === 0) },
+          },
+        ]);
+      }
+      const progressPublished = managedProgress !== null || agentProgressPublished;
       const securityReport = isSecurityMode(activeBundle.mode)
         ? await readSecurityReport(
             join(cwdFor(activeBundle), ".agent-sdlc", "security-findings.json"),
@@ -900,7 +915,7 @@ export function buildClaudeCodeArgs(bundle: RunBundle, restoredSessionState: boo
     "stream-json",
     "--verbose",
     "--permission-mode",
-    "bypassPermissions",
+    readOnlyEngineMode(bundle.mode) ? "plan" : "bypassPermissions",
     "--max-turns",
     "500",
   );
@@ -1424,6 +1439,19 @@ export function requiresAgentProgress(mode: string) {
     "po",
     "learning",
   ].includes(normalized);
+}
+
+function readOnlyEngineMode(mode: string) {
+  return normalizedMode(mode) === "architect";
+}
+
+export function readOnlyEngineProgress(completed: boolean) {
+  return [
+    "Preparing an implementation-ready plan from the repository in read-only mode.",
+    "",
+    "- [x] Prepare the isolated repository",
+    `${completed ? "- [x]" : "- [ ]"} Inspect the relevant code and produce the plan`,
+  ].join("\n");
 }
 
 export function deliveryFailure(
@@ -2399,9 +2427,10 @@ export function composedPrompt(bundle: RunBundle) {
   const objective = runObjectiveText(bundle.scope);
   const objectiveNote =
     bundle.scope.type !== "conversation" && objective ? `\n\n## Run objective\n${objective}` : "";
-  const progressNote = requiresAgentProgress(bundle.mode)
-    ? `\n\n## Live GitHub progress\nBefore substantive work, create \`.agent-sdlc/progress.md\` with a short task-specific context and a Markdown checkbox list of the steps you decided this task needs. Update it whenever you start or finish a step so a reviewer can understand real progress from GitHub. Keep it accurate and concise; do not put secrets, generic lifecycle milestones, or the final response in it. Facility transports this file into the existing GitHub progress comment.`
-    : "";
+  const progressNote =
+    requiresAgentProgress(bundle.mode) && !readOnlyEngineMode(bundle.mode)
+      ? `\n\n## Live GitHub progress\nBefore substantive work, create \`.agent-sdlc/progress.md\` with a short task-specific context and a Markdown checkbox list of the steps you decided this task needs. Update it whenever you start or finish a step so a reviewer can understand real progress from GitHub. Keep it accurate and concise; do not put secrets, generic lifecycle milestones, or the final response in it. Facility transports this file into the existing GitHub progress comment.`
+      : "";
   const repositoryOutputNote = bundle.repo.cloneUrl
     ? `\n\n## Repository output\nYour final response may be published directly on GitHub. Refer to repository files with relative paths or inline code. Never emit sandbox-local paths such as \`/work/repo/...\`.`
     : "";
@@ -2436,7 +2465,7 @@ export function buildCodexArgs(bundle: RunBundle) {
     "--json",
     "--ephemeral",
     "-s",
-    "danger-full-access",
+    readOnlyEngineMode(bundle.mode) ? "read-only" : "danger-full-access",
     "--config",
     `model_provider=${JSON.stringify(provider)}`,
     "--config",

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -34,6 +34,7 @@ import {
   readAgentDeliveryMetadata,
   readAgentProgress,
   readAgentUpdateMetadata,
+  readOnlyEngineProgress,
   readSecurityReport,
   requiresAgentProgress,
   resumeRecoveryPrompt,
@@ -798,6 +799,8 @@ describe("workspace preparation", () => {
     expect(requiresAgentProgress("codex-builder")).toBe(true);
     expect(requiresAgentProgress("ci-doctor")).toBe(true);
     expect(requiresAgentProgress("custom")).toBe(false);
+    expect(readOnlyEngineProgress(false)).toContain("- [ ] Inspect");
+    expect(readOnlyEngineProgress(true)).toContain("- [x] Inspect");
   });
 
   it("installs registry skills as discoverable SKILL.md packages for both engines", async () => {
@@ -1151,6 +1154,15 @@ describe("run prompt composition", () => {
 });
 
 describe("Claude resume controls", () => {
+  it("runs architects in native plan mode and keeps builders writable", () => {
+    const architectArgs = buildClaudeCodeArgs(bundle({ mode: "architect" }), false);
+    const builderArgs = buildClaudeCodeArgs(bundle({ mode: "builder" }), false);
+
+    expect(architectArgs.slice(architectArgs.indexOf("--permission-mode"), -2)).toContain("plan");
+    expect(architectArgs).not.toContain("bypassPermissions");
+    expect(builderArgs).toContain("bypassPermissions");
+  });
+
   it("uses --resume only after session state has been restored", () => {
     const runBundle = bundle({
       engine: "claude_code",
@@ -1274,6 +1286,16 @@ describe("Claude resume controls", () => {
 });
 
 describe("Codex model controls", () => {
+  it("runs architects in the read-only sandbox and keeps builders writable", () => {
+    const architectArgs = buildCodexArgs(bundle({ mode: "codex-architect" }));
+    const builderArgs = buildCodexArgs(bundle({ mode: "codex-builder" }));
+
+    expect(
+      architectArgs.slice(architectArgs.indexOf("-s"), architectArgs.indexOf("-s") + 2),
+    ).toEqual(["-s", "read-only"]);
+    expect(builderArgs).toContain("danger-full-access");
+  });
+
   it("applies the configured model and reasoning effort", () => {
     const args = buildCodexArgs(
       bundle({


### PR DESCRIPTION
## Summary

- run Claude architects in native plan mode and Codex architects in the read-only sandbox
- publish architect lifecycle progress from the trusted runner instead of requiring repository writes
- align the generated architect contract with the enforced read-only boundary

## Context

A production TAM-OS parity run showed that the architect contract alone was insufficient: the agent ignored the planning-only instruction, edited source and tests, attempted UI validation, and consumed 60 turns and $7.15 before an operator interrupted it. Facility detected repository changes only after the engine exited, so that gate could not prevent wasted execution.

## Verification

- `pnpm --filter @facility/runner test -- --runInBand` — 157 passed
- `pnpm --filter @facility/runner typecheck` — passed
- `pnpm --filter @theagilemonkeys/facility test` — 97 passed
- `pnpm exec biome check runner/src/index.ts runner/test/workspace.test.ts` — passed
- `git diff --check` — passed
