### PR TITLE
fix(runner): preserve resumable unbounded sessions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   protobufjs@>=7.5.0 <7.6.5: 7.6.5
   webpack-dev-server@<=5.2.5: 5.2.6
   dompurify@<=3.4.12: 3.4.13
-  nanoid@>=3.0.0 <3.3.17: 3.3.17
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
 
 patchedDependencies:
   image-size@2.0.2: 91c116f6f63aa8ff1be47af798f33721d884b495bae00fdf2adfe313bfbad42a
@@ -6253,8 +6253,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -16051,7 +16051,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -16863,7 +16863,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ overrides:
   "protobufjs@>=7.5.0 <7.6.5": 7.6.5
   "webpack-dev-server@<=5.2.5": 5.2.6
   "dompurify@<=3.4.12": 3.4.13
-  "nanoid@>=3.0.0 <3.3.17": 3.3.17
+  "nanoid@>=3.0.0 <3.3.18": 3.3.18
 
 # Postinstall build-script allowlist — nothing builds unless named here.
 allowBuilds:

--- a/runner/README.md
+++ b/runner/README.md
@@ -9,8 +9,10 @@ The AWS driver restores only pnpm's content-addressed store and npm's `_cacache`
 
 A run **succeeds only if the engine exits 0 AND every platform check passes** — a green agent report cannot make a red gate pass. Platform checks emit `check` events with `self_reported: false`, a pass/fail `status`, an `exit_code`, and (on failure) a capped, secret-redacted output tail; the agent's self-reports are flagged `self_reported: true` (the runner forces the flag, so provenance can't be spoofed). Check commands come from the sandbox profile's `setup.check_cmds`, falling back to the project's `settings.check_cmds`.
 
+Agent sessions have no Facility turn limit or wall-clock execution limit. They stop only at a manual cancellation or a governed policy boundary such as budget or security enforcement. Provider sandboxes still require finite leases (36 hours on CodeBuild and 5 hours on Vercel), so Facility requests the provider maximum, persists the engine session id as soon as it is observed, and uploads the Claude session plus governed workspace checkpoint every minute. A provider disconnect or lease boundary is therefore a resumable interruption, not a logical end to the work. Manual resume replays the checkpoint onto the current base; clean upstream changes are preserved and three-way conflicts remain in the worktree for the resumed agent to reconcile.
+
 ## Steering
 
 - `byo`: long-polls `/internal/runs/:id/steer`, appends delivered messages to `STEERING.md`, and emits a `steer` run event immediately. The BYO process can read that file.
-- `claude_code`: v1 baseline records steer messages in `STEERING.md` while the current `claude -p` turn runs. After the process exits, the next implementation can replay the queued text with `claude -p --resume <session_id>` when a session id is available; this runner does not pretend stdin turn injection works for the non-interactive CLI.
+- `claude_code`: records steer messages in `STEERING.md` while the current `claude -p` turn runs. A manual resume uses `claude -p --resume <session_id>` together with the latest periodic workspace checkpoint; this runner does not pretend stdin turn injection works for the non-interactive CLI.
 - `codex`: v1 baseline records steer messages in `STEERING.md` and emits audit events. `codex exec --json` is treated as a single non-interactive turn.

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -51,6 +51,7 @@ const AGENT_PROGRESS_MAX_BYTES = 16 * 1024;
 const SECURITY_REPORT_MAX_BYTES = 256 * 1024;
 const SECURITY_EVIDENCE_MAX_BYTES = 256 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
+const SESSION_CHECKPOINT_INTERVAL_MS = 60_000;
 const RATE_LIMIT_RETRY_LIMIT = 8;
 const DEFAULT_RETRY_AFTER_MS = 1_000;
 const MAX_RETRY_AFTER_MS = 60_000;
@@ -67,6 +68,8 @@ const PRIVATE_REGISTRY_INSTALL_COMMANDS = new Set([
   "yarn install --immutable",
 ]);
 let engineSessionId: string | null = null;
+let engineTerminalError: string | null = null;
+let requestSessionCheckpoint: (() => void) | null = null;
 let activeEngineChild: ReturnType<typeof spawn> | null = null;
 let clearInterruptEscalation: (() => void) | null = null;
 let interruptRequested = false;
@@ -105,6 +108,7 @@ async function main() {
   let bundle: RunBundle | null = null;
   let steerStop: (() => void) | undefined;
   let progressStop: (() => Promise<boolean>) | undefined;
+  let checkpointStop: (() => Promise<void>) | undefined;
   let preparedSecuritySweep: PreparedSecuritySweepEvidence | null = null;
   let restoredSessionState = false;
   secretsToRedact.add(runnerToken());
@@ -190,9 +194,11 @@ async function main() {
     }
     progressStop = startAgentProgressPoll(cwdFor(bundle));
     const stopProgress = progressStop;
+    checkpointStop = startSessionCheckpointPoll(activeBundle);
+    const stopCheckpoint = checkpointStop;
     const engineCode = await phases.measure(
       "agent",
-      () => runEngine(activeBundle, startedAt, restoredSessionState),
+      () => runEngine(activeBundle, restoredSessionState),
       (code) => ({
         outcome: interruptRequested ? "canceled" : code === 0 ? "succeeded" : "failed",
       }),
@@ -251,7 +257,8 @@ async function main() {
         ]).catch(() => undefined);
       }
       await uploadTranscript();
-      await uploadSessionState(activeBundle);
+      await stopCheckpoint();
+      checkpointStop = undefined;
       return {
         progressPublished,
         securityReport,
@@ -381,7 +388,10 @@ async function main() {
       succeeded
         ? undefined
         : engineCode !== 0
-          ? { code: engineCode }
+          ? {
+              code: engineCode,
+              ...(engineTerminalError ? { engine_error: engineTerminalError } : {}),
+            }
           : !checksConfigured
             ? { code: "checks_not_configured" }
             : !progressConfigured
@@ -404,6 +414,7 @@ async function main() {
     process.exitCode = 1;
   } finally {
     await progressStop?.().catch(() => false);
+    await checkpointStop?.().catch(() => undefined);
     steerStop?.();
   }
 }
@@ -544,8 +555,7 @@ async function pathExists(path: string) {
   }
 }
 
-async function runEngine(bundle: RunBundle, startedAt: number, restoredSessionState: boolean) {
-  const timeoutMin = bundle.timeoutMin;
+async function runEngine(bundle: RunBundle, restoredSessionState: boolean) {
   if (interruptRequested) return 130;
   if (bundle.engine === "claude_code") {
     await trustClaudeWorkspace(cwdFor(bundle));
@@ -557,8 +567,6 @@ async function runEngine(bundle: RunBundle, startedAt: number, restoredSessionSt
       cwdFor(bundle),
       parseClaudeStreamJsonLine,
       parseClaudeSessionId,
-      timeoutMin,
-      startedAt,
     );
   }
   if (bundle.engine === "codex") {
@@ -568,13 +576,11 @@ async function runEngine(bundle: RunBundle, startedAt: number, restoredSessionSt
       cwdFor(bundle),
       parseCodexJsonlLine,
       parseCodexSessionId,
-      timeoutMin,
-      startedAt,
       composedPrompt(bundle),
     );
   }
   const cmd = typeof bundle.engineConfig.cmd === "string" ? bundle.engineConfig.cmd : "printf ''";
-  return runShell(cmd, cwdFor(bundle), "assistant", timeoutMin);
+  return runShell(cmd, cwdFor(bundle), "assistant");
 }
 
 function startSteeringPoll() {
@@ -614,8 +620,6 @@ async function runJsonProcess(
   cwd: string,
   parse: (line: string) => RunEvent | null,
   parseSessionId: (line: string) => string | null,
-  timeoutMin: number,
-  startedAt: number,
   stdin?: string,
 ) {
   const child = spawn(command, args, {
@@ -639,7 +643,6 @@ async function runJsonProcess(
   }
   const stderr = createWriteStream(engineStderrFile, { flags: "a" });
   stderrStream.pipe(stderr);
-  const clearTimers = armEngineTimeout(child, timeoutMin);
   const rl = createInterface({ input: stdout });
   for await (const line of rl) {
     await appendFile(transcriptFile, `${redactSecrets(line)}\n`);
@@ -647,6 +650,7 @@ async function runJsonProcess(
       const sessionId = parseSessionId(line);
       if (sessionId) {
         engineSessionId = sessionId;
+        requestSessionCheckpoint?.();
         if (
           !(await emitEngineEventsBestEffort(
             [{ type: "session", data: { engine_session_id: sessionId } }],
@@ -658,6 +662,8 @@ async function runJsonProcess(
       }
     }
     const event = parse(line);
+    const terminalError = engineResultError(event);
+    if (terminalError) engineTerminalError = terminalError;
     if (event && !(await emitEngineEventsBestEffort([event], emit))) {
       engineEventTransportDegraded = true;
     }
@@ -666,12 +672,23 @@ async function runJsonProcess(
   if (activeEngineChild === child) activeEngineChild = null;
   clearInterruptEscalation?.();
   clearInterruptEscalation = null;
-  clearTimers();
   if (interruptRequested) return 130;
-  if (Date.now() - startedAt >= Math.max(1, timeoutMin - 2) * 60_000) {
-    return 124;
-  }
   return code;
+}
+
+export function engineResultError(event: RunEvent | null) {
+  if (event?.type !== "engine_result") return null;
+  const data = event.data ?? {};
+  const subtype = typeof data.subtype === "string" ? data.subtype : null;
+  if (data.is_error !== true && !subtype?.startsWith("error_")) return null;
+  const errors = Array.isArray(data.errors)
+    ? data.errors.filter((value): value is string => typeof value === "string")
+    : [];
+  const reason =
+    errors[0] ??
+    (typeof data.terminal_reason === "string" ? data.terminal_reason : null) ??
+    subtype;
+  return reason ? `engine_${reason}` : "engine_failed";
 }
 
 function startAgentProgressPoll(cwd: string) {
@@ -949,30 +966,99 @@ export async function restoreWorkspaceCheckpoint(
   const currentBaseSha = (
     await gitOutput(cwd, ["rev-parse", `origin/${expectedBaseBranch}`])
   ).trim();
-  if (currentBaseSha !== root.baseSha) throw new Error("resume_workspace_base_mismatch");
   const branch = existingGithubBranch(root.branch);
   const currentBranch = (await gitOutput(cwd, ["branch", "--show-current"])).trim();
   if (branch !== currentBranch) await gitOutput(cwd, ["checkout", "-B", branch]);
   const patchPath = join(source, resumePatchFile);
   const patch = await readFile(patchPath, "utf8");
   const existingPatch = await workspacePatch(cwd, expectedBaseBranch);
-  if (patch !== existingPatch) {
-    if (existingPatch.trim()) throw new Error("resume_workspace_conflict");
+  if (existingPatch.trim() && patch !== existingPatch) throw new Error("resume_workspace_conflict");
+  const files = root.files as string[];
+  for (const relativePath of files) {
+    safeRepositoryPath(relativePath);
+    const checkpointFile = join(source, resumeFilesDir, relativePath);
+    if (!(await pathExists(checkpointFile))) throw new Error("resume_workspace_file_missing");
+  }
+
+  const applyCheckpoint = async (includePatch = true) => {
     // The lifecycle process extracts the checkpoint as root, while every Git
     // command runs as the untrusted workspace user. Feed the already-read patch
     // through stdin so a root-owned 0600 archive entry cannot make a valid
     // checkpoint unreadable to `git apply`.
-    if (patch.trim()) {
+    if (includePatch && patch.trim()) {
       await gitOutput(cwd, ["apply", "--binary", "-"], false, GIT_COMMAND_TIMEOUT_MS, patch);
     }
+    for (const relativePath of files) {
+      const checkpointFile = join(source, resumeFilesDir, relativePath);
+      const target = join(cwd, relativePath);
+      await mkdir(dirname(target), { recursive: true });
+      await cp(checkpointFile, target, { recursive: true, preserveTimestamps: true });
+    }
+  };
+
+  if (currentBaseSha === root.baseSha) {
+    await applyCheckpoint(patch !== existingPatch);
+  } else {
+    if (existingPatch.trim()) throw new Error("resume_workspace_conflict");
+    const currentHead = (await gitOutput(cwd, ["rev-parse", "HEAD"])).trim();
+    try {
+      await gitOutput(cwd, ["cat-file", "-e", `${root.baseSha}^{commit}`]);
+    } catch {
+      await gitOutput(cwd, ["fetch", "origin", root.baseSha], true);
+    }
+    await gitOutput(cwd, ["checkout", "--detach", root.baseSha]);
+    try {
+      await applyCheckpoint();
+      await grantPathToUntrusted(cwd);
+      await gitOutput(cwd, ["add", "-A"]);
+      const staged = (
+        await gitOutput(cwd, ["status", "--porcelain", "--untracked-files=all"])
+      ).trim();
+      if (!staged) {
+        await gitOutput(cwd, ["checkout", "-B", branch, currentHead]);
+        await grantPathToUntrusted(cwd);
+        return true;
+      }
+      await gitOutput(cwd, [
+        "-c",
+        "user.name=Facility checkpoint",
+        "-c",
+        "user.email=checkpoint@facility.invalid",
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "chore: restore Facility checkpoint",
+      ]);
+      const checkpointCommit = (await gitOutput(cwd, ["rev-parse", "HEAD"])).trim();
+      await gitOutput(cwd, ["checkout", "-B", branch, currentHead]);
+      try {
+        await gitOutput(cwd, ["cherry-pick", "--no-commit", checkpointCommit]);
+      } catch (error) {
+        const conflicts = (await gitOutput(cwd, ["diff", "--name-only", "--diff-filter=U"]))
+          .split("\n")
+          .filter(Boolean);
+        // Conflicts are durable, useful continuation state. Leave the index and
+        // worktree intact so the resumed agent can reconcile upstream changes
+        // instead of silently losing either side of the checkpoint.
+        if (conflicts.length === 0) throw error;
+      }
+    } catch (error) {
+      const head = (await gitOutput(cwd, ["rev-parse", "HEAD"]).catch(() => "")).trim();
+      if (
+        head !== currentHead &&
+        !(await gitOutput(cwd, ["diff", "--name-only", "--diff-filter=U"]).catch(() => "")).trim()
+      ) {
+        await gitOutput(cwd, ["checkout", "-B", branch, currentHead]).catch(() => undefined);
+      }
+      throw error;
+    }
   }
-  for (const relativePath of root.files as string[]) {
-    safeRepositoryPath(relativePath);
-    const checkpointFile = join(source, resumeFilesDir, relativePath);
-    if (!(await pathExists(checkpointFile))) throw new Error("resume_workspace_file_missing");
+
+  for (const relativePath of files) {
     const target = join(cwd, relativePath);
-    await mkdir(dirname(target), { recursive: true });
-    await cp(checkpointFile, target, { recursive: true, preserveTimestamps: true });
+    if (!(await pathExists(target))) {
+      throw new Error("resume_workspace_file_missing");
+    }
   }
   // Node's lifecycle process performs the copies above and therefore owns new
   // untracked files. Return the repository to the engine identity before
@@ -1068,6 +1154,36 @@ async function uploadSessionState(bundle: RunBundle) {
   }
 }
 
+export function startSessionCheckpointPoll(
+  bundle: RunBundle,
+  intervalMs = SESSION_CHECKPOINT_INTERVAL_MS,
+) {
+  let stopped = false;
+  let active = Promise.resolve();
+  const checkpoint = async () => {
+    // Claude does not create its session directory until it has started. Avoid
+    // uploading a workspace-only archive that cannot be resumed as a session.
+    if (!engineSessionId || !(await pathExists(sessionStateDir))) return;
+    await uploadSessionState(bundle);
+  };
+  const schedule = () => {
+    active = active.then(checkpoint).catch(() => undefined);
+  };
+  const timer = setInterval(() => {
+    if (!stopped) schedule();
+  }, intervalMs);
+  timer.unref();
+  requestSessionCheckpoint = schedule;
+  return async () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+    if (requestSessionCheckpoint === schedule) requestSessionCheckpoint = null;
+    await active;
+    await checkpoint().catch(() => undefined);
+  };
+}
+
 export function buildClaudeCodeArgs(bundle: RunBundle, restoredSessionState: boolean) {
   const args =
     bundle.resume && restoredSessionState
@@ -1079,8 +1195,6 @@ export function buildClaudeCodeArgs(bundle: RunBundle, restoredSessionState: boo
     "--verbose",
     "--permission-mode",
     readOnlyEngineMode(bundle.mode) ? "plan" : "bypassPermissions",
-    "--max-turns",
-    "500",
   );
   const deliveryPrompt = deliverySystemPrompt(bundle.mode);
   const deliverySettings = claudeDeliverySettings(bundle.mode);
@@ -1138,7 +1252,7 @@ export function resumeContinuationPrompt(bundle: RunBundle) {
     scope: bundle.resume.fallbackScope ?? bundle.scope,
     resume: undefined,
   });
-  return `${priorPrompt}\n\n## Restored continuation\nFacility restored both the prior Claude session and its governed workspace checkpoint from run ${bundle.resume.sessionStateFrom}. Re-read the original objective and approved plan above; they remain authoritative even if the conversation was compacted. Inspect the restored worktree before changing it, continue rather than restarting completed work, and re-run relevant verification before delivery.\n\n## Resume instruction\n${bundle.resume.prompt}`;
+  return `${priorPrompt}\n\n## Restored continuation\nFacility restored both the prior Claude session and its governed workspace checkpoint from run ${bundle.resume.sessionStateFrom}. Re-read the original objective and approved plan above; they remain authoritative even if the conversation was compacted. Inspect the restored worktree before changing it, continue rather than restarting completed work, and re-run relevant verification before delivery. The repository base may have advanced since the checkpoint. Inspect \`git status\` first; if Facility replayed the checkpoint with conflicts, resolve every conflict while preserving both the completed work and compatible upstream changes before continuing.\n\n## Resume instruction\n${bundle.resume.prompt}`;
 }
 
 export function resumeRecoveryPrompt(bundle: RunBundle) {
@@ -1220,7 +1334,7 @@ async function runShell(
   command: string,
   cwd: string,
   eventType: string,
-  timeoutMin: number,
+  timeoutMin?: number,
   envOverrides?: NodeJS.ProcessEnv,
 ) {
   const child = spawn("sh", ["-c", command], {
@@ -1229,7 +1343,8 @@ async function runShell(
     stdio: ["ignore", "pipe", "pipe"],
     ...untrustedSpawnIdentity(),
   });
-  const clearTimers = armEngineTimeout(child, timeoutMin);
+  const clearTimers =
+    timeoutMin === undefined ? () => undefined : armCommandTimeout(child, timeoutMin);
   const drains = [child.stdout, child.stderr].map((stream) => drainLineEvents(stream, eventType));
   const code = await exitCode(child);
   // Wait for both stream readers to finish draining before returning, so no
@@ -2760,10 +2875,9 @@ export function exitCode(child: ReturnType<typeof spawn>) {
   return new Promise<number>((resolve) => child.once("close", (code) => resolve(code ?? 1)));
 }
 
-// Arm the engine timeout: SIGTERM at (timeout - 2min), then escalate to SIGKILL
-// if the engine ignores it, so a process that traps/ignores SIGTERM cannot run
-// (and bill) unbounded. Returns a disposer that cancels both timers on clean exit.
-function armEngineTimeout(child: ReturnType<typeof spawn>, timeoutMin: number) {
+// Package installation and provisioning remain bounded setup commands. Agent
+// execution deliberately does not use this timer.
+function armCommandTimeout(child: ReturnType<typeof spawn>, timeoutMin: number) {
   let killTimer: ReturnType<typeof setTimeout> | undefined;
   const termTimer = setTimeout(
     () => {
@@ -2778,7 +2892,7 @@ function armEngineTimeout(child: ReturnType<typeof spawn>, timeoutMin: number) {
   };
 }
 
-// Like armEngineTimeout, but signals the child's whole PROCESS GROUP (negative
+// Like armCommandTimeout, but signals the child's whole PROCESS GROUP (negative
 // pid) — the child must have been spawned `detached: true`. Used for checks so a
 // hung command's descendants die with it instead of being orphaned. Falls back to
 // signalling just the child if the group is already gone.

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -27,6 +27,7 @@ import {
   deliverySystemPrompt,
   emitEngineEventsBestEffort,
   engineEnv,
+  engineResultError,
   exitCode,
   githubRequest,
   gitOutput,
@@ -1399,7 +1400,7 @@ describe("Claude resume controls", () => {
     );
   });
 
-  it("rejects a workspace checkpoint when the admitted base changed", async () => {
+  it("replays a workspace checkpoint when the admitted base changed", async () => {
     const root = await mkdtemp(join(tmpdir(), "facility-runner-resume-stale-"));
     const source = join(root, "source");
     const target = join(root, "target");
@@ -1423,18 +1424,59 @@ describe("Claude resume controls", () => {
     execFileSync("git", ["commit", "-m", "chore: advance admitted base"], { cwd: target });
     execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: target });
 
-    await expect(restoreWorkspaceCheckpoint(target, checkpoint, "main")).rejects.toThrow(
-      "resume_workspace_base_mismatch",
-    );
+    await expect(restoreWorkspaceCheckpoint(target, checkpoint, "main")).resolves.toBe(true);
+    await expect(readFile(join(target, "task.txt"), "utf8")).resolves.toBe("resumable work\n");
+    await expect(readFile(join(target, "new-base.txt"), "utf8")).resolves.toBe("new base\n");
+    expect(
+      execFileSync("git", ["branch", "--show-current"], { cwd: target, encoding: "utf8" }).trim(),
+    ).toBe("main");
+  });
+
+  it("preserves three-way conflicts for the resumed agent to reconcile", async () => {
+    const root = await mkdtemp(join(tmpdir(), "facility-runner-resume-conflict-"));
+    const source = join(root, "source");
+    const target = join(root, "target");
+    const checkpoint = join(root, "checkpoint");
+    await mkdir(source);
+    execFileSync("git", ["init", "--initial-branch=main"], { cwd: source });
+    execFileSync("git", ["config", "user.name", "Facility Test"], { cwd: source });
+    execFileSync("git", ["config", "user.email", "facility@example.test"], { cwd: source });
+    await writeFile(join(source, "task.txt"), "shared baseline\n");
+    execFileSync("git", ["add", "task.txt"], { cwd: source });
+    execFileSync("git", ["commit", "-m", "chore: initialize conflict fixture"], { cwd: source });
+    execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: source });
+    await writeFile(join(source, "task.txt"), "checkpoint version\n");
+    await createWorkspaceCheckpoint(source, checkpoint, "main");
+
+    execFileSync("git", ["clone", "--branch", "main", source, target]);
+    execFileSync("git", ["config", "user.name", "Facility Test"], { cwd: target });
+    execFileSync("git", ["config", "user.email", "facility@example.test"], { cwd: target });
+    await writeFile(join(target, "task.txt"), "upstream version\n");
+    execFileSync("git", ["add", "task.txt"], { cwd: target });
+    execFileSync("git", ["commit", "-m", "chore: advance conflicting base"], { cwd: target });
+    execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: target });
+
+    await expect(restoreWorkspaceCheckpoint(target, checkpoint, "main")).resolves.toBe(true);
+    expect(
+      execFileSync("git", ["diff", "--name-only", "--diff-filter=U"], {
+        cwd: target,
+        encoding: "utf8",
+      }).trim(),
+    ).toBe("task.txt");
+    const conflicted = await readFile(join(target, "task.txt"), "utf8");
+    expect(conflicted).toContain("checkpoint version");
+    expect(conflicted).toContain("upstream version");
   });
 
   it("runs architects in native plan mode and keeps builders writable", () => {
     const architectArgs = buildClaudeCodeArgs(bundle({ mode: "architect" }), false);
     const builderArgs = buildClaudeCodeArgs(bundle({ mode: "builder" }), false);
 
-    expect(architectArgs.slice(architectArgs.indexOf("--permission-mode"), -2)).toContain("plan");
+    expect(architectArgs[architectArgs.indexOf("--permission-mode") + 1]).toBe("plan");
     expect(architectArgs).not.toContain("bypassPermissions");
     expect(builderArgs).toContain("bypassPermissions");
+    expect(architectArgs).not.toContain("--max-turns");
+    expect(builderArgs).not.toContain("--max-turns");
     expect(architectArgs).not.toContain("--append-system-prompt");
     expect(builderArgs).toContain("--append-system-prompt");
     expect(deliverySystemPrompt("builder")).toContain("facility-delivery write");
@@ -1443,6 +1485,16 @@ describe("Claude resume controls", () => {
       disableAllHooks: false,
       hooks: { Stop: [{ hooks: [{ command: "/usr/local/bin/facility-delivery" }] }] },
     });
+  });
+
+  it("reports the provider terminal boundary instead of the last assistant prose", () => {
+    expect(
+      engineResultError({
+        type: "engine_result",
+        data: { is_error: true, subtype: "error_max_turns", errors: [] },
+      }),
+    ).toBe("engine_error_max_turns");
+    expect(engineResultError({ type: "assistant", data: { text: "looks done" } })).toBeNull();
   });
 
   it("uses --resume only after session state has been restored", () => {

--- a/services/api/src/assistant/loop.ts
+++ b/services/api/src/assistant/loop.ts
@@ -19,10 +19,7 @@ import { registerAssistantTurn, releaseAssistantTurn } from "./turn-registry.js"
 
 type Db = ReturnType<typeof createDb>["db"];
 
-const MAX_ITERATIONS = 12;
 const MAX_TOKENS = 4096;
-const WALL_CLOCK_MS = 240_000;
-const KEY_TTL_MS = 15 * 60_000;
 const HISTORY_LIMIT = 30;
 const TOOL_RESULT_CAP = 40_000;
 const DELTA_FLUSH_CHARS = 800;
@@ -127,13 +124,13 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<void>
   const abort = new AbortController();
   turns.set(runId, abort);
   const turnToken = registerAssistantTurn(runId);
-  const timer = setTimeout(() => abort.abort(), WALL_CLOCK_MS);
   const emit = (type: string, data: Record<string, unknown>) =>
     appendRunEvents(db, orgId, runId, [{ type, data }]);
   let virtualKeyId: string | undefined;
   try {
-    // Per-turn gateway key: run-bound (metering attributes spend to this run;
-    // the orphan-key sweep is the safety net), model-pinned, short-lived.
+    // Per-turn gateway key: run-bound (metering attributes spend to this run)
+    // and model-pinned. Its lifecycle is terminal revocation rather than a
+    // wall clock, so a healthy tool loop cannot lose access mid-session.
     const key = await generateApiKey("fvk");
     await db.insert(virtualKeys).values({
       id: key.id,
@@ -145,7 +142,6 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<void>
       last4: key.last4,
       hash: key.hash,
       allowedModels: [input.agentModel],
-      expiresAt: new Date(Date.now() + KEY_TTL_MS),
     });
     virtualKeyId = key.id;
     await db
@@ -245,7 +241,7 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<void>
     };
 
     let final: AssistantModelTurn = { content: [], stopReason: null };
-    for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+    for (let iteration = 1; ; iteration++) {
       const current = await db
         .select({ status: runs.status })
         .from(runs)
@@ -352,7 +348,6 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<void>
     const message = error instanceof Error ? error.message : "assistant_turn_failed";
     await failRun(db, orgId, runId, message, "assistant_turn_failed").catch(() => undefined);
   } finally {
-    clearTimeout(timer);
     turns.delete(runId);
     releaseAssistantTurn(runId);
     if (virtualKeyId) await revokeRunKeys(db, { virtualKeyId }).catch(() => undefined);

--- a/services/api/src/github/run-progress.ts
+++ b/services/api/src/github/run-progress.ts
@@ -16,6 +16,7 @@ export type GithubRunProgressInput = {
   sender?: string | null;
   agentProgress?: string | null;
   finalText?: string | null;
+  error?: string | null;
   proposalId?: string | null;
   pullRequest?: { number: number; url: string } | null;
 };
@@ -67,7 +68,13 @@ export function renderGithubRunProgress(input: GithubRunProgressInput) {
 
   if (terminal) {
     lines.push("", "## Result", "");
-    if (input.finalText?.trim()) {
+    if (!succeeded && input.error?.trim()) {
+      lines.push(
+        `**Failure boundary:** \`${singleLine(input.error) ?? "run_failed"}\``,
+        "",
+        "The last assistant message may describe work completed before the interruption; it is not the failure reason. Resume this run from its latest Facility checkpoint after correcting any policy or provider issue.",
+      );
+    } else if (input.finalText?.trim()) {
       lines.push(truncate(input.finalText.trim(), RESULT_LIMIT));
     } else if (succeeded) {
       lines.push("_The run completed without a captured final message._");

--- a/services/api/src/routes/internal.ts
+++ b/services/api/src/routes/internal.ts
@@ -188,6 +188,26 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         run.id,
         request.body as z.infer<typeof EventBatch>,
       );
+      const sessionId = events
+        .filter((event) => event.type === "session")
+        .map((event) =>
+          event.data && typeof event.data === "object" && !Array.isArray(event.data)
+            ? (event.data as Record<string, unknown>).engine_session_id
+            : undefined,
+        )
+        .find(
+          (value): value is string =>
+            typeof value === "string" && value.trim().length > 0 && value.length <= 255,
+        );
+      if (sessionId) {
+        // Persist the provider session as soon as it is observed. A provider
+        // lease can disappear before /result, but that must remain a resumable
+        // interruption rather than erase the continuation handle.
+        await db
+          .update(runs)
+          .set({ engineSessionId: sessionId.trim(), updatedAt: new Date() })
+          .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id), isNull(runs.engineSessionId)));
+      }
       if (events.some((event) => event.type === "agent_progress")) {
         await updateGithubRunProgress(db, run.id, "running", {
           config,

--- a/services/api/src/sandbox/aws.ts
+++ b/services/api/src/sandbox/aws.ts
@@ -72,7 +72,11 @@ export class AwsSandboxDriver implements SandboxDriver {
         projectName: config.project,
         idempotencyToken: spec.runId,
         computeTypeOverride: codeBuildComputeType(spec.cpu, spec.memoryMb),
-        timeoutInMinutesOverride: clamp(Math.round(spec.timeoutMin), 5, 2160),
+        // CodeBuild requires a finite lease. Give agent runs the provider's
+        // maximum and rely on periodic Facility checkpoints for continuation
+        // across lease renewal; previews retain their explicit product TTL.
+        timeoutInMinutesOverride:
+          spec.kind === "preview" ? clamp(Math.round(spec.timeoutMin), 5, 2160) : 2160,
         environmentVariablesOverride: Object.entries(spec.env)
           .sort(([left], [right]) => left.localeCompare(right))
           .map(([name, value]) => ({ name, value, type: "PLAINTEXT" })),

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -125,7 +125,6 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
       last4: virtualKey.last4,
       hash: virtualKey.hash,
       allowedModels: allowedModelsForEngine(bundle.engine, bundle.engineConfig),
-      expiresAt: new Date(Date.now() + bundle.timeoutMin * 60_000),
     });
     // Track the moment it exists — before any further step that could throw.
     createdKeys.virtualKeyId = virtualKey.id;
@@ -153,10 +152,10 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
       projectId: run.projectId,
       roleId: harnessRoleId,
       createdBy: `run:${run.id}`,
-      // Same lifecycle as the virtual key: bound to the run, expires with it, so
-      // it can be swept on terminal + rejected once expired (no indefinite fak_).
+      // Same lifecycle as the virtual key: bound to the run and revoked on every
+      // terminal boundary. It deliberately has no wall-clock expiry because a
+      // healthy run has no time limit; terminal cleanup remains the security boundary.
       runId: run.id,
-      expiresAt: new Date(Date.now() + bundle.timeoutMin * 60_000),
     });
     createdKeys.platformKeyId = platformKey.id;
 
@@ -633,9 +632,7 @@ export async function updateGithubRunProgress(
           .limit(1)
       )[0]
     : undefined;
-  const finalText = ["succeeded", "failed", "canceled"].includes(phase)
-    ? await lastAssistantText(db, run)
-    : null;
+  const finalText = phase === "succeeded" ? await lastAssistantText(db, run) : null;
   const agentProgress = await lastAgentProgress(db, run);
   const commentId = progressCommentId(run.gh);
   if (!commentId) return false;
@@ -645,6 +642,7 @@ export async function updateGithubRunProgress(
       finalText,
       agentProgress,
       proposalId: proposal?.id,
+      error: phase === "failed" ? run.error : null,
     }),
   );
   return true;
@@ -657,6 +655,7 @@ function renderProgressForRun(
     finalText?: string | null;
     agentProgress?: string | null;
     proposalId?: string | null;
+    error?: string | null;
   } = {},
 ) {
   const gh = objectOrEmpty(run.gh);
@@ -678,6 +677,7 @@ function renderProgressForRun(
     sender: stringValue(progress.sender),
     agentProgress: result.agentProgress,
     finalText: result.finalText,
+    error: result.error,
     proposalId: result.proposalId,
     pullRequest: prNumber && prUrl ? { number: prNumber, url: prUrl } : null,
   });
@@ -1563,31 +1563,13 @@ export async function reconcileSandboxes(
       // whole tick (and skip the orphaned-key sweep below) — just skip that run.
       try {
         const sandbox = readSandbox(run.sandbox);
-        // In-process assistant turns have no sandbox driver. If the API died
-        // mid-turn (deploy, dev hot-reload) the run would stay "running" and
-        // its conversation locked forever — fail anything past its wall-clock.
+        // In-process assistant turns have no sandbox driver. They remain live
+        // until an operator or policy boundary terminates them.
         if (sandbox.inline === true) {
-          const startedAt = run.startedAt ? run.startedAt.getTime() : Number.NaN;
-          if (!Number.isNaN(startedAt) && Date.now() > startedAt + 10 * 60_000) {
-            await failRun(db, run.orgId, run.id, "assistant_timeout", "assistant_timeout");
-          }
           continue;
         }
         if (!sandbox.driver || !sandbox.ref) continue;
         const driver = await sandboxDriver(sandbox.driver);
-        // Hard cost cap / driver-level backstop: if a run has blown past its timeout
-        // (with grace beyond the runner's own SIGTERM→SIGKILL escalation), destroy
-        // the sandbox and fail the run — covers an engine that ignores signals or a
-        // wedged sandbox the in-container runner can't kill itself.
-        const launchedAt = sandbox.launchedAt ? Date.parse(sandbox.launchedAt) : Number.NaN;
-        const timeoutMin = Number(sandbox.bundle?.timeoutMin) || 60;
-        const deadline = Number.isNaN(launchedAt) ? null : launchedAt + (timeoutMin + 3) * 60_000;
-        if (deadline !== null && Date.now() > deadline) {
-          await driver.destroy(sandbox.ref).catch(() => undefined);
-          await failRun(db, run.orgId, run.id, "sandbox_timeout", "sandbox_timeout");
-          await updateGithubRunProgress(db, run.id, "failed", { config }).catch(() => undefined);
-          continue;
-        }
         const status = await driver.status(sandbox.ref);
         if (status === "exited" || status === "lost") {
           await failRun(db, run.orgId, run.id, "sandbox_lost", "sandbox_lost");

--- a/services/api/src/sandbox/vercel.ts
+++ b/services/api/src/sandbox/vercel.ts
@@ -113,7 +113,7 @@ export class VercelSandboxDriver implements SandboxDriver {
       name,
       image: vercelImage(spec.image),
       ...(spec.servicePort ? { ports: [spec.servicePort] } : {}),
-      timeout: timeoutMs(spec.timeoutMin),
+      timeout: providerLeaseTimeoutMs(spec),
       resources: { vcpus: vercelVcpus(spec.cpu, spec.memoryMb) },
       networkPolicy: vercelNetworkPolicy(spec.network, spec.env),
       tags,
@@ -152,7 +152,7 @@ export class VercelSandboxDriver implements SandboxDriver {
                 FACILITY_SANDBOX_PROVIDER: "vercel",
               },
         detached: true,
-        timeoutMs: timeoutMs(spec.timeoutMin),
+        timeoutMs: providerLeaseTimeoutMs(spec),
       });
       // Vercel currently keeps update() pending while a detached command is
       // alive. The command id is only recovery metadata: the opaque ref below
@@ -375,6 +375,10 @@ function runIdentity(runId: string) {
 
 function timeoutMs(timeoutMin: number) {
   return Math.min(300, Math.max(1, Math.ceil(timeoutMin))) * 60_000;
+}
+
+function providerLeaseTimeoutMs(spec: LaunchSpec) {
+  return spec.kind === "preview" ? timeoutMs(spec.timeoutMin) : timeoutMs(300);
 }
 
 function vercelVcpus(cpu: number, memoryMb: number) {

--- a/services/api/src/watchtower/platform-health.ts
+++ b/services/api/src/watchtower/platform-health.ts
@@ -27,7 +27,7 @@ async function detectStuckRuns(db: FacilityDb) {
         or(eq(sandboxProfiles.projectId, runs.projectId), isNull(sandboxProfiles.projectId)),
       ),
     )
-    .where(inArray(runs.status, ["queued", "provisioning", "running", "awaiting_human"]));
+    .where(inArray(runs.status, ["queued", "provisioning"]));
   const now = Date.now();
   for (const row of activeRuns) {
     const started = row.run.startedAt ?? row.run.queuedAt;

--- a/services/api/test/assistant.test.ts
+++ b/services/api/test/assistant.test.ts
@@ -180,6 +180,7 @@ describe("assistant ask endpoint", async () => {
 
     const keys = await db.select().from(virtualKeys).where(eq(virtualKeys.runId, ask.runId));
     expect(keys).toHaveLength(1);
+    expect(keys[0]?.expiresAt).toBeNull();
     expect(keys[0]?.revokedAt).not.toBeNull();
 
     const result = await app.inject({
@@ -189,6 +190,32 @@ describe("assistant ask endpoint", async () => {
     });
     expect(result.statusCode).toBe(200);
     expect((result.json() as { answer: string | null }).answer).toContain("on track");
+  });
+
+  it("continues beyond the former tool-iteration cap until the model finishes", async () => {
+    const project = await insertProject("Assistant Unbounded Loop");
+    await insertOwnerAgent(project.id);
+    let primaryCalls = 0;
+    setDriver(async ({ tools }) => {
+      if (tools.length === 0) return textTurn("Unbounded tool session");
+      primaryCalls += 1;
+      return primaryCalls <= 13
+        ? toolTurn("kb_space", {})
+        : textTurn("Finished after thirteen tool rounds.");
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${project.id}/ask`,
+      headers: { cookie },
+      payload: { body: "keep working until done" },
+    });
+    expect(response.statusCode).toBe(200);
+    const ask = response.json() as { conversationId: string; runId: string };
+    const run = await waitForTerminal(ask.runId);
+    expect(run.status).toBe("succeeded");
+    await waitForIdleThread(ask.conversationId);
+    expect(primaryCalls).toBe(14);
   });
 
   it("409s a second ask while a turn is in flight, and heals a stale lock", async () => {

--- a/services/api/test/aws-sandbox.test.ts
+++ b/services/api/test/aws-sandbox.test.ts
@@ -37,7 +37,7 @@ describe("AwsSandboxDriver", () => {
       projectName: "facility-test-runner",
       idempotencyToken: "run_test",
       computeTypeOverride: "BUILD_GENERAL1_LARGE",
-      timeoutInMinutesOverride: 30,
+      timeoutInMinutesOverride: 2160,
       environmentVariablesOverride: [
         { name: "RUN_ID", value: "run_test", type: "PLAINTEXT" },
         { name: "RUNNER_TOKEN", value: "secret", type: "PLAINTEXT" },
@@ -188,7 +188,7 @@ describe("AwsSandboxDriver", () => {
     ).rejects.toThrow("CodeBuild StartBuild did not return a build id");
     expect(
       (codebuild.commands[0] as StartBuildCommand | undefined)?.input.timeoutInMinutesOverride,
-    ).toBe(5);
+    ).toBe(2160);
   });
 
   it("can inspect and stop existing builds when only launch cache config is missing", async () => {

--- a/services/api/test/github-run-progress.test.ts
+++ b/services/api/test/github-run-progress.test.ts
@@ -44,6 +44,22 @@ describe("GitHub run progress", () => {
     expect(body).toContain("`prop_validation`");
   });
 
+  it("shows the actual failure boundary instead of incomplete assistant prose", () => {
+    const body = renderGithubRunProgress({
+      runId: "run_interrupted",
+      mode: "builder",
+      command: "/builder",
+      phase: "failed",
+      issueNumber: 937,
+      finalText: "All checks pass. Now let's prepare the delivery command.",
+      error: '{"code":1,"engine_error":"engine_error_max_turns"}',
+    });
+
+    expect(body).toContain("engine\\_error\\_max\\_turns");
+    expect(body).toContain("Resume this run from its latest Facility checkpoint");
+    expect(body).not.toContain("All checks pass");
+  });
+
   it("reads only a numeric stored progress comment id", () => {
     expect(progressCommentId({ progressComment: { id: 123 } })).toBe(123);
     expect(progressCommentId({ progressComment: { id: "123" } })).toBeNull();

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -287,6 +287,7 @@ describe("sandbox api", async () => {
     };
 
     const permissionSets: string[][] = [];
+    const runKeyExpirations: Array<{ virtual: Date | null; platform: Date | null }> = [];
     for (const harnessEnabled of [false, true]) {
       const agent = (
         await db
@@ -337,9 +338,25 @@ describe("sandbox api", async () => {
           )[0]
         : undefined;
       permissionSets.push(role?.permissions ?? []);
+      const [virtualKey] = await db
+        .select({ expiresAt: virtualKeys.expiresAt })
+        .from(virtualKeys)
+        .where(eq(virtualKeys.runId, run.id));
+      const [platformKey] = await db
+        .select({ expiresAt: apiKeys.expiresAt })
+        .from(apiKeys)
+        .where(eq(apiKeys.runId, run.id));
+      runKeyExpirations.push({
+        virtual: virtualKey?.expiresAt ?? null,
+        platform: platformKey?.expiresAt ?? null,
+      });
     }
 
     expect(permissionSets).toEqual([[], ["kb:read", "kb:write", "tasks:read", "tasks:write"]]);
+    expect(runKeyExpirations).toEqual([
+      { virtual: null, platform: null },
+      { virtual: null, platform: null },
+    ]);
   });
 
   it("dispatch persists engine-specific model policy on each run key", async () => {
@@ -895,6 +912,32 @@ describe("sandbox api", async () => {
     await finishRun(db, run, { status: "succeeded", engineSessionId: "sess_finish_123" });
     const stored = (await db.select().from(runs).where(eq(runs.id, run.id)).limit(1))[0];
     expect(stored?.engineSessionId).toBe("sess_finish_123");
+  });
+
+  it("persists the first engine session event before the runner reaches a result", async () => {
+    const token = "frt_early_session";
+    const run = await insertRunnerRun(token, "running");
+    const first = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/events`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: [{ type: "session", data: { engine_session_id: "sess_early_123" } }],
+    });
+    expect(first.statusCode).toBe(200);
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/events`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: [{ type: "session", data: { engine_session_id: "sess_must_not_replace" } }],
+    });
+    expect(second.statusCode).toBe(200);
+
+    const [stored] = await db
+      .select({ engineSessionId: runs.engineSessionId, status: runs.status })
+      .from(runs)
+      .where(eq(runs.id, run.id));
+    expect(stored).toEqual({ engineSessionId: "sess_early_123", status: "running" });
   });
 
   it("finishRun synchronizes only trusted qualifying security findings", async () => {
@@ -1588,6 +1631,24 @@ describe("sandbox api", async () => {
     expect(vkey?.revokedAt).not.toBeNull();
     const [pkey] = await db.select().from(apiKeys).where(eq(apiKeys.id, platformKeyId));
     expect(pkey?.revokedAt).not.toBeNull();
+  });
+
+  it("does not turn a healthy inline session into a wall-clock timeout", async () => {
+    const runId = newId("run");
+    await insertRunnerRun("frt_unbounded_inline", "running", runId, { inline: true });
+    await db
+      .update(runs)
+      .set({ startedAt: new Date(Date.now() - 24 * 60 * 60_000) })
+      .where(eq(runs.id, runId));
+
+    await reconcileSandboxes(config);
+
+    const [stored] = await db.select({ status: runs.status }).from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date() })
+      .where(eq(runs.id, runId));
   });
 
   it("rejects an expired run-scoped platform key at authentication", async () => {

--- a/services/api/test/vercel-sandbox.test.ts
+++ b/services/api/test/vercel-sandbox.test.ts
@@ -34,7 +34,7 @@ describe("VercelSandboxDriver", () => {
       teamId: "team_test",
       projectId: "prj_test",
       image: "facility-runner:stable",
-      timeout: 45 * 60_000,
+      timeout: 300 * 60_000,
       resources: { vcpus: 4 },
       persistent: false,
       tags: { facility: "1", kind: "run" },
@@ -68,7 +68,7 @@ describe("VercelSandboxDriver", () => {
           FACILITY_SANDBOX_PROVIDER: "vercel",
         },
         detached: true,
-        timeoutMs: 45 * 60_000,
+        timeoutMs: 300 * 60_000,
       },
     ]);
     expect(client.sandbox.updates[0]?.tags).toMatchObject({ command: "cmd-1" });


### PR DESCRIPTION
## What changes

- removes Facility turn, agent wall-clock, inline iteration, and inline wall-clock caps
- uses provider-maximum leases while checkpointing Claude session and workspace state every minute
- persists session IDs immediately and replays checkpoints over newer base commits, preserving conflicts for the resumed agent
- keeps run-scoped credentials valid until terminal revocation and improves failed-run diagnostics
- raises the transitive nanoid security floor required by the repository audit

## Why

A valid builder delivery could be discarded when Claude hit the harness max-turn boundary. Provider interruptions also left only a late terminal receipt, while base drift prevented the saved workspace from being resumed. Sessions should stop only for manual cancellation or governed policy, and infrastructure boundaries should remain recoverable.

## Verification

- [x] pnpm verify passes locally
- [x] Behaviour verified beyond the test suite: replayed checkpoints onto an advanced base in both clean and conflicting fixtures, and ran the database-backed assistant and sandbox integration suites
- [x] Documentation updated in runner/README.md