### PR TITLE
fix(images): rebuild runner tools with patched Go

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -14,27 +14,170 @@ RUN gcc -std=c11 -O2 -Wall -Wextra -Werror \
 # daemon/client/runtime set built with a current Go toolchain. Copying from one
 # digest-pinned source avoids Debian's lagging docker.io binaries and a second
 # architecture-specific download/checksum matrix.
-FROM docker:29-dind-rootless@sha256:7451e3dc398b11ba2d8183bb7915402683e3d32e5ec8cef835c215f314a65fef AS docker-tools
+FROM docker:29-dind-rootless@sha256:8a213afdd096a44dff403aaf8eb58b7a96a63113f18a4b094b98b7d0ed7d948b AS docker-tools
 
-# GitHub CLI has no official container image. Its immutable release archives
-# are verified per target architecture before the single binary crosses stages.
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS gh-build
-ARG TARGETARCH
-ARG GH_VERSION=2.97.0
+# Rebuild the exact Go-based releases shipped by Docker with the first Go
+# toolchain that contains the reviewed standard-library fixes. The upstream
+# image still supplies its shell bootstrap and docker-init; every Go binary
+# that crosses into the runner is rebuilt from a checksum-pinned source commit.
+FROM golang:1.26.6-trixie@sha256:ab563819a16cfe5faff0f96a8bb598fbb0e400ab2ac751996e60abcb23b106a3 AS go-tools-base
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl \
-  && case "$TARGETARCH" in \
-    amd64) gh_sha256="a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112" ;; \
-    arm64) gh_sha256="73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5" ;; \
-    *) echo "unsupported GitHub CLI architecture: $TARGETARCH" >&2; exit 1 ;; \
-  esac \
-  && archive="gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
+  && apt-get install -y --no-install-recommends ca-certificates curl libseccomp-dev pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+FROM go-tools-base AS moby-build
+ARG MOBY_VERSION=29.7.2
+ARG MOBY_COMMIT=6a43e3d5afddf4111da0f864bbc7cae5d7e95001
+ARG MOBY_SOURCE_SHA256=ab454c0ace36c1091f36f8750d857f1370a4af3f222f39a88de90a2f6a7e480b
+RUN archive=/tmp/moby.tar.gz \
   && curl --fail --silent --show-error --location --retry 3 \
-    "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" \
-    --output "/tmp/${archive}" \
-  && printf '%s  %s\n' "$gh_sha256" "/tmp/${archive}" | sha256sum --check --strict \
-  && tar -xzf "/tmp/${archive}" -C /tmp \
-  && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /gh
+    "https://github.com/moby/moby/archive/${MOBY_COMMIT}.tar.gz" --output "$archive" \
+  && printf '%s  %s\n' "$MOBY_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && cd /src \
+  && VERSION="$MOBY_VERSION" DOCKER_GITCOMMIT="$MOBY_COMMIT" \
+    EXCLUDE_AUTO_BUILDTAG_JOURNALD=1 SOURCE_DATE_EPOCH=1785456000 \
+    ./hack/make.sh binary-daemon binary-proxy \
+  && install -m 0755 bundles/binary-daemon/dockerd /out/dockerd \
+  && install -m 0755 bundles/binary-proxy/docker-proxy /out/docker-proxy \
+  && test "$(/out/dockerd --version | awk '{print $3}' | tr -d ',')" = "$MOBY_VERSION"
+
+FROM go-tools-base AS docker-cli-build
+ARG DOCKER_CLI_VERSION=29.7.2
+ARG DOCKER_CLI_COMMIT=a7dcaa6fdb6ed04aacbfdc76357fdae01605609e
+ARG DOCKER_CLI_SOURCE_SHA256=6e5c91d3a5a79db78cf989d07727d00e757aa0da4d135a3ce4b86061b83fb511
+RUN archive=/tmp/docker-cli.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/docker/cli/archive/${DOCKER_CLI_COMMIT}.tar.gz" --output "$archive" \
+  && printf '%s  %s\n' "$DOCKER_CLI_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && mkdir -p /go/src/github.com/docker \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && ln -s /src /go/src/github.com/docker/cli \
+  && cd /go/src/github.com/docker/cli \
+  && VERSION="$DOCKER_CLI_VERSION" GITCOMMIT="$DOCKER_CLI_COMMIT" \
+    CGO_ENABLED=0 GO_LINKMODE=static DISABLE_WARN_OUTSIDE_CONTAINER=1 \
+    SOURCE_DATE_EPOCH=1785456000 ./scripts/build/binary \
+  && install -m 0755 "build/docker-linux-$(go env GOARCH)" /out/docker \
+  && test "$(/out/docker --version | awk '{print $3}' | tr -d ',')" = "$DOCKER_CLI_VERSION"
+
+FROM go-tools-base AS containerd-build
+ARG CONTAINERD_VERSION=2.3.3
+ARG CONTAINERD_COMMIT=aad11006b869517fcd3009450b6f82da282e1a9b
+ARG CONTAINERD_SOURCE_SHA256=86793eec0b23ea8f7331ea61c5ef1e56ed6f8071de5ede9ce89b13310a1a072b
+RUN archive=/tmp/containerd.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/containerd/containerd/archive/${CONTAINERD_COMMIT}.tar.gz" --output "$archive" \
+  && printf '%s  %s\n' "$CONTAINERD_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && cd /src \
+  && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
+  && make VERSION="v${CONTAINERD_VERSION}" REVISION="$CONTAINERD_COMMIT" STATIC=1 \
+    GO_BUILD_FLAGS='-mod=mod -trimpath' \
+    bin/containerd bin/containerd-shim-runc-v2 bin/ctr \
+  && install -m 0755 bin/containerd bin/containerd-shim-runc-v2 bin/ctr /out/ \
+  && test "$(/out/containerd --version | awk '{print $3}')" = "v${CONTAINERD_VERSION}"
+
+FROM go-tools-base AS rootlesskit-build
+ARG ROOTLESSKIT_COMMIT=19f94521be524ae7b61e380a814d2aa0a3ef40a9
+ARG ROOTLESSKIT_SOURCE_SHA256=ce3a9857719b83f669c5889a69965b9faaba09f36d720e27bcbe4abf288a3b22
+RUN archive=/tmp/rootlesskit.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/rootless-containers/rootlesskit/archive/${ROOTLESSKIT_COMMIT}.tar.gz" \
+    --output "$archive" \
+  && printf '%s  %s\n' "$ROOTLESSKIT_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && cd /src \
+  && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
+  && CGO_ENABLED=0 go build -mod=mod -trimpath -ldflags='-s -w' -o /out/rootlesskit ./cmd/rootlesskit \
+  && test "$(/out/rootlesskit --version | awk '{print $3}')" = "3.0.2"
+
+FROM go-tools-base AS buildx-build
+ARG BUILDX_VERSION=v0.36.1
+ARG BUILDX_COMMIT=1d8dde89b8aba914e05e45366770736fea1fd690
+ARG BUILDX_SOURCE_SHA256=fb28b5c2a198d05482f0656dfb7ee161240a904e36697bf7108e5d517f23854b
+RUN archive=/tmp/buildx.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/docker/buildx/archive/${BUILDX_COMMIT}.tar.gz" --output "$archive" \
+  && printf '%s  %s\n' "$BUILDX_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && cd /src \
+  && CGO_ENABLED=0 go build -mod=vendor -trimpath \
+    -ldflags="-s -w -X github.com/docker/buildx/version.Version=${BUILDX_VERSION} \
+      -X github.com/docker/buildx/version.Revision=${BUILDX_COMMIT} \
+      -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
+    -o /out/docker-buildx ./cmd/buildx \
+  && test "$(/out/docker-buildx version | awk '{print $2}')" = "$BUILDX_VERSION"
+
+FROM go-tools-base AS compose-build
+ARG COMPOSE_VERSION=v5.4.0
+ARG COMPOSE_COMMIT=ef61d7410a0c816a71705026e638ec256a591d69
+ARG COMPOSE_SOURCE_SHA256=19bf54c1e4f6effdcc6e3f81356f0ca1d2a1dd447458d7e2ac8138fc38b4148b
+RUN archive=/tmp/compose.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/docker/compose/archive/${COMPOSE_COMMIT}.tar.gz" --output "$archive" \
+  && printf '%s  %s\n' "$COMPOSE_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && cd /src \
+  && CGO_ENABLED=0 GOMAXPROCS=1 go build -p=1 -mod=mod -trimpath -tags=e2e \
+    -ldflags="-s -w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
+    -o /out/docker-compose ./cmd \
+  && test "$(/out/docker-compose version --short)" = "${COMPOSE_VERSION#v}"
+
+FROM go-tools-base AS runc-build
+ARG RUNC_COMMIT=bb14dabeb7185bb72c8c86735d090dcb20f36587
+ARG RUNC_SOURCE_SHA256=0128f07fa8bd2ce25d3debf7b52961a2cdc7fbd5fa2da6e76f460d280641fb1b
+RUN archive=/tmp/runc.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/opencontainers/runc/archive/${RUNC_COMMIT}.tar.gz" \
+    --output "$archive" \
+  && printf '%s  %s\n' "$RUNC_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && make -C /src runc \
+  && test "$(/src/runc --version | awk '/^go:/{print $2}')" = "go1.26.6"
+
+FROM go-tools-base AS gh-build
+ARG GH_VERSION=2.97.0
+ARG GH_COMMIT=55dbb4dc6b7edb10b48e3d7fc5bccd32318d1b55
+ARG GH_SOURCE_SHA256=c4ee0ab20406291616de45ad771c8b8a927bc8f3fd00ca61a50d0e8ffa582130
+RUN archive=/tmp/gh.tar.gz \
+  && curl --fail --silent --show-error --location --retry 3 \
+    "https://github.com/cli/cli/archive/${GH_COMMIT}.tar.gz" --output "$archive" \
+  && printf '%s  %s\n' "$GH_SOURCE_SHA256" "$archive" | sha256sum --check --strict \
+  && mkdir /src /out \
+  && tar -xzf "$archive" --strip-components=1 -C /src \
+  && cd /src \
+  && CGO_ENABLED=0 GOTOOLCHAIN=local go build -mod=mod -trimpath \
+    -ldflags="-s -w -X github.com/cli/cli/v2/internal/build.Version=${GH_VERSION} \
+      -X github.com/cli/cli/v2/internal/build.Date=2026-07-31" \
+    -o /out/gh ./cmd/gh \
+  && test "$(/out/gh --version | awk 'NR == 1 {print $3}')" = "$GH_VERSION"
+
+# Keep the toolchain claim executable: fail the image build if any copied Go
+# binary was not produced by the patched compiler, or if the two projects that
+# pinned vulnerable x/net code did not resolve the reviewed replacement.
+FROM go-tools-base AS go-tools-audit
+COPY --from=moby-build /out/dockerd /out/docker-proxy /out/
+COPY --from=docker-cli-build /out/docker /out/
+COPY --from=containerd-build /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/
+COPY --from=rootlesskit-build /out/rootlesskit /out/
+COPY --from=buildx-build /out/docker-buildx /out/
+COPY --from=compose-build /out/docker-compose /out/
+COPY --from=runc-build /src/runc /out/
+COPY --from=gh-build /out/gh /out/
+RUN for binary in /out/*; do \
+    test "$(go version -m "$binary" | awk 'NR == 1 {print $2}')" = "go1.26.6"; \
+  done \
+  && for binary in /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/rootlesskit; do \
+    go version -m "$binary" | awk \
+      '$1 == "=>" && $2 == "golang.org/x/net" && $3 == "v0.56.0" { found = 1 } END { exit !found }'; \
+  done
 
 # The full Node image inherits buildpack-deps and silently carries unrelated
 # database, image-processing, DNS, and web-server development stacks. Agents
@@ -81,6 +224,7 @@ RUN test -n "$DEBIAN_SECURITY_REFRESH" \
     libnspr4 \
     libnss3 \
     libpango-1.0-0 \
+    libseccomp2 \
     libx11-6 \
     libxcb1 \
     libxcomposite1 \
@@ -122,7 +266,13 @@ RUN npm install --global "npm@${NPM_VERSION}" \
 
 COPY --from=docker-tools /usr/local/bin/ /usr/local/bin/
 COPY --from=docker-tools /usr/local/libexec/docker/cli-plugins/ /usr/local/libexec/docker/cli-plugins/
-COPY --from=gh-build /gh /usr/local/bin/gh
+COPY --from=go-tools-audit \
+  /out/docker /out/dockerd /out/docker-proxy /out/containerd \
+  /out/containerd-shim-runc-v2 /out/ctr /out/rootlesskit /out/runc /out/gh \
+  /usr/local/bin/
+COPY --from=go-tools-audit /out/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
+COPY --from=go-tools-audit /out/docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
+COPY --from=go-tools-audit /out/docker-compose /usr/local/bin/docker-compose
 RUN docker --version \
   && dockerd --version \
   && rootlesskit --version \

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -348,17 +348,33 @@ test("Bake keeps thin target boundaries and publishes every target through one g
     runnerDockerfile,
     /^FROM docker:29-dind-rootless@sha256:[0-9a-f]{64} AS docker-tools$/m,
   );
+  assert.match(
+    runnerDockerfile,
+    /^FROM golang:1\.26\.6-trixie@sha256:[0-9a-f]{64} AS go-tools-base$/m,
+  );
+  for (const stage of [
+    "moby-build",
+    "docker-cli-build",
+    "containerd-build",
+    "rootlesskit-build",
+    "buildx-build",
+    "compose-build",
+    "runc-build",
+    "gh-build",
+  ]) {
+    assert.match(runnerDockerfile, new RegExp(`^FROM go-tools-base AS ${stage}$`, "m"));
+  }
+  assert.match(runnerDockerfile, /^FROM go-tools-base AS go-tools-audit$/m);
+  assert.match(runnerDockerfile, /go version -m "\$binary"[\s\S]*go1\.26\.6/);
+  assert.match(runnerDockerfile, /golang\.org\/x\/net[\s\S]*v0\.56\.0/);
+  assert.match(runnerDockerfile, /COPY --from=go-tools-audit[\s\S]*\/usr\/local\/bin\//);
   assert.match(runnerDockerfile, /COPY --from=docker-tools \/usr\/local\/bin\//);
   assert.doesNotMatch(runnerDockerfile, /^\s+docker\.io\s+\\$/m);
   assert.doesNotMatch(runnerDockerfile, /^\s+rootlesskit\s+\\$/m);
   assert.match(runnerDockerfile, /GH_VERSION=2\.97\.0/);
   assert.match(
     runnerDockerfile,
-    /a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112/,
-  );
-  assert.match(
-    runnerDockerfile,
-    /73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5/,
+    /GH_SOURCE_SHA256=c4ee0ab20406291616de45ad771c8b8a927bc8f3fd00ca61a50d0e8ffa582130/,
   );
   const riskRules = [
     ...runnerGrypePolicy.matchAll(


### PR DESCRIPTION
## Summary

- rebuild every Go-based runner tool from checksum-pinned upstream source with Go 1.26.6
- preserve the digest-pinned Docker image bootstrap while replacing its vulnerable binaries
- enforce compiler and `golang.org/x/net` provenance during the image build
- keep the existing Grype policy unchanged

## Why

The production deployment correctly stopped after the upstream Docker toolchain exposed fixed, reachable Go vulnerabilities (GO-2026-5026 and GO-2026-5942). The official Docker image still ships binaries compiled with Go 1.26.5, so updating only the base image cannot clear the release gate.

## Validation

- `node --test scripts/images-build.test.mjs` — 6/6 passed
- `docker build --target runner -t facility-runner:go-1.26.6-all -f runner/Dockerfile .` — passed
- exact production Grype gate (`anchore/grype:v0.110.0`, `runner/grype.yaml`, `--only-fixed --fail-on high`) — exit 0; both Go findings absent
- CodeBuild security-boundary create-only smoke — passed locally (the full nested-Docker path runs on native x86 CI)
- `pnpm verify` — passed
