### PR TITLE
perf(github): coalesce webhook reconciliation

### DIFF
--- a/services/api/src/github/client.ts
+++ b/services/api/src/github/client.ts
@@ -632,6 +632,10 @@ export class FacilityGithubClient {
       this.repo,
     );
     if (!snapshot) return null;
+    // Failure names are only persisted and displayed for a failing aggregate.
+    // Avoid a second paginated GitHub request for the common pending/success
+    // states, where upsertPullRequestSnapshot deliberately stores an empty list.
+    if (snapshot.ciState !== "failure") return { ...snapshot, ciFailureNames: [] };
     const ciFailureNames = await this.getCurrentCiFailureNames(snapshot.headSha);
     return ciFailureNames ? { ...snapshot, ciFailureNames } : snapshot;
   }

--- a/services/api/src/github/processor.ts
+++ b/services/api/src/github/processor.ts
@@ -44,7 +44,12 @@ import {
   syncRepoPullRequests,
   upsertGhPullRequestFromWebhook,
 } from "./pull-requests-sync.js";
-import { laneFor, routeTrigger, type TriggerPayload } from "./router.js";
+import {
+  githubTriggerRequiresClient,
+  laneFor,
+  routeTrigger,
+  type TriggerPayload,
+} from "./router.js";
 import { renderGithubRunProgress } from "./run-progress.js";
 
 type WebhookPayload = TriggerPayload & {
@@ -129,6 +134,29 @@ type GithubWebhookLogger = {
   warn: (context: Record<string, unknown>, message: string) => void;
 };
 
+type GithubReconciliationWork = {
+  key: string;
+  eventId: string;
+  orgId: string;
+  receivedAt: Date;
+  payload: WebhookPayload;
+  runCiDoctor: boolean;
+};
+
+type DeferGithubReconciliation = (work: GithubReconciliationWork) => boolean;
+
+export type GithubWebhookBatchResult = {
+  events: number;
+  reconciledEvents: number;
+  reconciliations: number;
+  coalescedEvents: number;
+  projectionMs: number;
+  reconciliationMs: number;
+  maxReconciliationMs: number;
+};
+
+const GITHUB_RECONCILIATION_CONCURRENCY = 4;
+
 const fallbackGithubWebhookLogger: GithubWebhookLogger = {
   warn: (context, message) => console.warn(message, context),
 };
@@ -140,6 +168,7 @@ export async function processGithubWebhook(
   factory?: GithubClientFactory,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
   logger: GithubWebhookLogger = fallbackGithubWebhookLogger,
+  deferReconciliation?: DeferGithubReconciliation,
 ) {
   if (!data.inboundEventId) return;
   const event = (
@@ -147,6 +176,7 @@ export async function processGithubWebhook(
   )[0];
   if (!event || event.processedAt) return;
   const payload = event.payload as WebhookPayload;
+  let completionDeferred = false;
   try {
     if (event.eventType === "installation" || event.eventType === "installation_repositories") {
       await processInstallation(db, event.orgId, payload, enqueue);
@@ -160,6 +190,7 @@ export async function processGithubWebhook(
         factory ?? createGithubClientFactory(config),
         payload,
         enqueue,
+        event.id,
       );
     } else if (event.eventType === "issue_comment") {
       await bumpGhIssueCommentCount(db, event.orgId, payload);
@@ -169,6 +200,7 @@ export async function processGithubWebhook(
         factory ?? createGithubClientFactory(config),
         payload,
         enqueue,
+        event.id,
       );
     } else if (event.eventType === "pull_request") {
       await upsertGhPullRequestFromWebhook(db, event.orgId, payload);
@@ -214,6 +246,47 @@ export async function processGithubWebhook(
         enqueue,
       );
       if (isTerminalPullRequestSignal(event.eventType, payload)) {
+        completionDeferred =
+          deferReconciliation?.(githubReconciliationWork(event, payload, false)) ?? false;
+        if (!completionDeferred) {
+          await refreshPullRequestsBestEffort(
+            () =>
+              refreshPullRequestsAndPromoteReady(
+                db,
+                event.orgId,
+                payload,
+                factory ?? createGithubClientFactory(config),
+                { sourceEventId: event.id, observedAt: event.receivedAt },
+              ),
+            logger,
+            pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
+          );
+        }
+      }
+    } else if (event.eventType === "check_run" || event.eventType === "check_suite") {
+      if (event.eventType === "check_run") {
+        await processOperationalSignal(db, event.orgId, "check_run", payload);
+      }
+      completionDeferred =
+        deferReconciliation?.(
+          githubReconciliationWork(
+            event,
+            payload,
+            event.eventType === "check_run" &&
+              isTerminalPullRequestSignal(event.eventType, payload),
+          ),
+        ) ?? false;
+      if (!completionDeferred) {
+        if (event.eventType === "check_run") {
+          await processCiDoctorCheckRun(
+            db,
+            event.orgId,
+            event.id,
+            payload,
+            factory ?? createGithubClientFactory(config),
+            enqueue,
+          );
+        }
         await refreshPullRequestsBestEffort(
           () =>
             refreshPullRequestsAndPromoteReady(
@@ -227,14 +300,95 @@ export async function processGithubWebhook(
           pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
         );
       }
-    } else if (event.eventType === "check_run" || event.eventType === "check_suite") {
-      if (event.eventType === "check_run") {
-        await processOperationalSignal(db, event.orgId, "check_run", payload);
+    } else if (event.eventType === "status") {
+      if (isPullRequestStatusSignal(payload)) {
+        completionDeferred =
+          deferReconciliation?.(githubReconciliationWork(event, payload, false)) ?? false;
+        if (!completionDeferred) {
+          await refreshPullRequestsBestEffort(
+            () =>
+              refreshPullRequestsAndPromoteReady(
+                db,
+                event.orgId,
+                payload,
+                factory ?? createGithubClientFactory(config),
+                { sourceEventId: event.id, observedAt: event.receivedAt },
+              ),
+            logger,
+            pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
+          );
+        }
+      }
+    } else if (event.eventType === "deployment_status") {
+      await processOperationalSignal(db, event.orgId, "deployment_status", payload);
+    }
+    if (!completionDeferred) {
+      await db
+        .update(inboundEvents)
+        .set({ processedAt: new Date(), error: null })
+        .where(eq(inboundEvents.id, event.id));
+    }
+  } catch (error) {
+    await db
+      .update(inboundEvents)
+      .set({ error: error instanceof Error ? error.message : "unknown error" })
+      .where(eq(inboundEvents.id, event.id));
+    throw error;
+  }
+}
+
+export async function processGithubWebhookBatch(
+  db: FacilityDb,
+  config: AppConfig,
+  deliveries: Array<{ inboundEventId?: string }>,
+  factory?: GithubClientFactory,
+  enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+  logger: GithubWebhookLogger = fallbackGithubWebhookLogger,
+): Promise<GithubWebhookBatchResult> {
+  const startedAt = Date.now();
+  const reconciliations = new Map<
+    string,
+    {
+      eventIds: Set<string>;
+      latest: GithubReconciliationWork;
+      ciDoctor?: GithubReconciliationWork;
+    }
+  >();
+
+  for (const delivery of deliveries) {
+    await processGithubWebhook(db, config, delivery, factory, enqueue, logger, (work) => {
+      const current = reconciliations.get(work.key);
+      if (!current) {
+        reconciliations.set(work.key, {
+          eventIds: new Set([work.eventId]),
+          latest: work,
+          ...(work.runCiDoctor ? { ciDoctor: work } : {}),
+        });
+        return true;
+      }
+      current.eventIds.add(work.eventId);
+      if (isLaterGithubWork(work, current.latest)) current.latest = work;
+      if (work.runCiDoctor && (!current.ciDoctor || isLaterGithubWork(work, current.ciDoctor))) {
+        current.ciDoctor = work;
+      }
+      return true;
+    });
+  }
+
+  const projectionMs = Date.now() - startedAt;
+  const groups = [...reconciliations.values()];
+  const errors: unknown[] = [];
+  const reconciliationDurations: number[] = [];
+  const reconciliationStartedAt = Date.now();
+  await runWithConcurrency(groups, GITHUB_RECONCILIATION_CONCURRENCY, async (group) => {
+    const groupStartedAt = Date.now();
+    try {
+      if (group.ciDoctor) {
         await processCiDoctorCheckRun(
           db,
-          event.orgId,
-          event.id,
-          payload,
+          group.ciDoctor.orgId,
+          group.ciDoctor.eventId,
+          group.ciDoctor.payload,
           factory ?? createGithubClientFactory(config),
           enqueue,
         );
@@ -243,43 +397,48 @@ export async function processGithubWebhook(
         () =>
           refreshPullRequestsAndPromoteReady(
             db,
-            event.orgId,
-            payload,
+            group.latest.orgId,
+            group.latest.payload,
             factory ?? createGithubClientFactory(config),
-            { sourceEventId: event.id, observedAt: event.receivedAt },
+            {
+              sourceEventId: group.latest.eventId,
+              observedAt: group.latest.receivedAt,
+            },
           ),
         logger,
-        pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
+        pullRequestRefreshContext(
+          group.latest.eventId,
+          group.latest.orgId,
+          "github.reconciliation",
+          group.latest.payload,
+        ),
       );
-    } else if (event.eventType === "status") {
-      if (isPullRequestStatusSignal(payload)) {
-        await refreshPullRequestsBestEffort(
-          () =>
-            refreshPullRequestsAndPromoteReady(
-              db,
-              event.orgId,
-              payload,
-              factory ?? createGithubClientFactory(config),
-              { sourceEventId: event.id, observedAt: event.receivedAt },
-            ),
-          logger,
-          pullRequestRefreshContext(event.id, event.orgId, event.eventType, payload),
-        );
-      }
-    } else if (event.eventType === "deployment_status") {
-      await processOperationalSignal(db, event.orgId, "deployment_status", payload);
+      await db
+        .update(inboundEvents)
+        .set({ processedAt: new Date(), error: null })
+        .where(inArray(inboundEvents.id, [...group.eventIds]));
+    } catch (error) {
+      await db
+        .update(inboundEvents)
+        .set({ error: error instanceof Error ? error.message : "unknown error" })
+        .where(inArray(inboundEvents.id, [...group.eventIds]));
+      errors.push(error);
+    } finally {
+      reconciliationDurations.push(Date.now() - groupStartedAt);
     }
-    await db
-      .update(inboundEvents)
-      .set({ processedAt: new Date() })
-      .where(eq(inboundEvents.id, event.id));
-  } catch (error) {
-    await db
-      .update(inboundEvents)
-      .set({ error: error instanceof Error ? error.message : "unknown error" })
-      .where(eq(inboundEvents.id, event.id));
-    throw error;
-  }
+  });
+  if (errors.length) throw new AggregateError(errors, "GitHub webhook reconciliation batch failed");
+
+  const reconciledEvents = groups.reduce((count, group) => count + group.eventIds.size, 0);
+  return {
+    events: deliveries.length,
+    reconciledEvents,
+    reconciliations: groups.length,
+    coalescedEvents: Math.max(0, reconciledEvents - groups.length),
+    projectionMs,
+    reconciliationMs: Date.now() - reconciliationStartedAt,
+    maxReconciliationMs: Math.max(0, ...reconciliationDurations),
+  };
 }
 
 async function refreshPullRequestsBestEffort(
@@ -309,6 +468,60 @@ function isTerminalPullRequestSignal(eventType: string, payload: WebhookPayload)
     return ["success", "failure", "error"].includes(payload.state?.toLowerCase() ?? "");
   }
   return false;
+}
+
+function githubReconciliationWork(
+  event: { id: string; orgId: string; receivedAt: Date },
+  payload: WebhookPayload,
+  runCiDoctor: boolean,
+): GithubReconciliationWork {
+  const check = payload.check_run;
+  const headSha =
+    check?.head_sha ??
+    check?.check_suite?.head_sha ??
+    payload.check_suite?.head_sha ??
+    payload.workflow_run?.head_sha ??
+    payload.sha;
+  const pullNumbers = [
+    ...(check?.pull_requests ?? []),
+    ...(check?.check_suite?.pull_requests ?? []),
+    ...(payload.check_suite?.pull_requests ?? []),
+    ...(payload.workflow_run?.pull_requests ?? []),
+  ]
+    .flatMap((pull) => (typeof pull.number === "number" ? [pull.number] : []))
+    .sort((left, right) => left - right);
+  const repository = `${payload.repository?.owner?.login ?? "unknown"}/${payload.repository?.name ?? "unknown"}`;
+  const target = headSha ?? (pullNumbers.length ? `pulls:${pullNumbers.join(",")}` : event.id);
+  return {
+    key: `${event.orgId}:${repository}:${target}`,
+    eventId: event.id,
+    orgId: event.orgId,
+    receivedAt: event.receivedAt,
+    payload,
+    runCiDoctor,
+  };
+}
+
+function isLaterGithubWork(candidate: GithubReconciliationWork, current: GithubReconciliationWork) {
+  const timeDifference = candidate.receivedAt.getTime() - current.receivedAt.getTime();
+  return timeDifference > 0 || (timeDifference === 0 && candidate.eventId > current.eventId);
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+) {
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (next < items.length) {
+        const item = items[next];
+        next += 1;
+        if (item !== undefined) await task(item);
+      }
+    }),
+  );
 }
 
 function isPullRequestStatusSignal(payload: WebhookPayload) {
@@ -481,7 +694,9 @@ async function processTrigger(
   factory: GithubClientFactory,
   payload: WebhookPayload,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+  githubDeliveryId?: string,
 ) {
+  if (!githubTriggerRequiresClient(payload)) return;
   const owner = payload.repository?.owner?.login;
   const name = payload.repository?.name;
   const installationId = payload.installation?.id;
@@ -499,8 +714,8 @@ async function processTrigger(
     repo: name,
     defaultBranch: repo.defaultBranch,
   });
-  const result = await routeTrigger(db, orgId, client, payload, enqueue);
-  if (result.routed) {
+  const result = await routeTrigger(db, orgId, client, payload, enqueue, githubDeliveryId);
+  if (result.routed && result.reason !== "delivery_replayed") {
     await auditGithub(db, repo.orgId, "github.comment.created", repo, {
       issueNumber: payload.issue?.number,
       runId: result.runId,

--- a/services/api/src/github/router.ts
+++ b/services/api/src/github/router.ts
@@ -59,12 +59,24 @@ export function resolveSlashCommand(body: string): {
   return { command: raw.replace(/^codex-/, ""), agentCommand: raw, ambiguous: false };
 }
 
+export function githubTriggerRequiresClient(payload: TriggerPayload) {
+  if (payload.sender?.type === "Bot") return false;
+  if (payload.comment && payload.action && payload.action !== "created") return false;
+  if (!payload.comment && payload.action && payload.action !== "opened") return false;
+  if (payload.issue?.pull_request) return false;
+  const body =
+    payload.comment?.body ?? [payload.issue?.title ?? "", payload.issue?.body ?? ""].join("\n");
+  const command = resolveSlashCommand(body);
+  return !command.ambiguous && Boolean(command.command);
+}
+
 export async function routeTrigger(
   db: FacilityDb,
   orgId: string,
   client: FacilityGithubClient,
   payload: TriggerPayload,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+  githubDeliveryId?: string,
 ): Promise<{ routed: boolean; reason?: string; runId?: string }> {
   if (payload.sender?.type === "Bot") return { routed: false, reason: "bot_sender" };
   if (payload.comment && payload.action && payload.action !== "created") {
@@ -104,6 +116,10 @@ export async function routeTrigger(
   )[0];
   if (!repo) return { routed: false, reason: "repo_unmanaged" };
   if (!(await client.userCanWrite(sender))) return { routed: false, reason: "non_writer" };
+  if (githubDeliveryId) {
+    const replayedRunId = await resumeGithubDeliveryRun(db, repo.orgId, githubDeliveryId, enqueue);
+    if (replayedRunId) return { routed: true, reason: "delivery_replayed", runId: replayedRunId };
+  }
   // Reconcile from the default branch at handoff time, not only from an earlier
   // push delivery. This closes the merge/webhook race where the repository
   // workflow has already yielded to Facility but the database still has the
@@ -176,6 +192,7 @@ export async function routeTrigger(
           orgId: repo.orgId,
           projectId: repo.projectId,
           agentDefId: agent.id,
+          githubDeliveryId,
           mode: command,
           engine: agent.engine,
           trigger: accepted?.proposal
@@ -198,6 +215,7 @@ export async function routeTrigger(
           },
           createdBy: { type: "github", id: sender },
         })
+        .onConflictDoNothing()
         .returning()
     )[0];
     if (!created) return undefined;
@@ -224,6 +242,10 @@ export async function routeTrigger(
     }
     return created;
   });
+  if (!run && githubDeliveryId) {
+    const replayedRunId = await resumeGithubDeliveryRun(db, repo.orgId, githubDeliveryId, enqueue);
+    if (replayedRunId) return { routed: true, reason: "delivery_replayed", runId: replayedRunId };
+  }
   if (!run) return { routed: false, reason: "insert_failed" };
   try {
     const assigned = await client.assignIssue(issueNumber, sender);
@@ -250,13 +272,16 @@ export async function routeTrigger(
       payload: { decision: "approve", source: "github_command", builder_run_id: run.id },
     });
   }
-  await db.insert(runEvents).values({
-    orgId: repo.orgId,
-    runId: run.id,
-    seq: 1,
-    type: "queued",
-    data: { queue: "runs.dispatch" },
-  });
+  await db
+    .insert(runEvents)
+    .values({
+      orgId: repo.orgId,
+      runId: run.id,
+      seq: 1,
+      type: "queued",
+      data: { queue: "runs.dispatch" },
+    })
+    .onConflictDoNothing();
   // Actually dispatch to a sandbox — parity with manual run creation. The
   // slash-command path created the run but never enqueued it, so it never ran.
   // The GitHub comment is the end-user's live surface for this run. Comment
@@ -305,6 +330,32 @@ export async function routeTrigger(
   }
   await enqueue?.("runs.dispatch", { runId: run.id, orgId: repo.orgId });
   return { routed: true, runId: run.id };
+}
+
+async function resumeGithubDeliveryRun(
+  db: FacilityDb,
+  orgId: string,
+  githubDeliveryId: string,
+  enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+) {
+  const [run] = await db
+    .select({ id: runs.id })
+    .from(runs)
+    .where(and(eq(runs.orgId, orgId), eq(runs.githubDeliveryId, githubDeliveryId)))
+    .limit(1);
+  if (!run) return null;
+  await db
+    .insert(runEvents)
+    .values({
+      orgId,
+      runId: run.id,
+      seq: 1,
+      type: "queued",
+      data: { queue: "runs.dispatch", source: "github_delivery_replay" },
+    })
+    .onConflictDoNothing();
+  await enqueue?.("runs.dispatch", { runId: run.id, orgId });
+  return run.id;
 }
 
 async function auditAssignmentSkipped(

--- a/services/api/src/routes/webhooks.ts
+++ b/services/api/src/routes/webhooks.ts
@@ -24,7 +24,11 @@ export async function registerWebhookRoutes(app: FastifyInstance, config: AppCon
     webhookApp.post(
       "/webhooks/github",
       {
-        config: { public: true },
+        // GitHub deliveries are authenticated by HMAC and deduplicated by their
+        // delivery id below. The global per-IP API limiter rejects legitimate
+        // GitHub bursts before either protection can run, so this signed durable
+        // ingress has its own backpressure boundary in the job queue.
+        config: { public: true, rateLimit: false },
         schema: { response: { 202: Ok, 401: Ok } },
       },
       async (request, reply) => {
@@ -68,6 +72,13 @@ export async function registerWebhookRoutes(app: FastifyInstance, config: AppCon
           .onConflictDoNothing()
           .returning();
         if (inserted.length === 0) return reply.status(202).send({ ok: true, replayed: true });
+        if (!githubWebhookRequiresWorker(eventType, payload)) {
+          await app.facilityDb
+            .update(inboundEvents)
+            .set({ processedAt: new Date() })
+            .where(eq(inboundEvents.id, id));
+          return reply.status(202).send({ ok: true });
+        }
         await app.enqueue("github.webhook", { inboundEventId: id });
         return reply.status(202).send({ ok: true });
       },
@@ -135,6 +146,11 @@ export async function registerWebhookRoutes(app: FastifyInstance, config: AppCon
       },
     );
   });
+}
+
+export function githubWebhookRequiresWorker(eventType: string, payload: Record<string, unknown>) {
+  if (eventType !== "workflow_run") return true;
+  return payload.action === "completed";
 }
 
 function verifyInboundSignature(

--- a/services/api/src/worker.ts
+++ b/services/api/src/worker.ts
@@ -2,10 +2,11 @@ import { createDb } from "@facility/db";
 import PgBoss from "pg-boss";
 import pino from "pino";
 import { readConfig } from "./config.js";
+import { createGithubClientFactory } from "./github/client.js";
 import {
   enqueueFingerprintVerify,
   enqueueGithubIssuesSync,
-  processGithubWebhook,
+  processGithubWebhookBatch,
 } from "./github/processor.js";
 import { expireIdempotencyRecords } from "./idempotency.js";
 import { deliverPendingWebhooks } from "./integrations/outbound.js";
@@ -27,6 +28,10 @@ export async function startWorker() {
   const boss = new PgBoss({ connectionString: config.databaseUrl });
   boss.on("error", (error) => logger.error({ err: error }, "pg-boss error"));
   await boss.start();
+  const githubFactory =
+    config.githubAppId && config.githubAppPrivateKey
+      ? createGithubClientFactory(config)
+      : undefined;
   const queues = [
     "runs.dispatch",
     "deliveries.deliver",
@@ -51,9 +56,41 @@ export async function startWorker() {
     await boss.createQueue(queue);
   }
   for (const queue of queues) {
-    await boss.work(queue, async (job: PgBoss.Job<unknown> | PgBoss.Job<unknown>[]) => {
-      const jobId = Array.isArray(job) ? job[0]?.id : job.id;
-      const data = Array.isArray(job) ? job[0]?.data : job.data;
+    if (queue === "github.webhook") {
+      await boss.work<{ inboundEventId?: string }>(
+        queue,
+        { batchSize: 1_000, includeMetadata: true, pollingIntervalSeconds: 0.5 },
+        async (jobs) => {
+          const startedAt = Date.now();
+          const result = await processGithubWebhookBatch(
+            db,
+            config,
+            jobs.map((job) => job.data),
+            githubFactory,
+            (name, payload) => boss.send(name, payload),
+            {
+              warn: (context, message) => logger.warn(context, message),
+            },
+          );
+          const oldestCreatedAt = Math.min(...jobs.map((job) => job.createdOn.getTime()));
+          logger.info(
+            {
+              queue,
+              batchSize: jobs.length,
+              queueWaitMs: Math.max(0, startedAt - oldestCreatedAt),
+              handlerMs: Date.now() - startedAt,
+              ...result,
+            },
+            "worker completed GitHub webhook batch",
+          );
+        },
+      );
+      continue;
+    }
+    await boss.work(queue, async (jobs: PgBoss.Job<unknown>[]) => {
+      const job = jobs[0];
+      const jobId = job?.id;
+      const data = job?.data;
       let result: Record<string, unknown> | undefined;
       if (queue === "runs.dispatch") {
         await dispatchRun(config, data as { runId?: string; orgId?: string });
@@ -102,25 +139,14 @@ export async function startWorker() {
         await runLearningNightly(config, (targetQueue, targetData) =>
           boss.send(targetQueue, targetData),
         );
-      } else if (queue === "github.webhook") {
-        await processGithubWebhook(
-          db,
-          config,
-          data as { inboundEventId?: string },
-          undefined,
-          (name, payload) => boss.send(name, payload),
-          {
-            warn: (context, message) => logger.warn(context, message),
-          },
-        );
       } else if (queue === "fingerprints.verify") {
-        await enqueueFingerprintVerify(db, config, data as { repoId?: string });
+        await enqueueFingerprintVerify(db, config, data as { repoId?: string }, githubFactory);
       } else if (queue === "github.issues-sync") {
         result = await enqueueGithubIssuesSync(
           db,
           config,
           data as { repoId?: string; orgId?: string },
-          undefined,
+          githubFactory,
           (targetQueue, targetData) => boss.send(targetQueue, targetData),
         );
       }

--- a/services/api/test/github-client.test.ts
+++ b/services/api/test/github-client.test.ts
@@ -213,6 +213,45 @@ describe("GitHub pull-request snapshots", () => {
     });
   });
 
+  it("does not list check runs when the aggregate is not failing", async () => {
+    let checkCalls = 0;
+    const client = new FacilityGithubClient(
+      {
+        graphql: async () => ({
+          repository: {
+            pullRequest: {
+              number: 3,
+              title: "PR",
+              state: "OPEN",
+              headRefName: "feature",
+              headRefOid: "sha",
+              baseRefName: "main",
+              url: "https://github.test/octo/repo/pull/3",
+              commits: {
+                nodes: [{ commit: { oid: "sha", statusCheckRollup: { state: "SUCCESS" } } }],
+              },
+            },
+          },
+        }),
+        rest: {
+          checks: {
+            listForRef: async () => {
+              checkCalls += 1;
+              return { data: { check_runs: [] } };
+            },
+          },
+        },
+      } as never,
+      { owner: "octo", repo: "repo", defaultBranch: "main" },
+    );
+
+    await expect(client.getPullRequestSnapshot(3)).resolves.toMatchObject({
+      ciState: "success",
+      ciFailureNames: [],
+    });
+    expect(checkCalls).toBe(0);
+  });
+
   it("paginates closing references instead of truncating a large linked set", async () => {
     const variables: Record<string, unknown>[] = [];
     const client = new FacilityGithubClient(

--- a/services/api/test/github-platform-lane.test.ts
+++ b/services/api/test/github-platform-lane.test.ts
@@ -26,14 +26,18 @@ import {
   seed,
   userIdentities,
 } from "@facility/db";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../src/app.js";
 import { executeApprovedProposal } from "../src/executors.js";
 import type { GithubClientFactory, Octokit } from "../src/github/client.js";
 import { syncRepoIssues, upsertGhIssueFromWebhook } from "../src/github/issues-sync.js";
-import { enqueueGithubIssuesSync, processGithubWebhook } from "../src/github/processor.js";
+import {
+  enqueueGithubIssuesSync,
+  processGithubWebhook,
+  processGithubWebhookBatch,
+} from "../src/github/processor.js";
 import {
   syncRepoPullRequests,
   upsertGhPullRequestFromWebhook,
@@ -1134,6 +1138,212 @@ describe("github platform lane", async () => {
       .from(ghPullRequests)
       .where(and(eq(ghPullRequests.repoId, repo.id), eq(ghPullRequests.number, prNumber)));
     expect(mirrored?.ciState).toBe("pending");
+  });
+
+  it("coalesces a CI notification burst into one authoritative reconciliation", async () => {
+    const owner = `checks-batch-${Date.now()}`;
+    const repo = await insertRepoWithInstallation(owner);
+    const prNumber = 72_002;
+    const headSha = `batch-${newId("evt")}`;
+    await insertPullRequest(repo.id, prNumber, {
+      headRef: "feature/batched-checks",
+      headSha,
+      ciState: null,
+      ciHeadSha: null,
+    });
+    const [integration] = await db
+      .insert(integrations)
+      .values({ id: newId("int"), orgId, kind: "github", name: `checks-batch-${Date.now()}` })
+      .returning();
+    if (!integration) throw new Error("integration fixture missing");
+
+    const eventIds: string[] = [];
+    const events: Array<typeof inboundEvents.$inferInsert> = [];
+    for (let index = 0; index < 1_000; index += 1) {
+      const eventId = newId("evt");
+      eventIds.push(eventId);
+      const completed = index >= 500;
+      events.push({
+        id: eventId,
+        orgId,
+        integrationId: integration.id,
+        eventType: "check_run",
+        payload: {
+          action: completed ? "completed" : "created",
+          repository: { owner: { login: owner }, name: repo.name },
+          check_run: {
+            name: `check-${index % 10}`,
+            status: completed ? "completed" : "in_progress",
+            conclusion: completed ? "success" : null,
+            head_sha: headSha,
+            pull_requests: [{ number: prNumber }],
+            check_suite: { head_branch: "feature/batched-checks", head_sha: headSha },
+          },
+        },
+        verified: true,
+      });
+    }
+    await db.insert(inboundEvents).values(events);
+
+    let factoryCalls = 0;
+    let graphqlCalls = 0;
+    let checkCalls = 0;
+    const factory = async () => {
+      factoryCalls += 1;
+      return {
+        graphql: async (_query: string, variables: Record<string, unknown>) => {
+          graphqlCalls += 1;
+          return {
+            repository: {
+              pullRequest: {
+                number: variables.number,
+                title: "Batched CI",
+                state: "OPEN",
+                isDraft: false,
+                author: { login: "octocat" },
+                headRefName: "feature/batched-checks",
+                headRefOid: headSha,
+                baseRefName: "main",
+                url: `https://github.test/${owner}/repo/pull/${prNumber}`,
+                closingIssuesReferences: { nodes: [] },
+                commits: {
+                  nodes: [{ commit: { oid: headSha, statusCheckRollup: { state: "SUCCESS" } } }],
+                },
+              },
+            },
+          };
+        },
+        rest: {
+          checks: {
+            listForRef: async () => {
+              checkCalls += 1;
+              return { data: { check_runs: [] } };
+            },
+          },
+        },
+      } as never;
+    };
+
+    await expect(
+      processGithubWebhookBatch(
+        db,
+        config,
+        eventIds.map((inboundEventId) => ({ inboundEventId })),
+        factory,
+      ),
+    ).resolves.toEqual({
+      events: 1_000,
+      reconciledEvents: 1_000,
+      reconciliations: 1,
+      coalescedEvents: 999,
+      projectionMs: expect.any(Number),
+      reconciliationMs: expect.any(Number),
+      maxReconciliationMs: expect.any(Number),
+    });
+    expect(factoryCalls).toBe(1);
+    expect(graphqlCalls).toBe(1);
+    expect(checkCalls).toBe(0);
+
+    const processed = await db
+      .select({ id: inboundEvents.id, processedAt: inboundEvents.processedAt })
+      .from(inboundEvents)
+      .where(inArray(inboundEvents.id, eventIds));
+    expect(processed).toHaveLength(1_000);
+    expect(processed.every((event) => event.processedAt instanceof Date)).toBe(true);
+    const [pull] = await db
+      .select()
+      .from(ghPullRequests)
+      .where(and(eq(ghPullRequests.repoId, repo.id), eq(ghPullRequests.number, prNumber)));
+    expect(pull).toMatchObject({ ciState: "success", ciHeadSha: headSha });
+  });
+
+  it("resumes a replayed slash-command delivery without creating a second run", async () => {
+    const owner = `command-replay-${Date.now()}`;
+    const repo = await insertRepoWithInstallation(owner);
+    const installation = (
+      await db
+        .select()
+        .from(githubInstallations)
+        .where(eq(githubInstallations.id, repo.installationId ?? ""))
+        .limit(1)
+    )[0];
+    if (!installation) throw new Error("installation fixture missing");
+    await insertAgent("architect");
+    const [integration] = await db
+      .insert(integrations)
+      .values({ id: newId("int"), orgId, kind: "github", name: `command-${Date.now()}` })
+      .returning();
+    if (!integration) throw new Error("integration fixture missing");
+    const eventId = newId("evt");
+    await db.insert(inboundEvents).values({
+      id: eventId,
+      orgId,
+      integrationId: integration.id,
+      eventType: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: installation.installationId },
+        repository: { owner: { login: owner }, name: repo.name },
+        sender: { login: "maintainer", type: "User" },
+        issue: { number: 937, title: "Plan Facility flow", body: "Keep behavior stable." },
+        comment: { id: 44, body: "/architect" },
+      },
+      verified: true,
+    });
+
+    let progressComments = 0;
+    const factory = async () =>
+      ({
+        rest: {
+          repos: {
+            getCollaboratorPermissionLevel: async () => ({ data: { permission: "write" } }),
+            getContent: async () => ({
+              data: {
+                type: "file",
+                encoding: "base64",
+                content: Buffer.from(
+                  JSON.stringify({ executionLane: { architect: "platform" } }),
+                ).toString("base64"),
+              },
+            }),
+          },
+          issues: {
+            listComments: async () => ({ data: [] }),
+            addAssignees: async () => ({ data: { assignees: [{ login: "maintainer" }] } }),
+            createComment: async () => {
+              progressComments += 1;
+              return { data: { id: progressComments, html_url: "https://github.test/comment" } };
+            },
+          },
+        },
+      }) as never;
+    const dispatches: Array<{ queue: string; data: Record<string, unknown> }> = [];
+    const enqueue = async (queue: string, data: Record<string, unknown>) => {
+      dispatches.push({ queue, data });
+      return null;
+    };
+
+    await processGithubWebhook(db, config, { inboundEventId: eventId }, factory, enqueue);
+    await db.update(inboundEvents).set({ processedAt: null }).where(eq(inboundEvents.id, eventId));
+    await processGithubWebhook(db, config, { inboundEventId: eventId }, factory, enqueue);
+
+    const dispatchedRuns = await db
+      .select()
+      .from(runs)
+      .where(and(eq(runs.orgId, orgId), eq(runs.githubDeliveryId, eventId)));
+    expect(dispatchedRuns).toHaveLength(1);
+    expect(progressComments).toBe(1);
+    expect(
+      dispatches.filter(
+        (job) => job.queue === "runs.dispatch" && job.data.runId === dispatchedRuns[0]?.id,
+      ),
+    ).toHaveLength(2);
+    expect(
+      await db
+        .select()
+        .from(runEvents)
+        .where(and(eq(runEvents.runId, dispatchedRuns[0]?.id ?? ""), eq(runEvents.seq, 1))),
+    ).toHaveLength(1);
   });
 
   it("dispatches CI-doctor from the final complete rollup without persisting raw logs", async () => {

--- a/services/api/test/github-webhook-policy.test.ts
+++ b/services/api/test/github-webhook-policy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { githubTriggerRequiresClient } from "../src/github/router.js";
+import { githubWebhookRequiresWorker } from "../src/routes/webhooks.js";
+
+describe("GitHub webhook scheduling policy", () => {
+  it("persists but does not schedule workflow lifecycle actions with no processor output", () => {
+    expect(githubWebhookRequiresWorker("workflow_run", { action: "requested" })).toBe(false);
+    expect(githubWebhookRequiresWorker("workflow_run", { action: "in_progress" })).toBe(false);
+    expect(githubWebhookRequiresWorker("workflow_run", { action: "queued" })).toBe(false);
+    expect(githubWebhookRequiresWorker("workflow_run", { action: "completed" })).toBe(true);
+    expect(githubWebhookRequiresWorker("check_run", { action: "created" })).toBe(true);
+  });
+
+  it("creates a GitHub client only for supported human commands", () => {
+    const base = {
+      action: "created",
+      issue: { number: 42, title: "Task" },
+      repository: { owner: { login: "octo" }, name: "repo" },
+      sender: { login: "ada", type: "User" },
+    };
+    expect(
+      githubTriggerRequiresClient({ ...base, comment: { id: 1, body: "ordinary discussion" } }),
+    ).toBe(false);
+    expect(
+      githubTriggerRequiresClient({ ...base, comment: { id: 2, body: "/architect\nPlan this" } }),
+    ).toBe(true);
+    expect(
+      githubTriggerRequiresClient({
+        ...base,
+        sender: { login: "bot", type: "Bot" },
+        comment: { id: 3, body: "/architect" },
+      }),
+    ).toBe(false);
+    expect(
+      githubTriggerRequiresClient({
+        ...base,
+        action: "edited",
+        comment: { id: 4, body: "/architect" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/services/api/test/github.test.ts
+++ b/services/api/test/github.test.ts
@@ -352,6 +352,62 @@ describe("github integration", async () => {
     expect(rows).toHaveLength(1);
   });
 
+  it("accepts signed GitHub bursts outside the public API rate limit", async () => {
+    const limited = await buildApp(config, { rateLimitMax: 1 });
+    try {
+      await limited.ready();
+      expect((await limited.inject({ method: "GET", url: "/health" })).statusCode).toBe(200);
+      expect((await limited.inject({ method: "GET", url: "/health" })).statusCode).toBe(429);
+
+      const payload = Buffer.from(
+        JSON.stringify({
+          action: "requested",
+          installation: { id: 123 },
+          repository: { name: "repo", owner: { login: "octo" } },
+          workflow_run: { head_sha: "burst-sha" },
+        }),
+      );
+      const signature = `sha256=${createHmac("sha256", "webhook-secret").update(payload).digest("hex")}`;
+      let lastDelivery = "";
+      for (let index = 0; index < 3; index += 1) {
+        lastDelivery = newId("evt");
+        const response = await limited.inject({
+          method: "POST",
+          url: "/webhooks/github",
+          headers: {
+            "content-type": "application/json",
+            "x-github-event": "workflow_run",
+            "x-github-delivery": lastDelivery,
+            "x-hub-signature-256": signature,
+          },
+          payload,
+        });
+        expect(response.statusCode).toBe(202);
+      }
+      const [persisted] = await db
+        .select()
+        .from(inboundEvents)
+        .where(eq(inboundEvents.id, `gh_${lastDelivery}`));
+      expect(persisted).toMatchObject({ verified: true, eventType: "workflow_run" });
+      expect(persisted?.processedAt).toBeInstanceOf(Date);
+
+      const rejected = await limited.inject({
+        method: "POST",
+        url: "/webhooks/github",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "workflow_run",
+          "x-github-delivery": newId("evt"),
+          "x-hub-signature-256": "sha256=bad",
+        },
+        payload,
+      });
+      expect(rejected.statusCode).toBe(401);
+    } finally {
+      await limited.close();
+    }
+  });
+
   it("routes a webhook to the resolved org's repo when two tenants share a repo name", async () => {
     // repos are per-org unique (migration 0012), so two orgs can register the
     // same owner/name. The processor must select the repo of the webhook's


### PR DESCRIPTION
## What changes

- Batch up to 1,000 GitHub webhook jobs while preserving delivery order for local projections.
- Coalesce authoritative pull-request reconciliation by tenant, repository, and head SHA, with four bounded reconciliation workers.
- Reuse the worker-lifetime GitHub App factory and skip the REST check-run request when GraphQL already reports a non-failing aggregate.
- Persist but do not enqueue workflow lifecycle actions that have no processor output.
- Exempt the HMAC-authenticated, durably deduplicated GitHub ingress from the generic per-IP API limiter.
- Make slash-command delivery retries idempotent and observable, without giving commands queue priority.
- Log batch size, oldest queue wait, projection time, reconciliation time, and coalescing counts.

## Why

Production was accepting thousands of GitHub CI notifications faster than one worker could process them. Each notification could recreate GitHub App state and perform the same remote pull-request/check reconciliation, turning a 5,036-event burst into hours of duplicated network waits despite low API, database, and CPU utilization.

This keeps the end state and command ordering intact while collapsing equivalent remote work. A deterministic 1,000-delivery burst now produces one GraphQL reconciliation, zero redundant REST check-list calls, and marks all 1,000 deliveries processed.

## Verification

- Focused API acceptance:
  - `Test Files  4 passed (4)`
  - `Tests  82 passed (82)`
  - `Duration  5.51s`
- The 1,000-delivery regression asserts 999 coalesced deliveries, one GitHub client factory call, one GraphQL call, zero REST check calls, and all deliveries processed.
- Signed ingress tests prove normal API traffic is still rate-limited, valid GitHub bursts return 202, and an invalid HMAC remains 401.
- Replay integration proves one run, one progress comment, and one initial run event are created across a repeated delivery while dispatch is safely resumed.
- `pnpm --filter @facility/api typecheck` passes.
- `pnpm verify` completed lint, typecheck, and clean build. The local Docker VM was saturated (about 900% CPU): the critical suite hit fixed timeouts in unchanged Docker-dependent tests. Against an isolated local Postgres, the database suite passed 18/18 in 1.66s and the API suite passed 450/452 before two unchanged Docker-sandbox tests timed out. No thresholds or guards were relaxed.

- [ ] `pnpm verify` passes locally (blocked only by the Docker saturation described above; CI should run the clean environment check)
- [x] Behaviour verified beyond the test suite (deterministic 1,000-delivery burst and ingress/replay integration coverage)
- [x] Documentation updated, or no user-facing change (internal worker/ingress performance change)
