### PR TITLE
fix(runner): restore protected workspace checkpoints

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -958,7 +958,13 @@ export async function restoreWorkspaceCheckpoint(
   const existingPatch = await workspacePatch(cwd, expectedBaseBranch);
   if (patch !== existingPatch) {
     if (existingPatch.trim()) throw new Error("resume_workspace_conflict");
-    if (patch.trim()) await gitOutput(cwd, ["apply", "--binary", patchPath]);
+    // The lifecycle process extracts the checkpoint as root, while every Git
+    // command runs as the untrusted workspace user. Feed the already-read patch
+    // through stdin so a root-owned 0600 archive entry cannot make a valid
+    // checkpoint unreadable to `git apply`.
+    if (patch.trim()) {
+      await gitOutput(cwd, ["apply", "--binary", "-"], false, GIT_COMMAND_TIMEOUT_MS, patch);
+    }
   }
   for (const relativePath of root.files as string[]) {
     safeRepositoryPath(relativePath);
@@ -968,6 +974,10 @@ export async function restoreWorkspaceCheckpoint(
     await mkdir(dirname(target), { recursive: true });
     await cp(checkpointFile, target, { recursive: true, preserveTimestamps: true });
   }
+  // Node's lifecycle process performs the copies above and therefore owns new
+  // untracked files. Return the repository to the engine identity before
+  // Claude resumes, including recursively copied directories.
+  await grantPathToUntrusted(cwd);
   return true;
 }
 
@@ -2481,14 +2491,18 @@ export async function gitOutput(
   args: string[],
   trustedBootstrap = false,
   timeoutMs = GIT_COMMAND_TIMEOUT_MS,
+  input?: string | Buffer,
 ) {
   const child = spawn("git", ["-c", `safe.directory=${cwd}`, ...args], {
     cwd,
     env: trustedBootstrap ? process.env : engineEnv(),
-    stdio: ["ignore", "pipe", "pipe"],
+    // Always close a pipe for commands without input; this is equivalent to an
+    // ignored stdin while keeping the child streams statically non-null.
+    stdio: ["pipe", "pipe", "pipe"],
     detached: true,
     ...(trustedBootstrap ? {} : untrustedSpawnIdentity()),
   });
+  child.stdin.end(input);
   let timedOut = false;
   let killTimer: ReturnType<typeof setTimeout> | undefined;
   const timeout = setTimeout(() => {
@@ -2700,6 +2714,13 @@ async function grantWorkspaceToUntrusted() {
   // directory created next to them.
   await chown(workRoot, 0, workspaceGid);
   await chmod(workRoot, 0o3770);
+}
+
+async function grantPathToUntrusted(path: string) {
+  const identity = untrustedSpawnIdentity();
+  if (identity.uid === undefined || identity.gid === undefined) return;
+  await runCommand("chown", ["-R", `${identity.uid}:${identity.gid}`, path], dirname(path));
+  await runCommand("chmod", ["-R", "u+rwX", path], dirname(path));
 }
 
 async function prepareRunnerRuntime() {

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -7,6 +7,7 @@ import {
   readFile,
   realpath,
   rm,
+  stat,
   symlink,
   writeFile,
 } from "node:fs/promises";
@@ -1379,6 +1380,10 @@ describe("Claude resume controls", () => {
     });
 
     await createWorkspaceCheckpoint(source, checkpoint, "main");
+    // Checkpoint metadata is deliberately lifecycle-only. Restore must pass
+    // the patch over stdin instead of asking the untrusted Git process to open
+    // this root-owned 0600 path directly.
+    expect((await stat(join(checkpoint, "tracked.patch"))).mode & 0o777).toBe(0o600);
     execFileSync("git", ["clone", "--branch", "main", source, target]);
 
     await expect(restoreWorkspaceCheckpoint(target, checkpoint, "main")).resolves.toBe(true);


### PR DESCRIPTION
## What changes

- Feed protected checkpoint patches to the untrusted Git process over stdin.
- Return recursively restored untracked files to the agent UID/GID.
- Pin the checkpoint patch mode in the resume regression test.

## Why

Production verification of #145 found a real cross-UID failure: the lifecycle process extracted `.facility-resume/tracked.patch` as root with mode 0600, while `git apply` runs as the untrusted workspace UID. Resume therefore fell back with `Permission denied` even though the checkpoint existed.

## Verification

- [ ] `pnpm verify` passes locally (focused hotfix checks below; full CI is the release gate)
- [x] Behaviour verified beyond the test suite: reproduced in production run `run_019ffb0620797ed2bc85e44338a109d7` as `git apply ... Permission denied`; fix preserves 0600 and removes path access from the untrusted process
- [x] Documentation updated, or no user-facing change

Commands run:

- `pnpm --filter @facility/runner test` — 167/167 passed
- `pnpm --filter @facility/runner typecheck`
- `pnpm exec biome check runner/src/index.ts runner/test/workspace.test.ts`
- `pnpm --filter @facility/runner build`
- `pnpm guards`
- `git diff --check`

External Claude review was attempted but could not authenticate because the local OAuth session is expired.