### PR TITLE
perf(sandbox): provision delivery agents on demand

### DIFF
--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -49,7 +49,8 @@ const BUNDLED_ACTION_TYPES = [
   { name: "mcp_tool_call", required: ["toolName", "args", "requestedBy"] },
 ];
 
-const ANALYSIS_AGENT_NAMES = ["review", "security-sweep"] as const;
+const ANALYSIS_AGENT_NAMES = ["architect", "codex-architect", "review", "security-sweep"] as const;
+const DELIVERY_AGENT_NAMES = ["builder", "codex-builder", "address-review", "ci-doctor"] as const;
 
 export function defaultSandboxProfileId(orgId: string): string {
   return orgId === "org_dev_the_agile_monkeys" ? "sbx_dev_default" : `sbx_default_${orgId}`;
@@ -57,6 +58,10 @@ export function defaultSandboxProfileId(orgId: string): string {
 
 export function analysisSandboxProfileId(orgId: string): string {
   return orgId === "org_dev_the_agile_monkeys" ? "sbx_dev_analysis" : `sbx_analysis_${orgId}`;
+}
+
+export function builderSandboxProfileId(orgId: string): string {
+  return orgId === "org_dev_the_agile_monkeys" ? "sbx_dev_builder" : `sbx_builder_${orgId}`;
 }
 
 // The default sandbox profile must run the Facility runner (its ENTRYPOINT), or
@@ -338,6 +343,28 @@ async function seedOrgEssentialsSql(sql: postgres.Sql, orgId: string): Promise<v
   await sql`
     INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
     VALUES (
+      ${builderSandboxProfileId(orgId)},
+      ${orgId},
+      'Builder runner',
+      ${defaultSandboxDriver()},
+      ${defaultRunnerImage()},
+      '{"deps":[],"nested_docker":true,"provisioning":"deps_only"}'::jsonb,
+      ${sql.json(defaultSandboxResources())}::jsonb,
+      '{"egress":"restricted"}'::jsonb
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      name = EXCLUDED.name,
+      driver = EXCLUDED.driver,
+      image = EXCLUDED.image,
+      setup = EXCLUDED.setup,
+      resources = EXCLUDED.resources,
+      network = EXCLUDED.network,
+      updated_at = now()
+  `;
+
+  await sql`
+    INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
+    VALUES (
       ${analysisSandboxProfileId(orgId)},
       ${orgId},
       'Analysis runner',
@@ -390,6 +417,7 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
     org_id: orgId,
     profile_id: defaultSandboxProfileId(orgId),
     analysis_profile_id: analysisSandboxProfileId(orgId),
+    builder_profile_id: builderSandboxProfileId(orgId),
   }));
   await sql`
     WITH inputs AS (
@@ -405,6 +433,32 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
       ${defaultSandboxDriver()},
       ${defaultRunnerImage()},
       '{"deps":[]}'::jsonb,
+      ${sql.json(defaultSandboxResources())}::jsonb,
+      '{"egress":"restricted"}'::jsonb
+    FROM inputs
+    ON CONFLICT (id) DO UPDATE SET
+      name = EXCLUDED.name,
+      driver = EXCLUDED.driver,
+      image = EXCLUDED.image,
+      setup = EXCLUDED.setup,
+      resources = EXCLUDED.resources,
+      network = EXCLUDED.network,
+      updated_at = now()
+  `;
+  await sql`
+    WITH inputs AS (
+      SELECT *
+      FROM jsonb_to_recordset(${sql.json(orgInputs)}::jsonb)
+        AS value(org_id text, profile_id text, analysis_profile_id text, builder_profile_id text)
+    )
+    INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
+    SELECT
+      inputs.builder_profile_id,
+      inputs.org_id,
+      'Builder runner',
+      ${defaultSandboxDriver()},
+      ${defaultRunnerImage()},
+      '{"deps":[],"nested_docker":true,"provisioning":"deps_only"}'::jsonb,
       ${sql.json(defaultSandboxResources())}::jsonb,
       '{"egress":"restricted"}'::jsonb
     FROM inputs
@@ -444,14 +498,16 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
       updated_at = now()
   `;
   // One-time activation for legacy agents that still point at Facility's
-  // canonical default. The timestamp guard makes a later operator assignment
-  // back to the full profile durable; custom and NULL assignments also remain
-  // untouched. The org join prevents cross-tenant profile references.
+  // canonical default. The newly introduced Builder profile is the rollout
+  // marker for both managed sets, so architects created after the older
+  // Analysis profile are still migrated once. A later operator assignment back
+  // to the full profile remains durable; custom and NULL assignments also stay
+  // untouched. The org joins prevent cross-tenant profile references.
   await sql`
     WITH inputs AS (
       SELECT *
       FROM jsonb_to_recordset(${sql.json(orgInputs)}::jsonb)
-        AS value(org_id text, profile_id text, analysis_profile_id text)
+        AS value(org_id text, profile_id text, analysis_profile_id text, builder_profile_id text)
     )
     UPDATE agent_defs AS agents
     SET sandbox_profile_id = inputs.analysis_profile_id, updated_at = now()
@@ -459,10 +515,30 @@ async function seedOrgEssentialsForOrgsSql(sql: postgres.Sql, orgIds: string[]):
     INNER JOIN sandbox_profiles AS analysis_profiles
       ON analysis_profiles.id = inputs.analysis_profile_id
       AND analysis_profiles.org_id = inputs.org_id
+    INNER JOIN sandbox_profiles AS rollout_markers
+      ON rollout_markers.id = inputs.builder_profile_id
+      AND rollout_markers.org_id = inputs.org_id
     WHERE agents.org_id = inputs.org_id
       AND agents.sandbox_profile_id = inputs.profile_id
       AND agents.name = ANY(${[...ANALYSIS_AGENT_NAMES]})
-      AND agents.updated_at < analysis_profiles.created_at
+      AND agents.updated_at < rollout_markers.created_at
+  `;
+  await sql`
+    WITH inputs AS (
+      SELECT *
+      FROM jsonb_to_recordset(${sql.json(orgInputs)}::jsonb)
+        AS value(org_id text, profile_id text, analysis_profile_id text, builder_profile_id text)
+    )
+    UPDATE agent_defs AS agents
+    SET sandbox_profile_id = inputs.builder_profile_id, updated_at = now()
+    FROM inputs
+    INNER JOIN sandbox_profiles AS builder_profiles
+      ON builder_profiles.id = inputs.builder_profile_id
+      AND builder_profiles.org_id = inputs.org_id
+    WHERE agents.org_id = inputs.org_id
+      AND agents.sandbox_profile_id = inputs.profile_id
+      AND agents.name = ANY(${[...DELIVERY_AGENT_NAMES]})
+      AND agents.updated_at < builder_profiles.created_at
   `;
   const actionInputs = BUNDLED_ACTION_TYPES.map((actionType) => ({
     name: actionType.name,
@@ -518,6 +594,28 @@ async function seedOrgEssentialsDb(db: RegistryDb, orgId: string): Promise<void>
       ${defaultSandboxDriver()},
       ${defaultRunnerImage()},
       '{"deps":[]}'::jsonb,
+      ${defaultSandboxResourcesDrizzleSql()},
+      '{"egress":"restricted"}'::jsonb
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      name = EXCLUDED.name,
+      driver = EXCLUDED.driver,
+      image = EXCLUDED.image,
+      setup = EXCLUDED.setup,
+      resources = EXCLUDED.resources,
+      network = EXCLUDED.network,
+      updated_at = now()
+  `);
+
+  await db.execute(drizzleSql`
+    INSERT INTO sandbox_profiles (id, org_id, name, driver, image, setup, resources, network)
+    VALUES (
+      ${builderSandboxProfileId(orgId)},
+      ${orgId},
+      'Builder runner',
+      ${defaultSandboxDriver()},
+      ${defaultRunnerImage()},
+      '{"deps":[],"nested_docker":true,"provisioning":"deps_only"}'::jsonb,
       ${defaultSandboxResourcesDrizzleSql()},
       '{"egress":"restricted"}'::jsonb
     )

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   analysisSandboxProfileId,
   applyMigrations,
+  builderSandboxProfileId,
   createDb,
   defaultSandboxProfileId,
   deployDatabase,
@@ -418,6 +419,10 @@ describe("db", async () => {
           name: "Analysis runner",
           resources: { cpu: 2, memory_mb: 4096, timeout_min: 60 },
         }),
+        expect.objectContaining({
+          name: "Builder runner",
+          resources: { cpu: 2, memory_mb: 4096, timeout_min: 60 },
+        }),
       ]),
     );
   });
@@ -478,6 +483,7 @@ describe("db", async () => {
     ]);
     expect(seededProfiles.map((profile) => profile.name).sort()).toEqual([
       "Analysis runner",
+      "Builder runner",
       "Default runner",
     ]);
     expect(seededProfiles).toEqual(
@@ -488,6 +494,10 @@ describe("db", async () => {
         }),
         expect.objectContaining({
           name: "Analysis runner",
+          resources: { cpu: 2, memory_mb: 4096, timeout_min: 60 },
+        }),
+        expect.objectContaining({
+          name: "Builder runner",
           resources: { cpu: 2, memory_mb: 4096, timeout_min: 60 },
         }),
       ]),
@@ -549,7 +559,7 @@ describe("db", async () => {
     ).toEqual({ type: "webhook", config: { url: "https://hooks.invalid/plan" } });
   });
 
-  it("moves only managed lightweight analysis agents to their tenant's analysis profile", async () => {
+  it("moves only managed agents to their tenant's optimized profile", async () => {
     const orgA = newId("org");
     const orgB = newId("org");
     const projectA = newId("proj");
@@ -663,8 +673,8 @@ describe("db", async () => {
     expect(assignments.get(fixtures[0]?.id ?? "")).toBe(analysisSandboxProfileId(orgA));
     expect(assignments.get(fixtures[1]?.id ?? "")).toBe(customProfileId);
     expect(assignments.get(fixtures[2]?.id ?? "")).toBeNull();
-    expect(assignments.get(fixtures[3]?.id ?? "")).toBe(defaultSandboxProfileId(orgA));
-    expect(assignments.get(fixtures[4]?.id ?? "")).toBe(defaultSandboxProfileId(orgB));
+    expect(assignments.get(fixtures[3]?.id ?? "")).toBe(builderSandboxProfileId(orgA));
+    expect(assignments.get(fixtures[4]?.id ?? "")).toBe(analysisSandboxProfileId(orgB));
     expect(assignments.get(fixtures[4]?.id ?? "")).not.toBe(defaultSandboxProfileId(orgA));
 
     await db

--- a/services/api/src/routes/v1/projects-repos.ts
+++ b/services/api/src/routes/v1/projects-repos.ts
@@ -2,6 +2,7 @@ import { newId } from "@facility/core";
 import {
   agentDefs,
   analysisSandboxProfileId,
+  builderSandboxProfileId,
   defaultSandboxProfileId,
   githubInstallations,
   projects,
@@ -416,6 +417,9 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
     const analysisSandbox =
       availableSandboxes.find((profile) => profile.id === analysisSandboxProfileId(orgId)) ??
       defaultSandbox;
+    const builderSandbox =
+      availableSandboxes.find((profile) => profile.id === builderSandboxProfileId(orgId)) ??
+      defaultSandbox;
     const productChain = byName.get("product-chain");
     const poContract = byName.get("po-agent");
     const learningContract = byName.get("learning-agent");
@@ -433,7 +437,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
     const crew = [
       {
         name: "architect",
-        sandbox: "full",
+        sandbox: "analysis",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/architect",
@@ -444,7 +448,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "builder",
-        sandbox: "full",
+        sandbox: "builder",
         engine: "claude_code",
         model: { model: "claude-fable-5" },
         contract: "prompts/builder",
@@ -455,7 +459,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "codex-architect",
-        sandbox: "full",
+        sandbox: "analysis",
         engine: "codex",
         model: { primary: "gpt-5.6-sol", reasoning_effort: "high" },
         contract: "prompts/architect",
@@ -466,7 +470,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "codex-builder",
-        sandbox: "full",
+        sandbox: "builder",
         engine: "codex",
         model: { primary: "gpt-5.6-sol", reasoning_effort: "high" },
         contract: "prompts/builder",
@@ -485,7 +489,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "address-review",
-        sandbox: "full",
+        sandbox: "builder",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/address-review",
@@ -493,7 +497,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       },
       {
         name: "ci-doctor",
-        sandbox: "full",
+        sandbox: "builder",
         engine: "claude_code",
         model: { model: "claude-sonnet-5" },
         contract: "prompts/doctor",
@@ -574,8 +578,14 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
         triggers: [...spec.triggers],
         // This is a seed-time assignment, not run-time mode inference. Operators
         // can replace it through the existing agent/profile APIs. Keep the
-        // analysis set aligned with the runner's read-only repository modes.
-        sandboxProfileId: spec.sandbox === "analysis" ? analysisSandbox?.id : defaultSandbox?.id,
+        // managed sets aligned with read-only and delivery repository modes.
+        // Delivery agents retain nested Docker but provision services on demand.
+        sandboxProfileId:
+          spec.sandbox === "analysis"
+            ? analysisSandbox?.id
+            : spec.sandbox === "builder"
+              ? builderSandbox?.id
+              : defaultSandbox?.id,
         permissions: ["runs:read"],
         enabled: true,
       });

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -10,6 +10,7 @@ import {
   analysisSandboxProfileId,
   auditEvents,
   budgets,
+  builderSandboxProfileId,
   conversationMessages,
   conversations,
   createDb,
@@ -639,19 +640,13 @@ describe("api", async () => {
     const profileByAgent = new Map(
       projectAgents.map((agent) => [agent.name, agent.sandboxProfileId]),
     );
-    for (const name of ["review", "security-sweep"]) {
+    for (const name of ["architect", "codex-architect", "review", "security-sweep"]) {
       expect(profileByAgent.get(name), name).toBe(analysisSandboxProfileId(orgId));
     }
-    for (const name of [
-      "builder",
-      "architect",
-      "codex-builder",
-      "codex-architect",
-      "address-review",
-      "ci-doctor",
-      "project-owner",
-      "learning",
-    ]) {
+    for (const name of ["builder", "codex-builder", "address-review", "ci-doctor"]) {
+      expect(profileByAgent.get(name), name).toBe(builderSandboxProfileId(orgId));
+    }
+    for (const name of ["project-owner", "learning"]) {
       expect(profileByAgent.get(name), name).toBe(defaultSandboxProfileId(orgId));
     }
     const analysisProfile = (
@@ -663,6 +658,17 @@ describe("api", async () => {
     )[0];
     expect(analysisProfile?.setup).toMatchObject({
       nested_docker: false,
+      provisioning: "deps_only",
+    });
+    const builderProfile = (
+      await db
+        .select()
+        .from(sandboxProfiles)
+        .where(eq(sandboxProfiles.id, builderSandboxProfileId(orgId)))
+        .limit(1)
+    )[0];
+    expect(builderProfile?.setup).toMatchObject({
+      nested_docker: true,
       provisioning: "deps_only",
     });
     let listedProject = false;


### PR DESCRIPTION
## Summary

- add a managed Builder runner profile that keeps nested Docker available but installs dependencies only
- assign architects and read-only agents to the lightweight Analysis runner
- assign builders and repair agents to the Builder runner while preserving the full profile for project-owner, learning, custom agents, and explicit operator overrides
- migrate only canonical legacy assignments, scoped by tenant and guarded by a one-time rollout timestamp

## Why

The production TAM-OS builder spent 171 seconds starting and resetting Supabase before a change that neither used Supabase nor ran acceptance locally; GitHub Actions owned the acceptance boundary. This retains every capability while making infrastructure on-demand.

## Validation

- `pnpm exec biome check packages/db/src/seed.ts packages/db/test/db.test.ts services/api/src/routes/v1/projects-repos.ts services/api/test/api.test.ts`
- `pnpm --filter @facility/db build`
- `pnpm --filter @facility/api typecheck`
- local DB integration attempt recorded environmental timeouts: Docker Desktop had 29 running containers and fresh Postgres connections took 4.7-9.8 seconds against a 5-second test limit; hosted CI is the acceptance environment

## Safety

- no service or provider is removed
- delivery agents keep nested Docker
- custom, null, cross-tenant, and post-rollout operator assignments remain untouched
- no TAM-OS test PR is merged