### PR TITLE
fix(runner): skip baseline checks for learning runs

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -300,13 +300,13 @@ async function main() {
       ]);
     }
     // Acceptance checks prove changed work, so read-only modes (architect,
-    // review, security-sweep) skip them: those runs change nothing, and running
-    // the project's checks would measure the repo's baseline — e.g. an
-    // architect failing `npm test` on a repo whose bootstrap PR hasn't merged
-    // yet. Every other mode keeps the gate: builder deliveries, repair modes
-    // (address-review, ci-doctor — they push commits too), and custom/BYO
+    // review, security-sweep, learning) skip them: those runs change nothing,
+    // and running the project's checks would measure the repo's baseline — e.g.
+    // an architect failing `npm test` on a repo whose bootstrap PR hasn't
+    // merged yet. Every other mode keeps the gate: builder deliveries, repair
+    // modes (address-review, ci-doctor — they push commits too), and custom/BYO
     // modes that use checks as generic acceptance.
-    const readOnlyMode = readOnlyRepositoryMode(normalizedMode(bundle.mode));
+    const readOnlyMode = readOnlyRepositoryMode(bundle.mode);
     if (githubCi && engineCode === 0) {
       await emit([
         {
@@ -1800,8 +1800,14 @@ function repairRepositoryMode(mode: string) {
   return mode === "address_review" || mode === "ci_doctor";
 }
 
-function readOnlyRepositoryMode(mode: string) {
-  return mode === "architect" || mode === "review" || mode === "security_sweep";
+export function readOnlyRepositoryMode(mode: string) {
+  const normalized = normalizedMode(mode);
+  return (
+    normalized === "architect" ||
+    normalized === "review" ||
+    normalized === "security_sweep" ||
+    normalized === "learning"
+  );
 }
 
 export function parseGitNameStatus(raw: string) {

--- a/runner/test/checks.test.ts
+++ b/runner/test/checks.test.ts
@@ -6,6 +6,7 @@ import {
   engineEnv,
   githubCiOwnsAcceptance,
   parseSelfReportedChecks,
+  readOnlyRepositoryMode,
   redactEventData,
   redactSecrets,
   requiresDelivery,
@@ -13,6 +14,16 @@ import {
 } from "../src/index.js";
 
 describe("platform acceptance checks", () => {
+  it("does not measure read-only learning runs against the repository baseline", () => {
+    expect(readOnlyRepositoryMode("learning")).toBe(true);
+    expect(readOnlyRepositoryMode("codex-learning")).toBe(true);
+    expect(readOnlyRepositoryMode("architect")).toBe(true);
+    expect(readOnlyRepositoryMode("review")).toBe(true);
+    expect(readOnlyRepositoryMode("security-sweep")).toBe(true);
+    expect(readOnlyRepositoryMode("custom")).toBe(false);
+    expect(readOnlyRepositoryMode("builder")).toBe(false);
+  });
+
   it("reports the exit code of a passing command", async () => {
     const { code } = await runCheckCommand("echo ok; exit 0", tmpdir(), 5);
     expect(code).toBe(0);


### PR DESCRIPTION
## What changes

- Classify Learning as a read-only repository mode when deciding whether to run project-owned acceptance commands.
- Normalize mode names inside the shared read-only predicate so both `learning` and `codex-learning` follow the same lifecycle.
- Add regression coverage for Learning while preserving acceptance checks for Builder and custom modes.

## Why

Learning produces proposals and is forbidden from changing the repository. Running the repository baseline after a successful Learning agent makes that run depend on unrelated project health, which caused successful proposal runs to finish as `checks_failed`.

The existing delivery path still rejects repository mutations from Learning runs.

## Verification

- [ ] `pnpm verify` passes locally — lint, typecheck, clean build, and critical DB/CLI integration suites passed; the command then reproduced two unrelated 5-second API baseline timeouts (`admin readiness doctor` and `reconciler revokes orphaned run keys`) in unchanged API code, after 451/453 API assertions passed.
- [x] Behaviour verified beyond the test suite — imported the clean-built runner and confirmed `learning=true`, `codex-learning=true`, and `custom=false` from the production predicate.
- [x] Documentation updated, or no user-facing change — no documentation change is needed for this runner lifecycle correction.

Additional targeted checks:

- `pnpm --filter @facility/runner test` — 12 files and 159 tests passed.
- `pnpm --filter @facility/runner typecheck` — passed.
- `git diff --check` — passed.
- Critical database integration — 18/18 passed with no skips.
- Critical CLI integration — 98/98 passed with no skips.