### PR TITLE
feat(pipeline)!: replace ready stage with actionable story states

### DIFF
--- a/apps/web/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/page.tsx
@@ -1,15 +1,14 @@
-import { Eyebrow, StatusDot, toneFor } from "@facility/ui";
+import { Eyebrow, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { AiIdentity } from "@/components/ai-identity";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { InFlightList } from "@/components/project/in-flight-list";
 import { PipelineBoard } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
-import { engineIdentity } from "@/lib/ai-identity";
 import { api } from "@/lib/api";
+import { buildInFlightRows } from "@/lib/in-flight";
 import type { PipelineStageState } from "@/lib/pipeline";
 import { pipelineStories } from "@/lib/pipeline";
-import { fmtDuration, fmtStatus } from "@/lib/runs";
 
 export const metadata = { title: "overview" };
 
@@ -75,14 +74,24 @@ export default async function ProjectOverviewPage({
   params: Promise<{ projectId: string }>;
 }) {
   const { projectId } = await params;
-  const [project, runs, health, inbox, pipelineResult, repos] = await Promise.all([
-    api.project(projectId),
-    api.runs(projectId),
-    api.projectHealth(projectId),
-    api.inboxFull(),
-    api.pipeline(projectId),
-    api.projectRepos(projectId),
-  ]);
+  const runsRequest = api.runs(projectId);
+  const recentEventsRequest = runsRequest.then(async (result) => {
+    if (!result.ok) return [];
+    const visibleLive = result.data.filter((run) => LIVE.has(run.status)).slice(0, 6);
+    return Promise.all(
+      visibleLive.map(async (run) => [run.id, await api.recentRunEvents(run.id)] as const),
+    );
+  });
+  const [project, runs, health, inbox, pipelineResult, repos, recentEventResults] =
+    await Promise.all([
+      api.project(projectId),
+      runsRequest,
+      api.projectHealth(projectId),
+      api.inboxFull(),
+      api.pipeline(projectId),
+      api.projectRepos(projectId),
+      recentEventsRequest,
+    ]);
 
   if (!project.ok) {
     return project.offline ? (
@@ -96,6 +105,10 @@ export default async function ProjectOverviewPage({
   const runsError = runs.ok ? null : runs.message;
   const items = runs.ok ? runs.data : [];
   const live = items.filter((run) => LIVE.has(run.status));
+  const visibleLive = live.slice(0, 6);
+  const eventsByRun = new Map(
+    recentEventResults.map(([runId, result]) => [runId, result.ok ? result.data : []]),
+  );
   const blocked = items.filter((run) => run.status === "awaiting_human");
   const proposals = inbox.ok
     ? inbox.data.proposals.filter(
@@ -107,6 +120,12 @@ export default async function ProjectOverviewPage({
     : [];
   const pipeline = pipelineResult.ok ? pipelineResult.data : null;
   const pipelineError = pipelineResult.ok ? null : pipelineResult.message;
+  const inFlightRows = buildInFlightRows({
+    projectId,
+    runs: visibleLive,
+    pipeline,
+    eventsByRun,
+  });
   const stories = pipeline ? pipelineStories(pipeline) : [];
   const stateCount = (state: PipelineStageState) =>
     stories.filter((story) => story.stageState === state).length;
@@ -307,35 +326,7 @@ export default async function ProjectOverviewPage({
             ) : null}
           </p>
         ) : (
-          <div className="flex flex-col border border-(--line)">
-            {live.slice(0, 6).map((run) => (
-              <Link
-                key={run.id}
-                href={`/projects/${projectId}/sessions/${run.id}`}
-                className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
-              >
-                <StatusDot tone={toneFor(run.status)} pulse={run.status === "running"} />
-                <span className="font-mono text-[13px] text-(--ink)">{run.mode}</span>
-                <AiIdentity
-                  identity={engineIdentity(run.engine)}
-                  className="hidden font-mono text-[11px] text-(--dim) sm:inline-flex"
-                  iconClassName="size-3"
-                />
-                <span className="text-[12px] text-(--mut)">{fmtStatus(run.status)}</span>
-                <span className="ml-auto font-mono text-[11px] text-(--mut)">
-                  {fmtDuration(run.startedAt, null)}
-                </span>
-              </Link>
-            ))}
-            {live.length > 6 ? (
-              <Link
-                href={`/projects/${projectId}/sessions`}
-                className="px-5 py-3 text-[11.5px] text-(--dim) hover:text-(--ink)"
-              >
-                +{live.length - 6} more active sessions →
-              </Link>
-            ) : null}
-          </div>
+          <InFlightList projectId={projectId} rows={inFlightRows} total={live.length} />
         )}
       </section>
     </div>

--- a/apps/web/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/page.tsx
@@ -2,10 +2,12 @@ import { Eyebrow, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { DeliveryIntelligence } from "@/components/project/delivery-intelligence";
 import { InFlightList } from "@/components/project/in-flight-list";
 import { PipelineBoard } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api } from "@/lib/api";
+import { buildDeliveryIntelligence } from "@/lib/delivery-intelligence";
 import { buildInFlightRows } from "@/lib/in-flight";
 import type { PipelineStageState } from "@/lib/pipeline";
 import { pipelineStories } from "@/lib/pipeline";
@@ -74,7 +76,11 @@ export default async function ProjectOverviewPage({
   params: Promise<{ projectId: string }>;
 }) {
   const { projectId } = await params;
-  const runsRequest = api.runs(projectId);
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  const monthStartIso = monthStart.toISOString();
+  const runsRequest = api.runs(projectId, "?limit=200");
   const recentEventsRequest = runsRequest.then(async (result) => {
     if (!result.ok) return [];
     const visibleLive = result.data.filter((run) => LIVE.has(run.status)).slice(0, 6);
@@ -82,16 +88,33 @@ export default async function ProjectOverviewPage({
       visibleLive.map(async (run) => [run.id, await api.recentRunEvents(run.id)] as const),
     );
   });
-  const [project, runs, health, inbox, pipelineResult, repos, recentEventResults] =
-    await Promise.all([
-      api.project(projectId),
-      runsRequest,
-      api.projectHealth(projectId),
-      api.inboxFull(),
-      api.pipeline(projectId),
-      api.projectRepos(projectId),
-      recentEventsRequest,
-    ]);
+  const [
+    project,
+    runs,
+    health,
+    inbox,
+    pipelineResult,
+    repos,
+    recentEventResults,
+    spend,
+    agentsStatus,
+    outcomes,
+    llmRequests,
+    catalog,
+  ] = await Promise.all([
+    api.project(projectId),
+    runsRequest,
+    api.projectHealth(projectId),
+    api.inboxFull(),
+    api.pipeline(projectId),
+    api.projectRepos(projectId),
+    recentEventsRequest,
+    api.spend(`?projectId=${projectId}&groupBy=agent&from=${encodeURIComponent(monthStartIso)}`),
+    api.agentsStatus(projectId),
+    api.outcomes(`?state=terminal&projectId=${projectId}&limit=50`),
+    api.llmRequests(`?projectId=${projectId}&from=${encodeURIComponent(monthStartIso)}&limit=500`),
+    api.catalog(),
+  ]);
 
   if (!project.ok) {
     return project.offline ? (
@@ -153,6 +176,17 @@ export default async function ProjectOverviewPage({
           ? "project health requires attention"
           : "health unavailable"));
   const repoList = repos.ok ? repos.data : [];
+  const delivery = buildDeliveryIntelligence({
+    projectId,
+    periodStart: monthStartIso,
+    spend: spend.ok ? spend.data : [],
+    agents: agentsStatus.ok ? agentsStatus.data : [],
+    runs: items,
+    outcomes: outcomes.ok ? outcomes.data : [],
+    requests: llmRequests.ok ? llmRequests.data.items : [],
+    pipeline,
+    catalog: catalog.ok ? catalog.data : null,
+  });
 
   return (
     <div className="flex flex-col gap-10">
@@ -216,6 +250,8 @@ export default async function ProjectOverviewPage({
           <ErrorNotice message={`Couldn't load the story pipeline — ${pipelineError}`} />
         )}
       </section>
+
+      <DeliveryIntelligence projectId={projectId} data={delivery} />
 
       {needsYou > 0 ? (
         <section className="flex flex-col gap-4">

--- a/apps/web/app/(app)/projects/[projectId]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/page.tsx
@@ -1,18 +1,19 @@
-import { Cell, Divider, Eyebrow, HairlineGrid, Metric, StatusDot, toneFor } from "@facility/ui";
+import { Eyebrow, StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { AiIdentity } from "@/components/ai-identity";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { PipelineBoard } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { engineIdentity } from "@/lib/ai-identity";
-import { api, summarizeSpend } from "@/lib/api";
-import { pipelineStories, reviewablePullRequests, storyHref } from "@/lib/pipeline";
-import { fmtAgo, fmtCost, fmtDuration, fmtStatus } from "@/lib/runs";
+import { api } from "@/lib/api";
+import type { PipelineStageState } from "@/lib/pipeline";
+import { pipelineStories } from "@/lib/pipeline";
+import { fmtDuration, fmtStatus } from "@/lib/runs";
 
 export const metadata = { title: "overview" };
 
 const LIVE = new Set(["queued", "provisioning", "running"]);
-const OWNER_AGENT_NAMES = new Set(["project-owner", "learning"]);
 
 type HealthSignal = {
   kind: string;
@@ -38,12 +39,34 @@ function isHealthSignal(value: Record<string, unknown>): value is HealthSignal {
   );
 }
 
-function prLink(gh: Record<string, unknown> | null | undefined): string | null {
-  const pr = gh && typeof gh === "object" ? (gh as { pr?: unknown }).pr : null;
-  if (pr && typeof pr === "object" && typeof (pr as { url?: unknown }).url === "string") {
-    return (pr as { url: string }).url;
-  }
-  return null;
+function AttentionRow({
+  href,
+  tone,
+  count,
+  children,
+  action,
+}: {
+  href: string;
+  tone: "human" | "bad" | "agent";
+  count: number;
+  children: ReactNode;
+  action: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group flex min-h-12 items-center gap-3 border-b border-(--line) px-4 py-3 transition-colors last:border-b-0 hover:bg-(--card) sm:px-5"
+    >
+      <StatusDot tone={tone} />
+      <span className="w-7 text-right font-mono text-[12px] font-semibold text-(--ink)">
+        {count}
+      </span>
+      <span className="text-[12.5px] text-(--mut) group-hover:text-(--ink)">{children}</span>
+      <span className="ml-auto shrink-0 text-[11.5px] font-medium text-(--dim) group-hover:text-(--ink)">
+        {action} →
+      </span>
+    </Link>
+  );
 }
 
 export default async function ProjectOverviewPage({
@@ -52,18 +75,14 @@ export default async function ProjectOverviewPage({
   params: Promise<{ projectId: string }>;
 }) {
   const { projectId } = await params;
-  const [project, runs, spend, health, inbox, agentsStatus, allOutcomes, pipelineResult, repos] =
-    await Promise.all([
-      api.project(projectId),
-      api.runs(projectId),
-      api.spend(`?projectId=${projectId}&groupBy=agent`),
-      api.projectHealth(projectId),
-      api.inboxFull(),
-      api.agentsStatus(projectId),
-      api.outcomes(`?state=all&projectId=${projectId}&limit=6`),
-      api.pipeline(projectId),
-      api.projectRepos(projectId),
-    ]);
+  const [project, runs, health, inbox, pipelineResult, repos] = await Promise.all([
+    api.project(projectId),
+    api.runs(projectId),
+    api.projectHealth(projectId),
+    api.inboxFull(),
+    api.pipeline(projectId),
+    api.projectRepos(projectId),
+  ]);
 
   if (!project.ok) {
     return project.offline ? (
@@ -76,52 +95,45 @@ export default async function ProjectOverviewPage({
   const p = project.data;
   const runsError = runs.ok ? null : runs.message;
   const items = runs.ok ? runs.data : [];
-  const live = items.filter((r) => LIVE.has(r.status));
-  const workingCount = items.filter(
-    (r) => r.status === "running" || r.status === "provisioning",
-  ).length;
-  const queuedCount = items.filter((r) => r.status === "queued").length;
-  const blocked = items.filter((r) => r.status === "awaiting_human");
+  const live = items.filter((run) => LIVE.has(run.status));
+  const blocked = items.filter((run) => run.status === "awaiting_human");
   const proposals = inbox.ok
-    ? inbox.data.proposals.filter((x) => !x.projectId || x.projectId === projectId)
+    ? inbox.data.proposals.filter(
+        (proposal) => !proposal.projectId || proposal.projectId === projectId,
+      )
     : [];
   const watchtower = inbox.ok
-    ? inbox.data.issues.filter((x) => !x.projectId || x.projectId === projectId)
+    ? inbox.data.issues.filter((issue) => !issue.projectId || issue.projectId === projectId)
     : [];
   const pipeline = pipelineResult.ok ? pipelineResult.data : null;
   const pipelineError = pipelineResult.ok ? null : pipelineResult.message;
   const stories = pipeline ? pipelineStories(pipeline) : [];
-  const reviewStories = pipeline?.stages.find((stage) => stage.key === "review")?.stories ?? [];
-  const reviewPrs = reviewablePullRequests(reviewStories);
-  const needsYou = blocked.length + proposals.length + reviewPrs.length;
+  const stateCount = (state: PipelineStageState) =>
+    stories.filter((story) => story.stageState === state).length;
+  const planReviewCount = stateCount("needs_review");
+  const prReviewCount = stateCount("awaiting_review");
+  const readyToPlanCount = stateCount("ready_to_plan");
+  const proposalRunIds = new Set(proposals.map((proposal) => proposal.runId).filter(Boolean));
+  const unrepresentedBlocked = blocked.filter((run) => !proposalRunIds.has(run.id));
+  const otherProposals = proposals.filter((proposal) => proposal.actionType !== "plan_acceptance");
+  const needsYou =
+    planReviewCount +
+    prReviewCount +
+    unrepresentedBlocked.length +
+    otherProposals.length +
+    watchtower.length;
 
   const healthData = health.ok ? health.data : null;
   const signals = (healthData?.signals ?? []).filter(isHealthSignal);
-
-  const agentRows = agentsStatus.ok ? agentsStatus.data : [];
-  const agentNameById = new Map(agentRows.map((row) => [row.agentId, row.name]));
-  const ownerAgentIds = new Set(
-    agentRows.filter((row) => OWNER_AGENT_NAMES.has(row.name)).map((row) => row.agentId),
-  );
-  const ownerRuns = items.filter((r) => r.agentDefId && ownerAgentIds.has(r.agentDefId));
-  const lastOwnerRun = ownerRuns[0];
-
-  const recent = items.slice(0, 8);
-  const storyForProposal = (proposal: (typeof proposals)[number]) => {
-    const payload = proposal.payload as { issueNumber?: number; repoId?: string } | null;
-    const matches = stories.filter(
-      (story) =>
-        story.storyType === "issue" &&
-        story.number === payload?.issueNumber &&
-        (!payload?.repoId || story.repoId === payload.repoId),
-    );
-    return matches.length === 1 ? matches[0] : null;
-  };
+  const leadSignal = signals.find((signal) => signal.severity !== "info") ?? signals.at(0) ?? null;
+  const healthSummary =
+    healthData?.status === "ok"
+      ? "systems healthy"
+      : (leadSignal?.title ??
+        (healthData?.status === "red"
+          ? "project health requires attention"
+          : "health unavailable"));
   const repoList = repos.ok ? repos.data : [];
-  const spendSummary = spend.ok ? summarizeSpend(spend.data) : null;
-  const shipped = allOutcomes.ok
-    ? allOutcomes.data.filter((outcome) => outcome.terminalAt).slice(0, 5)
-    : [];
 
   return (
     <div className="flex flex-col gap-10">
@@ -133,12 +145,10 @@ export default async function ProjectOverviewPage({
           <h1 className="text-[clamp(22px,3.2vw,34px)] font-semibold tracking-tight">{p.name}</h1>
           <span className="inline-flex items-center gap-2 text-[12.5px] text-(--mut)">
             <StatusDot tone={healthTone(healthData?.status)} />
-            {healthData ? `health ${healthData.status}` : "health —"}
+            {healthSummary}
           </span>
           <span className="text-[12.5px] text-(--dim)">
-            {runsError
-              ? "sessions —"
-              : `${workingCount} working${queuedCount > 0 ? ` · ${queuedCount} queued` : ""} · ${blocked.length} blocked · ${needsYou} need you`}
+            {runsError ? "activity unavailable" : `${live.length} in flight · ${needsYou} need you`}
           </span>
         </div>
         {p.description ? (
@@ -169,13 +179,16 @@ export default async function ProjectOverviewPage({
       </div>
 
       <section className="flex flex-col gap-4">
-        <div className="flex items-baseline justify-between">
-          <Eyebrow>stories</Eyebrow>
+        <div className="flex items-baseline justify-between gap-4">
+          <div className="flex items-baseline gap-3">
+            <Eyebrow>story flow</Eyebrow>
+            <span className="text-[11.5px] text-(--dim)">select a status to act on it</span>
+          </div>
           <Link
             href={`/projects/${projectId}/stories`}
             className="text-[12px] font-medium text-(--mut) hover:text-(--ink)"
           >
-            open stories →
+            all stories →
           </Link>
         </div>
         {pipeline ? (
@@ -185,90 +198,84 @@ export default async function ProjectOverviewPage({
         )}
       </section>
 
-      {needsYou > 0 || watchtower.length > 0 ? (
+      {needsYou > 0 ? (
         <section className="flex flex-col gap-4">
-          <Eyebrow className="text-(--human)">needs you · {needsYou + watchtower.length}</Eyebrow>
+          <div className="flex items-baseline justify-between gap-4">
+            <Eyebrow className="text-(--human)">needs you · {needsYou}</Eyebrow>
+            <Link
+              href={`/projects/${projectId}/approvals`}
+              className="text-[12px] font-medium text-(--mut) hover:text-(--ink)"
+            >
+              all approvals →
+            </Link>
+          </div>
           <div className="flex flex-col border border-(--line)">
-            {blocked.map((run) => (
-              <Link
-                key={run.id}
-                href={`/projects/${projectId}/sessions/${run.id}`}
-                className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
-              >
-                <StatusDot tone="human" />
-                <span className="font-mono text-[13px] text-(--ink)">{run.mode}</span>
-                <span className="text-[12.5px] text-(--mut)">session is waiting on a human</span>
-                <span className="ml-auto font-mono text-[11px] text-(--dim)">
-                  {fmtAgo(run.queuedAt)}
-                </span>
-              </Link>
-            ))}
-            {reviewPrs.slice(0, 5).map(({ story, pull }) => (
-              <a
-                key={`${story.repoId}:${pull.number}`}
-                href={pull.url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
-              >
-                <StatusDot tone="human" />
-                <span className="font-mono text-[13px] text-(--ink)">
-                  {story.repoOwner}/{story.repoName}#{pull.number}
-                </span>
-                <span className="truncate text-[12.5px] text-(--mut)">
-                  {story.storyType === "issue"
-                    ? `implements #${story.number} ${story.title} — PR awaiting your review ↗`
-                    : `${story.title} — PR awaiting your review ↗`}
-                </span>
-              </a>
-            ))}
-            {proposals.slice(0, 5).map((proposal) => {
-              const story = storyForProposal(proposal);
-              return (
-                <Link
-                  key={proposal.id}
-                  href={
-                    story
-                      ? storyHref(projectId, story)
-                      : `/projects/${projectId}/approvals?focus=${proposal.id}`
-                  }
-                  className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
-                >
-                  <StatusDot tone="human" />
-                  <span className="text-[12px] font-medium text-(--human)">
-                    {proposal.actionType === "plan_acceptance"
-                      ? "plan approval"
-                      : proposal.actionType.replaceAll("_", " ")}
-                  </span>
-                  <span className="truncate text-[12.5px] text-(--mut)">
-                    {story
-                      ? `#${story.number} ${story.title} — waiting for your decision`
-                      : "waiting for your decision"}
-                  </span>
-                  <span className="ml-auto font-mono text-[11px] text-(--dim)">
-                    {fmtAgo(proposal.createdAt)}
-                  </span>
-                </Link>
-              );
-            })}
-            {watchtower.slice(0, 5).map((issue) => (
-              <Link
+            {watchtower.slice(0, 3).map((issue) => (
+              <AttentionRow
                 key={issue.id}
                 href={`/projects/${projectId}/approvals`}
-                className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
+                tone="bad"
+                count={1}
+                action="Investigate"
               >
-                <StatusDot tone="bad" />
-                <span className="text-[12px] font-medium text-(--bad)">{issue.severity}</span>
-                <span className="truncate text-[12.5px] text-(--mut)">{issue.title}</span>
-              </Link>
+                {issue.title}
+              </AttentionRow>
             ))}
+            {planReviewCount > 0 ? (
+              <AttentionRow
+                href={`/projects/${projectId}/stories?stage=planning&status=needs_review`}
+                tone="human"
+                count={planReviewCount}
+                action="Review plans"
+              >
+                {planReviewCount === 1
+                  ? "Plan awaiting your decision"
+                  : "Plans awaiting your decision"}
+              </AttentionRow>
+            ) : null}
+            {prReviewCount > 0 ? (
+              <AttentionRow
+                href={`/projects/${projectId}/stories?stage=review&status=awaiting_review`}
+                tone="human"
+                count={prReviewCount}
+                action="Review PRs"
+              >
+                {prReviewCount === 1
+                  ? "Pull request awaiting review"
+                  : "Pull requests awaiting review"}
+              </AttentionRow>
+            ) : null}
+            {unrepresentedBlocked.length > 0 ? (
+              <AttentionRow
+                href={`/projects/${projectId}/sessions`}
+                tone="human"
+                count={unrepresentedBlocked.length}
+                action="Respond"
+              >
+                {unrepresentedBlocked.length === 1
+                  ? "Agent waiting for your input"
+                  : "Agents waiting for your input"}
+              </AttentionRow>
+            ) : null}
+            {otherProposals.length > 0 ? (
+              <AttentionRow
+                href={`/projects/${projectId}/approvals`}
+                tone="human"
+                count={otherProposals.length}
+                action="Decide"
+              >
+                {otherProposals.length === 1
+                  ? "Proposal awaiting a decision"
+                  : "Proposals awaiting a decision"}
+              </AttentionRow>
+            ) : null}
           </div>
         </section>
       ) : null}
 
       <section className="flex flex-col gap-4">
         <div className="flex items-baseline justify-between">
-          <Eyebrow>in flight</Eyebrow>
+          <Eyebrow>in flight · {live.length}</Eyebrow>
           <Link
             href={`/projects/${projectId}/sessions`}
             className="text-[12px] font-medium text-(--mut) hover:text-(--ink)"
@@ -280,22 +287,32 @@ export default async function ProjectOverviewPage({
           <ErrorNotice message={`Couldn't load sessions — ${runsError}`} />
         ) : live.length === 0 ? (
           <p className="text-sm text-(--dim)">
-            No agent is working right now. Trigger one from{" "}
-            <Link
-              href={`/projects/${projectId}/stories`}
-              className="text-(--ink) underline underline-offset-4"
-            >
-              issues
-            </Link>
-            .
+            No agents running.{" "}
+            {planReviewCount > 0 ? (
+              <Link
+                href={`/projects/${projectId}/stories?stage=planning&status=needs_review`}
+                className="text-(--ink) underline underline-offset-4"
+              >
+                {planReviewCount} {planReviewCount === 1 ? "plan is" : "plans are"} waiting for
+                review →
+              </Link>
+            ) : readyToPlanCount > 0 ? (
+              <Link
+                href={`/projects/${projectId}/stories?stage=backlog&status=ready_to_plan`}
+                className="text-(--ink) underline underline-offset-4"
+              >
+                {readyToPlanCount} {readyToPlanCount === 1 ? "story is" : "stories are"} ready to
+                plan →
+              </Link>
+            ) : null}
           </p>
         ) : (
           <div className="flex flex-col border border-(--line)">
-            {live.map((run) => (
+            {live.slice(0, 6).map((run) => (
               <Link
                 key={run.id}
                 href={`/projects/${projectId}/sessions/${run.id}`}
-                className="flex items-center gap-4 border-b border-(--line) px-5 py-4 transition-colors last:border-b-0 hover:bg-(--card)"
+                className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 transition-colors last:border-b-0 hover:bg-(--card)"
               >
                 <StatusDot tone={toneFor(run.status)} pulse={run.status === "running"} />
                 <span className="font-mono text-[13px] text-(--ink)">{run.mode}</span>
@@ -310,181 +327,16 @@ export default async function ProjectOverviewPage({
                 </span>
               </Link>
             ))}
+            {live.length > 6 ? (
+              <Link
+                href={`/projects/${projectId}/sessions`}
+                className="px-5 py-3 text-[11.5px] text-(--dim) hover:text-(--ink)"
+              >
+                +{live.length - 6} more active sessions →
+              </Link>
+            ) : null}
           </div>
         )}
-      </section>
-
-      <Divider />
-
-      <HairlineGrid cols="lg:grid-cols-2">
-        <Cell className="p-0">
-          <div className="flex h-full flex-col">
-            <div className="border-b border-(--line) px-5 py-3">
-              <Eyebrow>the owner</Eyebrow>
-            </div>
-            <div className="flex flex-1 flex-col gap-3 px-5 py-4">
-              {ownerAgentIds.size === 0 ? (
-                <p className="text-sm text-(--dim)">
-                  No Project Owner agent is configured for this project yet.
-                </p>
-              ) : lastOwnerRun ? (
-                <Link
-                  href={`/projects/${projectId}/sessions/${lastOwnerRun.id}`}
-                  className="flex items-center gap-3 hover:text-(--ink)"
-                >
-                  <StatusDot tone={toneFor(lastOwnerRun.status)} />
-                  <span className="font-mono text-[12.5px] text-(--ink)">{lastOwnerRun.mode}</span>
-                  <span className="font-mono text-[11px] text-(--dim)">
-                    {fmtAgo(lastOwnerRun.queuedAt)} · {lastOwnerRun.status}
-                  </span>
-                </Link>
-              ) : (
-                <p className="text-sm text-(--dim)">
-                  The Project Owner hasn't run yet. It runs on its schedule or on demand.
-                </p>
-              )}
-              <p className="text-[11.5px] font-medium text-(--dim)">
-                knowledge base + conversation land with the Owner surface
-              </p>
-            </div>
-          </div>
-        </Cell>
-        <Cell className="p-0">
-          <div className="flex h-full flex-col">
-            <div className="border-b border-(--line) px-5 py-3">
-              <Eyebrow>system health</Eyebrow>
-            </div>
-            <div className="flex flex-1 flex-col gap-2 px-5 py-4">
-              {signals.length === 0 ? (
-                <p className="text-sm text-(--dim)">
-                  No open signals. Workflows, canary, and fingerprints are quiet.
-                </p>
-              ) : (
-                signals.slice(0, 5).map((signal) => (
-                  // lastSeen disambiguates repeated kind/title pairs (three
-                  // sandbox_lost signals are three rows, not one).
-                  <div
-                    key={`${signal.kind}-${signal.title}-${signal.lastSeen}`}
-                    className="flex items-center gap-3"
-                  >
-                    <StatusDot tone={signal.severity === "info" ? "machine" : "bad"} />
-                    <span className="text-[11.5px] text-(--dim)">{signal.kind}</span>
-                    <span className="truncate text-[12.5px] text-(--mut)">{signal.title}</span>
-                  </div>
-                ))
-              )}
-            </div>
-          </div>
-        </Cell>
-      </HairlineGrid>
-
-      <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="flex min-w-0 flex-col gap-4">
-          <Eyebrow>recent sessions</Eyebrow>
-          {recent.length === 0 ? (
-            <p className="text-sm text-(--dim)">No sessions in this project yet.</p>
-          ) : (
-            <div className="flex flex-col border border-(--line)">
-              {recent.map((run) => {
-                const pr = prLink(run.gh as Record<string, unknown>);
-                return (
-                  <div
-                    key={run.id}
-                    className="flex items-center gap-4 border-b border-(--line) px-5 py-3.5 last:border-b-0"
-                  >
-                    <StatusDot tone={toneFor(run.status)} />
-                    <Link
-                      href={`/projects/${projectId}/sessions/${run.id}`}
-                      className="font-mono text-[13px] text-(--ink) hover:text-(--accent)"
-                    >
-                      {run.mode}
-                    </Link>
-                    <AiIdentity
-                      identity={engineIdentity(run.engine)}
-                      className="hidden font-mono text-[11px] text-(--dim) sm:inline-flex"
-                      iconClassName="size-3"
-                    />
-                    {pr ? (
-                      <a
-                        href={pr}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
-                      >
-                        PR ↗
-                      </a>
-                    ) : null}
-                    <span className="ml-auto hidden font-mono text-[11px] text-(--mut) sm:inline">
-                      {fmtDuration(run.startedAt, run.endedAt)}
-                    </span>
-                    <span className="font-mono text-[11px] text-(--dim)">
-                      {fmtAgo(run.queuedAt)}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4">
-            <Eyebrow>spend · mtd</Eyebrow>
-            <div className="flex flex-col gap-3 border border-(--line) p-5">
-              <Metric
-                label="total"
-                value={spendSummary ? fmtCost(spendSummary.totalCents) : "—"}
-                hint="straight from the gateway"
-              />
-              {spendSummary?.groups.slice(0, 4).map((group) => (
-                <div key={group.key} className="flex justify-between gap-4 font-mono text-[12px]">
-                  <span className="truncate text-(--dim)">
-                    {agentNameById.get(group.key) ?? group.key}
-                  </span>
-                  <span className="text-(--code)">{fmtCost(group.cents)}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-          <div className="flex flex-col gap-4">
-            <Eyebrow>shipped</Eyebrow>
-            {shipped.length === 0 ? (
-              <p className="text-sm text-(--dim)">No terminal PRs recorded yet.</p>
-            ) : (
-              <div className="flex flex-col border border-(--line)">
-                {shipped.map((outcome) => (
-                  <a
-                    key={outcome.id}
-                    href={`https://github.com/${outcome.repo}/pull/${outcome.prNumber}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="flex items-center gap-3 border-b border-(--line) px-4 py-3 transition-colors last:border-b-0 hover:bg-(--card)"
-                  >
-                    <StatusDot tone={outcome.fate === "merged" ? "ok" : "machine"} />
-                    <span className="font-mono text-[11.5px] text-(--ink)">
-                      #{outcome.prNumber}
-                    </span>
-                    <span className="text-[12px] text-(--mut)">{outcome.fate ?? "open"}</span>
-                    {outcome.fate === "merged" && outcome.fixupCommits === 0 ? (
-                      <span
-                        className="border border-(--line) px-1.5 py-0.5 text-[10px] font-medium text-(--ok)"
-                        title="merged with zero fixup commits"
-                      >
-                        one-shot
-                      </span>
-                    ) : outcome.fixupCommits > 0 ? (
-                      <span className="font-mono text-[10px] text-(--dim)">
-                        {outcome.fixupCommits} fixup{outcome.fixupCommits === 1 ? "" : "s"}
-                      </span>
-                    ) : null}
-                    <span className="ml-auto font-mono text-[10px] text-(--dim)">
-                      {outcome.terminalAt ? fmtAgo(outcome.terminalAt) : ""}
-                    </span>
-                  </a>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
       </section>
     </div>
   );

--- a/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
@@ -7,8 +7,8 @@ import { ErrorNotice, Offline } from "@/components/offline";
 import { StageSection } from "@/components/project/stage-section";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api } from "@/lib/api";
-import type { PipelineStageKey, PipelineStageKind } from "@/lib/pipeline";
-import { pipelineStories } from "@/lib/pipeline";
+import type { PipelineStageKey, PipelineStageKind, PipelineStageState } from "@/lib/pipeline";
+import { pipelineStageStateLabel, pipelineStories } from "@/lib/pipeline";
 
 export const metadata = { title: "stories" };
 
@@ -35,9 +35,9 @@ export default async function ProjectStoriesPage({
   searchParams,
 }: {
   params: Promise<{ projectId: string }>;
-  searchParams: Promise<{ stage?: string }>;
+  searchParams: Promise<{ stage?: string; status?: string }>;
 }) {
-  const [{ projectId }, { stage }] = await Promise.all([params, searchParams]);
+  const [{ projectId }, { stage, status }] = await Promise.all([params, searchParams]);
   const [pipelineResult, me] = await Promise.all([api.pipeline(projectId), api.me()]);
 
   if (!pipelineResult.ok && pipelineResult.offline) return <Offline />;
@@ -50,12 +50,31 @@ export default async function ProjectStoriesPage({
   const activeStage =
     stage && stageKeys.has(stage as PipelineStageKey) ? (stage as PipelineStageKey) : null;
   const items = pipelineResult.ok ? pipelineStories(pipelineResult.data) : [];
+  const stageStates = new Set(items.map((story) => story.stageState));
+  const activeStatus =
+    activeStage && status && stageStates.has(status as PipelineStageState)
+      ? (status as PipelineStageState)
+      : null;
   const counts = [...stages].reverse();
   const activeOpenStoryCount = items.filter((story) => story.state === "open").length;
 
-  const visibleStages = activeStage
+  const stageFiltered = activeStage
     ? counts.filter((candidate) => candidate.key === activeStage)
     : counts;
+  const visibleStages = activeStatus
+    ? stageFiltered.map((candidate) => ({
+        ...candidate,
+        stories: candidate.stories.filter((story) => story.stageState === activeStatus),
+      }))
+    : stageFiltered;
+  const activeStatusLabel =
+    activeStage && activeStatus
+      ? pipelineStageStateLabel(
+          activeStage,
+          activeStatus,
+          visibleStages.reduce((total, candidate) => total + candidate.stories.length, 0),
+        )
+      : null;
 
   return (
     <div className="flex flex-col gap-8">
@@ -109,6 +128,21 @@ export default async function ProjectStoriesPage({
             </span>
           </Link>
         ))}
+        {activeStage && activeStatusLabel ? (
+          <>
+            <span className="font-mono text-[11px] text-(--dim)">/</span>
+            <span className="inline-flex items-center gap-2 border border-(--line-strong) px-3 py-1.5 text-[12px] font-medium text-(--ink)">
+              {activeStatusLabel}
+              <Link
+                href={`/projects/${projectId}/stories?stage=${activeStage}`}
+                aria-label="clear status filter"
+                className="text-(--dim) hover:text-(--ink)"
+              >
+                ×
+              </Link>
+            </span>
+          </>
+        ) : null}
       </div>
 
       {!pipelineResult.ok ? (

--- a/apps/web/components/issues/issue-row.tsx
+++ b/apps/web/components/issues/issue-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, StatusDot, toneFor } from "@facility/ui";
+import { Button, ButtonLink, StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -60,6 +60,110 @@ export function IssueRow({
   }
 
   const current = story.currentRun;
+  const openPull = story.prs.find((pull) => pull.state === "open") ?? null;
+  const failedAgent = current?.mode.includes("architect")
+    ? "architect"
+    : current?.mode.includes("builder")
+      ? "builder"
+      : null;
+
+  function action() {
+    if (story.stageState === "needs_review") {
+      return (
+        <ButtonLink size="sm" href={storyHref(projectId, story)}>
+          Review plan
+        </ButtonLink>
+      );
+    }
+    if (story.stageState === "ready_to_plan" && canTrigger && story.storyType === "issue") {
+      return (
+        <Button
+          size="sm"
+          variant="primary"
+          tone="agent"
+          disabled={busy !== null}
+          onClick={() => void trigger("architect")}
+        >
+          {busy === "architect" ? "queuing…" : "Plan"}
+        </Button>
+      );
+    }
+    if (story.stageState === "ready_to_build" && canTrigger && story.storyType === "issue") {
+      return (
+        <Button
+          size="sm"
+          variant="primary"
+          tone="agent"
+          disabled={busy !== null}
+          onClick={() => void trigger("builder")}
+        >
+          {busy === "builder" ? "queuing…" : "Build"}
+        </Button>
+      );
+    }
+    if (story.stageState === "failed" && failedAgent && canTrigger) {
+      return (
+        <Button
+          size="sm"
+          variant="danger"
+          disabled={busy !== null}
+          onClick={() => void trigger(failedAgent)}
+        >
+          {busy === failedAgent
+            ? "queuing…"
+            : failedAgent === "architect"
+              ? "Retry plan"
+              : "Retry build"}
+        </Button>
+      );
+    }
+    if (story.stageState === "draft_pr" && openPull) {
+      return (
+        <ButtonLink size="sm" href={openPull.url} target="_blank" rel="noreferrer">
+          Open draft ↗
+        </ButtonLink>
+      );
+    }
+    if (
+      (story.stageState === "checks_running" || story.stageState === "checks_failed") &&
+      story.ciUrl
+    ) {
+      return (
+        <ButtonLink
+          size="sm"
+          variant={story.stageState === "checks_failed" ? "danger" : "outline"}
+          href={story.ciUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {story.stageState === "checks_failed" ? "Inspect failure ↗" : "View checks ↗"}
+        </ButtonLink>
+      );
+    }
+    if (story.stageState === "awaiting_review" && openPull) {
+      return (
+        <ButtonLink size="sm" href={openPull.url} target="_blank" rel="noreferrer">
+          Review PR ↗
+        </ButtonLink>
+      );
+    }
+    if ((story.stageState === "in_progress" || story.stageState === "failed") && current) {
+      return (
+        <ButtonLink size="sm" href={`/projects/${projectId}/sessions/${current.id}`}>
+          View run
+        </ButtonLink>
+      );
+    }
+    if (story.stageState === "needs_attention") {
+      return (
+        <ButtonLink size="sm" variant="danger" href={storyHref(projectId, story)}>
+          Inspect
+        </ButtonLink>
+      );
+    }
+    return null;
+  }
+
   return (
     <div className="flex flex-col gap-2 border-b border-(--line) px-5 py-4 last:border-b-0">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
@@ -90,26 +194,7 @@ export function IssueRow({
           </span>
         ))}
         <span className="font-mono text-[10.5px] text-(--dim)">{fmtAgo(story.ghUpdatedAt)}</span>
-        {canTrigger && story.storyType === "issue" && story.state === "open" ? (
-          <div className="flex gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={busy !== null}
-              onClick={() => void trigger("architect")}
-            >
-              {busy === "architect" ? "queuing…" : "architect"}
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={busy !== null}
-              onClick={() => void trigger("builder")}
-            >
-              {busy === "builder" ? "queuing…" : "builder"}
-            </Button>
-          </div>
-        ) : null}
+        {action()}
       </div>
       {current || story.prs.length > 0 || story.ciState ? (
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-0 sm:pl-10">

--- a/apps/web/components/project/delivery-intelligence.tsx
+++ b/apps/web/components/project/delivery-intelligence.tsx
@@ -1,37 +1,16 @@
 import { Eyebrow, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import { AiIdentity } from "@/components/ai-identity";
-import { engineIdentity, modelIdentity, providerIdentity } from "@/lib/ai-identity";
+import { engineIdentity, modelProductLabel } from "@/lib/ai-identity";
 import type { DeliveryIntelligence as DeliveryData } from "@/lib/delivery-intelligence";
 import { fmtAgo, fmtCost } from "@/lib/runs";
 
-function Configuration({
-  engine,
-  provider,
-  model,
-  additionalModelCount,
-}: {
-  engine: string;
-  provider: string;
-  model: string;
-  additionalModelCount: number;
-}) {
+function Configuration({ engine, model }: { engine: string; model: string }) {
   return (
-    <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-(--dim)">
+    <span className="inline-flex min-w-0 items-center gap-1.5 text-[10.5px] text-(--dim)">
       <AiIdentity identity={engineIdentity(engine)} iconClassName="size-3" />
-      <span aria-hidden className="text-(--line-strong)">
-        ·
-      </span>
-      <AiIdentity identity={providerIdentity(provider)} iconClassName="size-3" />
-      <span aria-hidden className="text-(--line-strong)">
-        ·
-      </span>
-      <AiIdentity identity={modelIdentity(model)} iconClassName="size-3" />
-      {additionalModelCount > 0 ? (
-        <span>
-          +{additionalModelCount} {additionalModelCount === 1 ? "model" : "models"}
-        </span>
-      ) : null}
+      <span aria-hidden>–</span>
+      <span className="truncate">{modelProductLabel(model)}</span>
     </span>
   );
 }
@@ -74,7 +53,7 @@ export function DeliveryIntelligence({
           <div>
             <h2 className="text-[13px] font-semibold text-(--ink)">Spend by configuration</h2>
             <p className="mt-1 text-[11.5px] leading-relaxed text-(--dim)">
-              Gateway cost attributed to the agent, provider, and model that did the work.
+              Gateway cost attributed to the agent and model that did the work.
             </p>
           </div>
 
@@ -149,7 +128,7 @@ export function DeliveryIntelligence({
           <div className="border-b border-(--line) p-4 sm:p-5">
             <h2 className="text-[13px] font-semibold text-(--ink)">Recently shipped</h2>
             <p className="mt-1 text-[11.5px] leading-relaxed text-(--dim)">
-              The story, accountable person, producing agent, exact model path, and run cost.
+              The story, accountable person, producing agent and model, and run cost.
             </p>
           </div>
           {data.shippedRows.length === 0 ? (

--- a/apps/web/components/project/delivery-intelligence.tsx
+++ b/apps/web/components/project/delivery-intelligence.tsx
@@ -1,0 +1,237 @@
+import { Eyebrow, StatusDot } from "@facility/ui";
+import Link from "next/link";
+import { AiIdentity } from "@/components/ai-identity";
+import { engineIdentity, modelIdentity, providerIdentity } from "@/lib/ai-identity";
+import type { DeliveryIntelligence as DeliveryData } from "@/lib/delivery-intelligence";
+import { fmtAgo, fmtCost } from "@/lib/runs";
+
+function Configuration({
+  engine,
+  provider,
+  model,
+  additionalModelCount,
+}: {
+  engine: string;
+  provider: string;
+  model: string;
+  additionalModelCount: number;
+}) {
+  return (
+    <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-(--dim)">
+      <AiIdentity identity={engineIdentity(engine)} iconClassName="size-3" />
+      <span aria-hidden className="text-(--line-strong)">
+        ·
+      </span>
+      <AiIdentity identity={providerIdentity(provider)} iconClassName="size-3" />
+      <span aria-hidden className="text-(--line-strong)">
+        ·
+      </span>
+      <AiIdentity identity={modelIdentity(model)} iconClassName="size-3" />
+      {additionalModelCount > 0 ? (
+        <span>
+          +{additionalModelCount} {additionalModelCount === 1 ? "model" : "models"}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function SummaryMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1 border-l border-(--line) pl-3 first:border-l-0 first:pl-0 sm:pl-4">
+      <span className="eyebrow">{label}</span>
+      <span className="font-mono text-[18px] font-semibold tabular-nums text-(--ink) sm:text-[21px]">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function DeliveryIntelligence({
+  projectId,
+  data,
+}: {
+  projectId: string;
+  data: DeliveryData;
+}) {
+  const maxSpend = Math.max(...data.spendRows.map((row) => row.spendCents), 0);
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <Eyebrow>delivery · month to date</Eyebrow>
+          <span className="text-[11.5px] text-(--dim)">
+            compare agent configurations by cost and shipped work
+          </span>
+        </div>
+        <Link href="/analytics" className="text-[12px] font-medium text-(--mut) hover:text-(--ink)">
+          cost analytics →
+        </Link>
+      </div>
+
+      <div className="grid border border-(--line) lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <div className="flex min-w-0 flex-col gap-5 border-b border-(--line) p-4 sm:p-5 lg:border-r lg:border-b-0">
+          <div>
+            <h2 className="text-[13px] font-semibold text-(--ink)">Spend by configuration</h2>
+            <p className="mt-1 text-[11.5px] leading-relaxed text-(--dim)">
+              Gateway cost attributed to the agent, provider, and model that did the work.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <SummaryMetric label="spend" value={fmtCost(data.totalSpendCents)} />
+            <SummaryMetric label="shipped" value={String(data.shippedCount)} />
+            <SummaryMetric label="per ship" value={fmtCost(data.costPerShippedCents)} />
+          </div>
+
+          {data.spendRows.length === 0 ? (
+            <p className="border-t border-(--line) pt-4 text-[12px] text-(--dim)">
+              No metered model spend this month.
+            </p>
+          ) : (
+            <div
+              className="flex flex-col gap-4 border-t border-(--line) pt-4"
+              role="img"
+              aria-label="Month-to-date spend by agent configuration"
+            >
+              {data.spendRows.slice(0, 6).map((row) => (
+                <div key={row.key} className="flex flex-col gap-2">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                        {row.agentId ? (
+                          <Link
+                            href={`/projects/${projectId}/agents/${row.agentId}`}
+                            className="font-mono text-[11.5px] font-semibold text-(--ink) hover:text-(--accent)"
+                          >
+                            {row.agentName}
+                          </Link>
+                        ) : (
+                          <span className="font-mono text-[11.5px] font-semibold text-(--ink)">
+                            {row.agentName}
+                          </span>
+                        )}
+                        <span className="text-[10.5px] text-(--mut)">
+                          {row.shippedCount} shipped
+                          {row.costPerShippedCents !== null
+                            ? ` · ${fmtCost(row.costPerShippedCents)}/ship`
+                            : ""}
+                        </span>
+                      </div>
+                      <div className="mt-1">
+                        <Configuration {...row} />
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <div className="font-mono text-[12px] font-semibold tabular-nums text-(--code)">
+                        {fmtCost(row.spendCents)}
+                      </div>
+                      <div className="mt-0.5 font-mono text-[10px] text-(--dim)">
+                        {row.sharePercent}%
+                      </div>
+                    </div>
+                  </div>
+                  <div className="h-1.5 overflow-hidden bg-(--line)" aria-hidden="true">
+                    <div
+                      className="h-full bg-(--accent)"
+                      style={{
+                        width: `${maxSpend > 0 ? Math.max(2, (100 * row.spendCents) / maxSpend) : 0}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-col">
+          <div className="border-b border-(--line) p-4 sm:p-5">
+            <h2 className="text-[13px] font-semibold text-(--ink)">Recently shipped</h2>
+            <p className="mt-1 text-[11.5px] leading-relaxed text-(--dim)">
+              The story, accountable person, producing agent, exact model path, and run cost.
+            </p>
+          </div>
+          {data.shippedRows.length === 0 ? (
+            <p className="p-5 text-[12px] text-(--dim)">
+              No merged agent pull requests this month.
+            </p>
+          ) : (
+            <div className="flex flex-col">
+              {data.shippedRows.map((row) => (
+                <article
+                  key={row.outcomeId}
+                  className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 border-b border-(--line) px-4 py-3.5 last:border-b-0 hover:bg-(--card) sm:px-5"
+                >
+                  <StatusDot tone="ok" />
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                      <span className="shrink-0 font-mono text-[10.5px] text-(--dim)">
+                        {row.storyLabel}
+                      </span>
+                      {row.storyHref ? (
+                        <Link
+                          href={row.storyHref}
+                          className="break-words text-[12.5px] font-medium leading-snug text-(--ink) hover:text-(--accent)"
+                        >
+                          {row.storyTitle}
+                        </Link>
+                      ) : (
+                        <span className="break-words text-[12.5px] font-medium leading-snug text-(--ink)">
+                          {row.storyTitle}
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-(--mut)">
+                      <span>
+                        {row.assignees.length > 0
+                          ? `assigned ${row.assignees.map((assignee) => `@${assignee}`).join(", ")}`
+                          : "unassigned"}
+                      </span>
+                      <span aria-hidden className="text-(--line-strong)">
+                        ·
+                      </span>
+                      <span className="font-mono text-(--ink)">{row.agentName}</span>
+                      {row.oneShot ? (
+                        <span className="border border-(--line) px-1.5 py-0.5 text-[9.5px] font-medium text-(--ok)">
+                          one-shot
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="mt-1.5">
+                      <Configuration {...row} />
+                    </div>
+
+                    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10.5px]">
+                      <span className="font-semibold text-(--code)">
+                        cost {fmtCost(row.costCents)}
+                      </span>
+                      <span className="text-(--dim)">{fmtAgo(row.terminalAt)}</span>
+                      {row.runId ? (
+                        <Link
+                          href={`/projects/${projectId}/sessions/${row.runId}`}
+                          className="text-(--mut) hover:text-(--ink)"
+                        >
+                          inspect run →
+                        </Link>
+                      ) : null}
+                      <a
+                        href={row.pullHref}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-(--info) hover:underline"
+                      >
+                        PR #{row.pullNumber} ↗
+                      </a>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/project/in-flight-list.tsx
+++ b/apps/web/components/project/in-flight-list.tsx
@@ -1,0 +1,89 @@
+import { StatusDot, toneFor } from "@facility/ui";
+import Link from "next/link";
+import { AiIdentity } from "@/components/ai-identity";
+import { engineIdentity } from "@/lib/ai-identity";
+import type { InFlightRow } from "@/lib/in-flight";
+import { fmtDuration } from "@/lib/runs";
+
+export function InFlightList({
+  projectId,
+  rows,
+  total,
+}: {
+  projectId: string;
+  rows: InFlightRow[];
+  total: number;
+}) {
+  return (
+    <div className="flex flex-col border border-(--line)">
+      {rows.map((row) => (
+        <article
+          key={row.runId}
+          className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 border-b border-(--line) px-4 py-3.5 last:border-b-0 hover:bg-(--card) sm:px-5 lg:grid-cols-[auto_minmax(0,1fr)_auto] lg:items-center lg:gap-x-4"
+        >
+          <StatusDot tone={toneFor(row.runStatus)} pulse={row.runStatus === "running"} />
+
+          <div className="min-w-0">
+            {row.storyHref ? (
+              <Link
+                href={row.storyHref}
+                className="group flex flex-wrap items-baseline gap-x-2 gap-y-0.5"
+              >
+                <span className="shrink-0 font-mono text-[11px] text-(--dim) group-hover:text-(--mut)">
+                  {row.storyLabel}
+                </span>
+                <span className="break-words text-[13px] font-medium leading-snug text-(--ink) group-hover:text-(--accent)">
+                  {row.storyTitle}
+                </span>
+              </Link>
+            ) : (
+              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                <span className="font-mono text-[11px] text-(--dim)">{row.storyLabel}</span>
+                <span className="text-[13px] font-medium text-(--ink)">{row.storyTitle}</span>
+              </div>
+            )}
+
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11.5px]">
+              <span className="font-mono text-(--mut)">
+                {row.stageLabel} · {row.stateLabel.toLowerCase()}
+              </span>
+              <span aria-hidden className="text-(--line-strong)">
+                —
+              </span>
+              <span className="text-(--ink)">{row.activity}</span>
+            </div>
+          </div>
+
+          <div className="col-start-2 flex flex-wrap items-center gap-x-3 gap-y-1 lg:col-start-3 lg:row-start-1 lg:flex-nowrap lg:justify-end">
+            <span className="hidden font-mono text-[10.5px] text-(--dim) xl:inline">
+              {row.mode}
+            </span>
+            <AiIdentity
+              identity={engineIdentity(row.engine)}
+              className="hidden font-mono text-[10.5px] text-(--dim) sm:inline-flex"
+              iconClassName="size-3"
+            />
+            <span className="font-mono text-[10.5px] text-(--mut)">
+              {fmtDuration(row.startedAt, null)}
+            </span>
+            <Link
+              href={`/projects/${projectId}/sessions/${row.runId}`}
+              className="shrink-0 text-[11.5px] font-medium text-(--mut) hover:text-(--ink)"
+              aria-label={`Inspect the active session for ${row.storyLabel}`}
+            >
+              Inspect →
+            </Link>
+          </div>
+        </article>
+      ))}
+      {total > rows.length ? (
+        <Link
+          href={`/projects/${projectId}/sessions`}
+          className="px-5 py-3 text-[11.5px] text-(--dim) hover:text-(--ink)"
+        >
+          +{total - rows.length} more active {total - rows.length === 1 ? "session" : "sessions"} →
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/project/pipeline.tsx
+++ b/apps/web/components/project/pipeline.tsx
@@ -1,19 +1,6 @@
 import { cx, StatusDot } from "@facility/ui";
 import Link from "next/link";
-import type { ReactNode } from "react";
-import {
-  type PipelineStage,
-  type PipelineStageKind,
-  type PipelineStory,
-  storyHref,
-} from "@/lib/pipeline";
-
-const KIND_BORDER: Record<PipelineStageKind, string> = {
-  human: "border-t-(--human)",
-  agent: "border-t-(--line-strong)",
-  machine: "border-t-(--info)",
-  done: "border-t-(--ok)",
-};
+import { type PipelineStage, type PipelineStageKind, pipelineStageSummaries } from "@/lib/pipeline";
 
 const KIND_COUNT_TONE: Record<PipelineStageKind, string> = {
   human: "text-(--human)",
@@ -22,25 +9,11 @@ const KIND_COUNT_TONE: Record<PipelineStageKind, string> = {
   done: "text-(--ink)",
 };
 
-const KIND_DOT: Record<PipelineStageKind, (count: number) => ReactNode> = {
-  human: () => <StatusDot tone="human" />,
-  agent: (count) => <StatusDot tone={count > 0 ? "agent" : "machine"} pulse={count > 0} />,
-  machine: () => <StatusDot tone="machine" />,
-  done: () => <StatusDot tone="ok" />,
-};
-
 function countTone(kind: PipelineStageKind, count: number) {
   return count === 0 ? "text-(--dim)" : KIND_COUNT_TONE[kind];
 }
 
-/** The current run is the only run that explains a story's live placement. */
-export function RunStateDot({ story }: { story: PipelineStory }) {
-  if (story.runState === "failed") return <StatusDot tone="bad" />;
-  if (story.runState === "live") return <StatusDot tone="agent" pulse />;
-  return null;
-}
-
-/** The full board: one server-classified column per stage. */
+/** Durable lifecycle stages with actionable state queues inside each stage. */
 export function PipelineBoard({
   stages,
   projectId,
@@ -49,10 +22,11 @@ export function PipelineBoard({
   projectId?: string;
 }) {
   return (
-    <div className="grid grid-cols-2 border border-(--line) md:grid-cols-4 xl:grid-cols-7">
+    <div className="grid grid-cols-1 border border-(--line) sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
       {stages.map((stage) => {
+        const summaries = pipelineStageSummaries(stage);
         const header = (
-          <div className="flex flex-col gap-0.5">
+          <div className="flex flex-col gap-1">
             <div className="flex items-baseline gap-2">
               <span
                 className={cx(
@@ -62,19 +36,15 @@ export function PipelineBoard({
               >
                 {stage.count}
               </span>
-              <span className="text-[12px] font-medium text-(--ink)">{stage.label}</span>
-              {KIND_DOT[stage.kind](stage.count)}
+              <span className="text-[12.5px] font-semibold text-(--ink)">{stage.label}</span>
             </div>
-            <span className="text-[10.5px] leading-snug text-(--dim)">{stage.sub}</span>
+            <span className="text-[11px] leading-snug text-(--dim)">{stage.sub}</span>
           </div>
         );
         return (
           <div
             key={stage.key}
-            className={cx(
-              "-ml-px flex min-h-[132px] flex-col gap-3 border-l border-t-2 border-l-(--line) p-4",
-              KIND_BORDER[stage.kind],
-            )}
+            className="-ml-px -mt-px flex min-h-[174px] flex-col gap-4 border-l border-t border-(--line) p-4"
           >
             {projectId ? (
               <Link
@@ -86,44 +56,42 @@ export function PipelineBoard({
             ) : (
               header
             )}
-            <div className="flex flex-col gap-1.5">
-              {stage.stories.slice(0, 3).map((story) => (
-                <span key={story.key} className="flex min-w-0 items-center gap-1.5">
-                  <RunStateDot story={story} />
-                  {projectId ? (
-                    <Link
-                      href={storyHref(projectId, story)}
-                      className="min-w-0 truncate text-[11.5px] leading-snug text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
-                      title={story.title}
-                    >
-                      <span className="font-mono text-(--dim)">#{story.number}</span> {story.title}
-                    </Link>
-                  ) : (
-                    <a
-                      href={story.htmlUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="min-w-0 truncate text-[11.5px] leading-snug text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
-                      title={story.title}
-                    >
-                      <span className="font-mono text-(--dim)">#{story.number}</span> {story.title}
-                    </a>
-                  )}
-                  {story.ciState === "failure" && story.ciUrl ? (
-                    <a
-                      href={story.ciUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      aria-label="checks failed; open GitHub checks"
-                      className="shrink-0 font-mono text-[10px] text-(--bad) hover:underline"
-                    >
-                      <span aria-hidden="true">■</span> checks · failed
-                    </a>
-                  ) : null}
-                </span>
-              ))}
-              {stage.stories.length > 3 ? (
-                <span className="text-[10.5px] text-(--dim)">+{stage.stories.length - 3} more</span>
+            <div className="flex flex-col gap-1">
+              {summaries.map((summary) => {
+                const row = (
+                  <>
+                    <StatusDot
+                      tone={summary.tone}
+                      pulse={summary.state === "in_progress" || summary.state === "checks_running"}
+                    />
+                    <span className="w-6 text-right font-mono text-[12px] font-semibold text-(--ink)">
+                      {summary.count}
+                    </span>
+                    <span className="text-[11.5px] text-(--mut)">{summary.label}</span>
+                    {projectId ? (
+                      <span aria-hidden className="ml-auto text-[11px] text-(--dim)">
+                        →
+                      </span>
+                    ) : null}
+                  </>
+                );
+                return projectId ? (
+                  <Link
+                    key={summary.state}
+                    href={`/projects/${projectId}/stories?stage=${stage.key}&status=${summary.state}`}
+                    className="flex min-h-8 items-center gap-2 px-1 transition-colors hover:bg-(--card) hover:text-(--ink)"
+                    aria-label={`${summary.count} ${summary.label.toLowerCase()} in ${stage.label}`}
+                  >
+                    {row}
+                  </Link>
+                ) : (
+                  <div key={summary.state} className="flex min-h-8 items-center gap-2 px-1">
+                    {row}
+                  </div>
+                );
+              })}
+              {summaries.length === 0 ? (
+                <span className="px-1 py-2 text-[11.5px] text-(--dim)">Nothing here</span>
               ) : null}
             </div>
           </div>

--- a/apps/web/lib/ai-identity.test.ts
+++ b/apps/web/lib/ai-identity.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { engineIdentity, modelIdentity, providerIdentity } from "./ai-identity";
+import { engineIdentity, modelIdentity, modelProductLabel, providerIdentity } from "./ai-identity";
 
 describe("AI identity display", () => {
   it("humanizes known platform identifiers", () => {
@@ -32,6 +32,13 @@ describe("AI identity display", () => {
       brand: null,
       label: "local gateway",
     });
+  });
+
+  it("removes a redundant Claude prefix when the engine already carries the brand", () => {
+    expect(modelProductLabel("claude-opus-4-8")).toBe("Opus 4.8");
+    expect(modelProductLabel("claude-fable-5")).toBe("Fable 5");
+    expect(modelProductLabel("gpt-5.6-sol")).toBe("GPT-5.6 Sol");
+    expect(modelProductLabel("team_model-v2")).toBe("team_model-v2");
   });
 
   it("keeps the official vendor assets byte-identical", () => {

--- a/apps/web/lib/ai-identity.ts
+++ b/apps/web/lib/ai-identity.ts
@@ -39,6 +39,11 @@ export function modelIdentity(value: string): AiIdentity {
   return MODEL_IDENTITIES[value] ?? { brand: null, label: value };
 }
 
+/** Model name when its surrounding engine identity already communicates the Claude brand. */
+export function modelProductLabel(value: string): string {
+  return modelIdentity(value).label.replace(/^Claude /, "");
+}
+
 /** Known provider slugs get product names; custom provider names remain verbatim. */
 export function providerIdentity(value: string): AiIdentity {
   return PROVIDER_IDENTITIES[value] ?? { brand: null, label: value };

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -32,6 +32,8 @@ export type {
   KickstartAnswers,
   KickstartPreview,
   KickstartResult,
+  LlmRequest,
+  LlmRequestPage,
   Me,
   Member,
   MemberRow,
@@ -232,6 +234,8 @@ export const api = {
       query: { q, ...(type ? { type } : {}) } as never,
     }),
   spend: (params = "") => apiFetch("GET", "/v1/spend", { query: queryFromParams(params) }),
+  llmRequests: (params = "") =>
+    apiFetch("GET", "/v1/llm-requests", { query: queryFromParams(params) }),
   sandboxProfiles: () => apiFetch("GET", "/v1/sandbox-profiles"),
   members: () => apiFetch("GET", "/v1/members"),
   roles: () => apiFetch("GET", "/v1/roles"),

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -149,6 +149,8 @@ export const api = {
   run: (id: string) => apiFetch("GET", `/v1/runs/${id}`),
   runEvents: (id: string, afterSeq = 0, limit = 500) =>
     apiFetch("GET", `/v1/runs/${id}/events`, { query: { afterSeq, limit } }),
+  recentRunEvents: (id: string, tail = 20) =>
+    apiFetch("GET", `/v1/runs/${id}/events`, { query: { tail, limit: tail } }),
   // GET /v1/inbox returns { items, proposals, issues } — unwrap to the
   // proposals array both consumers expect (guarded so a bare array also works).
   inbox: async (): Promise<ApiResult<Proposal[]>> => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -41,6 +41,7 @@ export type {
   PipelineStage,
   PipelineStageKey,
   PipelineStageKind,
+  PipelineStageState,
   PipelineStory,
   Project,
   ProjectRepo,

--- a/apps/web/lib/delivery-intelligence.ts
+++ b/apps/web/lib/delivery-intelligence.ts
@@ -1,0 +1,293 @@
+import type {
+  AgentStatus,
+  Catalog,
+  LlmRequest,
+  Outcome,
+  Pipeline,
+  PipelineStory,
+  Run,
+  SpendRow,
+} from "./api";
+import { storyHref } from "./pipeline";
+
+export type AgentSpendRow = {
+  key: string;
+  agentId: string | null;
+  agentName: string;
+  engine: string;
+  provider: string;
+  model: string;
+  additionalModelCount: number;
+  spendCents: number;
+  sharePercent: number;
+  shippedCount: number;
+  costPerShippedCents: number | null;
+};
+
+export type ShippedDeliveryRow = {
+  outcomeId: string;
+  runId: string | null;
+  repo: string;
+  pullNumber: number;
+  pullHref: string;
+  storyHref: string | null;
+  storyLabel: string;
+  storyTitle: string;
+  assignees: string[];
+  agentName: string;
+  engine: string;
+  provider: string;
+  model: string;
+  additionalModelCount: number;
+  costCents: number | null;
+  terminalAt: string;
+  oneShot: boolean;
+};
+
+export type DeliveryIntelligence = {
+  totalSpendCents: number;
+  shippedCount: number;
+  costPerShippedCents: number | null;
+  spendRows: AgentSpendRow[];
+  shippedRows: ShippedDeliveryRow[];
+};
+
+type AgentConfiguration = {
+  agentName: string;
+  engine: string;
+  provider: string;
+  model: string;
+  additionalModelCount: number;
+};
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function configuredModel(value: unknown) {
+  const model = objectValue(value);
+  for (const key of ["model", "primary", "name"]) {
+    if (typeof model[key] === "string" && model[key]) return model[key];
+  }
+  return "default model";
+}
+
+function inferredProvider(model: string) {
+  if (model.startsWith("claude") || model.startsWith("opus") || model.startsWith("sonnet")) {
+    return "anthropic";
+  }
+  if (model.startsWith("gpt")) return "openai";
+  return "custom";
+}
+
+function receiptCost(run: Run | undefined) {
+  const receipt = objectValue(run?.receipt);
+  const usage = objectValue(receipt.usage);
+  return typeof usage.cost_cents === "number" ? usage.cost_cents : null;
+}
+
+function dominantConfiguration(
+  requests: LlmRequest[],
+): Pick<AgentConfiguration, "provider" | "model" | "additionalModelCount"> | null {
+  if (requests.length === 0) return null;
+  const costs = new Map<string, { provider: string; model: string; cents: number }>();
+  for (const request of requests) {
+    const key = `${request.provider}\0${request.model}`;
+    const row = costs.get(key) ?? { provider: request.provider, model: request.model, cents: 0 };
+    row.cents += request.costCents ?? 0;
+    costs.set(key, row);
+  }
+  const ordered = [...costs.values()].sort(
+    (left, right) => right.cents - left.cents || left.model.localeCompare(right.model),
+  );
+  const primary = ordered[0];
+  return primary
+    ? {
+        provider: primary.provider,
+        model: primary.model,
+        additionalModelCount: Math.max(0, ordered.length - 1),
+      }
+    : null;
+}
+
+function fallbackConfiguration(
+  agent: AgentStatus | undefined,
+  catalog: Catalog | null,
+): AgentConfiguration {
+  const model = agent ? configuredModel(agent.model) : "unknown model";
+  const provider = catalog?.models.find((candidate) => candidate.id === model)?.provider;
+  return {
+    agentName: agent?.name ?? "unattributed agent",
+    engine: agent?.engine ?? "unknown engine",
+    provider: provider ?? inferredProvider(model),
+    model,
+    additionalModelCount: 0,
+  };
+}
+
+function configurationFor(
+  agent: AgentStatus | undefined,
+  requests: LlmRequest[],
+  catalog: Catalog | null,
+) {
+  const fallback = fallbackConfiguration(agent, catalog);
+  return { ...fallback, ...(dominantConfiguration(requests) ?? {}) };
+}
+
+function storyForOutcome(outcome: Outcome, run: Run | undefined, stories: PipelineStory[]) {
+  const [owner, repoName] = outcome.repo.split("/");
+  const pullMatch = stories.find(
+    (story) =>
+      story.repoOwner === owner &&
+      story.repoName === repoName &&
+      story.prs.some((pull) => pull.number === outcome.prNumber),
+  );
+  if (pullMatch) return pullMatch;
+
+  const gh = objectValue(run?.gh);
+  const issueNumber = typeof gh.issueNumber === "number" ? gh.issueNumber : null;
+  if (issueNumber !== null) {
+    const issueMatch = stories.find(
+      (story) =>
+        story.repoOwner === owner && story.repoName === repoName && story.number === issueNumber,
+    );
+    if (issueMatch) return issueMatch;
+  }
+
+  return stories.find(
+    (story) =>
+      story.repoOwner === owner &&
+      story.repoName === repoName &&
+      story.storyType === "pull_request" &&
+      story.number === outcome.prNumber,
+  );
+}
+
+function isInPeriod(value: string | null, periodStart: string) {
+  return value !== null && new Date(value).getTime() >= new Date(periodStart).getTime();
+}
+
+/**
+ * Attribute spend and shipped outcomes to the exact agent configuration that produced them.
+ * Aggregate spend remains gateway-authoritative; request rows only supply provider/model identity.
+ */
+export function buildDeliveryIntelligence({
+  projectId,
+  periodStart,
+  spend,
+  agents,
+  runs,
+  outcomes,
+  requests,
+  pipeline,
+  catalog,
+}: {
+  projectId: string;
+  periodStart: string;
+  spend: SpendRow[];
+  agents: AgentStatus[];
+  runs: Run[];
+  outcomes: Outcome[];
+  requests: LlmRequest[];
+  pipeline: Pipeline | null;
+  catalog: Catalog | null;
+}): DeliveryIntelligence {
+  const agentsById = new Map(agents.map((agent) => [agent.agentId, agent]));
+  const runsById = new Map(runs.map((run) => [run.id, run]));
+  const requestsByAgent = new Map<string, LlmRequest[]>();
+  const requestsByRun = new Map<string, LlmRequest[]>();
+  for (const request of requests) {
+    if (request.agentDefId) {
+      const rows = requestsByAgent.get(request.agentDefId) ?? [];
+      rows.push(request);
+      requestsByAgent.set(request.agentDefId, rows);
+    }
+    if (request.runId) {
+      const rows = requestsByRun.get(request.runId) ?? [];
+      rows.push(request);
+      requestsByRun.set(request.runId, rows);
+    }
+  }
+
+  const mergedOutcomes = outcomes.filter(
+    (outcome) => outcome.fate === "merged" && isInPeriod(outcome.terminalAt, periodStart),
+  );
+  const shippedByAgent = new Map<string, number>();
+  for (const outcome of mergedOutcomes) {
+    const agentId = outcome.runId ? runsById.get(outcome.runId)?.agentDefId : null;
+    if (agentId) shippedByAgent.set(agentId, (shippedByAgent.get(agentId) ?? 0) + 1);
+  }
+
+  const totalSpendCents = spend.reduce((total, row) => total + row.cost_cents, 0);
+  const spendRows = spend
+    .filter((row) => row.cost_cents > 0)
+    .map((row): AgentSpendRow => {
+      const agentId = row.bucket === "none" ? null : row.bucket;
+      const configuration = configurationFor(
+        agentId ? agentsById.get(agentId) : undefined,
+        agentId ? (requestsByAgent.get(agentId) ?? []) : [],
+        catalog,
+      );
+      const shippedCount = agentId ? (shippedByAgent.get(agentId) ?? 0) : 0;
+      return {
+        key: row.bucket,
+        agentId,
+        ...configuration,
+        spendCents: row.cost_cents,
+        sharePercent:
+          totalSpendCents > 0 ? Math.round((1000 * row.cost_cents) / totalSpendCents) / 10 : 0,
+        shippedCount,
+        costPerShippedCents: shippedCount > 0 ? Math.round(row.cost_cents / shippedCount) : null,
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.spendCents - left.spendCents || left.agentName.localeCompare(right.agentName),
+    );
+
+  const stories = (pipeline?.stages ?? []).flatMap((stage) => stage.stories);
+  const shippedRows = mergedOutcomes
+    .map((outcome): ShippedDeliveryRow | null => {
+      if (!outcome.terminalAt) return null;
+      const run = outcome.runId ? runsById.get(outcome.runId) : undefined;
+      const agent = run?.agentDefId ? agentsById.get(run.agentDefId) : undefined;
+      const runRequests = outcome.runId ? (requestsByRun.get(outcome.runId) ?? []) : [];
+      const configuration = configurationFor(agent, runRequests, catalog);
+      const story = storyForOutcome(outcome, run, stories);
+      const requestCost = runRequests.reduce(
+        (total, request) => total + (request.costCents ?? 0),
+        0,
+      );
+      return {
+        outcomeId: outcome.id,
+        runId: outcome.runId,
+        repo: outcome.repo,
+        pullNumber: outcome.prNumber,
+        pullHref: `https://github.com/${outcome.repo}/pull/${outcome.prNumber}`,
+        storyHref: story ? storyHref(projectId, story) : null,
+        storyLabel: story
+          ? `${story.repoOwner}/${story.repoName}#${story.number}`
+          : `${outcome.repo} PR #${outcome.prNumber}`,
+        storyTitle: story?.title ?? `Pull request #${outcome.prNumber}`,
+        assignees: story?.assignees ?? [],
+        ...configuration,
+        costCents: receiptCost(run) ?? (runRequests.length > 0 ? Math.round(requestCost) : null),
+        terminalAt: outcome.terminalAt,
+        oneShot: outcome.reviewRounds === 0 && outcome.fixupCommits === 0,
+      };
+    })
+    .filter((row): row is ShippedDeliveryRow => row !== null)
+    .sort((left, right) => right.terminalAt.localeCompare(left.terminalAt))
+    .slice(0, 6);
+
+  return {
+    totalSpendCents,
+    shippedCount: mergedOutcomes.length,
+    costPerShippedCents:
+      mergedOutcomes.length > 0 ? Math.round(totalSpendCents / mergedOutcomes.length) : null,
+    spendRows,
+    shippedRows,
+  };
+}

--- a/apps/web/lib/in-flight.ts
+++ b/apps/web/lib/in-flight.ts
@@ -1,0 +1,197 @@
+import type { Pipeline, PipelineStageKey, PipelineStory, Run, RunEvent } from "./api";
+import { pipelineStageStateLabel, storyHref } from "./pipeline";
+
+export type InFlightRow = {
+  runId: string;
+  runStatus: string;
+  mode: string;
+  engine: string;
+  startedAt: string | null;
+  storyHref: string | null;
+  storyLabel: string;
+  storyTitle: string;
+  stageLabel: string;
+  stateLabel: string;
+  activity: string;
+};
+
+const IGNORED_ACTIVITY_EVENTS = new Set(["assistant", "engine", "heartbeat", "queued"]);
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(data: Record<string, unknown>, ...keys: string[]) {
+  for (const key of keys) {
+    const value = data[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function compactText(value: string, max = 120) {
+  const firstUsefulLine = value
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line && !line.startsWith("<!--"));
+  const text = (firstUsefulLine ?? value)
+    .replace(/^[-*#>\s]+/, "")
+    .replaceAll("`", "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+}
+
+function humanize(value: string) {
+  return value.replaceAll("_", " ").replaceAll("-", " ");
+}
+
+function phaseActivity(name: string) {
+  if (["bootstrap", "package_install", "provision", "runner_runtime", "workspace"].includes(name)) {
+    return "Preparing workspace";
+  }
+  if (name === "acceptance" || name === "checks" || name === "tests") {
+    return "Running acceptance checks";
+  }
+  if (name === "delivery") return "Preparing the pull request";
+  if (name === "planning") return "Drafting the implementation plan";
+  if (name === "implementation") return "Implementing the change";
+  return humanize(name);
+}
+
+function activityForEvent(event: RunEvent) {
+  if (IGNORED_ACTIVITY_EVENTS.has(event.type.toLowerCase())) return null;
+  const data = objectValue(event.data);
+
+  if (event.type === "agent_progress") {
+    const progress = stringValue(data, "markdown", "text", "message");
+    return progress ? compactText(progress) : null;
+  }
+  if (event.type === "phase") {
+    const phase = stringValue(data, "name", "phase");
+    return phase ? phaseActivity(phase) : null;
+  }
+  if (event.type === "check") {
+    const check = stringValue(data, "name", "command", "text", "message") ?? "acceptance checks";
+    const status = stringValue(data, "status", "result");
+    if (["ok", "passed", "success", "succeeded"].includes(status ?? "")) {
+      return compactText(`${check} passed`);
+    }
+    if (["error", "failed", "failure"].includes(status ?? "")) {
+      return compactText(`${check} failed`);
+    }
+    return compactText(`Running check · ${check}`);
+  }
+  if (event.type === "shell") {
+    const command = stringValue(data, "command", "text", "message");
+    return command ? compactText(`Running · ${command}`) : null;
+  }
+  if (event.type === "tool") {
+    const tool = stringValue(data, "name", "tool", "command", "text");
+    return tool ? compactText(`Using ${tool}`) : null;
+  }
+  if (event.type === "provisioning") return "Preparing workspace";
+
+  const text = stringValue(data, "text", "message", "phase", "name");
+  return text ? compactText(text) : null;
+}
+
+function fallbackActivity(mode: string, status: string) {
+  if (status === "queued") return "Waiting for an available runner";
+  if (status === "provisioning") return "Preparing workspace";
+  if (mode === "architect" || mode.endsWith("-architect")) {
+    return "Drafting the implementation plan";
+  }
+  if (mode === "builder" || mode.endsWith("-builder")) return "Implementing the accepted plan";
+  if (mode === "review") return "Reviewing the proposed change";
+  if (mode === "address_review") return "Addressing review feedback";
+  if (mode === "ci_doctor") return "Diagnosing failed checks";
+  if (mode === "security_sweep") return "Reviewing security findings";
+  return "Working on the session objective";
+}
+
+export function latestRunActivity(mode: string, status: string, events: RunEvent[]) {
+  const ordered = [...events].sort((left, right) => right.seq - left.seq);
+  for (const event of ordered) {
+    const activity = activityForEvent(event);
+    if (activity) return activity;
+  }
+  return fallbackActivity(mode, status);
+}
+
+function githubIdentity(run: Run) {
+  const gh = objectValue(run.gh);
+  return {
+    number: typeof gh.issueNumber === "number" ? gh.issueNumber : null,
+    owner: typeof gh.owner === "string" ? gh.owner : null,
+    repo: typeof gh.repo === "string" ? gh.repo : null,
+  };
+}
+
+function storyForRun(
+  run: Run,
+  storiesByRun: Map<
+    string,
+    { story: PipelineStory; stageKey: PipelineStageKey; stageLabel: string }
+  >,
+  stories: Array<{ story: PipelineStory; stageKey: PipelineStageKey; stageLabel: string }>,
+) {
+  const exact = storiesByRun.get(run.id);
+  if (exact) return exact;
+
+  const identity = githubIdentity(run);
+  if (identity.number === null) return null;
+  return (
+    stories.find(
+      ({ story }) =>
+        story.number === identity.number &&
+        (!identity.owner || story.repoOwner === identity.owner) &&
+        (!identity.repo || story.repoName === identity.repo),
+    ) ?? null
+  );
+}
+
+/** Join runtime sessions to the durable story model used everywhere else on the overview. */
+export function buildInFlightRows({
+  projectId,
+  runs,
+  pipeline,
+  eventsByRun,
+}: {
+  projectId: string;
+  runs: Run[];
+  pipeline: Pipeline | null;
+  eventsByRun: Map<string, RunEvent[]>;
+}): InFlightRow[] {
+  const stories = (pipeline?.stages ?? []).flatMap((stage) =>
+    stage.stories.map((story) => ({ story, stageKey: stage.key, stageLabel: stage.label })),
+  );
+  const storiesByRun = new Map(
+    stories.flatMap((entry) =>
+      entry.story.currentRun?.id ? ([[entry.story.currentRun.id, entry]] as const) : [],
+    ),
+  );
+
+  return runs.map((run) => {
+    const match = storyForRun(run, storiesByRun, stories);
+    return {
+      runId: run.id,
+      runStatus: run.status,
+      mode: humanize(run.mode),
+      engine: run.engine,
+      startedAt: run.startedAt,
+      storyHref: match ? storyHref(projectId, match.story) : null,
+      storyLabel: match
+        ? `${match.story.repoOwner}/${match.story.repoName}#${match.story.number}`
+        : `session ${run.id.slice(-8)}`,
+      storyTitle: match?.story.title ?? "No linked story",
+      stageLabel: match?.stageLabel ?? "Session",
+      stateLabel: match
+        ? pipelineStageStateLabel(match.stageKey, match.story.stageState, 1)
+        : humanize(run.status),
+      activity: latestRunActivity(run.mode, run.status, eventsByRun.get(run.id) ?? []),
+    };
+  });
+}

--- a/apps/web/lib/pipeline.ts
+++ b/apps/web/lib/pipeline.ts
@@ -1,12 +1,96 @@
-import type { Pipeline, PipelineStory } from "./api";
+import type {
+  Pipeline,
+  PipelineStage,
+  PipelineStageKey,
+  PipelineStageState,
+  PipelineStory,
+} from "./api";
 
 export type {
   Pipeline,
   PipelineStage,
   PipelineStageKey,
   PipelineStageKind,
+  PipelineStageState,
   PipelineStory,
 } from "./api";
+
+export type PipelineStatusTone = "human" | "agent" | "machine" | "bad" | "ok";
+
+const STATUS_ORDER: Record<PipelineStageKey, PipelineStageState[]> = {
+  backlog: ["needs_attention", "ready_to_plan"],
+  planning: ["in_progress", "needs_review", "ready_to_build", "failed"],
+  building: ["in_progress", "draft_pr", "failed"],
+  validating: ["checks_running", "checks_failed"],
+  review: ["in_progress", "awaiting_review", "failed"],
+  shipped: ["shipped_recently"],
+};
+
+const STATUS_TONE: Record<PipelineStageState, PipelineStatusTone> = {
+  ready_to_plan: "human",
+  needs_attention: "bad",
+  in_progress: "agent",
+  needs_review: "human",
+  ready_to_build: "agent",
+  failed: "bad",
+  draft_pr: "machine",
+  checks_running: "machine",
+  checks_failed: "bad",
+  awaiting_review: "human",
+  shipped_recently: "ok",
+};
+
+export function pipelineStageStateLabel(
+  stage: PipelineStageKey,
+  state: PipelineStageState,
+  count: number,
+) {
+  switch (state) {
+    case "ready_to_plan":
+      return "Ready to plan";
+    case "needs_attention":
+      return "Need attention";
+    case "in_progress":
+      return "In progress";
+    case "needs_review":
+      return "Need plan review";
+    case "ready_to_build":
+      return "Ready to build";
+    case "failed":
+      if (stage === "planning") return count === 1 ? "Plan failed" : "Plans failed";
+      if (stage === "building") return count === 1 ? "Build failed" : "Builds failed";
+      return count === 1 ? "Review failed" : "Reviews failed";
+    case "draft_pr":
+      return count === 1 ? "Draft PR" : "Draft PRs";
+    case "checks_running":
+      return "Checks running";
+    case "checks_failed":
+      return "Checks failed";
+    case "awaiting_review":
+      return "Awaiting your review";
+    case "shipped_recently":
+      return "Shipped this week";
+  }
+}
+
+export function pipelineStageStateTone(state: PipelineStageState) {
+  return STATUS_TONE[state];
+}
+
+export function pipelineStageSummaries(stage: PipelineStage) {
+  const countByState = new Map<PipelineStageState, number>();
+  for (const story of stage.stories) {
+    countByState.set(story.stageState, (countByState.get(story.stageState) ?? 0) + 1);
+  }
+  return STATUS_ORDER[stage.key]
+    .map((state) => ({
+      state,
+      count: countByState.get(state) ?? 0,
+      label: pipelineStageStateLabel(stage.key, state, countByState.get(state) ?? 0),
+      tone: pipelineStageStateTone(state),
+    }))
+    .filter((summary) => summary.count > 0);
+}
 
 /** Stable story identity for projects that mirror more than one repository. */
 function storyQuery(story: Pick<PipelineStory, "repoId" | "storyType">) {

--- a/apps/web/lib/story.ts
+++ b/apps/web/lib/story.ts
@@ -10,7 +10,6 @@ export type StoryPr = StoryGithubActivity["prs"][number];
 const TIMELINE_STAGES: Record<PipelineStageKey, PipelineStageKey> = {
   backlog: "backlog",
   planning: "planning",
-  ready: "ready",
   building: "building",
   validating: "validating",
   review: "review",
@@ -81,7 +80,7 @@ function stageEntered(item: StoryItem): PipelineStageKey | null {
       return null;
     }
     case "proposal":
-      return item.proposal.actionType === "plan_acceptance" ? TIMELINE_STAGES.ready : null;
+      return item.proposal.actionType === "plan_acceptance" ? TIMELINE_STAGES.planning : null;
     case "pr_opened":
       if (item.pr.draft) return TIMELINE_STAGES.building;
       return item.pr.ciState === "pending" ? TIMELINE_STAGES.validating : TIMELINE_STAGES.review;

--- a/apps/web/test/delivery-intelligence.test.ts
+++ b/apps/web/test/delivery-intelligence.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { AgentStatus, Catalog, LlmRequest, Outcome, Pipeline, Run, SpendRow } from "@/lib/api";
+import { buildDeliveryIntelligence } from "@/lib/delivery-intelligence";
+
+const periodStart = "2026-08-01T00:00:00.000Z";
+
+const agents = [
+  {
+    agentId: "agent_builder",
+    name: "builder",
+    engine: "codex",
+    model: { primary: "gpt-5.6-sol" },
+  },
+  {
+    agentId: "agent_architect",
+    name: "architect",
+    engine: "claude_code",
+    model: { model: "claude-opus-4-8" },
+  },
+] as unknown as AgentStatus[];
+
+const runs = [
+  {
+    id: "run_builder",
+    agentDefId: "agent_builder",
+    engine: "codex",
+    gh: { owner: "theam", repo: "tam-os", issueNumber: 1092 },
+    receipt: { usage: { cost_cents: 384 } },
+  },
+] as unknown as Run[];
+
+const pipeline = {
+  stages: [
+    {
+      key: "shipped",
+      label: "Shipped",
+      stories: [
+        {
+          repoId: "repo_tam_os",
+          repoOwner: "theam",
+          repoName: "tam-os",
+          storyType: "issue",
+          number: 1092,
+          title: "External share: one polymorphic core for every resource",
+          assignees: ["adrian-lorenzo"],
+          prs: [
+            {
+              number: 1102,
+              url: "https://github.com/theam/tam-os/pull/1102",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} as unknown as Pipeline;
+
+const outcome = {
+  id: "outcome_1102",
+  runId: "run_builder",
+  projectId: "proj_tam_os",
+  repo: "theam/tam-os",
+  prNumber: 1102,
+  agentLane: "builder",
+  terminalAt: "2026-08-11T18:00:00.000Z",
+  fate: "merged",
+  reviewRounds: 0,
+  fixupCommits: 0,
+} as unknown as Outcome;
+
+const requests = [
+  {
+    id: "llm_1",
+    runId: "run_builder",
+    agentDefId: "agent_builder",
+    provider: "openai",
+    model: "gpt-5.6-sol",
+    costCents: 300,
+    createdAt: "2026-08-11T17:00:00.000Z",
+  },
+  {
+    id: "llm_2",
+    runId: "run_builder",
+    agentDefId: "agent_builder",
+    provider: "openai",
+    model: "gpt-5.6-terra",
+    costCents: 84,
+    createdAt: "2026-08-11T17:30:00.000Z",
+  },
+] as unknown as LlmRequest[];
+
+describe("delivery intelligence", () => {
+  it("compares gateway spend using agent, engine, provider, model, and shipped yield", () => {
+    const result = buildDeliveryIntelligence({
+      projectId: "proj_tam_os",
+      periodStart,
+      spend: [
+        { bucket: "agent_builder", cost_cents: 1200 },
+        { bucket: "agent_architect", cost_cents: 800 },
+      ] as SpendRow[],
+      agents,
+      runs,
+      outcomes: [outcome],
+      requests,
+      pipeline,
+      catalog: { models: [] } as unknown as Catalog,
+    });
+
+    expect(result).toMatchObject({
+      totalSpendCents: 2000,
+      shippedCount: 1,
+      costPerShippedCents: 2000,
+    });
+    expect(result.spendRows[0]).toMatchObject({
+      agentName: "builder",
+      engine: "codex",
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      additionalModelCount: 1,
+      spendCents: 1200,
+      sharePercent: 60,
+      shippedCount: 1,
+      costPerShippedCents: 1200,
+    });
+    expect(result.spendRows[1]).toMatchObject({
+      agentName: "architect",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      shippedCount: 0,
+      costPerShippedCents: null,
+    });
+  });
+
+  it("makes shipped work identifiable and auditable without reducing it to a PR number", () => {
+    const result = buildDeliveryIntelligence({
+      projectId: "proj_tam_os",
+      periodStart,
+      spend: [{ bucket: "agent_builder", cost_cents: 384 }] as SpendRow[],
+      agents,
+      runs,
+      outcomes: [outcome],
+      requests,
+      pipeline,
+      catalog: null,
+    });
+
+    expect(result.shippedRows).toEqual([
+      expect.objectContaining({
+        storyLabel: "theam/tam-os#1092",
+        storyTitle: "External share: one polymorphic core for every resource",
+        storyHref: "/projects/proj_tam_os/stories/1092?repoId=repo_tam_os&storyType=issue",
+        assignees: ["adrian-lorenzo"],
+        agentName: "builder",
+        engine: "codex",
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        additionalModelCount: 1,
+        costCents: 384,
+        pullHref: "https://github.com/theam/tam-os/pull/1102",
+        oneShot: true,
+      }),
+    ]);
+  });
+
+  it("does not report closed but unmerged pull requests as shipped", () => {
+    const result = buildDeliveryIntelligence({
+      projectId: "proj_tam_os",
+      periodStart,
+      spend: [],
+      agents,
+      runs,
+      outcomes: [{ ...outcome, fate: "closed" } as unknown as Outcome],
+      requests,
+      pipeline,
+      catalog: null,
+    });
+
+    expect(result.shippedCount).toBe(0);
+    expect(result.shippedRows).toEqual([]);
+  });
+});

--- a/apps/web/test/in-flight.test.ts
+++ b/apps/web/test/in-flight.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { Pipeline, Run, RunEvent } from "@/lib/api";
+import { buildInFlightRows, latestRunActivity } from "@/lib/in-flight";
+
+const run = {
+  id: "run_1109",
+  status: "running",
+  mode: "architect",
+  engine: "codex",
+  startedAt: "2026-08-12T10:00:00.000Z",
+  gh: { owner: "theam", repo: "tam-os", issueNumber: 1109 },
+} as unknown as Run;
+
+const pipeline = {
+  stages: [
+    {
+      key: "planning",
+      label: "Planning",
+      sub: "shape the approach",
+      kind: "agent",
+      count: 1,
+      stories: [
+        {
+          number: 1109,
+          repoId: "repo_tam_os",
+          repoOwner: "theam",
+          repoName: "tam-os",
+          storyType: "issue",
+          title: "Hiring chat fallback: narrow the grounding it hands the retry",
+          stageState: "in_progress",
+          currentRun: { id: "run_1109", mode: "architect", status: "running", engine: "codex" },
+        },
+      ],
+    },
+  ],
+} as Pipeline;
+
+describe("in-flight rows", () => {
+  it("makes the story, lifecycle state, and latest activity the run identity", () => {
+    const progress = {
+      runId: run.id,
+      seq: 4,
+      type: "agent_progress",
+      data: { markdown: "Inspecting retry grounding and tracing fallback inputs" },
+    } as unknown as RunEvent;
+
+    expect(
+      buildInFlightRows({
+        projectId: "proj_tam_os",
+        runs: [run],
+        pipeline,
+        eventsByRun: new Map([[run.id, [progress]]]),
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        storyLabel: "theam/tam-os#1109",
+        storyTitle: "Hiring chat fallback: narrow the grounding it hands the retry",
+        storyHref: "/projects/proj_tam_os/stories/1109?repoId=repo_tam_os&storyType=issue",
+        stageLabel: "Planning",
+        stateLabel: "In progress",
+        activity: "Inspecting retry grounding and tracing fallback inputs",
+      }),
+    ]);
+  });
+
+  it("uses a role-specific activity when a live run has not emitted progress yet", () => {
+    expect(latestRunActivity("builder", "running", [])).toBe("Implementing the accepted plan");
+    expect(latestRunActivity("architect", "provisioning", [])).toBe("Preparing workspace");
+  });
+
+  it("ignores noisy heartbeats and translates execution phases", () => {
+    const events = [
+      { seq: 9, type: "heartbeat", data: { status: "alive" } },
+      { seq: 8, type: "phase", data: { name: "acceptance" } },
+    ] as unknown as RunEvent[];
+
+    expect(latestRunActivity("builder", "running", events)).toBe("Running acceptance checks");
+  });
+});

--- a/apps/web/test/pipeline-story.test.ts
+++ b/apps/web/test/pipeline-story.test.ts
@@ -256,7 +256,6 @@ function storyDetail(): StoryDetail {
     pipelineStages: [
       { key: "backlog", label: "Backlog" },
       { key: "planning", label: "Planning" },
-      { key: "ready", label: "Ready" },
       { key: "building", label: "Building" },
       { key: "validating", label: "Validating" },
       { key: "review", label: "In review" },

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11602,7 +11602,6 @@
                             "enum": [
                               "backlog",
                               "planning",
-                              "ready",
                               "building",
                               "validating",
                               "review",
@@ -11710,6 +11709,22 @@
                                   "nullable": true,
                                   "type": "string",
                                   "format": "date-time"
+                                },
+                                "stageState": {
+                                  "type": "string",
+                                  "enum": [
+                                    "ready_to_plan",
+                                    "needs_attention",
+                                    "in_progress",
+                                    "needs_review",
+                                    "ready_to_build",
+                                    "failed",
+                                    "draft_pr",
+                                    "checks_running",
+                                    "checks_failed",
+                                    "awaiting_review",
+                                    "shipped_recently"
+                                  ]
                                 },
                                 "runState": {
                                   "nullable": true,
@@ -11856,6 +11871,7 @@
                                 "ghCreatedAt",
                                 "ghUpdatedAt",
                                 "closedAt",
+                                "stageState",
                                 "runState",
                                 "currentRun",
                                 "attemptCount",
@@ -12484,7 +12500,6 @@
                           "enum": [
                             "backlog",
                             "planning",
-                            "ready",
                             "building",
                             "validating",
                             "review",
@@ -12511,7 +12526,6 @@
                             "enum": [
                               "backlog",
                               "planning",
-                              "ready",
                               "building",
                               "validating",
                               "review",

--- a/packages/sdk/src/contracts.ts
+++ b/packages/sdk/src/contracts.ts
@@ -235,6 +235,7 @@ export type PipelineStage = ArrayItem<Pipeline["stages"]>;
 export type PipelineStageKey = PipelineStage["key"];
 export type PipelineStageKind = PipelineStage["kind"];
 export type PipelineStory = ArrayItem<PipelineStage["stories"]>;
+export type PipelineStageState = PipelineStory["stageState"];
 export type PipelinePullRequest = ArrayItem<PipelineStory["prs"]>;
 export type StoryDetail = FacilityGeneratedResponse<
   "GET",

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -8882,7 +8882,7 @@ export interface operations {
                     "application/json": {
                         stages: {
                             /** @enum {string} */
-                            key: "backlog" | "planning" | "ready" | "building" | "validating" | "review" | "shipped";
+                            key: "backlog" | "planning" | "building" | "validating" | "review" | "shipped";
                             label: string;
                             sub: string;
                             /** @enum {string} */
@@ -8911,6 +8911,8 @@ export interface operations {
                                 ghUpdatedAt: string | null;
                                 /** Format: date-time */
                                 closedAt: string | null;
+                                /** @enum {string} */
+                                stageState: "ready_to_plan" | "needs_attention" | "in_progress" | "needs_review" | "ready_to_build" | "failed" | "draft_pr" | "checks_running" | "checks_failed" | "awaiting_review" | "shipped_recently";
                                 /** @enum {string|null} */
                                 runState: "live" | "failed" | null;
                                 currentRun: {
@@ -9220,12 +9222,12 @@ export interface operations {
                         }[];
                         stage: {
                             /** @enum {string} */
-                            key: "backlog" | "planning" | "ready" | "building" | "validating" | "review" | "shipped";
+                            key: "backlog" | "planning" | "building" | "validating" | "review" | "shipped";
                             label: string;
                         } | null;
                         pipelineStages: {
                             /** @enum {string} */
-                            key: "backlog" | "planning" | "ready" | "building" | "validating" | "review" | "shipped";
+                            key: "backlog" | "planning" | "building" | "validating" | "review" | "shipped";
                             label: string;
                         }[];
                         allowLegacyProposalNumber: boolean;

--- a/services/api/src/assistant/tools.ts
+++ b/services/api/src/assistant/tools.ts
@@ -29,7 +29,7 @@ export const ASSISTANT_TOOLS: AssistantTool[] = [
   {
     name: "get_pipeline",
     description:
-      "The project's delivery pipeline: repository-qualified stories grouped by stage (Backlog → Planning → Ready → Building → Validating → In review → Shipped) with current runs, mirrored PRs, aggregate CI and human gates. Use this for 'what is in flight / where is X'.",
+      "The project's delivery pipeline: repository-qualified stories grouped by durable stage (Backlog → Planning → Building → Validating → In review → Shipped), with an actionable state inside each stage, current runs, mirrored PRs, CI, and human gates. Use this for 'what is in flight / where is X / what needs action'.",
     inputSchema: NO_ARGS,
     toRequest: (_a, ctx) => ({ method: "GET", path: `/v1/projects/${ctx.projectId}/pipeline` }),
   },

--- a/services/api/src/pipeline.ts
+++ b/services/api/src/pipeline.ts
@@ -3,21 +3,32 @@
 export type PipelineStage =
   | "backlog"
   | "planning"
-  | "ready"
   | "building"
   | "validating"
   | "review"
   | "shipped";
 
+export type PipelineStageState =
+  | "ready_to_plan"
+  | "needs_attention"
+  | "in_progress"
+  | "needs_review"
+  | "ready_to_build"
+  | "failed"
+  | "draft_pr"
+  | "checks_running"
+  | "checks_failed"
+  | "awaiting_review"
+  | "shipped_recently";
+
 export type StageKind = "human" | "agent" | "machine" | "done";
 
 export const PIPELINE_STAGES = [
-  { key: "backlog", label: "Backlog", sub: "yours — pick up & launch", kind: "human" },
-  { key: "planning", label: "Planning", sub: "architect drafts the plan", kind: "agent" },
-  { key: "ready", label: "Ready", sub: "yours — review the plan", kind: "human" },
-  { key: "building", label: "Building", sub: "builder implements the plan", kind: "agent" },
-  { key: "validating", label: "Validating", sub: "machines check the PR", kind: "machine" },
-  { key: "review", label: "In review", sub: "yours — review the PR & iterate", kind: "human" },
+  { key: "backlog", label: "Backlog", sub: "work not started", kind: "human" },
+  { key: "planning", label: "Planning", sub: "shape the approach", kind: "agent" },
+  { key: "building", label: "Building", sub: "implement the plan", kind: "agent" },
+  { key: "validating", label: "Validating", sub: "run the checks", kind: "machine" },
+  { key: "review", label: "In review", sub: "review and merge", kind: "human" },
   { key: "shipped", label: "Shipped", sub: "merged · last 7 days", kind: "done" },
 ] as const satisfies ReadonlyArray<{
   key: PipelineStage;
@@ -72,6 +83,7 @@ export type PipelineStoryInput = {
 };
 
 export type PlacedPipelineStory = Omit<PipelineStoryInput, "linkedRuns"> & {
+  stageState: PipelineStageState;
   runState: "live" | "failed" | null;
   currentRun: { id: string; mode: string; status: string; engine: string } | null;
   attemptCount: number;
@@ -311,7 +323,7 @@ export function classifyPipeline(
       story.storyType === "issue" ? story.state === "closed" : story.state === "merged";
     const closedStamp = story.closedAt ?? story.ghUpdatedAt;
     if (shipped && closedStamp && now - closedStamp.getTime() < WEEK_MS) {
-      stages.get("shipped")?.push(placeBase(story));
+      stages.get("shipped")?.push(placeBase(story, "shipped_recently"));
     }
   }
   for (const placed of stages.values()) {
@@ -331,32 +343,55 @@ function placeOpen(
 ): { stage: PipelineStage; placed: PlacedPipelineStory } {
   const runs = [...story.linkedRuns].sort((a, b) => a.id.localeCompare(b.id));
   const current = runs.at(-1) ?? null;
-  const placed = placeBase(story);
   if (current && LIVE.has(current.status)) {
-    return { stage: stageForMode(current), placed: { ...placed, runState: "live" } };
+    return {
+      stage: stageForMode(current),
+      placed: { ...placeBase(story, "in_progress"), runState: "live" },
+    };
   }
   if (current?.status === "failed") {
-    return { stage: stageForMode(current), placed: { ...placed, runState: "failed" } };
+    return {
+      stage: stageForMode(current),
+      placed: { ...placeBase(story, "failed"), runState: "failed" },
+    };
   }
   const openPulls = story.prs.filter((pull) => pull.state === "open");
   const reviewablePulls = openPulls.filter((pull) => !pull.draft);
+  const checksFailed = reviewablePulls.some(hasCurrentCiState("failure"));
+  if (checksFailed) {
+    return { stage: "validating", placed: placeBase(story, "checks_failed") };
+  }
   const pending = reviewablePulls.some(hasCurrentCiState("pending"));
-  if (pending) return { stage: "validating", placed };
+  if (pending) return { stage: "validating", placed: placeBase(story, "checks_running") };
   const builderDelivered = runs.some(
     (run) =>
       isMode(run, "builder") &&
       run.status === "succeeded" &&
       numberValue(objectValue(objectValue(run.gh).pr).number) !== null,
   );
-  if (reviewablePulls.length > 0) return { stage: "review", placed };
-  if (openPulls.some((pull) => pull.draft)) return { stage: "building", placed };
-  if (builderDelivered) return { stage: "review", placed };
+  if (reviewablePulls.length > 0) {
+    return { stage: "review", placed: placeBase(story, "awaiting_review") };
+  }
+  if (openPulls.some((pull) => pull.draft)) {
+    return { stage: "building", placed: placeBase(story, "draft_pr") };
+  }
+  if (builderDelivered) {
+    return { stage: "review", placed: placeBase(story, "awaiting_review") };
+  }
   const planPublished = runs.some((run) => isMode(run, "architect") && run.status === "succeeded");
-  if (hasOpenProposal || planPublished) return { stage: "ready", placed };
-  return { stage: "backlog", placed };
+  if (hasOpenProposal) {
+    return { stage: "planning", placed: placeBase(story, "needs_review") };
+  }
+  if (planPublished) {
+    return { stage: "planning", placed: placeBase(story, "ready_to_build") };
+  }
+  return {
+    stage: "backlog",
+    placed: placeBase(story, runs.length > 0 ? "needs_attention" : "ready_to_plan"),
+  };
 }
 
-function placeBase(story: PipelineStoryInput): PlacedPipelineStory {
+function placeBase(story: PipelineStoryInput, stageState: PipelineStageState): PlacedPipelineStory {
   const runs = [...story.linkedRuns].sort((a, b) => a.id.localeCompare(b.id));
   const current = runs.at(-1) ?? null;
   const reviewablePulls = story.prs.filter((pull) => pull.state === "open" && !pull.draft);
@@ -366,6 +401,7 @@ function placeBase(story: PipelineStoryInput): PlacedPipelineStory {
   const { linkedRuns: _linkedRuns, ...fields } = story;
   return {
     ...fields,
+    stageState,
     runState: null,
     currentRun: current
       ? { id: current.id, mode: current.mode, status: current.status, engine: current.engine }

--- a/services/api/src/routes/v1/github.ts
+++ b/services/api/src/routes/v1/github.ts
@@ -155,11 +155,23 @@ function activityPullState(state: string): StoryGithubPull["state"] {
 const PipelineStageSchema = z.enum([
   "backlog",
   "planning",
-  "ready",
   "building",
   "validating",
   "review",
   "shipped",
+]);
+const PipelineStageStateSchema = z.enum([
+  "ready_to_plan",
+  "needs_attention",
+  "in_progress",
+  "needs_review",
+  "ready_to_build",
+  "failed",
+  "draft_pr",
+  "checks_running",
+  "checks_failed",
+  "awaiting_review",
+  "shipped_recently",
 ]);
 const PipelineStageKindSchema = z.enum(["human", "agent", "machine", "done"]);
 const PipelinePullRequestSchema = z.object({
@@ -193,6 +205,7 @@ const PipelineStorySchema = z.object({
   ghCreatedAt: DateValue.nullable(),
   ghUpdatedAt: DateValue.nullable(),
   closedAt: DateValue.nullable(),
+  stageState: PipelineStageStateSchema,
   runState: z.enum(["live", "failed"]).nullable(),
   currentRun: z
     .object({ id: z.string(), mode: z.string(), status: z.string(), engine: z.string() })

--- a/services/api/test/pipeline.test.ts
+++ b/services/api/test/pipeline.test.ts
@@ -144,7 +144,8 @@ describe("server-owned story pipeline", () => {
       ciUrl: "https://github.test/alice/alpha/pull/10/checks",
       ciFailureNames: [],
     });
-    expect(staged.get("review")?.find((story) => story.number === 2)).toMatchObject({
+    expect(staged.get("validating")?.find((story) => story.number === 2)).toMatchObject({
+      stageState: "checks_failed",
       ciState: "failure",
       ciFailureNames: ["guards", "typecheck"],
     });

--- a/services/api/test/pipeline.test.ts
+++ b/services/api/test/pipeline.test.ts
@@ -70,8 +70,12 @@ describe("server-owned story pipeline", () => {
     expect(assembly.stories[0]?.prs.map((candidate) => candidate.number)).toEqual([20]);
     expect(assembly.stories[0]?.linkedRuns.map((candidate) => candidate.id)).toEqual(["run_01"]);
     expect(
-      classifyPipeline(assembly.stories, new Set(), NOW.getTime()).get("review")?.[0],
-    ).toMatchObject({ key: "repo_a:issue:7", ciState: "failure" });
+      classifyPipeline(assembly.stories, new Set(), NOW.getTime()).get("validating")?.[0],
+    ).toMatchObject({
+      key: "repo_a:issue:7",
+      stageState: "checks_failed",
+      ciState: "failure",
+    });
   });
 
   it("applies current-run precedence, current-head CI, and the Validating machine stage", () => {
@@ -103,17 +107,19 @@ describe("server-owned story pipeline", () => {
       NOW.getTime(),
     );
 
-    expect(staged.get("validating")?.map((story) => story.number)).toEqual([10]);
-    expect(staged.get("review")?.map((story) => [story.number, story.ciState])).toEqual([
-      [12, null],
-      [11, "failure"],
+    expect(staged.get("validating")?.map((story) => [story.number, story.stageState])).toEqual([
+      [11, "checks_failed"],
+      [10, "checks_running"],
     ]);
-    expect(staged.get("building")?.map((story) => [story.number, story.runState])).toEqual([
-      [2, "live"],
+    expect(staged.get("review")?.map((story) => [story.number, story.stageState])).toEqual([
+      [12, "awaiting_review"],
     ]);
-    expect(staged.get("planning")?.map((story) => [story.number, story.runState])).toEqual([
-      [3, "failed"],
-    ]);
+    expect(
+      staged.get("building")?.map((story) => [story.number, story.runState, story.stageState]),
+    ).toEqual([[2, "live", "in_progress"]]);
+    expect(
+      staged.get("planning")?.map((story) => [story.number, story.runState, story.stageState]),
+    ).toEqual([[3, "failed", "failed"]]);
     expect(PIPELINE_STAGES.map((stage) => [stage.key, stage.kind])).toContainEqual([
       "validating",
       "machine",
@@ -127,6 +133,7 @@ describe("server-owned story pipeline", () => {
     expect(staged.get("building")?.map((story) => [story.key, story.ciState, story.ciUrl])).toEqual(
       [[draft.key, null, null]],
     );
+    expect(staged.get("building")?.[0]?.stageState).toBe("draft_pr");
     expect(staged.get("validating")).toEqual([]);
     expect(staged.get("review")).toEqual([]);
   });
@@ -156,8 +163,64 @@ describe("server-owned story pipeline", () => {
     };
 
     const staged = classifyPipeline([pending, delivered], new Set(), NOW.getTime());
-    expect(staged.get("backlog")?.map((story) => story.number)).toContain(40);
-    expect(staged.get("review")?.map((story) => story.number)).toContain(41);
+    expect(staged.get("backlog")?.find((story) => story.number === 40)?.stageState).toBe(
+      "needs_attention",
+    );
+    expect(staged.get("review")?.find((story) => story.number === 41)?.stageState).toBe(
+      "awaiting_review",
+    );
+  });
+
+  it("keeps planning work together while exposing its actionable state", () => {
+    const live = {
+      ...storyWith({}),
+      key: "repo_a:issue:50",
+      number: 50,
+      prs: [],
+      linkedRuns: [run("run_50", "alice", "alpha", 50, "architect", "running")],
+    };
+    const awaitingReview = {
+      ...storyWith({}),
+      key: "repo_a:issue:51",
+      number: 51,
+      prs: [],
+      linkedRuns: [run("run_51", "alice", "alpha", 51, "architect", "succeeded")],
+    };
+    const readyToBuild = {
+      ...storyWith({}),
+      key: "repo_a:issue:52",
+      number: 52,
+      prs: [],
+      linkedRuns: [run("run_52", "alice", "alpha", 52, "architect", "succeeded")],
+    };
+    const failed = {
+      ...storyWith({}),
+      key: "repo_a:issue:53",
+      number: 53,
+      prs: [],
+      linkedRuns: [run("run_53", "alice", "alpha", 53, "architect", "failed")],
+    };
+
+    const staged = classifyPipeline(
+      [live, awaitingReview, readyToBuild, failed],
+      new Set([awaitingReview.key]),
+      NOW.getTime(),
+    );
+
+    expect(staged.get("planning")?.map((story) => [story.number, story.stageState])).toEqual([
+      [53, "failed"],
+      [52, "ready_to_build"],
+      [51, "needs_review"],
+      [50, "in_progress"],
+    ]);
+    expect(PIPELINE_STAGES.map((stage) => stage.key)).toEqual([
+      "backlog",
+      "planning",
+      "building",
+      "validating",
+      "review",
+      "shipped",
+    ]);
   });
 
   it("ships recent closed issues and merged orphan PRs, but not abandoned PRs", () => {
@@ -194,6 +257,7 @@ describe("server-owned story pipeline", () => {
       "repo_a:pull_request:30",
       "repo_a:issue:1",
     ]);
+    expect(shipped?.every((story) => story.stageState === "shipped_recently")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What changes

- Replace the transient `Ready` pipeline stage with durable stages plus actionable `stageState` values.
- Reframe the project overview around compact, clickable status aggregates and a short “needs you” queue.
- Make “in flight” story-centered: every row shows the full repository-qualified story, lifecycle stage/state, latest meaningful run activity, elapsed time, and separate Story/Inspect targets.
- Add a prominent month-to-date delivery comparison: spend, shipped count, cost per ship, and proportional spend bars by agent configuration.
- Attribute each configuration to the agent, engine, observed provider and dominant model, including shipped yield and cost per shipped story.
- Make shipped work story-centered: full story identity/title, assignees, producing agent, engine/provider/model path, run cost, age, run inspection, and PR actions.
- Add stage-and-status story filters with context-specific actions such as Plan, Review plan, Build, Retry, Inspect checks, and Review PR.
- Update the story timeline, assistant contract, OpenAPI document, generated SDK types, and pipeline regression coverage.

## Why

The previous overview showed too much non-functional detail: story titles were truncated, the board did not make the next action obvious, and `Ready` represented a transient handoff rather than a meaningful lifecycle phase. The old in-flight rows repeated only “builder · Codex · running,” describing the worker without identifying the work. Spend and shipping were similarly reduced to totals and PR numbers, making it impossible to compare agent configurations or see who and what produced a delivery.

This keeps the six durable phases visible while making queued work, active work, cost, and delivered outcomes concrete and actionable. Cost remains gateway-authoritative; provider/model identity comes from observed model requests, with the configured agent model used only when a run has no request row.

## Verification

- [ ] `pnpm verify` passes locally
- [x] Desktop and mobile behavior verified at 2048px and 390px: full story titles wrap; status, story, run, and PR actions render; three agent configurations and five attributed deliveries render from the local API; no horizontal overflow or Next.js error overlay.
- [x] Documentation updated, or no user-facing change (OpenAPI/SDK and assistant pipeline description regenerated)

Latest focused checks:

- `pnpm --filter @facility/web test` — 60 passed
- `pnpm --filter @facility/web typecheck` — passed
- `pnpm --filter @facility/web build` — passed
- `pnpm --filter @facility/sdk test` — 23 passed
- `pnpm --filter @facility/sdk typecheck` — passed
- `pnpm exec biome check ...` and `git diff --check` — passed

Pipeline checks after merging current `main`:

- `pnpm --filter @facility/api exec vitest run --fileParallelism=false test/pipeline.test.ts` — 8 passed
- Migration compatibility — passed

Full-gate note: the latest local `pnpm verify` passed repository lint, all 16 typecheck tasks, and all 10 clean uncached production builds. It then stopped in the critical DB suite because the migration `beforeAll` at `packages/db/test/db.test.ts:56` exceeded its 10,000ms hook timeout while the shared Docker PostgreSQL VM was saturated. The DB file reported 15 skipped tests after the hook; this was a timeout, not an assertion failure. The pull-request `verify` job subsequently passed the full suite.

BREAKING CHANGE: The pipeline no longer emits the `ready` stage. Planning stories now expose `needs_review` or `ready_to_build` through `stageState`.
