### PR TITLE
feat(web): add stage-specific story workspaces

### DIFF
--- a/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
@@ -1,33 +1,160 @@
 import { cx, Eyebrow, StatusDot } from "@facility/ui";
 import Link from "next/link";
-import type { ReactNode } from "react";
 import { IssueRow } from "@/components/issues/issue-row";
+import { ReviewQueue } from "@/components/issues/review-queue";
 import { SyncIssuesButton } from "@/components/issues/sync-button";
 import { ErrorNotice, Offline } from "@/components/offline";
-import { StageSection } from "@/components/project/stage-section";
+import { PipelineBoard } from "@/components/project/pipeline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api } from "@/lib/api";
-import type { PipelineStageKey, PipelineStageKind, PipelineStageState } from "@/lib/pipeline";
-import { pipelineStageStateLabel, pipelineStories } from "@/lib/pipeline";
+import type {
+  PipelineStage,
+  PipelineStageKey,
+  PipelineStageState,
+  PipelineStory,
+} from "@/lib/pipeline";
+import {
+  pipelineStageDescription,
+  pipelineStageStateDescription,
+  pipelineStageSummaries,
+  pipelineStories,
+} from "@/lib/pipeline";
 
 export const metadata = { title: "stories" };
 
-const FILTER_DOT: Record<PipelineStageKind, ReactNode> = {
-  human: <StatusDot tone="human" />,
-  agent: <StatusDot tone="agent" />,
-  machine: <StatusDot tone="machine" />,
-  done: <StatusDot tone="ok" />,
-};
-const FILTER_COUNT_TONE: Record<PipelineStageKind, string> = {
-  human: "text-(--human)",
-  agent: "text-(--ink)",
-  machine: "text-(--info)",
-  done: "text-(--ink)",
-};
-
 function hasPermission(permissions: string[], permission: string) {
   const [resource] = permission.split(":");
-  return permissions.some((p) => p === "*" || p === permission || p === `${resource}:*`);
+  return permissions.some((candidate) => ["*", permission, `${resource}:*`].includes(candidate));
+}
+
+function StageWorkspace({
+  projectId,
+  stage,
+  activeStatus,
+  canTrigger,
+}: {
+  projectId: string;
+  stage: PipelineStage;
+  activeStatus: PipelineStageState | null;
+  canTrigger: boolean;
+}) {
+  const summaries = pipelineStageSummaries(stage);
+  const visibleSummaries = activeStatus
+    ? summaries.filter((summary) => summary.state === activeStatus)
+    : summaries;
+
+  return (
+    <div className="flex flex-col gap-8">
+      {summaries.length > 0 ? (
+        <nav
+          aria-label={`${stage.label} statuses`}
+          className={cx(
+            "grid w-full grid-cols-1 border border-(--line)",
+            summaries.length === 1 && "sm:max-w-lg",
+            summaries.length === 2 && "sm:max-w-4xl sm:grid-cols-2",
+            summaries.length === 3 && "sm:grid-cols-3",
+            summaries.length >= 4 && "sm:grid-cols-2 xl:grid-cols-4",
+          )}
+        >
+          {summaries.map((summary) => {
+            const selected = activeStatus === summary.state;
+            return (
+              <Link
+                key={summary.state}
+                href={
+                  selected
+                    ? `/projects/${projectId}/stories?stage=${stage.key}`
+                    : `/projects/${projectId}/stories?stage=${stage.key}&status=${summary.state}`
+                }
+                aria-current={selected ? "page" : undefined}
+                className={cx(
+                  "-ml-px -mt-px flex min-h-24 flex-col justify-between gap-3 border border-(--line) p-4 transition-colors hover:bg-(--card)",
+                  selected && "border-(--line-strong) bg-(--card)",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <StatusDot
+                    tone={summary.tone}
+                    pulse={summary.state === "in_progress" || summary.state === "checks_running"}
+                  />
+                  <span className="text-[12.5px] font-medium text-(--ink)">{summary.label}</span>
+                  <span className="ml-auto font-mono text-[17px] font-semibold text-(--ink)">
+                    {summary.count}
+                  </span>
+                </div>
+                <span className="text-[11px] leading-relaxed text-(--dim)">
+                  {pipelineStageStateDescription(summary.state)}
+                </span>
+              </Link>
+            );
+          })}
+        </nav>
+      ) : null}
+
+      {visibleSummaries.length === 0 ? (
+        <p className="max-w-lg text-sm leading-relaxed text-(--dim)">
+          Nothing is in {stage.label.toLowerCase()} right now.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-8">
+          {visibleSummaries.map((summary) => {
+            const stories = stage.stories.filter((story) => story.stageState === summary.state);
+            return (
+              <section key={summary.state} className="flex flex-col gap-3">
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <StatusDot
+                    tone={summary.tone}
+                    pulse={summary.state === "in_progress" || summary.state === "checks_running"}
+                  />
+                  <h2 className="text-[14px] font-semibold tracking-tight">{summary.label}</h2>
+                  <span className="font-mono text-[11px] text-(--dim)">{stories.length}</span>
+                  <span className="text-[11.5px] text-(--dim)">
+                    {pipelineStageStateDescription(summary.state)}
+                  </span>
+                </div>
+                {stage.key === "review" && summary.state === "awaiting_review" ? (
+                  <ReviewQueue projectId={projectId} stories={stories} canTrigger={canTrigger} />
+                ) : (
+                  <StoryQueue
+                    projectId={projectId}
+                    stage={stage.key}
+                    stories={stories}
+                    canTrigger={canTrigger}
+                  />
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StoryQueue({
+  projectId,
+  stage,
+  stories,
+  canTrigger,
+}: {
+  projectId: string;
+  stage: PipelineStageKey;
+  stories: PipelineStory[];
+  canTrigger: boolean;
+}) {
+  return (
+    <div className="flex flex-col border border-(--line)">
+      {stories.map((story) => (
+        <IssueRow
+          key={story.key}
+          projectId={projectId}
+          story={story}
+          canTrigger={canTrigger}
+          stage={stage}
+        />
+      ))}
+    </div>
+  );
 }
 
 export default async function ProjectStoriesPage({
@@ -37,7 +164,7 @@ export default async function ProjectStoriesPage({
   params: Promise<{ projectId: string }>;
   searchParams: Promise<{ stage?: string; status?: string }>;
 }) {
-  const [{ projectId }, { stage, status }] = await Promise.all([params, searchParams]);
+  const [{ projectId }, requested] = await Promise.all([params, searchParams]);
   const [pipelineResult, me] = await Promise.all([api.pipeline(projectId), api.me()]);
 
   if (!pipelineResult.ok && pipelineResult.offline) return <Offline />;
@@ -46,103 +173,34 @@ export default async function ProjectStoriesPage({
   const canTrigger = hasPermission(permissions, "runs:trigger");
   const canSync = hasPermission(permissions, "repos:write");
   const stages = pipelineResult.ok ? pipelineResult.data.stages : [];
-  const stageKeys = new Set(stages.map((candidate) => candidate.key));
-  const activeStage =
-    stage && stageKeys.has(stage as PipelineStageKey) ? (stage as PipelineStageKey) : null;
-  const items = pipelineResult.ok ? pipelineStories(pipelineResult.data) : [];
-  const stageStates = new Set(items.map((story) => story.stageState));
+  const activeStage = stages.find((candidate) => candidate.key === requested.stage) ?? null;
   const activeStatus =
-    activeStage && status && stageStates.has(status as PipelineStageState)
-      ? (status as PipelineStageState)
+    activeStage &&
+    requested.status &&
+    activeStage.stories.some((story) => story.stageState === requested.status)
+      ? (requested.status as PipelineStageState)
       : null;
-  const counts = [...stages].reverse();
-  const activeOpenStoryCount = items.filter((story) => story.state === "open").length;
-
-  const stageFiltered = activeStage
-    ? counts.filter((candidate) => candidate.key === activeStage)
-    : counts;
-  const visibleStages = activeStatus
-    ? stageFiltered.map((candidate) => ({
-        ...candidate,
-        stories: candidate.stories.filter((story) => story.stageState === activeStatus),
-      }))
-    : stageFiltered;
-  const activeStatusLabel =
-    activeStage && activeStatus
-      ? pipelineStageStateLabel(
-          activeStage,
-          activeStatus,
-          visibleStages.reduce((total, candidate) => total + candidate.stories.length, 0),
-        )
-      : null;
+  const stories = pipelineResult.ok ? pipelineStories(pipelineResult.data) : [];
+  const openCount = stories.filter((story) => story.state === "open").length;
 
   return (
     <div className="flex flex-col gap-8">
       <LiveRefresh seconds={30} />
       <div className="flex flex-wrap items-end justify-between gap-4">
-        <div className="flex flex-col gap-2">
-          <Eyebrow>stories</Eyebrow>
-          <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">Stories</h1>
-          <p className="text-[12.5px] text-(--dim)">
-            {pipelineResult.ok
-              ? `${activeOpenStoryCount} active open stories · closest to shipping on top`
-              : "pipeline unavailable"}{" "}
-            · the full life of each unit of work — synced with GitHub
+        <div className="flex max-w-3xl flex-col gap-2">
+          <Eyebrow>{activeStage ? `stories / ${activeStage.key}` : "stories"}</Eyebrow>
+          <h1 className="text-[clamp(22px,3vw,32px)] font-semibold tracking-tight">
+            {activeStage?.label ?? "Stories"}
+          </h1>
+          <p className="text-[12.5px] leading-relaxed text-(--dim)">
+            {!pipelineResult.ok
+              ? "Pipeline unavailable"
+              : activeStage
+                ? `${activeStage.count} ${activeStage.count === 1 ? "story" : "stories"} · ${pipelineStageDescription(activeStage.key)}`
+                : `${openCount} open stories · lifecycle orientation and queues that need action.`}
           </p>
         </div>
         {canSync ? <SyncIssuesButton projectId={projectId} /> : null}
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <Link
-          href={`/projects/${projectId}/stories`}
-          className={cx(
-            "border px-3 py-1.5 text-[12px] font-medium transition-colors",
-            !activeStage
-              ? "border-(--line-strong) text-(--ink)"
-              : "border-(--line) text-(--mut) hover:text-(--ink)",
-          )}
-        >
-          all
-        </Link>
-        {counts.map((s) => (
-          <Link
-            key={s.key}
-            href={`/projects/${projectId}/stories?stage=${s.key}`}
-            className={cx(
-              "inline-flex items-center gap-2 border px-3 py-1.5 text-[12px] font-medium transition-colors",
-              activeStage === s.key
-                ? "border-(--line-strong) text-(--ink)"
-                : "border-(--line) text-(--mut) hover:text-(--ink)",
-            )}
-          >
-            {FILTER_DOT[s.kind]}
-            {s.label}
-            <span
-              className={cx(
-                "font-mono text-[11px]",
-                s.count > 0 ? FILTER_COUNT_TONE[s.kind] : "text-(--dim)",
-              )}
-            >
-              {s.count}
-            </span>
-          </Link>
-        ))}
-        {activeStage && activeStatusLabel ? (
-          <>
-            <span className="font-mono text-[11px] text-(--dim)">/</span>
-            <span className="inline-flex items-center gap-2 border border-(--line-strong) px-3 py-1.5 text-[12px] font-medium text-(--ink)">
-              {activeStatusLabel}
-              <Link
-                href={`/projects/${projectId}/stories?stage=${activeStage}`}
-                aria-label="clear status filter"
-                className="text-(--dim) hover:text-(--ink)"
-              >
-                ×
-              </Link>
-            </span>
-          </>
-        ) : null}
       </div>
 
       {!pipelineResult.ok ? (
@@ -153,50 +211,23 @@ export default async function ProjectStoriesPage({
               : `Couldn't load stories — ${pipelineResult.message}`
           }
         />
-      ) : items.length === 0 ? (
-        <p className="max-w-lg text-sm leading-relaxed text-(--dim)">
-          No active stories right now. Closed and merged stories leave Shipped after seven days;
-          sync refreshes the GitHub mirror.
-        </p>
+      ) : activeStage ? (
+        <StageWorkspace
+          projectId={projectId}
+          stage={activeStage}
+          activeStatus={activeStatus}
+          canTrigger={canTrigger}
+        />
       ) : (
-        <div className="flex flex-col gap-6">
-          {visibleStages.map((s) => {
-            const stageItems = s.stories;
-            return (
-              <StageSection
-                key={s.key}
-                label={s.label}
-                sub={s.sub}
-                kind={s.kind}
-                total={stageItems.length}
-                liveCount={stageItems.filter((story) => story.runState === "live").length}
-                failedCount={
-                  stageItems.filter(
-                    (story) => story.runState === "failed" || story.ciState === "failure",
-                  ).length
-                }
-                defaultOpen={activeStage !== null || s.key !== "shipped"}
-              >
-                {stageItems.length === 0 ? (
-                  <p className="border border-(--line) px-5 py-3.5 text-[12.5px] text-(--dim)">
-                    Nothing here right now.
-                  </p>
-                ) : (
-                  <div className="flex flex-col border border-(--line)">
-                    {stageItems.map((story) => (
-                      <IssueRow
-                        key={story.key}
-                        projectId={projectId}
-                        story={story}
-                        canTrigger={canTrigger}
-                      />
-                    ))}
-                  </div>
-                )}
-              </StageSection>
-            );
-          })}
-        </div>
+        <section className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <h2 className="text-[14px] font-semibold tracking-tight">Lifecycle</h2>
+            <span className="text-[11.5px] text-(--dim)">
+              Choose a stage to enter its working context.
+            </span>
+          </div>
+          <PipelineBoard stages={stages} projectId={projectId} />
+        </section>
       )}
     </div>
   );

--- a/apps/web/components/issues/issue-row.tsx
+++ b/apps/web/components/issues/issue-row.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonLink, StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import type { PipelineStory } from "@/lib/pipeline";
+import type { PipelineStageKey, PipelineStory } from "@/lib/pipeline";
 import { storyHref } from "@/lib/pipeline";
 
 function fmtAgo(iso: string | null) {
@@ -20,10 +20,12 @@ export function IssueRow({
   projectId,
   story,
   canTrigger,
+  stage,
 }: {
   projectId: string;
   story: PipelineStory;
   canTrigger: boolean;
+  stage: PipelineStageKey;
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState<string | null>(null);
@@ -66,6 +68,14 @@ export function IssueRow({
     : current?.mode.includes("builder")
       ? "builder"
       : null;
+  const showLabels = stage === "backlog";
+  const showRun = stage === "planning" || stage === "building";
+  const showPulls = stage === "building" || stage === "validating" || stage === "shipped";
+  const showChecks = stage === "validating";
+  const hasStageDetail =
+    (showRun && current !== null) ||
+    (showPulls && story.prs.length > 0) ||
+    (showChecks && story.ciState !== null);
 
   function action() {
     if (story.stageState === "needs_review") {
@@ -185,20 +195,25 @@ export function IssueRow({
         >
           ↗
         </a>
-        {story.labels.slice(0, 3).map((label) => (
-          <span
-            key={label}
-            className="border border-(--line) px-1.5 py-0.5 font-mono text-[10px] text-(--dim)"
-          >
-            {label}
-          </span>
-        ))}
-        <span className="font-mono text-[10.5px] text-(--dim)">{fmtAgo(story.ghUpdatedAt)}</span>
+        {showLabels
+          ? story.labels.slice(0, 3).map((label) => (
+              <span
+                key={label}
+                className="border border-(--line) px-1.5 py-0.5 font-mono text-[10px] text-(--dim)"
+              >
+                {label}
+              </span>
+            ))
+          : null}
+        <span className="font-mono text-[10.5px] text-(--dim)">
+          {stage === "shipped" ? "shipped" : "updated"}{" "}
+          {fmtAgo(story.closedAt ?? story.ghUpdatedAt)}
+        </span>
         {action()}
       </div>
-      {current || story.prs.length > 0 || story.ciState ? (
+      {hasStageDetail ? (
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-0 sm:pl-10">
-          {current ? (
+          {showRun && current ? (
             <span className="flex items-center gap-2">
               <StatusDot tone={toneFor(current.status)} pulse={story.runState === "live"} />
               <Link
@@ -214,18 +229,20 @@ export function IssueRow({
               ) : null}
             </span>
           ) : null}
-          {story.prs.map((pr) => (
-            <a
-              key={pr.number}
-              href={pr.url}
-              target="_blank"
-              rel="noreferrer"
-              className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
-            >
-              PR #{pr.number} ↗
-            </a>
-          ))}
-          {story.ciState === "failure" && story.ciUrl ? (
+          {showPulls
+            ? story.prs.map((pr) => (
+                <a
+                  key={pr.number}
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-mono text-[11px] text-(--info) underline-offset-4 hover:underline"
+                >
+                  {pr.draft ? "Draft" : "PR"} #{pr.number} ↗
+                </a>
+              ))
+            : null}
+          {showChecks && story.ciState === "failure" && story.ciUrl ? (
             <a
               href={story.ciUrl}
               target="_blank"
@@ -235,7 +252,7 @@ export function IssueRow({
               <StatusDot tone="bad" />
               checks · failed
             </a>
-          ) : story.ciState === "pending" && story.ciUrl ? (
+          ) : showChecks && story.ciState === "pending" && story.ciUrl ? (
             <a
               href={story.ciUrl}
               target="_blank"

--- a/apps/web/components/issues/review-queue.tsx
+++ b/apps/web/components/issues/review-queue.tsx
@@ -4,16 +4,23 @@ import type { PipelineStory } from "@/lib/api";
 import { storyHref } from "@/lib/pipeline";
 import { fmtAgo } from "@/lib/run-format";
 import { reviewPullRequestGroups } from "@/lib/story-groups";
+import { IssueRow } from "./issue-row";
 
 /** A pull request is one review action even when it delivers several stories. */
 export function ReviewQueue({
   projectId,
   stories,
+  canTrigger,
 }: {
   projectId: string;
   stories: PipelineStory[];
+  canTrigger: boolean;
 }) {
   const groups = reviewPullRequestGroups(stories);
+  const groupedStories = new Set(
+    groups.flatMap((group) => group.stories.map((story) => story.key)),
+  );
+  const ungroupedStories = stories.filter((story) => !groupedStories.has(story.key));
 
   return (
     <div className="flex flex-col border border-(--line)">
@@ -52,9 +59,11 @@ export function ReviewQueue({
                   checks {pull.ciState}
                 </span>
               ) : null}
-              <span className="font-mono text-[10.5px] text-(--dim)">
-                opened {fmtAgo(pull.createdAt)}
-              </span>
+              {pull.createdAt ? (
+                <span className="font-mono text-[10.5px] text-(--dim)">
+                  opened {fmtAgo(pull.createdAt)}
+                </span>
+              ) : null}
               <ButtonLink size="sm" href={pull.url} target="_blank" rel="noreferrer">
                 Review PR ↗
               </ButtonLink>
@@ -83,6 +92,15 @@ export function ReviewQueue({
           </article>
         );
       })}
+      {ungroupedStories.map((story) => (
+        <IssueRow
+          key={story.key}
+          projectId={projectId}
+          story={story}
+          canTrigger={canTrigger}
+          stage="review"
+        />
+      ))}
     </div>
   );
 }

--- a/apps/web/components/issues/review-queue.tsx
+++ b/apps/web/components/issues/review-queue.tsx
@@ -1,0 +1,88 @@
+import { ButtonLink, StatusDot } from "@facility/ui";
+import Link from "next/link";
+import type { PipelineStory } from "@/lib/api";
+import { storyHref } from "@/lib/pipeline";
+import { fmtAgo } from "@/lib/run-format";
+import { reviewPullRequestGroups } from "@/lib/story-groups";
+
+/** A pull request is one review action even when it delivers several stories. */
+export function ReviewQueue({
+  projectId,
+  stories,
+}: {
+  projectId: string;
+  stories: PipelineStory[];
+}) {
+  const groups = reviewPullRequestGroups(stories);
+
+  return (
+    <div className="flex flex-col border border-(--line)">
+      {groups.map(({ key, pull, stories: includedStories }) => {
+        const representative = includedStories[0];
+        if (!representative) return null;
+        return (
+          <article
+            key={key}
+            className="flex flex-col gap-3 border-b border-(--line) px-5 py-4 last:border-b-0"
+          >
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+              <span className="font-mono text-[11px] text-(--info)">PR #{pull.number}</span>
+              <a
+                href={pull.url}
+                target="_blank"
+                rel="noreferrer"
+                className="min-w-64 flex-1 text-[13.5px] font-medium text-(--ink) underline-offset-4 hover:underline"
+              >
+                {pull.title}
+              </a>
+              <span className="font-mono text-[10.5px] text-(--dim)">
+                {representative.repoOwner}/{representative.repoName}
+              </span>
+              {pull.ciState ? (
+                <span className="inline-flex items-center gap-2 font-mono text-[10.5px] text-(--mut)">
+                  <StatusDot
+                    tone={
+                      pull.ciState === "failure"
+                        ? "bad"
+                        : pull.ciState === "pending"
+                          ? "info"
+                          : "ok"
+                    }
+                  />
+                  checks {pull.ciState}
+                </span>
+              ) : null}
+              <span className="font-mono text-[10.5px] text-(--dim)">
+                opened {fmtAgo(pull.createdAt)}
+              </span>
+              <ButtonLink size="sm" href={pull.url} target="_blank" rel="noreferrer">
+                Review PR ↗
+              </ButtonLink>
+            </div>
+
+            <details className="group">
+              <summary className="flex w-fit cursor-pointer list-none items-center gap-2 font-mono text-[10.5px] text-(--dim) hover:text-(--mut) [&::-webkit-details-marker]:hidden">
+                <span aria-hidden className="transition-transform group-open:rotate-90">
+                  ▸
+                </span>
+                {includedStories.length} {includedStories.length === 1 ? "story" : "stories"}
+              </summary>
+              <div className="mt-2 flex flex-col gap-1 border-l border-(--line) pl-4">
+                {includedStories.map((story) => (
+                  <Link
+                    key={story.key}
+                    href={storyHref(projectId, story)}
+                    className="text-[12px] text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
+                  >
+                    <span className="font-mono text-[10.5px] text-(--dim)">#{story.number}</span>{" "}
+                    {story.title}
+                  </Link>
+                ))}
+              </div>
+            </details>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/shell/nav.tsx
+++ b/apps/web/components/shell/nav.tsx
@@ -2,8 +2,9 @@
 
 import { cx } from "@facility/ui";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import { storyNavigation } from "@/lib/story-navigation";
 
 export type NavProject = { id: string; slug: string; name?: string };
 
@@ -98,6 +99,42 @@ function NavLinks({
   );
 }
 
+function StoryNavLinks({ projectId, onNavigate }: { projectId: string; onNavigate?: () => void }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const selectedStage = searchParams.get("stage");
+  const root = `/projects/${projectId}/stories`;
+
+  return (
+    <nav className="flex flex-col" aria-label="Stories">
+      {storyNavigation(projectId).map((item, i) => {
+        const active = item.stage
+          ? pathname === root && selectedStage === item.stage
+          : pathname === root && selectedStage === null;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={onNavigate}
+            aria-current={active ? "page" : undefined}
+            className={cx(
+              "group flex items-baseline gap-3 border-l-2 px-5 py-2 text-[13px] transition-colors",
+              active
+                ? "border-(--line-strong) font-medium text-(--ink)"
+                : "border-transparent text-(--mut) hover:text-(--ink)",
+            )}
+          >
+            <span className={cx("font-mono text-[10px]", active ? "text-(--ink)" : "text-(--dim)")}>
+              {String(i + 1).padStart(2, "0")}
+            </span>
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <span className="px-5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-(--dim)">
@@ -115,6 +152,8 @@ function NavSections({
   inboxCount?: number;
   onNavigate?: () => void;
 }) {
+  const pathname = usePathname();
+
   if (!project) {
     return (
       <div className="flex flex-col gap-6">
@@ -126,6 +165,31 @@ function NavSections({
       </div>
     );
   }
+  const projectRoot = `/projects/${project.id}`;
+  const storiesRoot = `${projectRoot}/stories`;
+  const inStories = pathname === storiesRoot || pathname.startsWith(`${storiesRoot}/`);
+
+  if (inStories) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Link
+          href={projectRoot}
+          onClick={onNavigate}
+          className="flex items-center gap-2 px-5 text-[12px] text-(--mut) transition-colors hover:text-(--ink)"
+        >
+          <span aria-hidden className="font-mono">
+            ←
+          </span>
+          Back to {project.name ?? project.slug}
+        </Link>
+        <div className="flex flex-col gap-2">
+          <SectionLabel>Stories</SectionLabel>
+          <StoryNavLinks projectId={project.id} onNavigate={onNavigate} />
+        </div>
+      </div>
+    );
+  }
+
   // Project mode: the sidebar belongs to the project. The way out is explicit
   // (back link on top) and the section is titled by the project itself.
   return (

--- a/apps/web/lib/pipeline.ts
+++ b/apps/web/lib/pipeline.ts
@@ -26,6 +26,29 @@ const STATUS_ORDER: Record<PipelineStageKey, PipelineStageState[]> = {
   shipped: ["shipped_recently"],
 };
 
+const STAGE_DESCRIPTION: Record<PipelineStageKey, string> = {
+  backlog: "Choose what deserves planning. Priority and product context matter here.",
+  planning: "Shape the approach, resolve open decisions, and approve plans for building.",
+  building: "Follow active implementation, drafts, and work that needs intervention.",
+  validating: "Use check evidence to decide whether a change is ready for human review.",
+  review: "Review each pull request once, including every story it delivers.",
+  shipped: "See what reached the product recently and trace it back to its stories.",
+};
+
+const STATUS_DESCRIPTION: Record<PipelineStageState, string> = {
+  ready_to_plan: "Unstarted stories that can be sent to the architect.",
+  needs_attention: "Earlier activity stopped without producing a usable plan.",
+  in_progress: "An agent is actively working on these stories.",
+  needs_review: "Plans waiting for a human decision before implementation.",
+  ready_to_build: "Approved plans that can be sent to the builder.",
+  failed: "Agent work that stopped and needs inspection or another attempt.",
+  draft_pr: "Implementation has produced a draft change that is still being worked.",
+  checks_running: "Pull requests whose current-head checks have not finished.",
+  checks_failed: "Pull requests whose current-head checks need investigation.",
+  awaiting_review: "Pull requests ready for a human review and merge decision.",
+  shipped_recently: "Stories merged during the last seven days.",
+};
+
 const STATUS_TONE: Record<PipelineStageState, PipelineStatusTone> = {
   ready_to_plan: "human",
   needs_attention: "bad",
@@ -75,6 +98,18 @@ export function pipelineStageStateLabel(
 
 export function pipelineStageStateTone(state: PipelineStageState) {
   return STATUS_TONE[state];
+}
+
+export function pipelineStageDescription(stage: PipelineStageKey) {
+  return STAGE_DESCRIPTION[stage];
+}
+
+export function pipelineStageStateDescription(state: PipelineStageState) {
+  return STATUS_DESCRIPTION[state];
+}
+
+export function pipelineStageStates(stage: PipelineStageKey) {
+  return [...STATUS_ORDER[stage]];
 }
 
 export function pipelineStageSummaries(stage: PipelineStage) {

--- a/apps/web/lib/story-groups.ts
+++ b/apps/web/lib/story-groups.ts
@@ -10,9 +10,7 @@ export type PullRequestStoryGroup<Story extends Pick<PipelineStory, "repoId" | "
  * Review happens once per pull request even when that change carries several
  * stories. Preserve pipeline order while collecting every affected story.
  */
-export function groupStoriesByPullRequest<
-  Story extends Pick<PipelineStory, "repoId" | "prs">,
->(
+export function groupStoriesByPullRequest<Story extends Pick<PipelineStory, "repoId" | "prs">>(
   stories: Story[],
   include: (pull: PipelinePullRequest) => boolean,
 ): PullRequestStoryGroup<Story>[] {

--- a/apps/web/lib/story-groups.ts
+++ b/apps/web/lib/story-groups.ts
@@ -1,0 +1,41 @@
+import type { PipelinePullRequest, PipelineStory } from "./api";
+
+export type PullRequestStoryGroup<Story extends Pick<PipelineStory, "repoId" | "prs">> = {
+  key: string;
+  pull: PipelinePullRequest;
+  stories: Story[];
+};
+
+/**
+ * Review happens once per pull request even when that change carries several
+ * stories. Preserve pipeline order while collecting every affected story.
+ */
+export function groupStoriesByPullRequest<
+  Story extends Pick<PipelineStory, "repoId" | "prs">,
+>(
+  stories: Story[],
+  include: (pull: PipelinePullRequest) => boolean,
+): PullRequestStoryGroup<Story>[] {
+  const groups = new Map<string, PullRequestStoryGroup<Story>>();
+
+  for (const story of stories) {
+    for (const pull of story.prs) {
+      if (!include(pull)) continue;
+      const key = `${story.repoId}:${pull.number}`;
+      const group = groups.get(key);
+      if (group) {
+        group.stories.push(story);
+      } else {
+        groups.set(key, { key, pull, stories: [story] });
+      }
+    }
+  }
+
+  return [...groups.values()];
+}
+
+export function reviewPullRequestGroups<Story extends Pick<PipelineStory, "repoId" | "prs">>(
+  stories: Story[],
+) {
+  return groupStoriesByPullRequest(stories, (pull) => pull.state === "open" && !pull.draft);
+}

--- a/apps/web/lib/story-navigation.ts
+++ b/apps/web/lib/story-navigation.ts
@@ -1,0 +1,29 @@
+import type { PipelineStageKey } from "./api";
+
+export type StoryNavigationItem = {
+  href: string;
+  label: string;
+  stage?: PipelineStageKey;
+};
+
+/** The durable lifecycle is navigation; transient conditions live inside each stage. */
+export const STORY_STAGES = [
+  { stage: "backlog", label: "Backlog" },
+  { stage: "planning", label: "Planning" },
+  { stage: "building", label: "Building" },
+  { stage: "validating", label: "Validating" },
+  { stage: "review", label: "Review" },
+  { stage: "shipped", label: "Shipped" },
+] as const satisfies ReadonlyArray<{ stage: PipelineStageKey; label: string }>;
+
+export function storyNavigation(projectId: string): StoryNavigationItem[] {
+  const base = `/projects/${projectId}/stories`;
+  return [
+    { href: base, label: "Overview" },
+    ...STORY_STAGES.map(({ stage, label }) => ({
+      href: `${base}?stage=${stage}`,
+      label,
+      stage,
+    })),
+  ];
+}

--- a/apps/web/test/pipeline-story.test.ts
+++ b/apps/web/test/pipeline-story.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, it } from "vitest";
 import type { PipelineStageKey, PipelineStory, Proposal, StoryDetail } from "@/lib/api";
-import { reviewablePullRequests, storyHref } from "@/lib/pipeline";
+import { pipelineStageStates, reviewablePullRequests, storyHref } from "@/lib/pipeline";
 import { deriveStoryTimeline, proposalsForStory } from "@/lib/story";
 
 describe("story presentation contract", () => {
+  it("exposes only statuses that make sense within each stage workspace", () => {
+    expect(pipelineStageStates("backlog")).toEqual(["needs_attention", "ready_to_plan"]);
+    expect(pipelineStageStates("planning")).toEqual([
+      "in_progress",
+      "needs_review",
+      "ready_to_build",
+      "failed",
+    ]);
+    expect(pipelineStageStates("validating")).toEqual(["checks_running", "checks_failed"]);
+    expect(pipelineStageStates("review")).toEqual(["in_progress", "awaiting_review", "failed"]);
+    expect(pipelineStageStates("backlog")).not.toContain("failed");
+  });
+
   it("keeps repository and story kind in every detail link", () => {
     expect(
       storyHref("project-1", {

--- a/apps/web/test/story-groups.test.ts
+++ b/apps/web/test/story-groups.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { PipelineStory } from "@/lib/api";
+import { reviewPullRequestGroups } from "@/lib/story-groups";
+
+describe("story review groups", () => {
+  it("represents a shared pull request as one review action", () => {
+    const pull = pullRequest(1035);
+    const groups = reviewPullRequestGroups([
+      story("repo-1", 1085, [pull]),
+      story("repo-1", 1084, [pull]),
+      story("repo-1", 1083, [pull]),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      key: "repo-1:1035",
+      pull: { number: 1035 },
+    });
+    expect(groups[0]?.stories.map(({ number }) => number)).toEqual([1085, 1084, 1083]);
+  });
+
+  it("keeps same-number pull requests from different repositories separate", () => {
+    const groups = reviewPullRequestGroups([
+      story("repo-1", 1, [pullRequest(17)]),
+      story("repo-2", 2, [pullRequest(17)]),
+    ]);
+
+    expect(groups.map(({ key }) => key)).toEqual(["repo-1:17", "repo-2:17"]);
+  });
+
+  it("omits drafts and closed pull requests from the human review queue", () => {
+    const groups = reviewPullRequestGroups([
+      story("repo-1", 1, [
+        pullRequest(10, { draft: true }),
+        pullRequest(11, { state: "closed" }),
+        pullRequest(12),
+      ]),
+    ]);
+
+    expect(groups.map(({ pull }) => pull.number)).toEqual([12]);
+  });
+});
+
+function story(repoId: string, number: number, prs: PipelineStory["prs"]): PipelineStory {
+  return { repoId, number, prs } as PipelineStory;
+}
+
+function pullRequest(
+  number: number,
+  overrides: Partial<PipelineStory["prs"][number]> = {},
+): PipelineStory["prs"][number] {
+  return {
+    number,
+    title: `PR ${number}`,
+    url: `https://github.test/octo/repo/pull/${number}`,
+    state: "open",
+    draft: false,
+    headSha: `head-${number}`,
+    ciState: "success",
+    ciHeadSha: `head-${number}`,
+    createdAt: "2026-08-12T09:00:00Z",
+    closedAt: null,
+    mergedAt: null,
+    ...overrides,
+  };
+}

--- a/apps/web/test/story-navigation.test.ts
+++ b/apps/web/test/story-navigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { STORY_STAGES, storyNavigation } from "@/lib/story-navigation";
+
+describe("story navigation", () => {
+  it("uses only the six durable stages as workspace destinations", () => {
+    expect(STORY_STAGES.map(({ stage }) => stage)).toEqual([
+      "backlog",
+      "planning",
+      "building",
+      "validating",
+      "review",
+      "shipped",
+    ]);
+  });
+
+  it("keeps the overview separate from stage selection", () => {
+    expect(storyNavigation("project-1")).toEqual([
+      { href: "/projects/project-1/stories", label: "Overview" },
+      {
+        href: "/projects/project-1/stories?stage=backlog",
+        label: "Backlog",
+        stage: "backlog",
+      },
+      {
+        href: "/projects/project-1/stories?stage=planning",
+        label: "Planning",
+        stage: "planning",
+      },
+      {
+        href: "/projects/project-1/stories?stage=building",
+        label: "Building",
+        stage: "building",
+      },
+      {
+        href: "/projects/project-1/stories?stage=validating",
+        label: "Validating",
+        stage: "validating",
+      },
+      {
+        href: "/projects/project-1/stories?stage=review",
+        label: "Review",
+        stage: "review",
+      },
+      {
+        href: "/projects/project-1/stories?stage=shipped",
+        label: "Shipped",
+        stage: "shipped",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## What changes

- Replaces the all-stories workspace with a lifecycle overview and a dedicated workspace for each of the six durable stages.
- Adds a second-level Stories sidebar with Overview, Backlog, Planning, Building, Validating, Review, and Shipped navigation.
- Gives each stage its own meaningful statuses, filters, and at-a-glance metadata instead of showing inapplicable information.
- Groups Review work by pull request so one PR spanning several stories appears once and can be expanded.

## Why

Engineers make different decisions in each stage. A backlog item needs readiness and prioritization context; a validating item needs evidence and failure context; a review item needs pull-request context. Separating these workspaces reduces the amount of simultaneous information while preserving a compact project-wide lifecycle summary.

Closes #135.

This PR is stacked on #136, which introduces the simplified six-stage lifecycle and stage-local status model.

## Verification

- pnpm --filter @facility/web test — 8 files and 46 tests passed.
- pnpm --filter @facility/web typecheck — passed.
- pnpm --filter @facility/web build — passed after building workspace dependencies.
- git diff --check — passed.
- Browser-verified the lifecycle overview, Planning workspace, grouped Review queue, mobile Stories navigation, absence of Ready, and absence of runtime overlays/errors against realistic TAM-OS data.
- The repository-wide verifier completed lint, clean typecheck, and clean build locally. Its critical DB phase could not complete while other worktrees were concurrently using the repository's fixed facility_test database; isolated GitHub CI is the authoritative full-suite run for this branch.

- [ ] pnpm verify passes locally
- [x] Behaviour verified beyond the test suite (responsive browser smoke test against realistic data)
- [ ] Documentation updated, or no user-facing change
