### PR TITLE
fix(web): add Facility favicon

### DIFF
--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,0 +1,13 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Facility mark: a unit of work traveling the pipeline between two human gates">
+  <!-- facility mark — the pipeline, two human gates, one unit of work in
+       flight. Yellow is reserved for agent work (site rule). -->
+  <!-- palette roles: void #0A0C10 · line #8B949E · gate #F0F3F6 · agent #FFD923 -->
+  <rect width="96" height="96" rx="4" fill="#0A0C10"/>
+  <!-- the pipeline -->
+  <line x1="12" y1="48" x2="84" y2="48" stroke="#8B949E" stroke-width="3"/>
+  <!-- two human gates -->
+  <line x1="32" y1="36" x2="32" y2="60" stroke="#F0F3F6" stroke-width="3"/>
+  <line x1="64" y1="36" x2="64" y2="60" stroke="#F0F3F6" stroke-width="3"/>
+  <!-- the unit of work, agent-built, mid-flight between the gates -->
+  <circle cx="48" cy="48" r="7" fill="#FFD923"/>
+</svg>

--- a/apps/web/test/favicon.test.ts
+++ b/apps/web/test/favicon.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("web favicon", () => {
+  it("uses the canonical Facility mark", async () => {
+    const [favicon, mark] = await Promise.all([
+      readFile(new URL("../app/icon.svg", import.meta.url), "utf8"),
+      readFile(new URL("../../../assets/mark.svg", import.meta.url), "utf8"),
+    ]);
+
+    expect(favicon).toBe(mark);
+  });
+});


### PR DESCRIPTION
## What changes

- Publish the canonical Facility mark through the Next.js App Router icon convention.
- Add a regression test that keeps the web favicon byte-for-byte aligned with the canonical brand asset.

## Why

The web app did not publish icon metadata, so browser tabs displayed a generic fallback instead of the Facility mark. The root cause was the absence of an App Router icon file.

## Verification

- [ ] `pnpm verify` passes locally — the web build passed, but the critical database suite failed twice outside this change (a migration-hook timeout, then a forbidden skipped suite).
- [x] Behaviour verified beyond the test suite — the production build emitted `/icon.svg`; a local request returned `200 OK` with `image/svg+xml`; the login page included the generated `rel="icon"` link; and the served bytes matched `assets/mark.svg`.
- [ ] Documentation updated, or no user-facing change — no documentation change is needed for this browser-chrome asset fix.
