### PR TITLE
perf(runner): use the slim Node base image

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -90,6 +90,7 @@ RUN test -n "$DEBIAN_SECURITY_REFRESH" \
     libxkbcommon0 \
     libxrandr2 \
     pkg-config \
+    procps \
     python3 \
     ripgrep \
     slirp4netns \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -36,7 +36,11 @@ RUN apt-get update \
   && tar -xzf "/tmp/${archive}" -C /tmp \
   && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /gh
 
-FROM node:24-trixie@sha256:66bb8d36ae1ddd72199ed235a089904874ca4079ee517936ca3adb80506a75c1 AS runner-base
+# The full Node image inherits buildpack-deps and silently carries unrelated
+# database, image-processing, DNS, and web-server development stacks. Agents
+# need a native compiler toolchain, not that entire transitive surface, so start
+# from the official slim variant and install the small explicit toolchain below.
+FROM node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d AS runner-base
 
 # The digest-pinned Node base can lag Debian security uploads, while BuildKit
 # correctly caches an earlier apt upgrade against the unchanged base digest.
@@ -48,8 +52,9 @@ RUN test -n "$DEBIAN_SECURITY_REFRESH" \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
-    ca-certificates \
+    build-essential \
     busybox-static \
+    ca-certificates \
     curl \
     fonts-noto-color-emoji \
     fonts-freefont-ttf \
@@ -84,6 +89,8 @@ RUN test -n "$DEBIAN_SECURITY_REFRESH" \
     libxfixes3 \
     libxkbcommon0 \
     libxrandr2 \
+    pkg-config \
+    python3 \
     ripgrep \
     slirp4netns \
     uidmap \

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -317,11 +317,19 @@ test("Bake keeps thin target boundaries and publishes every target through one g
     }
   }
   assert.match(runnerDockerfile, /ARG NPM_VERSION=12\.0\.2/);
-  assert.ok(
-    runnerDockerfile.indexOf("FROM node:24-trixie@sha256:") <
-      runnerDockerfile.indexOf("ARG NPM_VERSION=12.0.2"),
-    "the patched npm runtime must be installed in the Node stage",
+  assert.match(
+    runnerDockerfile,
+    /^FROM node:24-trixie-slim@sha256:[0-9a-f]{64} AS runner-base$/m,
+    "the runner must use the digest-pinned official slim Node base",
   );
+  assert.doesNotMatch(runnerDockerfile, /^FROM node:24-trixie@sha256:/m);
+  for (const runtimePackage of ["build-essential", "pkg-config", "procps", "python3"]) {
+    assert.match(
+      runnerDockerfile,
+      new RegExp(`^    ${runtimePackage.replace("-", "\\-")} \\\\?$`, "m"),
+      `the slim runner must explicitly install ${runtimePackage}`,
+    );
+  }
   for (const patchedPackage of [
     "brace-expansion@5.0.9",
     "ip-address@10.3.1",


### PR DESCRIPTION
## Summary

- replace the official full `node:24-trixie` runner base with the official `node:24-trixie-slim` variant
- retain common native Node builds with explicit `build-essential`, `python3`, and `pkg-config` packages
- keep the existing official rootless Docker toolchain, browser runtime libraries, agent CLIs, and sandbox boundaries unchanged

## Why

The full Node image inherits `buildpack-deps`, which added unrelated image-processing, database, DNS, and web-server development packages to every runner. AWS Inspector traced runner findings to unused OpenEXR, LibRaw, MariaDB, APR, Unbound, and development-library trees. This removes that accidental surface instead of suppressing CVEs.

## Validation

```text
$ docker buildx build --check --platform linux/amd64 --target runner -f runner/Dockerfile .
Check complete, no warnings found.
```

Hosted CI builds and exercises the complete runner boundary on clean amd64 infrastructure.