### PR TITLE
fix: treat blank optional env strings as undefined in API config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/
 *.tfstate
 *.tfstate.*
 crash.log
+
+# GitHub App private keys
+*.pem

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -13,6 +13,11 @@ const OptionalUrl = z.preprocess(
   z.string().url().optional(),
 );
 
+const OptionalString = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+  z.string().trim().min(1).optional(),
+);
+
 const OptionalGithubOrganization = z.preprocess(
   (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
   z
@@ -69,13 +74,13 @@ const EnvSchema = z
     S3_SECRET_KEY: z.string().optional(),
     S3_BUCKET: z.string().optional(),
     AWS_REGION: z.string().optional(),
-    FACILITY_AWS_CODEBUILD_PROJECT: z.string().trim().min(1).optional(),
-    FACILITY_AWS_CODEBUILD_CACHE_BASE_LOCATION: z.string().trim().min(1).optional(),
-    VERCEL_TOKEN: z.string().trim().min(1).optional(),
-    VERCEL_OIDC_TOKEN: z.string().trim().min(1).optional(),
-    VERCEL_TEAM_ID: z.string().trim().min(1).optional(),
-    VERCEL_PROJECT_ID: z.string().trim().min(1).optional(),
-    PACKAGE_REGISTRY_TOKEN: z.string().trim().min(1).optional(),
+    FACILITY_AWS_CODEBUILD_PROJECT: OptionalString,
+    FACILITY_AWS_CODEBUILD_CACHE_BASE_LOCATION: OptionalString,
+    VERCEL_TOKEN: OptionalString,
+    VERCEL_OIDC_TOKEN: OptionalString,
+    VERCEL_TEAM_ID: OptionalString,
+    VERCEL_PROJECT_ID: OptionalString,
+    PACKAGE_REGISTRY_TOKEN: OptionalString,
     GITHUB_APP_ID: z.string().optional(),
     GITHUB_APP_PRIVATE_KEY: z.string().optional(),
     GITHUB_APP_WEBHOOK_SECRET: z.string().optional(),


### PR DESCRIPTION
## What

Seven fields in `EnvSchema` used `z.string().trim().min(1).optional()` without a preprocess step to coerce empty strings to `undefined`. When `dotenv` loads a blank value (e.g. `VERCEL_TOKEN=`) it produces `""`, not `undefined`, so Zod's `.optional()` never applies and `.min(1)` fails with a validation error at startup.

Affected fields:
- `VERCEL_TOKEN`
- `VERCEL_OIDC_TOKEN`
- `VERCEL_TEAM_ID`
- `VERCEL_PROJECT_ID`
- `FACILITY_AWS_CODEBUILD_PROJECT`
- `FACILITY_AWS_CODEBUILD_CACHE_BASE_LOCATION`
- `PACKAGE_REGISTRY_TOKEN`

## How

The fix follows the pattern already established in the codebase for `OptionalUrl`, `OptionalGithubOrganization`, and `FACILITY_PREVIEW_SURFACE_TOKEN`: a preprocess step that converts blank strings to `undefined` before Zod's type checking runs. This change extracts that pattern into an `OptionalString` helper and applies it to the affected fields.

## How I found it

Hit this following the quickstart in the README. Running `pnpm dev` with a fresh `.env` (generated from `.env.example`) crashes the API and worker immediately on startup because `.env.example` leaves these fields blank. The stack never comes up without either filling in Vercel/CodeBuild credentials you don't have, or manually deleting the blank lines.

Also adds `*.pem` to `.gitignore` — the quickstart guide instructs users to generate a GitHub App private key which downloads as a `.pem` file, and the repo root is the natural place to put it.

## Verification

Confirmed locally: fresh `.env` from `.env.example` with all optional fields blank, API and worker both start cleanly after this fix.