### PR TITLE
fix(web): load every run event page

### DIFF
--- a/apps/web/components/run/cockpit.tsx
+++ b/apps/web/components/run/cockpit.tsx
@@ -5,6 +5,7 @@ import { Button, Cell, cx, Eyebrow, HairlineGrid, Metric, StatusDot, toneFor } f
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RunTranscript } from "@/components/run/transcript";
 import type { Project, Run, RunEvent } from "@/lib/api";
+import { fetchRunEventPages } from "@/lib/run-event-pages";
 import { fmtCost, fmtDuration, fmtStatus } from "@/lib/run-format";
 
 const LIVE = new Set(["queued", "provisioning", "running", "awaiting_human"]);
@@ -318,6 +319,7 @@ export function RunCockpit({
   const [action, setAction] = useState<ActionState>(null);
   const [busy, setBusy] = useState<"cancel" | "retry" | "interrupt" | "resume" | null>(null);
   const lastSeq = useRef(initialEvents.at(-1)?.seq ?? 0);
+  const pulling = useRef(false);
   // Session identity lands on runs written after the resume infrastructure —
   // older rows simply don't offer resume.
   const engineSessionId = (run as { engineSessionId?: string | null }).engineSessionId ?? null;
@@ -342,14 +344,16 @@ export function RunCockpit({
   const artifacts = useMemo(() => githubArtifacts(run), [run]);
 
   const pull = useCallback(async () => {
-    const res = await fetch(`/api/v1/runs/${run.id}/events?afterSeq=${lastSeq.current}`, {
-      cache: "no-store",
-    });
-    if (!res.ok) return;
-    const body = (await res.json()) as RunEvent[];
-    if (body.length) {
-      lastSeq.current = body.at(-1)?.seq ?? lastSeq.current;
-      setEvents((prev) => mergeEvents(prev, body));
+    if (pulling.current) return;
+    pulling.current = true;
+    try {
+      const body = await fetchRunEventPages(run.id, lastSeq.current);
+      if (body.length) {
+        lastSeq.current = Math.max(lastSeq.current, body.at(-1)?.seq ?? lastSeq.current);
+        setEvents((prev) => mergeEvents(prev, body));
+      }
+    } finally {
+      pulling.current = false;
     }
   }, [run.id]);
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -146,8 +146,8 @@ export const api = {
     apiFetch("GET", `/v1/projects/${projectId}/runs`, { query: queryFromParams(params) }),
   allRuns: (params = "") => apiFetch("GET", "/v1/runs", { query: queryFromParams(params) }),
   run: (id: string) => apiFetch("GET", `/v1/runs/${id}`),
-  runEvents: (id: string, afterSeq = 0) =>
-    apiFetch("GET", `/v1/runs/${id}/events`, { query: { afterSeq } }),
+  runEvents: (id: string, afterSeq = 0, limit = 500) =>
+    apiFetch("GET", `/v1/runs/${id}/events`, { query: { afterSeq, limit } }),
   // GET /v1/inbox returns { items, proposals, issues } — unwrap to the
   // proposals array both consumers expect (guarded so a bare array also works).
   inbox: async (): Promise<ApiResult<Proposal[]>> => {

--- a/apps/web/lib/run-event-pages.ts
+++ b/apps/web/lib/run-event-pages.ts
@@ -1,0 +1,44 @@
+import type { RunEvent } from "@/lib/api";
+
+export const RUN_EVENT_PAGE_LIMIT = 500;
+
+type EventPageResponse = {
+  ok: boolean;
+  json(): Promise<unknown>;
+};
+
+export type EventPageFetcher = (
+  input: string,
+  init: { cache: "no-store" },
+) => Promise<EventPageResponse>;
+
+/**
+ * Drain every durable event after a cursor. The API deliberately bounds each
+ * response, while a completed run can contain many pages of engine output.
+ */
+export async function fetchRunEventPages(
+  runId: string,
+  afterSeq: number,
+  fetcher: EventPageFetcher = fetch,
+): Promise<RunEvent[]> {
+  const events: RunEvent[] = [];
+  let cursor = afterSeq;
+
+  while (true) {
+    const response = await fetcher(
+      `/api/v1/runs/${runId}/events?afterSeq=${cursor}&limit=${RUN_EVENT_PAGE_LIMIT}`,
+      { cache: "no-store" },
+    );
+    if (!response.ok) return events;
+
+    const page = (await response.json()) as RunEvent[];
+    if (!Array.isArray(page) || page.length === 0) return events;
+
+    const nextCursor = page.at(-1)?.seq;
+    if (typeof nextCursor !== "number" || nextCursor <= cursor) return events;
+
+    events.push(...page);
+    cursor = nextCursor;
+    if (page.length < RUN_EVENT_PAGE_LIMIT) return events;
+  }
+}

--- a/apps/web/test/run-event-pages.test.ts
+++ b/apps/web/test/run-event-pages.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { RunEvent } from "@/lib/api";
+import {
+  type EventPageFetcher,
+  fetchRunEventPages,
+  RUN_EVENT_PAGE_LIMIT,
+} from "@/lib/run-event-pages";
+
+function event(seq: number): RunEvent {
+  return {
+    orgId: "org_test",
+    runId: "run_test",
+    seq,
+    ts: "2026-08-08T00:00:00.000Z",
+    type: "engine",
+    data: { seq },
+  };
+}
+
+describe("run event pagination", () => {
+  it("loads every page instead of stopping before a completed run's terminal events", async () => {
+    const firstPage = Array.from({ length: RUN_EVENT_PAGE_LIMIT }, (_, index) => event(index + 1));
+    const secondPage = [event(RUN_EVENT_PAGE_LIMIT + 1)];
+    const pages = [firstPage, secondPage];
+    const requests: string[] = [];
+    const fetcher: EventPageFetcher = async (input) => {
+      requests.push(input);
+      return { ok: true, json: async () => pages.shift() ?? [] };
+    };
+
+    const events = await fetchRunEventPages("run_test", 0, fetcher);
+
+    expect(events).toHaveLength(RUN_EVENT_PAGE_LIMIT + 1);
+    expect(events.at(-1)?.seq).toBe(RUN_EVENT_PAGE_LIMIT + 1);
+    expect(requests).toEqual([
+      `/api/v1/runs/run_test/events?afterSeq=0&limit=${RUN_EVENT_PAGE_LIMIT}`,
+      `/api/v1/runs/run_test/events?afterSeq=${RUN_EVENT_PAGE_LIMIT}&limit=${RUN_EVENT_PAGE_LIMIT}`,
+    ]);
+  });
+
+  it("stops safely if a malformed page does not advance the cursor", async () => {
+    const fetcher: EventPageFetcher = async () => ({
+      ok: true,
+      json: async () => [event(7)],
+    });
+
+    await expect(fetchRunEventPages("run_test", 7, fetcher)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- fetch up to 500 initial run events during server rendering
- drain every remaining event page after hydration without overlapping polls
- cover multi-page terminal runs and non-advancing cursors

## Validation

- `pnpm --filter @facility/web test`
- `pnpm --filter @facility/web typecheck`
- `pnpm exec biome check apps/web/lib/run-event-pages.ts apps/web/lib/api.ts apps/web/components/run/cockpit.tsx apps/web/test/run-event-pages.test.ts`
- `git diff --check`