### PR TITLE
fix(images): remove unused OpenSSL headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ WORKDIR /app
 # stages, but delete their global dependency trees from the runtime rootfs so
 # unused npm/Corepack code cannot become a production CVE surface.
 FROM base AS runtime
-RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /pnpm \
+RUN rm -rf /usr/local/include/node \
+    /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /pnpm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm \
     /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg \
     /usr/local/bin/corepack \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 # Removing their vendored dependencies keeps unused tooling out of the image
 # CVE inventory and makes a future base-layout change fail visibly at build time.
 FROM base AS runtime
-RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /pnpm \
+RUN rm -rf /usr/local/include/node \
+    /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /pnpm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm \
     /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg \
     /usr/local/bin/corepack \

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -311,7 +311,8 @@ test("Bake keeps thin target boundaries and publishes every target through one g
     [webDockerfile, ["web"]],
   ]) {
     assert.match(dockerfile, /FROM base AS runtime[\s\S]*runtime package manager remains/);
-    assert.match(dockerfile, /rm -rf \/usr\/local\/lib\/node_modules\/npm/);
+    assert.match(dockerfile, /rm -rf \/usr\/local\/include\/node/);
+    assert.match(dockerfile, /\/usr\/local\/lib\/node_modules\/npm/);
     for (const target of targets) {
       assert.match(dockerfile, new RegExp(`FROM runtime AS ${target}`));
     }


### PR DESCRIPTION
## Summary

- remove Node development headers from every production runtime image
- eliminate the actionable OpenSSL header finding that blocked the production security gate
- keep a structural regression assertion for both the header removal and package-manager removal

## Verification

- `docker build --target web -f apps/web/Dockerfile -t facility-web:cve-2026-14456 .`
- `docker run --rm facility-web:cve-2026-14456 sh -lc 'test ! -e /usr/local/include/node/openssl && node --version && ! command -v npm'`
- `node --test scripts/images-build.test.mjs`
- `pnpm verify`
