### PR TITLE
fix: show CI on stories

### DIFF
--- a/apps/docs/docs/self-host/github-app.md
+++ b/apps/docs/docs/self-host/github-app.md
@@ -99,6 +99,11 @@ Then save the App settings. If one of those checkboxes is missing, return to
 **Permissions**, grant its required read permission, save, and open the App
 settings again.
 
+After deployment, run `facility doctor --platform` (or inspect the admin
+readiness doctor) to verify that the App still has **Checks: Read-only** and is
+subscribed to **Check run**. Facility reports a failing readiness check instead
+of leaving the Validating stage silently empty when either setting is missing.
+
 Every GitHub App receives `installation` events automatically; GitHub does not
 offer a checkbox for them. GitHub also sends installation-repository changes
 when repositories are added to or removed from the installation.

--- a/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
@@ -1,6 +1,7 @@
 import { Eyebrow, PillTag, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { CiStatusLink } from "@/components/ci-status";
 import { Markdown } from "@/components/markdown";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
@@ -90,6 +91,7 @@ export default async function StoryPage({
     outcomes: outcomes.ok ? outcomes.data : [],
     comments,
     prs: activity.ok ? activityPrs : undefined,
+    ciEvents: activity.ok ? activity.data.ciEvents : undefined,
     allowLegacyProposalNumber,
     stageLabels,
   });
@@ -137,6 +139,13 @@ export default async function StoryPage({
             <span className="text-[12px] font-medium text-(--mut)">{story.state}</span>
           </span>
           {stage ? <PillTag>{stage.label}</PillTag> : null}
+          {story.ciState && story.ciUrl ? (
+            <CiStatusLink
+              state={story.ciState}
+              url={story.ciUrl}
+              failureNames={story.ciFailureNames}
+            />
+          ) : null}
           {story.labels.slice(0, 4).map((label) => (
             <span
               key={label}

--- a/apps/web/components/ci-status.tsx
+++ b/apps/web/components/ci-status.tsx
@@ -1,0 +1,47 @@
+import { StatusDot } from "@facility/ui";
+
+type CiState = "pending" | "success" | "failure";
+
+export function CiStatusLink({
+  state,
+  url,
+  failureNames = [],
+  className = "",
+}: {
+  state: CiState;
+  url: string;
+  failureNames?: string[];
+  className?: string;
+}) {
+  const label = ciStatusLabel(state, failureNames);
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      title={
+        state === "failure" && failureNames.length > 3
+          ? `checks · failed · ${failureNames.join(", ")}`
+          : undefined
+      }
+      className={`flex items-center gap-2 font-mono text-[11px] text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline ${className}`}
+    >
+      <StatusDot tone={ciTone(state)} />
+      {label}
+    </a>
+  );
+}
+
+export function ciStatusLabel(state: CiState, failureNames: string[] = []) {
+  const outcome = state === "success" ? "passed" : state;
+  if (state !== "failure" || failureNames.length === 0) return `checks · ${outcome}`;
+  const visible = failureNames.slice(0, 3);
+  const remaining = failureNames.length - visible.length;
+  return `checks · failed · ${visible.join(", ")}${remaining > 0 ? ` +${remaining}` : ""}`;
+}
+
+function ciTone(state: CiState): "info" | "ok" | "bad" {
+  if (state === "success") return "ok";
+  if (state === "failure") return "bad";
+  return "info";
+}

--- a/apps/web/components/issues/issue-row.tsx
+++ b/apps/web/components/issues/issue-row.tsx
@@ -4,6 +4,7 @@ import { Button, StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { CiStatusLink } from "@/components/ci-status";
 import type { PipelineStory } from "@/lib/pipeline";
 import { storyHref } from "@/lib/pipeline";
 
@@ -140,26 +141,12 @@ export function IssueRow({
               PR #{pr.number} ↗
             </a>
           ))}
-          {story.ciState === "failure" && story.ciUrl ? (
-            <a
-              href={story.ciUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2 font-mono text-[11px] text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
-            >
-              <StatusDot tone="bad" />
-              checks · failed
-            </a>
-          ) : story.ciState === "pending" && story.ciUrl ? (
-            <a
-              href={story.ciUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2 font-mono text-[11px] text-(--mut) underline-offset-4 hover:text-(--ink) hover:underline"
-            >
-              <StatusDot tone="info" />
-              checks · pending
-            </a>
+          {story.ciState && story.ciUrl ? (
+            <CiStatusLink
+              state={story.ciState}
+              url={story.ciUrl}
+              failureNames={story.ciFailureNames}
+            />
           ) : null}
         </div>
       ) : null}

--- a/apps/web/components/story/timeline.tsx
+++ b/apps/web/components/story/timeline.tsx
@@ -1,5 +1,6 @@
 import { StatusDot, toneFor } from "@facility/ui";
 import Link from "next/link";
+import { CiStatusLink } from "@/components/ci-status";
 import { ProposalCard } from "@/components/inbox/proposal-card";
 import { type LinkReference, Markdown } from "@/components/markdown";
 import { RunOutcome } from "@/components/story/run-outcome";
@@ -67,6 +68,8 @@ function keyOf(item: StoryItem): string {
       return `pr-open-${item.pr.number}`;
     case "pr_closed":
       return `pr-closed-${item.pr.number}`;
+    case "ci":
+      return `ci-${item.event.id}`;
     case "stage":
       return `stage-${item.stage}-${item.ts}`;
     default:
@@ -209,6 +212,18 @@ function TimelineItem({
           }`}
           tone={item.pr.state === "merged" ? "ok" : "machine"}
         />
+      );
+    case "ci":
+      return (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <CiStatusLink
+            state={item.event.state}
+            url={`${item.pr.url}/checks`}
+            failureNames={item.event.failureNames}
+          />
+          <span className="font-mono text-[10.5px] text-(--dim)">PR #{item.pr.number}</span>
+          <Stamp ts={item.ts} />
+        </div>
       );
     default:
       return null;

--- a/apps/web/lib/story.ts
+++ b/apps/web/lib/story.ts
@@ -4,6 +4,7 @@ import type { Outcome, PipelineStageKey, Proposal, StoryDetail, StoryGithubActiv
 export type StoryRun = StoryDetail["runs"][number];
 export type StoryComment = StoryGithubActivity["comments"][number];
 export type StoryPr = StoryGithubActivity["prs"][number];
+export type StoryCiEvent = StoryGithubActivity["ciEvents"][number];
 
 // Timeline replay is intentionally not the current-state classifier, but it
 // must acknowledge every server-published stage when the generated union grows.
@@ -30,6 +31,7 @@ export type StoryItem =
   | { kind: "comment"; ts: string; comment: StoryComment }
   | { kind: "pr_opened"; ts: string; outcome: Outcome | null; pr: StoryPr }
   | { kind: "pr_closed"; ts: string; outcome: Outcome | null; pr: StoryPr }
+  | { kind: "ci"; ts: string; event: StoryCiEvent; pr: StoryPr }
   | { kind: "issue_closed"; ts: string }
   | { kind: "stage"; ts: string; stage: PipelineStageKey; label: string };
 
@@ -87,6 +89,8 @@ function stageEntered(item: StoryItem): PipelineStageKey | null {
       return item.pr.ciState === "pending" ? TIMELINE_STAGES.validating : TIMELINE_STAGES.review;
     case "pr_closed":
       return item.pr.state === "merged" ? TIMELINE_STAGES.shipped : null;
+    case "ci":
+      return item.event.state === "pending" ? TIMELINE_STAGES.validating : TIMELINE_STAGES.review;
     case "issue_closed":
       return TIMELINE_STAGES.shipped;
     default:
@@ -100,6 +104,7 @@ export function deriveStoryTimeline(input: {
   outcomes: Outcome[];
   comments?: StoryComment[];
   prs?: StoryPr[];
+  ciEvents?: StoryCiEvent[];
   allowLegacyProposalNumber: boolean;
   stageLabels: ReadonlyMap<PipelineStageKey, string>;
 }): StoryItem[] {
@@ -156,7 +161,10 @@ export function deriveStoryTimeline(input: {
       closedAt: stamp(pull.closedAt),
       mergedAt: stamp(pull.mergedAt),
       ciState: pull.ciState,
+      ciFailureNames: pull.ciFailureNames,
     }));
+  const ciEventPullNumbers = new Set((input.ciEvents ?? []).map((event) => event.pullNumber));
+  const timelinePullsByNumber = new Map(timelinePulls.map((pull) => [pull.number, pull]));
   for (const pr of timelinePulls) {
     const outcome = outcomesByPull.get(pr.number) ?? null;
     const detailPull = detailPulls.get(pr.number);
@@ -165,12 +173,20 @@ export function deriveStoryTimeline(input: {
         ? detailPull.ciState
         : null
       : pr.ciState;
-    const timelinePr = { ...pr, ciState: currentCiState };
+    const timelinePr = {
+      ...pr,
+      ciState: ciEventPullNumbers.has(pr.number) ? null : currentCiState,
+    };
     if (pr.createdAt) {
       items.push({ kind: "pr_opened", ts: pr.createdAt, outcome, pr: timelinePr });
     }
     const terminalAt = pr.mergedAt ?? pr.closedAt;
     if (terminalAt) items.push({ kind: "pr_closed", ts: terminalAt, outcome, pr: timelinePr });
+  }
+
+  for (const event of input.ciEvents ?? []) {
+    const pr = timelinePullsByNumber.get(event.pullNumber);
+    if (pr) items.push({ kind: "ci", ts: event.observedAt, event, pr });
   }
 
   const closed = stamp(detail.closedAt);

--- a/apps/web/test/pipeline-story.test.ts
+++ b/apps/web/test/pipeline-story.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { ciStatusLabel } from "@/components/ci-status";
 import type { PipelineStageKey, PipelineStory, Proposal, StoryDetail } from "@/lib/api";
 import { reviewablePullRequests, storyHref } from "@/lib/pipeline";
 import { deriveStoryTimeline, proposalsForStory } from "@/lib/story";
 
 describe("story presentation contract", () => {
+  it("uses the established CI grammar for green and named failures", () => {
+    expect(ciStatusLabel("success")).toBe("checks · passed");
+    expect(ciStatusLabel("failure", ["guards", "typecheck"])).toBe(
+      "checks · failed · guards, typecheck",
+    );
+  });
+
   it("keeps repository and story kind in every detail link", () => {
     expect(
       storyHref("project-1", {
@@ -26,6 +34,7 @@ describe("story presentation contract", () => {
         headSha: "head-22",
         ciState: "pending",
         ciHeadSha: "head-22",
+        ciFailureNames: [],
         createdAt: "2026-08-02T00:00:00Z",
         closedAt: "2026-08-03T00:00:00Z",
         mergedAt: "2026-08-03T00:00:00Z",
@@ -49,6 +58,7 @@ describe("story presentation contract", () => {
           closedAt: "2026-08-03T00:00:00Z",
           mergedAt: "2026-08-03T00:00:00Z",
           ciState: "pending",
+          ciFailureNames: [],
         },
       ],
       allowLegacyProposalNumber: true,
@@ -80,6 +90,7 @@ describe("story presentation contract", () => {
         headSha: "new-head",
         ciState: "pending",
         ciHeadSha: "old-head",
+        ciFailureNames: [],
         createdAt: "2026-08-02T00:00:00Z",
         closedAt: null,
         mergedAt: null,
@@ -103,6 +114,7 @@ describe("story presentation contract", () => {
           closedAt: null,
           mergedAt: null,
           ciState: "pending",
+          ciFailureNames: [],
         },
       ],
       allowLegacyProposalNumber: true,
@@ -135,6 +147,70 @@ describe("story presentation contract", () => {
     );
     expect(timeline).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ kind: "stage", stage: "review" })]),
+    );
+  });
+
+  it("replays every stored CI rollup transition with failed check detail", () => {
+    const detail = storyDetail();
+    detail.prs = [
+      pipelinePull(25, {
+        ciState: "failure",
+        ciHeadSha: "head-25",
+        ciFailureNames: ["guards", "typecheck"],
+      }),
+    ];
+    const timeline = deriveStoryTimeline({
+      detail,
+      proposals: [],
+      outcomes: [],
+      prs: undefined,
+      ciEvents: [
+        {
+          id: "cie-pending",
+          pullNumber: 25,
+          headSha: "head-25",
+          state: "pending",
+          failureNames: [],
+          observedAt: "2026-08-02T00:01:00Z",
+        },
+        {
+          id: "cie-success",
+          pullNumber: 25,
+          headSha: "head-25",
+          state: "success",
+          failureNames: [],
+          observedAt: "2026-08-02T00:02:00Z",
+        },
+        {
+          id: "cie-failure",
+          pullNumber: 25,
+          headSha: "head-25",
+          state: "failure",
+          failureNames: ["guards", "typecheck"],
+          observedAt: "2026-08-02T00:03:00Z",
+        },
+      ],
+      allowLegacyProposalNumber: true,
+      stageLabels: new Map([
+        ["review", "In review"],
+        ["validating", "Validating"],
+      ]),
+    });
+
+    expect(
+      timeline
+        .filter((item) => item.kind === "ci")
+        .map((item) => [item.event.state, item.event.failureNames]),
+    ).toEqual([
+      ["pending", []],
+      ["success", []],
+      ["failure", ["guards", "typecheck"]],
+    ]);
+    expect(timeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "stage", stage: "validating" }),
+        expect.objectContaining({ kind: "stage", stage: "review" }),
+      ]),
     );
   });
 
@@ -224,6 +300,7 @@ function pipelinePull(
     headSha: `head-${number}`,
     ciState: null,
     ciHeadSha: null,
+    ciFailureNames: [],
     createdAt: "2026-08-02T00:00:00Z",
     closedAt: null,
     mergedAt: null,
@@ -252,6 +329,9 @@ function storyDetail(): StoryDetail {
     ghUpdatedAt: "2026-08-01T00:00:00Z",
     closedAt: null,
     prs: [],
+    ciState: null,
+    ciUrl: null,
+    ciFailureNames: [],
     stage: { key: "backlog", label: "Backlog" },
     pipelineStages: [
       { key: "backlog", label: "Backlog" },

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -26,6 +26,7 @@ export const ID_PREFIXES = {
   iss: "iss",
   ghi: "ghi",
   ghp: "ghp",
+  cie: "cie",
   evt: "evt",
   int: "int",
   fp: "fp",

--- a/packages/db/migrations/0041_github_ci_story_events.sql
+++ b/packages/db/migrations/0041_github_ci_story_events.sql
@@ -1,0 +1,26 @@
+ALTER TABLE gh_pull_requests
+  ADD COLUMN ci_failure_names text[] NOT NULL DEFAULT '{}';
+
+CREATE TABLE gh_ci_events (
+  id text PRIMARY KEY,
+  org_id text NOT NULL REFERENCES orgs(id),
+  project_id text NOT NULL REFERENCES projects(id),
+  repo_id text NOT NULL REFERENCES repos(id),
+  pull_number integer NOT NULL,
+  head_sha text NOT NULL,
+  state text NOT NULL,
+  failure_names text[] NOT NULL DEFAULT '{}',
+  source_event_id text,
+  observed_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT gh_ci_events_state_check CHECK (state IN ('pending', 'success', 'failure'))
+);
+
+CREATE INDEX gh_ci_events_repo_pull_observed_idx
+  ON gh_ci_events(repo_id, pull_number, observed_at);
+
+CREATE INDEX gh_ci_events_org_project_observed_idx
+  ON gh_ci_events(org_id, project_id, observed_at);
+
+CREATE UNIQUE INDEX gh_ci_events_source_pull_uidx
+  ON gh_ci_events(source_event_id, repo_id, pull_number)
+  WHERE source_event_id IS NOT NULL;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -279,6 +279,7 @@ export const ghPullRequests = pgTable(
     closingIssues: integer("closing_issues").array().notNull().default(sql`'{}'::integer[]`),
     ciState: text("ci_state"),
     ciHeadSha: text("ci_head_sha"),
+    ciFailureNames: text("ci_failure_names").array().notNull().default(sql`'{}'::text[]`),
     ciUpdatedAt: timestamp("ci_updated_at", { withTimezone: true }),
     ghCreatedAt: timestamp("gh_created_at", { withTimezone: true }),
     ghUpdatedAt: timestamp("gh_updated_at", { withTimezone: true }),
@@ -297,6 +298,44 @@ export const ghPullRequests = pgTable(
       "gh_pull_requests_ci_state_check",
       sql`${table.ciState} is null or ${table.ciState} in ('pending', 'success', 'failure')`,
     ),
+  ],
+);
+
+export const ghCiEvents = pgTable(
+  "gh_ci_events",
+  {
+    id: text("id").primaryKey(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => orgs.id),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id),
+    repoId: text("repo_id")
+      .notNull()
+      .references(() => repos.id),
+    pullNumber: integer("pull_number").notNull(),
+    headSha: text("head_sha").notNull(),
+    state: text("state").notNull(),
+    failureNames: text("failure_names").array().notNull().default(sql`'{}'::text[]`),
+    sourceEventId: text("source_event_id"),
+    observedAt: timestamp("observed_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    check("gh_ci_events_state_check", sql`${table.state} in ('pending', 'success', 'failure')`),
+    index("gh_ci_events_repo_pull_observed_idx").on(
+      table.repoId,
+      table.pullNumber,
+      table.observedAt,
+    ),
+    index("gh_ci_events_org_project_observed_idx").on(
+      table.orgId,
+      table.projectId,
+      table.observedAt,
+    ),
+    uniqueIndex("gh_ci_events_source_pull_uidx")
+      .on(table.sourceEventId, table.repoId, table.pullNumber)
+      .where(sql`${table.sourceEventId} is not null`),
   ],
 );
 

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -786,7 +786,10 @@ describe("db", async () => {
           'gh_pull_requests_repo_number_uidx',
           'gh_pull_requests_org_project_state_idx',
           'gh_pull_requests_repo_head_sha_idx',
-          'gh_pull_requests_closing_issues_idx'
+          'gh_pull_requests_closing_issues_idx',
+          'gh_ci_events_repo_pull_observed_idx',
+          'gh_ci_events_org_project_observed_idx',
+          'gh_ci_events_source_pull_uidx'
         )
       `,
     )) as Iterable<{ indexname: string }>;
@@ -825,6 +828,10 @@ describe("db", async () => {
         "gh_pull_requests_org_project_state_idx",
         "gh_pull_requests_repo_head_sha_idx",
         "gh_pull_requests_closing_issues_idx",
+        // Append-only CI rollup transitions for story timelines (migration 0041).
+        "gh_ci_events_repo_pull_observed_idx",
+        "gh_ci_events_org_project_observed_idx",
+        "gh_ci_events_source_pull_uidx",
       ]),
     );
     const pullRequestChecks = (await db.execute(
@@ -846,6 +853,17 @@ describe("db", async () => {
         "gh_pull_requests_repo_number_uidx",
       ]),
     );
+    const ciEventChecks = (await db.execute(
+      sql`
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'gh_ci_events'::regclass
+          AND conname = 'gh_ci_events_state_check'
+      `,
+    )) as Iterable<{ conname: string }>;
+    expect(Array.from(ciEventChecks).map((row) => row.conname)).toEqual([
+      "gh_ci_events_state_check",
+    ]);
     const applied = (await db.execute(
       sql`
         SELECT name
@@ -856,9 +874,7 @@ describe("db", async () => {
     // A developer database can include later migrations from another worktree;
     // assert this checkout's latest migration was applied without assuming it
     // is the newest row in that shared database.
-    expect(Array.from(applied).map((row) => row.name)).toContain(
-      "0040_provider_credential_auth_mode.sql",
-    );
+    expect(Array.from(applied).map((row) => row.name)).toContain("0041_github_ci_story_events.sql");
     const providerCredentialChecks = (await db.execute(
       sql`
         SELECT conname

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11793,6 +11793,12 @@
                                         "nullable": true,
                                         "type": "string"
                                       },
+                                      "ciFailureNames": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
                                       "createdAt": {
                                         "nullable": true,
                                         "type": "string",
@@ -11818,6 +11824,7 @@
                                       "headSha",
                                       "ciState",
                                       "ciHeadSha",
+                                      "ciFailureNames",
                                       "createdAt",
                                       "closedAt",
                                       "mergedAt"
@@ -11830,12 +11837,19 @@
                                   "type": "string",
                                   "enum": [
                                     "pending",
+                                    "success",
                                     "failure"
                                   ]
                                 },
                                 "ciUrl": {
                                   "nullable": true,
                                   "type": "string"
+                                },
+                                "ciFailureNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 }
                               },
                               "required": [
@@ -11861,7 +11875,8 @@
                                 "attemptCount",
                                 "prs",
                                 "ciState",
-                                "ciUrl"
+                                "ciUrl",
+                                "ciFailureNames"
                               ],
                               "additionalProperties": false
                             }
@@ -12443,6 +12458,12 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "ciFailureNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "createdAt": {
                             "nullable": true,
                             "type": "string",
@@ -12468,11 +12489,31 @@
                           "headSha",
                           "ciState",
                           "ciHeadSha",
+                          "ciFailureNames",
                           "createdAt",
                           "closedAt",
                           "mergedAt"
                         ],
                         "additionalProperties": false
+                      }
+                    },
+                    "ciState": {
+                      "nullable": true,
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "success",
+                        "failure"
+                      ]
+                    },
+                    "ciUrl": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ciFailureNames": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
                       }
                     },
                     "stage": {
@@ -12602,6 +12643,9 @@
                     "ghUpdatedAt",
                     "closedAt",
                     "prs",
+                    "ciState",
+                    "ciUrl",
+                    "ciFailureNames",
                     "stage",
                     "pipelineStages",
                     "allowLegacyProposalNumber",
@@ -12842,6 +12886,12 @@
                               "success",
                               "failure"
                             ]
+                          },
+                          "ciFailureNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
                           }
                         },
                         "required": [
@@ -12855,7 +12905,53 @@
                           "createdAt",
                           "closedAt",
                           "mergedAt",
-                          "ciState"
+                          "ciState",
+                          "ciFailureNames"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "ciEvents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "pullNumber": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "headSha": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "success",
+                              "failure"
+                            ]
+                          },
+                          "failureNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "observedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "pullNumber",
+                          "headSha",
+                          "state",
+                          "failureNames",
+                          "observedAt"
                         ],
                         "additionalProperties": false
                       }
@@ -12863,7 +12959,8 @@
                   },
                   "required": [
                     "comments",
-                    "prs"
+                    "prs",
+                    "ciEvents"
                   ],
                   "additionalProperties": false
                 }

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -8931,6 +8931,7 @@ export interface operations {
                                     /** @enum {string|null} */
                                     ciState: "pending" | "success" | "failure" | null;
                                     ciHeadSha: string | null;
+                                    ciFailureNames: string[];
                                     /** Format: date-time */
                                     createdAt: string | null;
                                     /** Format: date-time */
@@ -8939,8 +8940,9 @@ export interface operations {
                                     mergedAt: string | null;
                                 }[];
                                 /** @enum {string|null} */
-                                ciState: "pending" | "failure" | null;
+                                ciState: "pending" | "success" | "failure" | null;
                                 ciUrl: string | null;
+                                ciFailureNames: string[];
                             }[];
                         }[];
                     };
@@ -9211,6 +9213,7 @@ export interface operations {
                             /** @enum {string|null} */
                             ciState: "pending" | "success" | "failure" | null;
                             ciHeadSha: string | null;
+                            ciFailureNames: string[];
                             /** Format: date-time */
                             createdAt: string | null;
                             /** Format: date-time */
@@ -9218,6 +9221,10 @@ export interface operations {
                             /** Format: date-time */
                             mergedAt: string | null;
                         }[];
+                        /** @enum {string|null} */
+                        ciState: "pending" | "success" | "failure" | null;
+                        ciUrl: string | null;
+                        ciFailureNames: string[];
                         stage: {
                             /** @enum {string} */
                             key: "backlog" | "planning" | "ready" | "building" | "validating" | "review" | "shipped";
@@ -9362,6 +9369,16 @@ export interface operations {
                             mergedAt: string | null;
                             /** @enum {string|null} */
                             ciState: "pending" | "success" | "failure" | null;
+                            ciFailureNames: string[];
+                        }[];
+                        ciEvents: {
+                            id: string;
+                            pullNumber: number;
+                            headSha: string;
+                            /** @enum {string} */
+                            state: "pending" | "success" | "failure";
+                            failureNames: string[];
+                            observedAt: string;
                         }[];
                     };
                 };

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -67,6 +67,7 @@ export async function buildApp(
   app.decorate("facilityDb", db);
   app.decorate("githubClientFactory", undefined);
   app.decorate("githubInstallationTokenFactory", undefined);
+  app.decorate("githubAppMetadataReader", undefined);
 
   // Producer-only pg-boss handle: routes enqueue, the worker consumes.
   const boss = new PgBoss({ connectionString: config.databaseUrl });

--- a/services/api/src/doctor.ts
+++ b/services/api/src/doctor.ts
@@ -20,6 +20,7 @@ import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { verifyEnvelopeRoundTrip } from "./envelopes.js";
+import { createGithubAppMetadataReader, type GithubAppMetadataReader } from "./github/client.js";
 import { verifyStoredReceipts } from "./receipt-integrity.js";
 import { DockerSandboxDriver } from "./sandbox/docker.js";
 import type { AppConfig } from "./types.js";
@@ -81,8 +82,10 @@ export async function runReadinessDoctor(input: {
   now?: Date;
   codeBuildClient?: DoctorCodeBuildSender;
   vercelClient?: DoctorVercelClient;
+  githubAppMetadataReader?: GithubAppMetadataReader;
 }): Promise<DoctorResponse> {
   const now = input.now ?? new Date();
+  const githubApp = checkGithubApp(input.config);
   const checks = await Promise.all([
     checkDatabase(input.db),
     checkObjectStorage(input.config, input.orgId, now),
@@ -95,7 +98,8 @@ export async function runReadinessDoctor(input: {
     ...(input.config.sandboxDriver === "vercel"
       ? [checkVercelSandbox(input.config, input.vercelClient)]
       : []),
-    checkGithubApp(input.config),
+    githubApp,
+    checkGithubCheckRunSubscription(input.config, input.githubAppMetadataReader, githubApp),
     checkAuthConfig(input.config),
     checkPreviewProtection(input.config),
     checkAuditHashChain(input.db, input.orgId),
@@ -598,6 +602,68 @@ export function checkGithubApp(config: AppConfig): DoctorCheck {
     );
   }
   return pass("github_app", "GitHub App configuration", "Required GitHub App values are set.");
+}
+
+export async function checkGithubCheckRunSubscription(
+  config: AppConfig,
+  providedReader?: GithubAppMetadataReader,
+  appConfiguration = checkGithubApp(config),
+): Promise<DoctorCheck> {
+  if (appConfiguration.status !== "pass") {
+    return warn(
+      "github_check_run",
+      "GitHub Check run subscription",
+      "Check run delivery was not verified because the GitHub App is disabled or incomplete.",
+      "Configure the GitHub App first, then rerun facility doctor.",
+    );
+  }
+  try {
+    const metadata = await (providedReader ?? createGithubAppMetadataReader(config))();
+    const checksPermission = metadata.permissions?.checks?.toLowerCase();
+    const hasChecksPermission = checksPermission === "read" || checksPermission === "write";
+    const hasCheckRunEvent = metadata.events?.includes("check_run") === true;
+    if (!metadata.permissions || !metadata.events) {
+      return fail(
+        "github_check_run",
+        "GitHub Check run subscription",
+        "GitHub returned incomplete App permissions or event metadata, so Check run delivery cannot be verified.",
+        "Verify the GitHub App credentials and rerun facility doctor.",
+      );
+    }
+    if (!hasChecksPermission || !hasCheckRunEvent) {
+      const missing = [
+        !hasChecksPermission ? "Checks: Read permission" : null,
+        !hasCheckRunEvent ? "Check run event subscription" : null,
+      ].filter((value): value is string => value !== null);
+      return fail(
+        "github_check_run",
+        "GitHub Check run subscription",
+        `GitHub App is missing ${missing.join(" and ")}; CI rollups will not update from check runs.`,
+        "In the GitHub App settings, grant Repository permissions → Checks: Read-only, then subscribe to Check run under events.",
+      );
+    }
+    return pass(
+      "github_check_run",
+      "GitHub Check run subscription",
+      "GitHub App can read checks and is subscribed to Check run events.",
+    );
+  } catch (error) {
+    const status = httpStatus(error);
+    if (status === 401 || status === 403 || status === 404) {
+      return fail(
+        "github_check_run",
+        "GitHub Check run subscription",
+        `GitHub rejected App metadata verification (${status}).`,
+        "Verify GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY, then rerun facility doctor.",
+      );
+    }
+    return warn(
+      "github_check_run",
+      "GitHub Check run subscription",
+      "GitHub App permissions and event subscriptions could not be verified because of a transient provider error.",
+      "Retry facility doctor; if the warning persists, inspect GitHub service health and deployment egress.",
+    );
+  }
 }
 
 function checkAuthConfig(config: AppConfig): DoctorCheck {

--- a/services/api/src/github/client.ts
+++ b/services/api/src/github/client.ts
@@ -156,6 +156,11 @@ export type Octokit = {
 };
 
 export type GithubClientFactory = (installationId: number) => Promise<Octokit>;
+export type GithubAppMetadata = {
+  permissions?: Record<string, string>;
+  events?: string[];
+};
+export type GithubAppMetadataReader = () => Promise<GithubAppMetadata>;
 export type GithubInstallationTokenFactory = (input: {
   installationId: number;
   owner: string;
@@ -184,6 +189,34 @@ export function createGithubClientFactory(config: AppConfig): GithubClientFactor
   });
   return async (installationId: number) =>
     (await app.getInstallationOctokit(installationId)) as unknown as Octokit;
+}
+
+export function createGithubAppMetadataReader(config: AppConfig): GithubAppMetadataReader {
+  if (!config.githubAppId || !config.githubAppPrivateKey) {
+    throw new Error("GitHub App credentials are not configured");
+  }
+  const app = new App({
+    appId: config.githubAppId,
+    privateKey: config.githubAppPrivateKey,
+  });
+  return async () => {
+    const response = await app.octokit.request("GET /app");
+    const data = response.data as {
+      permissions?: Record<string, unknown>;
+      events?: unknown[];
+    };
+    const permissions = data.permissions
+      ? Object.fromEntries(
+          Object.entries(data.permissions).flatMap(([key, value]) =>
+            typeof value === "string" ? [[key, value]] : [],
+          ),
+        )
+      : undefined;
+    const events = Array.isArray(data.events)
+      ? data.events.filter((event): event is string => typeof event === "string")
+      : undefined;
+    return { permissions, events };
+  };
 }
 
 export function createGithubInstallationTokenFactory(
@@ -238,6 +271,8 @@ export type GithubPullRequestSnapshot = {
   closingIssues: number[];
   ciState: "pending" | "success" | "failure" | null;
   ciHeadSha: string | null;
+  /** Present on focused refreshes; omitted by bulk reconciliation snapshots. */
+  ciFailureNames?: string[];
   createdAt: string | null;
   updatedAt: string | null;
   closedAt: string | null;
@@ -592,10 +627,35 @@ export class FacilityGithubClient {
       repo: this.repo.repo,
       number,
     });
-    return pullRequestSnapshot(
+    const snapshot = pullRequestSnapshot(
       await this.completeClosingIssuePages(data.repository?.pullRequest ?? null),
       this.repo,
     );
+    if (!snapshot) return null;
+    const ciFailureNames = await this.getCurrentCiFailureNames(snapshot.headSha);
+    return ciFailureNames ? { ...snapshot, ciFailureNames } : snapshot;
+  }
+
+  private async getCurrentCiFailureNames(headSha: string): Promise<string[] | undefined> {
+    const listForRef = this.octokit.rest.checks?.listForRef;
+    if (!listForRef) return undefined;
+    try {
+      const pages = await boundedGithubPages("check runs", (page) =>
+        listForRef({
+          owner: this.repo.owner,
+          repo: this.repo.repo,
+          ref: headSha,
+          filter: "latest",
+          per_page: GITHUB_EVIDENCE_PAGE_SIZE,
+          page,
+        }).then((response) => response.data.check_runs ?? []),
+      );
+      return currentCiFailureNames(pages.flat());
+    } catch {
+      // Names are display detail. The aggregate rollup remains authoritative
+      // and must still refresh when the Checks REST endpoint is unavailable.
+      return undefined;
+    }
   }
 
   async createIssue(input: {
@@ -1237,6 +1297,33 @@ function githubCiState(value: string | null | undefined): "pending" | "success" 
   if (state === "FAILURE" || state === "ERROR") return "failure";
   if (state === "PENDING" || state === "EXPECTED") return "pending";
   return null;
+}
+
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "startup_failure",
+  "timed_out",
+]);
+
+function currentCiFailureNames(
+  checks: Array<{ name?: string | null; conclusion?: string | null }>,
+): string[] {
+  return [
+    ...new Set(
+      checks.flatMap((check) => {
+        if (!FAILURE_CONCLUSIONS.has(check.conclusion?.toLowerCase() ?? "")) return [];
+        const name = check.name
+          ?.replace(/[\r\n\t]+/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+        return name ? [name.slice(0, 160)] : [];
+      }),
+    ),
+  ]
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, 20);
 }
 
 function objectRecord(value: unknown): Record<string, unknown> {

--- a/services/api/src/github/processor.ts
+++ b/services/api/src/github/processor.ts
@@ -187,6 +187,7 @@ export async function processGithubWebhook(
             event.orgId,
             payload,
             factory ?? createGithubClientFactory(config),
+            { sourceEventId: event.id, observedAt: event.receivedAt },
           ),
         logger,
         pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
@@ -220,6 +221,7 @@ export async function processGithubWebhook(
               event.orgId,
               payload,
               factory ?? createGithubClientFactory(config),
+              { sourceEventId: event.id, observedAt: event.receivedAt },
             ),
           logger,
           pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
@@ -237,21 +239,20 @@ export async function processGithubWebhook(
           enqueue,
         );
       }
-      if (isTerminalPullRequestSignal(event.eventType, payload)) {
-        await refreshPullRequestsBestEffort(
-          () =>
-            refreshPullRequestsAndPromoteReady(
-              db,
-              event.orgId,
-              payload,
-              factory ?? createGithubClientFactory(config),
-            ),
-          logger,
-          pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
-        );
-      }
+      await refreshPullRequestsBestEffort(
+        () =>
+          refreshPullRequestsAndPromoteReady(
+            db,
+            event.orgId,
+            payload,
+            factory ?? createGithubClientFactory(config),
+            { sourceEventId: event.id, observedAt: event.receivedAt },
+          ),
+        logger,
+        pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
+      );
     } else if (event.eventType === "status") {
-      if (isTerminalPullRequestSignal(event.eventType, payload)) {
+      if (isPullRequestStatusSignal(payload)) {
         await refreshPullRequestsBestEffort(
           () =>
             refreshPullRequestsAndPromoteReady(
@@ -259,6 +260,7 @@ export async function processGithubWebhook(
               event.orgId,
               payload,
               factory ?? createGithubClientFactory(config),
+              { sourceEventId: event.id, observedAt: event.receivedAt },
             ),
           logger,
           pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
@@ -307,6 +309,10 @@ function isTerminalPullRequestSignal(eventType: string, payload: WebhookPayload)
     return ["success", "failure", "error"].includes(payload.state?.toLowerCase() ?? "");
   }
   return false;
+}
+
+function isPullRequestStatusSignal(payload: WebhookPayload) {
+  return ["pending", "success", "failure", "error"].includes(payload.state?.toLowerCase() ?? "");
 }
 
 function pullRequestRefreshContext(
@@ -1540,6 +1546,7 @@ async function refreshPullRequestFromWebhook(
   orgId: string,
   payload: WebhookPayload,
   factory: GithubClientFactory,
+  observation: { sourceEventId: string; observedAt: Date },
 ) {
   const owner = payload.repository?.owner?.login;
   const name = payload.repository?.name;
@@ -1555,7 +1562,7 @@ async function refreshPullRequestFromWebhook(
   if (!repo) return;
   // The basic row is written first; callers keep this richer snapshot
   // best-effort so GraphQL availability cannot block webhook lifecycle work.
-  await refreshGhPullRequest(db, factory, repo, number);
+  await refreshGhPullRequest(db, factory, repo, number, observation);
 }
 
 async function refreshPullRequestsAndPromoteReady(
@@ -1563,6 +1570,7 @@ async function refreshPullRequestsAndPromoteReady(
   orgId: string,
   payload: WebhookPayload,
   factory: GithubClientFactory,
+  observation: { sourceEventId: string; observedAt: Date },
 ) {
   const owner = payload.repository?.owner?.login;
   const name = payload.repository?.name;
@@ -1590,7 +1598,11 @@ async function refreshPullRequestsAndPromoteReady(
     payload.check_suite?.head_sha ??
     payload.workflow_run?.head_sha ??
     payload.sha;
-  const refreshed = await refreshPullRequestsForSignal(db, factory, repo, { numbers, headSha });
+  const refreshed = await refreshPullRequestsForSignal(db, factory, repo, {
+    numbers,
+    headSha,
+    ...observation,
+  });
   await promotePassingFacilityDrafts(db, factory, repo, { numbers, headSha });
   return refreshed;
 }

--- a/services/api/src/github/pull-requests-sync.ts
+++ b/services/api/src/github/pull-requests-sync.ts
@@ -1,6 +1,7 @@
 import { newId } from "@facility/core";
 import {
   type FacilityDb,
+  ghCiEvents,
   ghPullRequests,
   githubInstallations,
   repos,
@@ -18,6 +19,11 @@ const PR_WATERMARK_PREFIX = "github.pull_requests";
 const MAX_PAGES_PER_CONNECTION = 10;
 const SYNC_OVERLAP_MS = 2 * 60 * 1000;
 const INITIAL_WATERMARK = new Date(0);
+
+type CiObservation = {
+  sourceEventId?: string;
+  observedAt?: Date;
+};
 
 export type GithubPullRequestWebhookPayload = {
   action?: string;
@@ -80,6 +86,7 @@ export async function upsertGhPullRequestFromWebhook(
         mergedAt: values.mergedAt,
         ciState: sql`case when ${ghPullRequests.headSha} = ${values.headSha} then ${ghPullRequests.ciState} else null end`,
         ciHeadSha: sql`case when ${ghPullRequests.headSha} = ${values.headSha} then ${ghPullRequests.ciHeadSha} else null end`,
+        ciFailureNames: sql`case when ${ghPullRequests.headSha} = ${values.headSha} then ${ghPullRequests.ciFailureNames} else '{}'::text[] end`,
         ciUpdatedAt: sql`case when ${ghPullRequests.headSha} = ${values.headSha} then ${ghPullRequests.ciUpdatedAt} else null end`,
         syncedAt: values.syncedAt,
         updatedAt: values.updatedAt,
@@ -152,19 +159,20 @@ export async function refreshGhPullRequest(
   clientFactory: GithubClientFactory,
   repo: typeof repos.$inferSelect,
   number: number,
+  observation: CiObservation = {},
 ) {
   const client = await clientForRepo(db, clientFactory, repo);
   if (!client) return null;
   if (!client.supportsPullRequestSnapshots()) return null;
   const snapshot = await client.getPullRequestSnapshot(number);
-  return snapshot ? upsertPullRequestSnapshot(db, repo, snapshot) : null;
+  return snapshot ? upsertPullRequestSnapshot(db, repo, snapshot, observation) : null;
 }
 
 export async function refreshPullRequestsForSignal(
   db: FacilityDb,
   clientFactory: GithubClientFactory,
   repo: typeof repos.$inferSelect,
-  input: { headSha?: string | null; numbers?: number[] },
+  input: { headSha?: string | null; numbers?: number[] } & CiObservation,
 ) {
   const numbers = new Set((input.numbers ?? []).filter((number) => number > 0));
   if (input.headSha) {
@@ -181,7 +189,7 @@ export async function refreshPullRequestsForSignal(
     for (const row of rows) numbers.add(row.number);
   }
   for (const number of numbers) {
-    await refreshGhPullRequest(db, clientFactory, repo, number);
+    await refreshGhPullRequest(db, clientFactory, repo, number, input);
   }
   return numbers.size;
 }
@@ -190,65 +198,140 @@ export async function upsertPullRequestSnapshot(
   db: FacilityDb,
   repo: typeof repos.$inferSelect,
   pull: GithubPullRequestSnapshot,
+  observation: CiObservation = {},
 ) {
   const now = new Date();
-  const values = {
-    id: newId("ghp"),
-    orgId: repo.orgId,
-    projectId: repo.projectId,
-    repoId: repo.id,
-    number: pull.number,
-    title: pull.title,
-    state: pull.state,
-    draft: pull.draft,
-    author: pull.author,
-    headRef: pull.headRef,
-    headSha: pull.headSha,
-    baseRef: pull.baseRef,
-    htmlUrl: pull.url,
-    bodyMd: capBody(pull.body),
-    closingIssues: pull.closingIssues,
-    ciState: pull.ciState,
-    ciHeadSha: pull.ciHeadSha,
-    ciUpdatedAt: now,
-    ghCreatedAt: dateOrNull(pull.createdAt),
-    ghUpdatedAt: dateOrNull(pull.updatedAt),
-    closedAt: dateOrNull(pull.closedAt),
-    mergedAt: dateOrNull(pull.mergedAt),
-    syncedAt: now,
-    updatedAt: now,
-  };
-  const [row] = await db
-    .insert(ghPullRequests)
-    .values(values)
-    .onConflictDoUpdate({
-      target: [ghPullRequests.repoId, ghPullRequests.number],
-      set: {
-        orgId: values.orgId,
-        projectId: values.projectId,
-        title: values.title,
-        state: values.state,
-        draft: values.draft,
-        author: values.author,
-        headRef: values.headRef,
-        headSha: values.headSha,
-        baseRef: values.baseRef,
-        htmlUrl: values.htmlUrl,
-        bodyMd: values.bodyMd,
-        closingIssues: values.closingIssues,
-        ciState: values.ciState,
-        ciHeadSha: values.ciHeadSha,
-        ciUpdatedAt: values.ciUpdatedAt,
-        ghCreatedAt: values.ghCreatedAt,
-        ghUpdatedAt: values.ghUpdatedAt,
-        closedAt: values.closedAt,
-        mergedAt: values.mergedAt,
-        syncedAt: now,
-        updatedAt: now,
-      },
-    })
-    .returning();
-  return row ?? null;
+  return db.transaction(async (tx) => {
+    // Webhook delivery and scheduled reconciliation can refresh the same PR at once.
+    // Serialize the read/upsert/event sequence so the timeline records each transition once.
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${`facility:github-ci:${repo.id}:${pull.number}`}, 0))`,
+    );
+    const [previous] = await tx
+      .select({
+        ciState: ghPullRequests.ciState,
+        ciHeadSha: ghPullRequests.ciHeadSha,
+        ciFailureNames: ghPullRequests.ciFailureNames,
+      })
+      .from(ghPullRequests)
+      .where(and(eq(ghPullRequests.repoId, repo.id), eq(ghPullRequests.number, pull.number)))
+      .limit(1);
+    const suppliedFailureNames = sanitizeFailureNames(pull.ciFailureNames ?? []);
+    const insertedFailureNames =
+      pull.ciState === "failure" && pull.ciFailureNames !== undefined ? suppliedFailureNames : [];
+    const values = {
+      id: newId("ghp"),
+      orgId: repo.orgId,
+      projectId: repo.projectId,
+      repoId: repo.id,
+      number: pull.number,
+      title: pull.title,
+      state: pull.state,
+      draft: pull.draft,
+      author: pull.author,
+      headRef: pull.headRef,
+      headSha: pull.headSha,
+      baseRef: pull.baseRef,
+      htmlUrl: pull.url,
+      bodyMd: capBody(pull.body),
+      closingIssues: pull.closingIssues,
+      ciState: pull.ciState,
+      ciHeadSha: pull.ciHeadSha,
+      ciFailureNames: insertedFailureNames,
+      ciUpdatedAt: now,
+      ghCreatedAt: dateOrNull(pull.createdAt),
+      ghUpdatedAt: dateOrNull(pull.updatedAt),
+      closedAt: dateOrNull(pull.closedAt),
+      mergedAt: dateOrNull(pull.mergedAt),
+      syncedAt: now,
+      updatedAt: now,
+    };
+    const [row] = await tx
+      .insert(ghPullRequests)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [ghPullRequests.repoId, ghPullRequests.number],
+        set: {
+          orgId: values.orgId,
+          projectId: values.projectId,
+          title: values.title,
+          state: values.state,
+          draft: values.draft,
+          author: values.author,
+          headRef: values.headRef,
+          headSha: values.headSha,
+          baseRef: values.baseRef,
+          htmlUrl: values.htmlUrl,
+          bodyMd: values.bodyMd,
+          closingIssues: values.closingIssues,
+          ciState: values.ciState,
+          ciHeadSha: values.ciHeadSha,
+          ciFailureNames:
+            pull.ciState !== "failure"
+              ? []
+              : pull.ciFailureNames !== undefined
+                ? suppliedFailureNames
+                : sql`case when ${ghPullRequests.headSha} = ${values.headSha} and ${ghPullRequests.ciHeadSha} = ${values.ciHeadSha} then ${ghPullRequests.ciFailureNames} else '{}'::text[] end`,
+          ciUpdatedAt: values.ciUpdatedAt,
+          ghCreatedAt: values.ghCreatedAt,
+          ghUpdatedAt: values.ghUpdatedAt,
+          closedAt: values.closedAt,
+          mergedAt: values.mergedAt,
+          syncedAt: now,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    if (!row) return null;
+
+    const currentCiState =
+      pull.ciHeadSha === pull.headSha && pull.ciState !== null ? pull.ciState : null;
+    const transitioned =
+      currentCiState !== null &&
+      (previous?.ciState !== currentCiState || previous?.ciHeadSha !== pull.ciHeadSha);
+    if (transitioned && pull.ciHeadSha) {
+      const failureNames =
+        currentCiState === "failure"
+          ? pull.ciFailureNames !== undefined
+            ? suppliedFailureNames
+            : previous?.ciHeadSha === pull.ciHeadSha
+              ? previous.ciFailureNames
+              : []
+          : [];
+      await tx
+        .insert(ghCiEvents)
+        .values({
+          id: newId("cie"),
+          orgId: repo.orgId,
+          projectId: repo.projectId,
+          repoId: repo.id,
+          pullNumber: pull.number,
+          headSha: pull.ciHeadSha,
+          state: currentCiState,
+          failureNames,
+          sourceEventId: observation.sourceEventId,
+          observedAt: observation.observedAt ?? now,
+        })
+        .onConflictDoNothing();
+    }
+    return row;
+  });
+}
+
+function sanitizeFailureNames(names: string[]) {
+  return [
+    ...new Set(
+      names.flatMap((name) => {
+        const value = name
+          .replace(/[\r\n\t]+/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+        return value ? [value.slice(0, 160)] : [];
+      }),
+    ),
+  ]
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, 20);
 }
 
 async function clientForRepo(

--- a/services/api/src/pipeline.ts
+++ b/services/api/src/pipeline.ts
@@ -44,6 +44,7 @@ export type PipelinePullRequest = {
   headSha: string | null;
   ciState: "pending" | "success" | "failure" | null;
   ciHeadSha: string | null;
+  ciFailureNames: string[];
   createdAt: Date | null;
   closedAt: Date | null;
   mergedAt: Date | null;
@@ -75,8 +76,9 @@ export type PlacedPipelineStory = Omit<PipelineStoryInput, "linkedRuns"> & {
   runState: "live" | "failed" | null;
   currentRun: { id: string; mode: string; status: string; engine: string } | null;
   attemptCount: number;
-  ciState: "pending" | "failure" | null;
+  ciState: "pending" | "success" | "failure" | null;
   ciUrl: string | null;
+  ciFailureNames: string[];
 };
 
 export type PipelineIssueRecord = {
@@ -107,6 +109,7 @@ export type PipelinePullRequestRecord = {
   headSha: string;
   ciState: string | null;
   ciHeadSha: string | null;
+  ciFailureNames: string[];
   closingIssues: number[];
   ghCreatedAt: Date | null;
   ghUpdatedAt: Date | null;
@@ -271,6 +274,7 @@ export function assemblePipelineStories(input: {
             headSha: null,
             ciState: null,
             ciHeadSha: null,
+            ciFailureNames: [],
             createdAt: null,
             closedAt: null,
             mergedAt: null,
@@ -362,7 +366,8 @@ function placeBase(story: PipelineStoryInput): PlacedPipelineStory {
   const reviewablePulls = story.prs.filter((pull) => pull.state === "open" && !pull.draft);
   const failedPull = reviewablePulls.find(hasCurrentCiState("failure"));
   const pendingPull = reviewablePulls.find(hasCurrentCiState("pending"));
-  const ciPull = failedPull ?? pendingPull;
+  const successfulPull = reviewablePulls.find(hasCurrentCiState("success"));
+  const ciPull = failedPull ?? pendingPull ?? successfulPull;
   const { linkedRuns: _linkedRuns, ...fields } = story;
   return {
     ...fields,
@@ -371,12 +376,13 @@ function placeBase(story: PipelineStoryInput): PlacedPipelineStory {
       ? { id: current.id, mode: current.mode, status: current.status, engine: current.engine }
       : null,
     attemptCount: runs.length,
-    ciState: failedPull ? "failure" : pendingPull ? "pending" : null,
+    ciState: failedPull ? "failure" : pendingPull ? "pending" : successfulPull ? "success" : null,
     ciUrl: ciPull ? `${ciPull.url}/checks` : null,
+    ciFailureNames: failedPull?.ciFailureNames ?? [],
   };
 }
 
-function hasCurrentCiState(state: "pending" | "failure") {
+function hasCurrentCiState(state: "pending" | "success" | "failure") {
   return (pull: PipelinePullRequest) =>
     pull.ciState === state &&
     Boolean(pull.headSha) &&
@@ -409,6 +415,7 @@ function pullRequestOf(pull: PipelinePullRequestRecord): PipelinePullRequest {
         ? pull.ciState
         : null,
     ciHeadSha: pull.ciHeadSha,
+    ciFailureNames: pull.ciFailureNames,
     createdAt: pull.ghCreatedAt,
     closedAt: pull.closedAt,
     mergedAt: pull.mergedAt,

--- a/services/api/src/routes/v1/admin-doctor.ts
+++ b/services/api/src/routes/v1/admin-doctor.ts
@@ -11,7 +11,12 @@ export async function registerAdminDoctorRoutes(app: FastifyInstance, context: V
     },
     async (request) => {
       const p = principal(request);
-      return runReadinessDoctor({ db: context.db, config: context.config, orgId: p.orgId });
+      return runReadinessDoctor({
+        db: context.db,
+        config: context.config,
+        orgId: p.orgId,
+        githubAppMetadataReader: app.githubAppMetadataReader,
+      });
     },
   );
 }

--- a/services/api/src/routes/v1/github.ts
+++ b/services/api/src/routes/v1/github.ts
@@ -1,6 +1,7 @@
 import { newId } from "@facility/core";
 import {
   actionTypes,
+  ghCiEvents,
   ghIssues,
   ghPullRequests,
   githubInstallations,
@@ -124,6 +125,17 @@ const StoryGithubActivitySchema = z.object({
       closedAt: z.string().nullable(),
       mergedAt: z.string().nullable(),
       ciState: z.enum(["pending", "success", "failure"]).nullable(),
+      ciFailureNames: z.array(z.string()),
+    }),
+  ),
+  ciEvents: z.array(
+    z.object({
+      id: z.string(),
+      pullNumber: z.number().int(),
+      headSha: z.string(),
+      state: z.enum(["pending", "success", "failure"]),
+      failureNames: z.array(z.string()),
+      observedAt: z.string(),
     }),
   ),
 });
@@ -145,6 +157,7 @@ function activityPullFromPipeline(pull: PipelinePullRequest): StoryGithubPull {
     closedAt: pull.closedAt?.toISOString() ?? null,
     mergedAt: pull.mergedAt?.toISOString() ?? null,
     ciState: currentCiState,
+    ciFailureNames: currentCiState === "failure" ? pull.ciFailureNames : [],
   };
 }
 
@@ -171,6 +184,7 @@ const PipelinePullRequestSchema = z.object({
   headSha: z.string().nullable(),
   ciState: z.enum(["pending", "success", "failure"]).nullable(),
   ciHeadSha: z.string().nullable(),
+  ciFailureNames: z.array(z.string()),
   createdAt: DateValue.nullable(),
   closedAt: DateValue.nullable(),
   mergedAt: DateValue.nullable(),
@@ -199,8 +213,9 @@ const PipelineStorySchema = z.object({
     .nullable(),
   attemptCount: z.number().int(),
   prs: z.array(PipelinePullRequestSchema),
-  ciState: z.enum(["pending", "failure"]).nullable(),
+  ciState: z.enum(["pending", "success", "failure"]).nullable(),
   ciUrl: z.string().nullable(),
+  ciFailureNames: z.array(z.string()),
 });
 const PipelineResponseSchema = z.object({
   stages: z.array(
@@ -234,6 +249,9 @@ const StoryDetailSchema = z.object({
   ghUpdatedAt: DateValue.nullable(),
   closedAt: DateValue.nullable(),
   prs: z.array(PipelinePullRequestSchema),
+  ciState: z.enum(["pending", "success", "failure"]).nullable(),
+  ciUrl: z.string().nullable(),
+  ciFailureNames: z.array(z.string()),
   stage: z.object({ key: PipelineStageSchema, label: z.string() }).nullable(),
   pipelineStages: z.array(z.object({ key: PipelineStageSchema, label: z.string() })),
   allowLegacyProposalNumber: z.boolean(),
@@ -619,10 +637,16 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
       const stageDefinition = PIPELINE_STAGES.find((stage) =>
         (staged.get(stage.key) ?? []).some((story) => story.key === selected.key),
       );
+      const placedStory = stageDefinition
+        ? (staged.get(stageDefinition.key) ?? []).find((story) => story.key === selected.key)
+        : null;
       const { linkedRuns: _linkedRuns, ...story } = selected;
       return {
         ...story,
         bodyMd: bodyRow?.bodyMd ?? null,
+        ciState: placedStory?.ciState ?? null,
+        ciUrl: placedStory?.ciUrl ?? null,
+        ciFailureNames: placedStory?.ciFailureNames ?? [],
         stage: stageDefinition ? { key: stageDefinition.key, label: stageDefinition.label } : null,
         pipelineStages: PIPELINE_STAGES.map(({ key, label }) => ({ key, label })),
         allowLegacyProposalNumber: selected.storyType === "issue" && sameNumberIssues.length === 1,
@@ -685,6 +709,28 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
               ),
             )
         : [];
+      const ciEvents = pullNumbers.length
+        ? await db
+            .select()
+            .from(ghCiEvents)
+            .where(
+              and(
+                eq(ghCiEvents.orgId, p.orgId),
+                eq(ghCiEvents.projectId, projectId),
+                eq(ghCiEvents.repoId, story.repoId),
+                inArray(ghCiEvents.pullNumber, pullNumbers),
+              ),
+            )
+            .orderBy(ghCiEvents.observedAt, ghCiEvents.id)
+        : [];
+      const presentedCiEvents = ciEvents.map((event) => ({
+        id: event.id,
+        pullNumber: event.pullNumber,
+        headSha: event.headSha,
+        state: event.state as "pending" | "success" | "failure",
+        failureNames: event.failureNames,
+        observedAt: event.observedAt.toISOString(),
+      }));
       const prsByNumber = new Map<number, StoryGithubPull>(
         story.prs.map((pull) => [pull.number, activityPullFromPipeline(pull)]),
       );
@@ -704,6 +750,7 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
           closedAt: pull.closedAt?.toISOString() ?? null,
           mergedAt: pull.mergedAt?.toISOString() ?? null,
           ciState: fallback?.ciState ?? null,
+          ciFailureNames: fallback?.ciFailureNames ?? [],
         });
       }
       const sortedPrs = () => [...prsByNumber.values()].sort((a, b) => a.number - b.number);
@@ -720,7 +767,9 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
           )
           .limit(1)
       )[0];
-      if (!repo?.installationId) return { comments: [], prs: sortedPrs() };
+      if (!repo?.installationId) {
+        return { comments: [], prs: sortedPrs(), ciEvents: presentedCiEvents };
+      }
       try {
         const factory = app.githubClientFactory ?? createGithubClientFactory(config);
         const client = await createGithubClientForRepo(db, factory, repo);
@@ -794,7 +843,7 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
           .filter((comment) => comment.authorType !== "Bot")
           .map(({ authorType: _authorType, body, ...rest }) => ({ ...rest, bodyMd: body }))
           .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-        return { comments, prs: sortedPrs() };
+        return { comments, prs: sortedPrs(), ciEvents: presentedCiEvents };
       } catch (error) {
         // GitHub being unreachable degrades to the Facility-only timeline.
         request.log.warn(
@@ -808,7 +857,7 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
           },
           "GitHub story activity unavailable; returning the Facility-only timeline",
         );
-        return { comments: [], prs: sortedPrs() };
+        return { comments: [], prs: sortedPrs(), ciEvents: presentedCiEvents };
       }
     },
   );

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -1,5 +1,9 @@
 import type { AuditInsert, FacilityDb } from "@facility/db";
-import type { GithubClientFactory, GithubInstallationTokenFactory } from "./github/client.js";
+import type {
+  GithubAppMetadataReader,
+  GithubClientFactory,
+  GithubInstallationTokenFactory,
+} from "./github/client.js";
 
 export type Principal = {
   type: "user" | "key";
@@ -93,6 +97,7 @@ declare module "fastify" {
     enqueue: (queue: string, data: Record<string, unknown>) => Promise<string | null>;
     githubClientFactory?: GithubClientFactory;
     githubInstallationTokenFactory?: GithubInstallationTokenFactory;
+    githubAppMetadataReader?: GithubAppMetadataReader;
   }
   interface FastifyRequest {
     principal?: Principal;

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -3999,6 +3999,7 @@ describe("api", async () => {
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
     const address = server.address();
     if (!address || typeof address === "string") throw new Error("test server did not bind");
+    const previousGithubAppMetadataReader = app.githubAppMetadataReader;
     const previous = {
       s3Bucket: config.s3Bucket,
       s3Endpoint: config.s3Endpoint,
@@ -4019,6 +4020,10 @@ describe("api", async () => {
     config.githubAppPrivateKey = githubAppTestKey;
     config.githubAppWebhookSecret = "secret";
     config.githubAppSlug = "facility-test";
+    app.githubAppMetadataReader = async () => ({
+      permissions: { checks: "read" },
+      events: ["check_run", "pull_request"],
+    });
     const first = await insertAuditEvent(db, {
       orgId,
       actor: { type: "system", id: "doctor-test" },
@@ -4051,6 +4056,7 @@ describe("api", async () => {
       expect(checkStatus(healthy.json(), "audit_hash_chain")).toBe("pass");
       expect(checkStatus(healthy.json(), "worker_heartbeat")).toBe("pass");
       expect(checkStatus(healthy.json(), "github_app")).toBe("pass");
+      expect(checkStatus(healthy.json(), "github_check_run")).toBe("pass");
       expect(
         healthy.json().checks.some((check: { id: string }) => check.id === "aws_sandbox"),
       ).toBe(false);
@@ -4073,6 +4079,22 @@ describe("api", async () => {
       expect(checkStatus(invalidGithubKey.json(), "github_app")).toBe("fail");
       expect(JSON.stringify(invalidGithubKey.json())).not.toContain("not-a-private-key");
       config.githubAppPrivateKey = githubAppTestKey;
+
+      app.githubAppMetadataReader = async () => ({
+        permissions: { checks: "read" },
+        events: ["pull_request"],
+      });
+      const missingCheckRun = await app.inject({
+        method: "GET",
+        url: "/v1/admin/doctor",
+        headers: { cookie },
+      });
+      expect(missingCheckRun.json().ok).toBe(false);
+      expect(checkStatus(missingCheckRun.json(), "github_check_run")).toBe("fail");
+      app.githubAppMetadataReader = async () => ({
+        permissions: { checks: "read" },
+        events: ["check_run"],
+      });
 
       await db.update(auditEvents).set({ hash: "broken" }).where(eq(auditEvents.id, second.id));
       const broken = await app.inject({
@@ -4106,6 +4128,7 @@ describe("api", async () => {
         .where(eq(auditEvents.id, second.id));
       await db.delete(schedulerWatermarks).where(eq(schedulerWatermarks.name, "agent.schedules"));
       Object.assign(config, previous);
+      app.githubAppMetadataReader = previousGithubAppMetadataReader;
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });

--- a/services/api/test/doctor-aws.test.ts
+++ b/services/api/test/doctor-aws.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   checkAwsSandbox,
   checkGithubApp,
+  checkGithubCheckRunSubscription,
   checkVercelSandbox,
   type DoctorCodeBuildSender,
   type DoctorVercelClient,
@@ -158,22 +159,61 @@ describe("AWS production doctor", () => {
 });
 
 describe("GitHub App production doctor", () => {
+  const privateKey = generateKeyPairSync("rsa", { modulusLength: 1024 })
+    .privateKey.export({ type: "pkcs8", format: "pem" })
+    .toString();
   const configured = {
     ...baseConfig,
     githubAppId: "1",
+    githubAppPrivateKey: privateKey,
     githubAppWebhookSecret: "webhook-secret",
     githubAppSlug: "facility",
   };
 
   it("accepts a parseable private key and rejects malformed key material without echoing it", () => {
-    const privateKey = generateKeyPairSync("rsa", { modulusLength: 1024 })
-      .privateKey.export({ type: "pkcs8", format: "pem" })
-      .toString();
-    expect(checkGithubApp({ ...configured, githubAppPrivateKey: privateKey }).status).toBe("pass");
+    expect(checkGithubApp(configured).status).toBe("pass");
 
     const invalid = checkGithubApp({ ...configured, githubAppPrivateKey: "private-secret" });
     expect(invalid.status).toBe("fail");
     expect(JSON.stringify(invalid)).not.toContain("private-secret");
+  });
+
+  it("verifies both Checks permission and the Check run event subscription", async () => {
+    await expect(
+      checkGithubCheckRunSubscription(configured, async () => ({
+        permissions: { checks: "read" },
+        events: ["check_run", "pull_request"],
+      })),
+    ).resolves.toMatchObject({ id: "github_check_run", status: "pass", ok: true });
+
+    await expect(
+      checkGithubCheckRunSubscription(configured, async () => ({
+        permissions: { checks: "read" },
+        events: ["pull_request"],
+      })),
+    ).resolves.toMatchObject({ id: "github_check_run", status: "fail", ok: false });
+    await expect(
+      checkGithubCheckRunSubscription(configured, async () => ({
+        permissions: { contents: "read" },
+        events: ["check_run"],
+      })),
+    ).resolves.toMatchObject({ id: "github_check_run", status: "fail", ok: false });
+  });
+
+  it("fails on rejected or malformed App metadata and warns on transient errors", async () => {
+    await expect(
+      checkGithubCheckRunSubscription(configured, async () => ({ events: ["check_run"] })),
+    ).resolves.toMatchObject({ status: "fail", ok: false });
+    await expect(
+      checkGithubCheckRunSubscription(configured, async () => {
+        throw Object.assign(new Error("revoked private key"), { status: 401 });
+      }),
+    ).resolves.toMatchObject({ status: "fail", ok: false });
+    await expect(
+      checkGithubCheckRunSubscription(configured, async () => {
+        throw new Error("provider unavailable");
+      }),
+    ).resolves.toMatchObject({ status: "warn", ok: true });
   });
 });
 

--- a/services/api/test/github-client.test.ts
+++ b/services/api/test/github-client.test.ts
@@ -171,6 +171,48 @@ describe("GitHub pull-request snapshots", () => {
     await expect(client.getPullRequestSnapshot(3)).resolves.toMatchObject({ ciState: expected });
   });
 
+  it("adds bounded failed check names to focused snapshots without replacing the rollup", async () => {
+    const client = new FacilityGithubClient(
+      {
+        graphql: async () => ({
+          repository: {
+            pullRequest: {
+              number: 3,
+              title: "PR",
+              state: "OPEN",
+              headRefName: "feature",
+              headRefOid: "sha",
+              baseRefName: "main",
+              url: "https://github.test/octo/repo/pull/3",
+              commits: {
+                nodes: [{ commit: { oid: "sha", statusCheckRollup: { state: "FAILURE" } } }],
+              },
+            },
+          },
+        }),
+        rest: {
+          checks: {
+            listForRef: async () => ({
+              data: {
+                check_runs: [
+                  { name: "typecheck", conclusion: "failure" },
+                  { name: "guards", conclusion: "timed_out" },
+                  { name: "lint", conclusion: "success" },
+                ],
+              },
+            }),
+          },
+        },
+      } as never,
+      { owner: "octo", repo: "repo", defaultBranch: "main" },
+    );
+
+    await expect(client.getPullRequestSnapshot(3)).resolves.toMatchObject({
+      ciState: "failure",
+      ciFailureNames: ["guards", "typecheck"],
+    });
+  });
+
   it("paginates closing references instead of truncating a large linked set", async () => {
     const variables: Record<string, unknown>[] = [];
     const client = new FacilityGithubClient(

--- a/services/api/test/github-platform-lane.test.ts
+++ b/services/api/test/github-platform-lane.test.ts
@@ -4,6 +4,7 @@ import {
   apiKeys,
   auditEvents,
   createDb,
+  ghCiEvents,
   ghIssues,
   ghPullRequests,
   githubInstallations,
@@ -865,8 +866,8 @@ describe("github platform lane", async () => {
     await insertPullRequest(repo.id, prNumber, {
       headRef: "feature/checks",
       headSha: "feature-sha",
-      ciState: "pending",
-      ciHeadSha: "feature-sha",
+      ciState: null,
+      ciHeadSha: null,
     });
     const integration = (
       await db
@@ -876,7 +877,7 @@ describe("github platform lane", async () => {
     )[0];
     if (!integration) throw new Error("integration fixture missing");
 
-    let rollupState: "PENDING" | "SUCCESS" | "FAILURE" = "FAILURE";
+    let rollupState: "PENDING" | "SUCCESS" | "FAILURE" = "PENDING";
     let refreshCalls = 0;
     const factory = async () =>
       ({
@@ -911,7 +912,21 @@ describe("github platform lane", async () => {
             },
           };
         },
-        rest: {},
+        rest: {
+          checks: {
+            listForRef: async () => ({
+              data: {
+                check_runs:
+                  rollupState === "FAILURE"
+                    ? [
+                        { name: "guards", conclusion: "failure" },
+                        { name: "typecheck", conclusion: "timed_out" },
+                      ]
+                    : [],
+              },
+            }),
+          },
+        },
       }) as never;
     const deliver = async (eventType: string, payload: Record<string, unknown>) => {
       const eventId = newId("evt");
@@ -948,10 +963,11 @@ describe("github platform lane", async () => {
       },
     });
     await deliver("status", { state: "pending", sha: "feature-sha" });
-    expect(refreshCalls).toBe(0);
+    expect(refreshCalls).toBe(3);
 
     // A green individual event still re-reads GitHub's red aggregate. The
     // empty PR array exercises fork delivery resolution by head SHA.
+    rollupState = "FAILURE";
     await deliver("check_run", {
       check_run: {
         name: "build",
@@ -962,12 +978,13 @@ describe("github platform lane", async () => {
         check_suite: { head_branch: "feature/checks", head_sha: "feature-sha" },
       },
     });
-    expect(refreshCalls).toBe(1);
+    expect(refreshCalls).toBe(4);
     let [mirrored] = await db
       .select()
       .from(ghPullRequests)
       .where(and(eq(ghPullRequests.repoId, repo.id), eq(ghPullRequests.number, prNumber)));
     expect(mirrored?.ciState).toBe("failure");
+    expect(mirrored?.ciFailureNames).toEqual(["guards", "typecheck"]);
     rollupState = "SUCCESS";
     await deliver("check_suite", {
       action: "completed",
@@ -977,7 +994,7 @@ describe("github platform lane", async () => {
         pull_requests: [{ number: prNumber }],
       },
     });
-    expect(refreshCalls).toBe(2);
+    expect(refreshCalls).toBe(5);
     [mirrored] = await db
       .select()
       .from(ghPullRequests)
@@ -986,12 +1003,26 @@ describe("github platform lane", async () => {
 
     rollupState = "FAILURE";
     await deliver("status", { state: "failure", sha: "feature-sha" });
-    expect(refreshCalls).toBe(3);
+    expect(refreshCalls).toBe(6);
     [mirrored] = await db
       .select()
       .from(ghPullRequests)
       .where(and(eq(ghPullRequests.repoId, repo.id), eq(ghPullRequests.number, prNumber)));
     expect(mirrored?.ciState).toBe("failure");
+    expect(
+      (
+        await db
+          .select()
+          .from(ghCiEvents)
+          .where(and(eq(ghCiEvents.repoId, repo.id), eq(ghCiEvents.pullNumber, prNumber)))
+          .orderBy(ghCiEvents.observedAt)
+      ).map((event) => [event.state, event.failureNames]),
+    ).toEqual([
+      ["pending", []],
+      ["failure", ["guards", "typecheck"]],
+      ["success", []],
+      ["failure", ["guards", "typecheck"]],
+    ]);
     expect(
       await db
         .select()
@@ -2031,6 +2062,37 @@ describe("github platform lane", async () => {
         },
       },
     });
+    const successfulIssueNumber = number + 11;
+    const successfulPullNumber = number + 12;
+    await insertIssue(repoA.id, successfulIssueNumber, "open", "2026-08-01T00:00:00Z");
+    await insertPullRequest(repoA.id, successfulPullNumber, {
+      title: "Checks passed",
+      closingIssues: [successfulIssueNumber],
+      ciState: "success",
+      ciHeadSha: `head-${successfulPullNumber}`,
+    });
+    await db.insert(ghCiEvents).values([
+      {
+        id: newId("evt"),
+        orgId,
+        projectId,
+        repoId: repoA.id,
+        pullNumber: successfulPullNumber,
+        headSha: `head-${successfulPullNumber}`,
+        state: "pending",
+        observedAt: new Date("2026-08-01T01:00:00Z"),
+      },
+      {
+        id: newId("evt"),
+        orgId,
+        projectId,
+        repoId: repoA.id,
+        pullNumber: successfulPullNumber,
+        headSha: `head-${successfulPullNumber}`,
+        state: "success",
+        observedAt: new Date("2026-08-01T01:02:00Z"),
+      },
+    ]);
     const legacyProposal = await app.inject({
       method: "POST",
       url: "/v1/proposals",
@@ -2057,6 +2119,7 @@ describe("github platform lane", async () => {
         storyType: string;
         currentRun: { id: string } | null;
         ciState: string | null;
+        ciFailureNames: string[];
         prs: Array<{ number: number; draft: boolean; ciState: string | null }>;
       }>;
     }>;
@@ -2108,6 +2171,34 @@ describe("github platform lane", async () => {
       stage: { key: pendingBoardStory?.stage },
       prs: pendingBoardStory?.prs,
     });
+    const successfulBoardStory = stories.find(
+      (story) => story.key === `${repoA.id}:issue:${successfulIssueNumber}`,
+    );
+    expect(successfulBoardStory).toMatchObject({
+      stage: "review",
+      ciState: "success",
+      ciFailureNames: [],
+    });
+    const successfulDetail = await app.inject({
+      method: "GET",
+      url: `/v1/projects/${projectId}/stories/${successfulIssueNumber}?${issueQuery}`,
+      headers: { cookie },
+    });
+    expect(successfulDetail.statusCode, successfulDetail.body).toBe(200);
+    expect(successfulDetail.json()).toMatchObject({
+      ciState: "success",
+      ciUrl: `https://github.com/o/r/pull/${successfulPullNumber}/checks`,
+    });
+    const successfulActivity = await app.inject({
+      method: "GET",
+      url: `/v1/projects/${projectId}/stories/${successfulIssueNumber}/github-activity?${issueQuery}`,
+      headers: { cookie },
+    });
+    expect(successfulActivity.statusCode, successfulActivity.body).toBe(200);
+    expect(successfulActivity.json().ciEvents).toEqual([
+      expect.objectContaining({ pullNumber: successfulPullNumber, state: "pending" }),
+      expect.objectContaining({ pullNumber: successfulPullNumber, state: "success" }),
+    ]);
     const draftBoardStory = stories.find(
       (story) => story.key === `${repoA.id}:issue:${draftIssueNumber}`,
     );

--- a/services/api/test/pipeline.test.ts
+++ b/services/api/test/pipeline.test.ts
@@ -120,6 +120,30 @@ describe("server-owned story pipeline", () => {
     ]);
   });
 
+  it("carries successful CI and failed check names through the story rollup", () => {
+    const successful = storyWith({ ciState: "success", ciHeadSha: "head-10" });
+    const failed = storyWith({
+      ciState: "failure",
+      ciHeadSha: "head-10",
+      ciFailureNames: ["guards", "typecheck"],
+    });
+    const staged = classifyPipeline(
+      [successful, { ...failed, key: "repo_a:issue:2", number: 2 }],
+      new Set(),
+      NOW.getTime(),
+    );
+
+    expect(staged.get("review")?.find((story) => story.number === 1)).toMatchObject({
+      ciState: "success",
+      ciUrl: "https://github.test/alice/alpha/pull/10/checks",
+      ciFailureNames: [],
+    });
+    expect(staged.get("review")?.find((story) => story.number === 2)).toMatchObject({
+      ciState: "failure",
+      ciFailureNames: ["guards", "typecheck"],
+    });
+  });
+
   it("keeps draft pull requests in Building until they are reviewable", () => {
     const draft = storyWith({ ciState: "failure", ciHeadSha: "head-10", draft: true });
     const staged = classifyPipeline([draft], new Set(), NOW.getTime());
@@ -232,6 +256,7 @@ function pull(
     headSha: `head-${number}`,
     ciState: null,
     ciHeadSha: null,
+    ciFailureNames: [],
     closingIssues: [],
     ghCreatedAt: NOW,
     ghUpdatedAt: NOW,
@@ -261,6 +286,7 @@ function run(
 function storyWith(ci: {
   ciState?: "pending" | "success" | "failure" | null;
   ciHeadSha?: string | null;
+  ciFailureNames?: string[];
   draft?: boolean;
 }) {
   return {
@@ -292,6 +318,7 @@ function storyWith(ci: {
         headSha: "head-10",
         ciState: ci.ciState ?? null,
         ciHeadSha: ci.ciHeadSha ?? null,
+        ciFailureNames: ci.ciFailureNames ?? [],
         createdAt: NOW,
         closedAt: null,
         mergedAt: null,


### PR DESCRIPTION
## What changes

- Carry GitHub's successful aggregate CI state through the story rollup and render linked pending, passed, and failed status on story surfaces.
- Record append-only CI transitions per PR head SHA for the story timeline, including bounded failed-check names while keeping `statusCheckRollup` authoritative.
- Add a readiness doctor check for the GitHub App's Checks permission and `check_run` event subscription.

## Why

Stories currently collapse passed checks into the same blank state as missing CI, omit CI entirely from the story timeline, and give operators no signal when the GitHub App cannot receive check-run events.

Fixes #100.

## Verification

- API unit regression coverage: 32 tests passed across pipeline, GitHub client, and doctor behavior.
- Web story projection coverage: 10 tests passed.
- GitHub platform integration coverage exercised `pending → failure → success → failure`, failed-check names, current green status, and persisted timeline events.
- DB suite: 18 tests passed, including migration 0041 constraints and indexes.
- Clean production build completed for all 10 build targets; lint and repository guards passed.
- `pnpm verify` reached the critical suite but Docker Desktop timed out the script's forced IPv4 `127.0.0.1` connection and the no-skips guard stopped it. Running the same DB suite over `localhost` completed 18/18; the affected API DB integrations passed independently.

- [ ] `pnpm verify` passes locally
- [x] Behaviour verified beyond the unit suite through deterministic webhook/API/DB integration tests
- [x] Documentation updated, or no user-facing change
