### PR TITLE
fix(gateway): meter Anthropic streaming input tokens from message_start

### DIFF
--- a/services/gateway/src/usage.ts
+++ b/services/gateway/src/usage.ts
@@ -111,9 +111,16 @@ export class UsageTee extends Transform {
     try {
       const parsed = JSON.parse(text);
       if (this.provider === "anthropic") {
-        const direct = usageFromJson("anthropic", parsed);
-        const delta = usageFromJson("anthropic", { usage: parsed.delta?.usage });
-        mergeUsage(this.usage, { ...direct, ...delta });
+        // Anthropic splits streamed usage across frames: `message_start` carries
+        // input and cache tokens under `message.usage`, `message_delta` carries
+        // output tokens under `delta.usage`, and a non-streamed body reports
+        // everything under a top-level `usage`. Merge each source separately
+        // rather than spreading them into one object: a spread copies absent
+        // keys as `undefined` and would drop an earlier frame's input tokens
+        // when the later frame reports only output.
+        for (const source of [parsed, parsed?.message, parsed?.delta]) {
+          mergeUsage(this.usage, usageFromJson("anthropic", source));
+        }
       } else {
         mergeUsage(this.usage, usageFromJson("openai", parsed));
       }

--- a/services/gateway/test/gateway.test.ts
+++ b/services/gateway/test/gateway.test.ts
@@ -374,6 +374,15 @@ describe("gateway", async () => {
       await db.select().from(llmRequests).where(eq(llmRequests.virtualKeyId, setup.keyId))
     )[0];
     expect(row?.outputTokens).toBe(1_000_000);
+    // Anthropic reports streamed input usage in message_start, output in
+    // message_delta. Both have to reach the row and the budget counter:
+    // claude-sonnet-5 is $3/1M input + $15/1M output, so 1M each is 1800 cents.
+    expect(row?.inputTokens).toBe(1_000_000);
+    expect(row?.costCents).toBe(1800);
+    const counter = (
+      await db.select().from(spendCounters).where(eq(spendCounters.budgetId, setup.budgetId))
+    )[0];
+    expect(counter?.spentCents).toBe(1800);
   });
 
   it("2b. shutdown drains post-response metering before closing Postgres", async () => {

--- a/services/gateway/test/usage.test.ts
+++ b/services/gateway/test/usage.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { UsageTee } from "../src/usage.js";
+
+const MESSAGE_START =
+  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1000,"cache_read_input_tokens":40,"cache_creation_input_tokens":25}}}\n\n';
+const CONTENT_DELTA =
+  'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"ok"}}\n\n';
+const MESSAGE_DELTA =
+  'event: message_delta\ndata: {"type":"message_delta","delta":{"usage":{"output_tokens":700}}}\n\n';
+
+describe("UsageTee anthropic streaming usage", () => {
+  it("meters input and cache tokens reported by message_start", async () => {
+    const tee = new UsageTee("anthropic");
+    await feed(tee, [MESSAGE_START, CONTENT_DELTA, MESSAGE_DELTA]);
+
+    expect(tee.usage).toEqual({
+      inputTokens: 1000,
+      outputTokens: 700,
+      cacheReadTokens: 40,
+      cacheWriteTokens: 25,
+    });
+  });
+
+  it("keeps message_start input tokens when message_delta reports only output", async () => {
+    const tee = new UsageTee("anthropic");
+    await feed(tee, [MESSAGE_START, MESSAGE_DELTA]);
+
+    // The output-only frame arrives last; it must not erase the earlier fields.
+    expect(tee.usage.inputTokens).toBe(1000);
+    expect(tee.usage.cacheReadTokens).toBe(40);
+    expect(tee.usage.outputTokens).toBe(700);
+  });
+
+  it("meters usage from frames split across chunk boundaries", async () => {
+    const tee = new UsageTee("anthropic");
+    const stream = MESSAGE_START + CONTENT_DELTA + MESSAGE_DELTA;
+    // Single-byte chunks split every frame, including the "\n\n" terminator.
+    const passthrough = await feed(tee, [...stream]);
+
+    expect(passthrough).toBe(stream);
+    expect(tee.usage).toEqual({
+      inputTokens: 1000,
+      outputTokens: 700,
+      cacheReadTokens: 40,
+      cacheWriteTokens: 25,
+    });
+  });
+
+  it("passes malformed frames through and still meters the valid ones", async () => {
+    const tee = new UsageTee("anthropic");
+    const malformed = 'event: message_start\ndata: {"type":"message_start","message":\n\n';
+    const stream = malformed + MESSAGE_START + MESSAGE_DELTA;
+    const passthrough = await feed(tee, [stream]);
+
+    expect(passthrough).toBe(stream);
+    expect(tee.usage.inputTokens).toBe(1000);
+    expect(tee.usage.outputTokens).toBe(700);
+  });
+
+  it("still meters a non-streamed body reporting a top-level usage", async () => {
+    const tee = new UsageTee("anthropic");
+    await feed(tee, [JSON.stringify({ usage: { input_tokens: 12, output_tokens: 34 } })]);
+
+    expect(tee.usage.inputTokens).toBe(12);
+    expect(tee.usage.outputTokens).toBe(34);
+  });
+});
+
+async function feed(tee: UsageTee, chunks: string[]): Promise<string> {
+  const seen: Buffer[] = [];
+  tee.on("data", (chunk: Buffer) => seen.push(chunk));
+  for (const chunk of chunks) tee.write(Buffer.from(chunk, "utf8"));
+  tee.end();
+  await new Promise((resolve) => tee.once("end", resolve));
+  return Buffer.concat(seen).toString("utf8");
+}


### PR DESCRIPTION
## What changes

- Merge `message_start.message.usage` into the Anthropic streaming usage sources, so input and cache tokens are metered alongside the output tokens `message_delta` already reported.
- Merge the three usage sources separately instead of spreading them into one object, so a later output-only frame cannot erase input tokens an earlier frame reported.
- Assert input tokens, request-row cost, and the spend counter in the existing streaming integration test, and add unit coverage for valid, split-chunk, malformed, and non-streamed frames.

## Why

Closes #54.

Anthropic reports streamed input and cache usage under `message_start.message.usage`, while `UsageTee` read only the top-level `usage` and `delta.usage`. Streamed input tokens never reached metering, so with the existing 1M-input/1M-output fixture the gateway recorded 1500 cents against the 1800 cents owed. That undercounts the `llm_requests` row and the `spend_counters` row a hard budget enforces against, so a project can outspend its cap on streamed traffic.

The gap survived because the streaming test asserted only `outputTokens`. It now asserts the input tokens, the row cost, and the counter, so an undercount fails the suite rather than the invoice.

## Verification

- [ ] `pnpm verify` passes locally — it reached the critical integration step and stopped on API timeout flakes unrelated to this change, detailed below.
- [x] Behaviour verified beyond the test suite — reverted `usage.ts` alone and re-ran the new unit file: 4 of 5 tests fail with input tokens at 0, and the single pass is the non-streamed top-level `usage` case the change does not touch. Restored, all pass. The integration assertion moves 1500 → 1800 cents on both the request row and the spend counter.
- [x] Documentation updated, or no user-facing change — no user-facing surface changes; the correction is to recorded usage.

Commands run:

- `pnpm --filter @facility/gateway test` — 57/57 passed against an isolated `facility_gw`
- `pnpm --filter @facility/gateway typecheck`
- `pnpm lint`
- `pnpm guards` — 2 guards ran, 0 failed
- `git diff --check`

On the `pnpm verify` box: the failures are in `services/api`, which does not depend on `@facility/gateway` and cannot import the changed file. The gateway suite also runs after the API suite, against a separate database. Running the same 42-file API suite three times gave three different results: `test/assistant.test.ts` failed during `pnpm verify`, unmodified `main` passed 42/42, and this branch produced two 5-second timeouts in `test/watchtower.test.ts`. That is the same class of unrelated 5-second API timeout reported in #143. Happy to re-run anything on request.

Acceptance criteria from #54: `message_start` input and cache fields are metered; a later `message_delta` merges output without erasing them; unit coverage spans valid, split-chunk, and malformed frames; and the integration proof runs against local Postgres and a stub provider, with no live credentials or network.
