### PR TITLE
feat(web): make story references clickable

### DIFF
--- a/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
@@ -7,7 +7,9 @@ import { LiveRefresh } from "@/components/shell/live-refresh";
 import { StoryTimeline } from "@/components/story/timeline";
 import { StoryTriggerButtons } from "@/components/story/trigger-buttons";
 import { api } from "@/lib/api";
+import { pipelineStories } from "@/lib/pipeline";
 import { deriveStoryTimeline, proposalsForStory } from "@/lib/story";
+import { createStoryReferenceLink } from "@/lib/story-reference";
 
 export async function generateMetadata({ params }: { params: Promise<{ number: string }> }) {
   const { number } = await params;
@@ -33,11 +35,12 @@ export default async function StoryPage({
     ...(storyType ? { storyType } : {}),
   };
 
-  const [detail, inbox, outcomes, activity, me] = await Promise.all([
+  const [detail, inbox, outcomes, activity, pipeline, me] = await Promise.all([
     api.story(projectId, number, query),
     api.inboxAll(),
     api.outcomes(`?state=all&projectId=${projectId}&limit=200`),
     api.storyGithubActivity(projectId, number, query),
+    api.pipeline(projectId),
     api.me(),
   ]);
 
@@ -68,6 +71,11 @@ export default async function StoryPage({
   }
 
   const story = detail.data;
+  const linkReference = createStoryReferenceLink({
+    projectId,
+    currentStory: story,
+    stories: pipeline.ok ? pipelineStories(pipeline.data) : [],
+  });
   const proposals = (inbox.ok ? inbox.data : []).filter(
     (proposal) => proposal.projectId === projectId,
   );
@@ -172,14 +180,19 @@ export default async function StoryPage({
             {story.storyType === "issue" ? "issue" : "PR"} body
           </summary>
           <div className="border-t border-(--line) px-5 py-4">
-            <Markdown source={story.bodyMd} />
+            <Markdown source={story.bodyMd} linkReference={linkReference} />
           </div>
         </details>
       ) : null}
 
       <div className="flex flex-col gap-4">
         <Eyebrow>timeline</Eyebrow>
-        <StoryTimeline projectId={projectId} items={timeline} canDecide={has("hitl:decide")} />
+        <StoryTimeline
+          projectId={projectId}
+          items={timeline}
+          canDecide={has("hitl:decide")}
+          linkReference={linkReference}
+        />
       </div>
 
       <p className="text-[11.5px] text-(--dim)">

--- a/apps/web/components/markdown.tsx
+++ b/apps/web/components/markdown.tsx
@@ -22,9 +22,25 @@ import type { JSX } from "react";
  */
 export type LinkArtifact = (id: string) => string | null;
 
+export type GitHubReference = {
+  owner: string | null;
+  repo: string | null;
+  number: number;
+  githubUrl: string | null;
+};
+
+/**
+ * Optional resolver for GitHub issue and pull-request references. The caller
+ * owns repository context and decides whether a reference belongs inside
+ * Facility or should link back to GitHub.
+ */
+export type LinkReference = (reference: GitHubReference) => string | null;
+
 const ARTIFACT_TOKEN_RE = /(\[\[[^\]]+\]\]|\b(?:S|D|T|V|R|H|E|F|L|CR|SR)\d{3}\b)/g;
 const WIKILINK_RE = /^\[\[([^\]|#]+)(?:[|#]([^\]]*))?\]\]$/;
 const BARE_ID_RE = /^(?:S|D|T|V|R|H|E|F|L|CR|SR)\d{3}$/;
+const GITHUB_REFERENCE_RE =
+  /https:\/\/github\.com\/[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]+\/(?:issues|pull)\/[1-9]\d*(?![\w/-])|(?<![\w/@.])[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]+#[1-9]\d*(?![\w/-])|(?<![\w/])#[1-9]\d*(?![\w/-])/gi;
 
 /**
  * Code spans are lifted out before anything else — their contents must stay
@@ -46,14 +62,16 @@ function renderInline(
   text: string,
   key: string,
   linkArtifact?: LinkArtifact,
+  linkReference?: LinkReference,
 ): (string | JSX.Element)[] {
   const codes: string[] = [];
   const masked = text.replace(/`([^`]+)`/g, (_match, body: string) => {
     codes.push(body);
     return `${CODE_MARK}c${codes.length - 1}${CODE_MARK}`;
   });
-  // Order matters: artifact references, then links, then bold, then italic.
-  return renderArtifacts(masked, key, linkArtifact, codes);
+  // Order matters: artifact references and explicit links are protected before
+  // emphasis and GitHub references are expanded at the text leaves.
+  return renderArtifacts(masked, key, linkArtifact, linkReference, codes);
 }
 
 /** Expand code placeholders in a fully-parsed text leaf. */
@@ -87,15 +105,18 @@ function renderArtifacts(
   text: string,
   key: string,
   linkArtifact: LinkArtifact | undefined,
+  linkReference: LinkReference | undefined,
   codes: string[],
 ): (string | JSX.Element)[] {
-  if (!linkArtifact) return renderLinks(text, key, linkArtifact, codes);
+  if (!linkArtifact && !linkReference) {
+    return renderLinks(text, key, linkArtifact, linkReference, codes);
+  }
   const out: (string | JSX.Element)[] = [];
   let n = 0;
   for (const part of text.split(ARTIFACT_TOKEN_RE)) {
     const wiki = part.match(WIKILINK_RE);
     const id = wiki?.[1]?.trim() ?? (BARE_ID_RE.test(part) ? part : null);
-    if (id) {
+    if (id && linkArtifact) {
       const label = wiki?.[2]?.trim() || id;
       const href = linkArtifact(id);
       out.push(
@@ -115,7 +136,15 @@ function renderArtifacts(
       );
       continue;
     }
-    if (part) out.push(...renderLinks(part, `${key}-a${n++}`, linkArtifact, codes));
+    if (part) {
+      // Keep an unresolved wikilink intact. In particular, its #anchor is not
+      // a GitHub reference and must not reach the reference pass.
+      out.push(
+        ...(wiki
+          ? renderEmphasis(part, `${key}-a${n++}`, undefined, codes)
+          : renderLinks(part, `${key}-a${n++}`, linkArtifact, linkReference, codes)),
+      );
+    }
   }
   return out;
 }
@@ -124,6 +153,7 @@ function renderLinks(
   text: string,
   key: string,
   _linkArtifact: LinkArtifact | undefined,
+  linkReference: LinkReference | undefined,
   codes: string[],
 ): (string | JSX.Element)[] {
   const out: (string | JSX.Element)[] = [];
@@ -145,12 +175,17 @@ function renderLinks(
       );
       continue;
     }
-    out.push(...renderEmphasis(part, `${key}-l${n++}`, codes));
+    out.push(...renderEmphasis(part, `${key}-l${n++}`, linkReference, codes));
   }
   return out;
 }
 
-function renderEmphasis(text: string, key: string, codes: string[]): (string | JSX.Element)[] {
+function renderEmphasis(
+  text: string,
+  key: string,
+  linkReference: LinkReference | undefined,
+  codes: string[],
+): (string | JSX.Element)[] {
   const out: (string | JSX.Element)[] = [];
   let n = 0;
   for (const part of text.split(/(\*\*[^*]+\*\*|\*[^*]+\*|_[^_]+_)/g)) {
@@ -158,21 +193,79 @@ function renderEmphasis(text: string, key: string, codes: string[]): (string | J
       const bkey = `${key}-b${n++}`;
       out.push(
         <strong key={bkey} className="font-semibold text-(--ink)">
-          {renderCode(part.slice(2, -2), bkey, codes)}
+          {renderReferences(part.slice(2, -2), bkey, linkReference, codes)}
         </strong>,
       );
     } else if (/^\*[^*]+\*$/.test(part) || /^_[^_]+_$/.test(part)) {
       const ikey = `${key}-i${n++}`;
       out.push(
         <em key={ikey} className="italic">
-          {renderCode(part.slice(1, -1), ikey, codes)}
+          {renderReferences(part.slice(1, -1), ikey, linkReference, codes)}
         </em>,
       );
     } else if (part) {
-      out.push(...renderCode(part, `${key}-t${n++}`, codes));
+      out.push(...renderReferences(part, `${key}-t${n++}`, linkReference, codes));
     }
   }
   return out;
+}
+
+function renderReferences(
+  text: string,
+  key: string,
+  linkReference: LinkReference | undefined,
+  codes: string[],
+): (string | JSX.Element)[] {
+  if (!linkReference) return renderCode(text, key, codes);
+  const out: (string | JSX.Element)[] = [];
+  let cursor = 0;
+  let n = 0;
+  for (const match of text.matchAll(GITHUB_REFERENCE_RE)) {
+    const token = match[0];
+    const index = match.index;
+    if (index > cursor) out.push(...renderCode(text.slice(cursor, index), `${key}-r${n++}`, codes));
+    const reference = parseGitHubReference(token);
+    const href = reference ? linkReference(reference) : null;
+    const rkey = `${key}-r${n++}`;
+    if (href) {
+      out.push(
+        <a
+          key={rkey}
+          href={href}
+          target={href.startsWith("http") ? "_blank" : undefined}
+          rel="noreferrer"
+          className="text-(--info) underline underline-offset-4"
+        >
+          {renderCode(token, rkey, codes)}
+        </a>,
+      );
+    } else {
+      out.push(...renderCode(token, rkey, codes));
+    }
+    cursor = index + token.length;
+  }
+  if (cursor < text.length) out.push(...renderCode(text.slice(cursor), `${key}-r${n}`, codes));
+  return out;
+}
+
+function parseGitHubReference(token: string): GitHubReference | null {
+  const url = token.match(
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/([1-9]\d*)$/i,
+  );
+  if (url?.[1] && url[2] && url[3]) {
+    return { owner: url[1], repo: url[2], number: Number(url[3]), githubUrl: token };
+  }
+  const qualified = token.match(/^([^/]+)\/([^/#]+)#([1-9]\d*)$/);
+  if (qualified?.[1] && qualified[2] && qualified[3]) {
+    return {
+      owner: qualified[1],
+      repo: qualified[2],
+      number: Number(qualified[3]),
+      githubUrl: `https://github.com/${qualified[1]}/${qualified[2]}/issues/${qualified[3]}`,
+    };
+  }
+  const local = token.match(/^#([1-9]\d*)$/);
+  return local?.[1] ? { owner: null, repo: null, number: Number(local[1]), githubUrl: null } : null;
 }
 
 const TASK_RE = /^\[([ xX])\]\s+(.*)$/;
@@ -192,9 +285,11 @@ function splitRow(line: string): string[] {
 export function Markdown({
   source,
   linkArtifact,
+  linkReference,
 }: {
   source: string;
   linkArtifact?: LinkArtifact;
+  linkReference?: LinkReference;
 }) {
   // Strip the code-span placeholder marker (see renderInline) so no document
   // can smuggle a forged placeholder past the masking pass.
@@ -209,7 +304,12 @@ export function Markdown({
     const key = `p-${blocks.length}`;
     blocks.push(
       <p key={key} className="text-(--mut)">
-        {renderInline(paragraph.map((line) => line.trim()).join(" "), key, linkArtifact)}
+        {renderInline(
+          paragraph.map((line) => line.trim()).join(" "),
+          key,
+          linkArtifact,
+          linkReference,
+        )}
       </p>,
     );
     paragraph = [];
@@ -229,14 +329,14 @@ export function Markdown({
               {done ? "☑" : "☐"}
             </span>
             <span className={done ? "text-(--dim) line-through" : undefined}>
-              {renderInline(task[2], key, linkArtifact)}
+              {renderInline(task[2], key, linkArtifact, linkReference)}
             </span>
           </li>
         );
       }
       return (
         <li key={key} className="leading-relaxed">
-          {renderInline(item, key, linkArtifact)}
+          {renderInline(item, key, linkArtifact, linkReference)}
         </li>
       );
     });
@@ -305,7 +405,7 @@ export function Markdown({
                     key={`${tkey}-h${c}`}
                     className="border border-(--line) bg-(--card) px-3 py-1.5 text-left font-mono text-[11px] font-medium text-(--ink)"
                   >
-                    {renderInline(cell, `${tkey}-h${c}`, linkArtifact)}
+                    {renderInline(cell, `${tkey}-h${c}`, linkArtifact, linkReference)}
                   </th>
                 ))}
               </tr>
@@ -320,7 +420,12 @@ export function Markdown({
                       key={`${tkey}-r${r}c${c}`}
                       className="border border-(--line) px-3 py-1.5 align-top text-(--mut)"
                     >
-                      {renderInline(cells[c] ?? "", `${tkey}-r${r}c${c}`, linkArtifact)}
+                      {renderInline(
+                        cells[c] ?? "",
+                        `${tkey}-r${r}c${c}`,
+                        linkArtifact,
+                        linkReference,
+                      )}
                     </td>
                   ))}
                 </tr>
@@ -339,7 +444,7 @@ export function Markdown({
       const level = heading[1]?.length ?? 1;
       const size = level === 1 ? "text-[18px]" : level === 2 ? "text-[16px]" : "text-[14px]";
       const cls = `scroll-mt-6 text-pretty font-semibold tracking-tight text-(--ink) ${size}`;
-      const content = renderInline(heading[2], `h-${blocks.length}`, linkArtifact);
+      const content = renderInline(heading[2], `h-${blocks.length}`, linkArtifact, linkReference);
       const key = `h-${blocks.length}`;
       blocks.push(
         level === 1 ? (
@@ -389,7 +494,12 @@ export function Markdown({
           key={`q-${blocks.length}`}
           className="border-l-2 border-(--line-strong) pl-4 text-(--mut) italic"
         >
-          {renderInline(raw.replace(/^\s*>\s?/, ""), `q-${blocks.length}`, linkArtifact)}
+          {renderInline(
+            raw.replace(/^\s*>\s?/, ""),
+            `q-${blocks.length}`,
+            linkArtifact,
+            linkReference,
+          )}
         </blockquote>,
       );
       continue;

--- a/apps/web/components/story/timeline.tsx
+++ b/apps/web/components/story/timeline.tsx
@@ -1,7 +1,7 @@
 import { StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
 import { ProposalCard } from "@/components/inbox/proposal-card";
-import { Markdown } from "@/components/markdown";
+import { type LinkReference, Markdown } from "@/components/markdown";
 import { RunOutcome } from "@/components/story/run-outcome";
 import type { Proposal } from "@/lib/api";
 import { fmtCost, fmtDuration } from "@/lib/runs";
@@ -18,10 +18,12 @@ export function StoryTimeline({
   projectId,
   items,
   canDecide,
+  linkReference,
 }: {
   projectId: string;
   items: StoryItem[];
   canDecide: boolean;
+  linkReference: LinkReference;
 }) {
   if (items.length === 0) {
     return (
@@ -38,7 +40,12 @@ export function StoryTimeline({
             aria-hidden
             className="absolute top-1.5 -left-[3.5px] h-[7px] w-[7px] border border-(--line-strong) bg-(--bg)"
           />
-          <TimelineItem projectId={projectId} item={item} canDecide={canDecide} />
+          <TimelineItem
+            projectId={projectId}
+            item={item}
+            canDecide={canDecide}
+            linkReference={linkReference}
+          />
         </li>
       ))}
     </ol>
@@ -71,10 +78,12 @@ function TimelineItem({
   projectId,
   item,
   canDecide,
+  linkReference,
 }: {
   projectId: string;
   item: StoryItem;
   canDecide: boolean;
+  linkReference: LinkReference;
 }) {
   switch (item.kind) {
     case "story_opened":
@@ -122,7 +131,7 @@ function TimelineItem({
             </span>
           </div>
           <div className="text-[12.5px]">
-            <Markdown source={item.comment.bodyMd} />
+            <Markdown source={item.comment.bodyMd} linkReference={linkReference} />
           </div>
         </div>
       );
@@ -183,7 +192,7 @@ function TimelineItem({
                 PR description
               </summary>
               <div className="mt-2 border-t border-(--line) pt-3 text-[12.5px]">
-                <Markdown source={item.pr.bodyMd} />
+                <Markdown source={item.pr.bodyMd} linkReference={linkReference} />
               </div>
             </details>
           ) : null}

--- a/apps/web/lib/story-reference.ts
+++ b/apps/web/lib/story-reference.ts
@@ -1,0 +1,59 @@
+import type { LinkReference } from "@/components/markdown";
+
+type ReferenceStory = {
+  number: number;
+  repoId: string;
+  repoOwner: string;
+  repoName: string;
+  prs: readonly { number: number }[];
+};
+
+type ReferenceTarget = Pick<ReferenceStory, "number" | "repoId">;
+
+/**
+ * Resolve GitHub references into the owning Facility story when that target is
+ * present in the story index. Pull request numbers are aliases for the story
+ * they belong to, so linked PRs do not lead to a nonexistent orphan-PR page.
+ */
+export function createStoryReferenceLink(input: {
+  projectId: string;
+  currentStory: ReferenceStory;
+  stories: readonly ReferenceStory[];
+}): LinkReference {
+  const repoIdByName = new Map<string, string>();
+  const targetByRepoAndNumber = new Map<string, ReferenceTarget>();
+  const indexedStories = [...input.stories, input.currentStory];
+
+  for (const story of indexedStories) {
+    repoIdByName.set(repoNameKey(story.repoOwner, story.repoName), story.repoId);
+    const target = { number: story.number, repoId: story.repoId };
+    targetByRepoAndNumber.set(referenceKey(story.repoId, story.number), target);
+    for (const pull of story.prs) {
+      targetByRepoAndNumber.set(referenceKey(story.repoId, pull.number), target);
+    }
+  }
+
+  return (reference) => {
+    const owner = reference.owner ?? input.currentStory.repoOwner;
+    const repo = reference.repo ?? input.currentStory.repoName;
+    const fallback =
+      reference.githubUrl ?? `https://github.com/${owner}/${repo}/issues/${reference.number}`;
+    const repoId =
+      reference.owner && reference.repo
+        ? repoIdByName.get(repoNameKey(reference.owner, reference.repo))
+        : input.currentStory.repoId;
+    if (!repoId) return fallback;
+    const target = targetByRepoAndNumber.get(referenceKey(repoId, reference.number));
+    if (!target) return fallback;
+    const query = new URLSearchParams({ repoId: target.repoId });
+    return `/projects/${input.projectId}/stories/${target.number}?${query}`;
+  };
+}
+
+function repoNameKey(owner: string, repo: string) {
+  return `${owner}/${repo}`.toLowerCase();
+}
+
+function referenceKey(repoId: string, number: number) {
+  return `${repoId}:${number}`;
+}

--- a/apps/web/test/markdown.test.ts
+++ b/apps/web/test/markdown.test.ts
@@ -1,12 +1,15 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
-import { Markdown } from "@/components/markdown";
+import { describe, expect, it, vi } from "vitest";
+import { type LinkReference, Markdown } from "@/components/markdown";
 
 const MARK = "\uE000";
 
-function render(source: string): string {
-  return renderToStaticMarkup(createElement(Markdown, { source }));
+function render(
+  source: string,
+  options: { linkReference?: LinkReference; linkArtifact?: (id: string) => string | null } = {},
+): string {
+  return renderToStaticMarkup(createElement(Markdown, { source, ...options }));
 }
 
 describe("Markdown inline parsing", () => {
@@ -96,5 +99,102 @@ The next paragraph remains separate.`);
     expect(html).toContain("vulnerable path reachable");
     expect(html).toContain('translate="no"');
     expect(html).toContain("&lt;/what_to_audit&gt;");
+  });
+});
+
+describe("Markdown GitHub references", () => {
+  it("links local, repository-qualified, and raw GitHub references", () => {
+    const linkReference = vi.fn<LinkReference>((reference) => `/stories/${reference.number}`);
+    const html = render(
+      "Closes #98, follows theam/facility#97 and https://github.com/theam/facility/pull/96.",
+      { linkReference },
+    );
+
+    expect(html.match(/<a/g)).toHaveLength(3);
+    expect(html).toContain('href="/stories/98"');
+    expect(html).toContain('href="/stories/97"');
+    expect(html).toContain('href="/stories/96"');
+    expect(linkReference).toHaveBeenNthCalledWith(1, {
+      owner: null,
+      repo: null,
+      number: 98,
+      githubUrl: null,
+    });
+    expect(linkReference).toHaveBeenNthCalledWith(2, {
+      owner: "theam",
+      repo: "facility",
+      number: 97,
+      githubUrl: "https://github.com/theam/facility/issues/97",
+    });
+    expect(linkReference).toHaveBeenNthCalledWith(3, {
+      owner: "theam",
+      repo: "facility",
+      number: 96,
+      githubUrl: "https://github.com/theam/facility/pull/96",
+    });
+  });
+
+  it("keeps reference-like text in code spans and fenced blocks literal", () => {
+    const linkReference = vi.fn<LinkReference>(() => "/unexpected");
+    const html = render("Use `#98` here.\n\n```\ntheam/facility#97\n```", { linkReference });
+
+    expect(html).toContain("<code");
+    expect(html).toContain("<pre");
+    expect(html).not.toContain("<a");
+    expect(linkReference).not.toHaveBeenCalled();
+  });
+
+  it("does not replace references inside an existing Markdown link", () => {
+    const linkReference = vi.fn<LinkReference>(() => "/unexpected");
+    const html = render(
+      "[#98](https://example.com) [PR](https://github.com/theam/facility/pull/97)",
+      {
+        linkReference,
+      },
+    );
+
+    expect(html.match(/<a/g)).toHaveLength(2);
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('href="https://github.com/theam/facility/pull/97"');
+    expect(linkReference).not.toHaveBeenCalled();
+  });
+
+  it("keeps a wikilink anchor ahead of the GitHub reference pass", () => {
+    const linkReference = vi.fn<LinkReference>(() => "/unexpected");
+    const plain = render("See [[page#123]].", { linkReference });
+    const linked = render("See [[page#123]].", {
+      linkReference,
+      linkArtifact: (id) => `/kb/${id}`,
+    });
+
+    expect(plain).toContain("[[page#123]]");
+    expect(plain).not.toContain("<a");
+    expect(linked).toContain('href="/kb/page"');
+    expect(linked).not.toContain("/unexpected");
+    expect(linkReference).not.toHaveBeenCalled();
+  });
+
+  it("preserves emphasis around a linked reference", () => {
+    const html = render("**Closes #98**", { linkReference: () => "/stories/98" });
+
+    expect(html).toContain("<strong");
+    expect(html).toContain('href="/stories/98"');
+    expect(html).not.toContain("**");
+  });
+
+  it("leaves a recognized reference as text when the resolver declines it", () => {
+    const html = render("Closes #98", { linkReference: () => null });
+
+    expect(html).toContain("Closes #98");
+    expect(html).not.toContain("<a");
+  });
+
+  it("does not find a repository reference inside another URL", () => {
+    const linkReference = vi.fn<LinkReference>(() => "/unexpected");
+    const html = render("https://example.com/theam/facility#98", { linkReference });
+
+    expect(html).toContain("https://example.com/theam/facility#98");
+    expect(html).not.toContain("<a");
+    expect(linkReference).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/test/story-reference.test.ts
+++ b/apps/web/test/story-reference.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { GitHubReference } from "@/components/markdown";
+import { createStoryReferenceLink } from "@/lib/story-reference";
+
+const currentStory = {
+  number: 98,
+  repoId: "repo_facility",
+  repoOwner: "theam",
+  repoName: "facility",
+  prs: [{ number: 140 }],
+};
+
+const siblingStory = {
+  number: 12,
+  repoId: "repo_docs",
+  repoOwner: "theam",
+  repoName: "docs",
+  prs: [{ number: 21 }],
+};
+
+function reference(fields: Partial<GitHubReference> = {}): GitHubReference {
+  return {
+    owner: null,
+    repo: null,
+    number: 98,
+    githubUrl: null,
+    ...fields,
+  };
+}
+
+describe("story reference links", () => {
+  const linkReference = createStoryReferenceLink({
+    projectId: "proj_1",
+    currentStory,
+    stories: [siblingStory],
+  });
+
+  it("opens a same-repository reference inside Facility", () => {
+    expect(linkReference(reference())).toBe("/projects/proj_1/stories/98?repoId=repo_facility");
+  });
+
+  it("maps a linked PR number to its owning Facility story", () => {
+    expect(linkReference(reference({ number: 140 }))).toBe(
+      "/projects/proj_1/stories/98?repoId=repo_facility",
+    );
+  });
+
+  it("resolves a connected repository case-insensitively", () => {
+    expect(
+      linkReference(
+        reference({
+          owner: "THEAM",
+          repo: "DOCS",
+          number: 21,
+          githubUrl: "https://github.com/THEAM/DOCS/pull/21",
+        }),
+      ),
+    ).toBe("/projects/proj_1/stories/12?repoId=repo_docs");
+  });
+
+  it("falls back to GitHub for an unknown qualified reference", () => {
+    expect(
+      linkReference(
+        reference({
+          owner: "someone",
+          repo: "elsewhere",
+          number: 7,
+          githubUrl: "https://github.com/someone/elsewhere/pull/7",
+        }),
+      ),
+    ).toBe("https://github.com/someone/elsewhere/pull/7");
+  });
+
+  it("falls back to the current GitHub repository for an unknown local reference", () => {
+    expect(linkReference(reference({ number: 404 }))).toBe(
+      "https://github.com/theam/facility/issues/404",
+    );
+  });
+});


### PR DESCRIPTION
## What changes

- Recognize `#123`, `owner/repo#123`, and bare GitHub issue/PR URLs in Facility's dependency-free Markdown renderer.
- Resolve mirrored issue and linked-PR numbers to their owning Facility story, including connected repositories; fall back to GitHub when no mirrored target is known.
- Apply the resolver to story bodies, GitHub comments, and PR descriptions while keeping code spans, fenced blocks, wikilinks, and existing Markdown links untouched.
- Add parser and resolver regression coverage.

## Why

Story references currently render as dead text, forcing readers to leave Facility to follow the work. This keeps known references inside the story view, where runs, gates, and cost remain available.

Fixes #98.

## Verification

- [x] Clean CI `verify` passed the full release-shaped verification.
- [x] `pnpm test:uncached` passes, including 52/52 web tests and the new regression cases.
- [x] `pnpm guards` passes (2/2 guards).
- [x] `pnpm audit --audit-level low` exits successfully (2 existing high findings ignored by repository policy).
- [ ] `pnpm verify` passes locally
  - Lint, typecheck, clean production build, and the isolated DB critical tests passed.
  - Two complete attempts then failed in unchanged DB/API integration code through cascading local PostgreSQL timeouts. The second API result was:
    ```
    Test Files  4 failed | 34 passed | 2 skipped (40)
         Tests  17 failed | 369 passed | 49 skipped (435)
        Errors  1 error
    ```
  - This branch has no changes under `services/api`, `packages/db`, or `scripts`; the clean-environment CI acceptance run is green.
- [ ] Behaviour verified beyond the test suite (the optional one-off TSX runner is not installed in the web workspace).
- [ ] Documentation updated, or no user-facing change — no documentation was changed for this inline navigation behavior.

### Review note

The repository-mandated Claude UI/API second-opinion command was attempted, but the local Claude OAuth session is expired and could not be refreshed.