### PR TITLE
fix(platform): keep in-flight runs alive across control-plane restarts

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -79,6 +79,12 @@ const TRANSIENT_RETRY_MAX_DELAY_MS = 10_000;
 // longer budget than ordinary calls before abandoning the control plane.
 const RESULT_RETRY_BUDGET_MS = 5 * 60_000;
 const STEER_POLL_RETRY_DELAY_MS = 5_000;
+// How many consecutive failed polls before the channel's outage is recorded to
+// the container log, which is the only place left for it: the degraded event
+// reports a window that ended, so an outage that never ends is reported nowhere.
+// At the fixed retry delay above this is a minute of a silent control channel
+// before the record, long enough that an ordinary restart passes without one.
+const STEER_POLL_FAILURES_BEFORE_REPORT = 12;
 // Pacing for the one poll that has nothing of its own to wait on: a batch the
 // steer route answers again at once because nothing in it reached the ack. The
 // delay doubles from the base and stops at the max, so a message left pending for
@@ -139,6 +145,12 @@ const AMBIGUOUS_NETWORK_CODES = new Set([
 // wrap. What this table cannot see is a call that reaches the control plane
 // without that transport at all, which is why the derivation test in the
 // runner's retry suite also refuses any bare request beyond the loop's own.
+// Every entry states a decision. replaySafe is required here, unlike on
+// TransientRetryOptions where a caller may leave the pacing fields out: an entry
+// added without reading its handler must not be indistinguishable from a
+// classified one, so it fails to compile instead. The entries are readonly so
+// the table cannot be edited through a reference the resolver handed out.
+type EndpointRetryPolicy = Readonly<TransientRetryOptions> & { readonly replaySafe: boolean };
 export const ENDPOINT_RETRY_POLICIES = {
   // The handshake is one-shot by design: it claims the provisioning→running
   // transition and stamps virtualKeyRevealedAt, so a replay after a lost response
@@ -174,14 +186,16 @@ export const ENDPOINT_RETRY_POLICIES = {
   // wrong receipt rather than a cosmetic artifact — this needs server-side
   // idempotency before it can opt in.
   events: { replaySafe: false },
-} as const satisfies Record<string, TransientRetryOptions>;
+} as const satisfies Record<string, EndpointRetryPolicy>;
 // An unclassified endpoint fails on an ambiguous loss instead of replaying it.
 // Every way of getting here is safe in that direction: a new route whose handler
 // nobody has read yet, or a renamed one whose entry no longer matches, degrades
 // to a lost response failing the run rather than to a duplicated effect.
-export const ENDPOINT_RETRY_POLICY_DEFAULT: TransientRetryOptions = { replaySafe: false };
+export const ENDPOINT_RETRY_POLICY_DEFAULT = {
+  replaySafe: false,
+} as const satisfies EndpointRetryPolicy;
 
-export function endpointRetryPolicy(path: string): TransientRetryOptions {
+export function endpointRetryPolicy(path: string): EndpointRetryPolicy {
   // Query and fragment are per-call arguments (the steer poll's acks), not part
   // of the endpoint's identity. hasOwn keeps an inherited property of the table's
   // prototype from being read as a classification.
@@ -752,9 +766,14 @@ async function runEngine(bundle: RunBundle, restoredSessionState: boolean) {
 // id matches its ACK_ID shape, so each id is encoded individually: the separator
 // has to stay literal between ids while a comma or an `&` inside one is escaped
 // rather than read as another id or another query parameter.
+//
+// The parameter itself is always emitted, empty value included, because its
+// presence is what identifies this protocol to the route: a request carrying no
+// ack parameter at all is served the semantics that predate it, which mark the
+// rows they serve. Emitting it only when there is something to name would put
+// this runner's own first poll — which has handled nothing yet — on that path.
 export function steerPollPath(runId: string, ack: string[]) {
-  const query = ack.length > 0 ? `?ack=${ack.map(encodeURIComponent).join(",")}` : "";
-  return `/internal/runs/${runId}/steer${query}`;
+  return `/internal/runs/${runId}/steer?ack=${ack.map(encodeURIComponent).join(",")}`;
 }
 
 // The shape the steer route's ack accepts, which is exactly what newId("evt")
@@ -870,15 +889,17 @@ export async function steeringPollLoop({
       // long-polls while nothing is pending and answers the instant something
       // is, so a batch no id of which reached the ack is served again on the
       // next poll immediately: without this the loop would poll as fast as the
-      // control plane can answer, for the rest of the run. Reachable two ways —
-      // an interrupt whose kill keeps throwing, which is deliberately never
-      // retired, and a message whose id the ack cannot carry. The counter resets
-      // as soon as any id newly reaches the ack, so the poll that follows a batch
-      // which made progress is not delayed. The sleep is not free, though: it
-      // runs before the next poll, so anything created while the loop is stalled
-      // — an interrupt included — waits out the rest of it before the poll that
-      // would fetch it even starts. The window doubles from
-      // STEER_STALLED_POLL_BASE_DELAY_MS and stops at
+      // control plane can answer, for the rest of the run. Reachable three ways
+      // — a steer whose durable action is still failing and has not yet reached
+      // CONTROL_MESSAGE_MAX_ATTEMPTS, which is the full-disk case that bound is
+      // written for; an interrupt whose kill keeps throwing, which is
+      // deliberately never retired; and a message whose id the ack cannot carry.
+      // The counter resets as soon as any id newly reaches the ack, so the poll
+      // that follows a batch which made progress is not delayed. The sleep is
+      // not free, though: it runs before the next poll, so anything created
+      // while the loop is stalled — an interrupt included — waits out the rest
+      // of it before the poll that would fetch it even starts. The window
+      // doubles from STEER_STALLED_POLL_BASE_DELAY_MS and stops at
       // STEER_STALLED_POLL_MAX_DELAY_MS, and each delay is drawn from the top
       // half of its window, so that wait is at most 15 seconds, and 7.5 to 15
       // seconds from the fifth consecutive stalled poll on. That is what not
@@ -903,6 +924,14 @@ export async function steeringPollLoop({
       // rest of a possibly hours-long run. Only a terminal run ends it.
       if (isRunTerminalConflict(error) || isStopped()) return;
       failedPolls += 1;
+      // Once per outage, on the poll that reaches the bound: the count keeps
+      // climbing past it and only a poll that comes back resets it, so a channel
+      // that stays down costs one line rather than one per poll. The event above
+      // is left as it was — it reports the window after the fact, which is all it
+      // can do, and says nothing at all if no poll ever resolves again.
+      if (failedPolls === STEER_POLL_FAILURES_BEFORE_REPORT) {
+        process.stderr.write(steerPollUnreachableLog(failedPolls, error));
+      }
       await sleep(STEER_POLL_RETRY_DELAY_MS);
     }
   }
@@ -1600,10 +1629,11 @@ type ControlHandlers = {
 
 export async function handleControlMessage(message: ControlMessage, handlers: ControlHandlers) {
   // The durable action — the kill, the steer-file append — must land before,
-  // and regardless of, any ack the event transport may fail to carry
-  // mid-outage; a lost ack must not surface as a failed message. The steer
-  // event is observability; the id this message is acked under on the next poll
-  // is what records delivery.
+  // and regardless of, the steer event reporting it, which the event transport
+  // may fail to carry mid-outage; a lost event must not surface as a failed
+  // message. That event is observability only. What records delivery is the ack
+  // parameter the next poll names this id in, which is a separate channel and
+  // the one the rest of this file means by "ack".
   if (message.kind === "interrupt") {
     await handlers.interrupt();
     await handlers
@@ -1639,9 +1669,12 @@ export async function applyControlMessages(
   messages: ControlMessage[],
   handlers: ControlHandlers,
   // Consecutive failures per message id, owned by the caller so the count
-  // survives the redeliveries that produce it. A handled id is dropped from it;
-  // a failing one keeps counting up, which is what makes the diagnostic below
-  // fire on one attempt only.
+  // survives the redeliveries that produce it. Only an id whose action landed is
+  // dropped from it: a failing one keeps counting up, and a retired one keeps
+  // the count it was retired on for the rest of the run. That is what makes the
+  // diagnostic below fire on one attempt only — it fires where the count equals
+  // the bound, so dropping a retired id would restart the next redelivery at
+  // zero and walk it up to that same attempt again.
   failures: Map<string, number> = new Map(),
   maxAttempts = CONTROL_MESSAGE_MAX_ATTEMPTS,
 ): Promise<{ handled: string[]; error?: unknown }> {
@@ -1660,8 +1693,11 @@ export async function applyControlMessages(
     try {
       await handleControlMessage(message, handlers);
       failures.delete(message.id);
-      // Only an id whose durable action landed goes into the ack, so anything
-      // else is served again on the next poll.
+      // The durable action landed, so the id goes into the ack and the route
+      // retires the row. It is not the only way in — a retired steer is acked
+      // below, and an already-retired copy above, neither of them having applied
+      // anything — but every other outcome stays out and is served again on the
+      // next poll.
       handled.push(message.id);
     } catch (caught) {
       error = caught;
@@ -1670,6 +1706,11 @@ export async function applyControlMessages(
       // Exactly at the bound, never past it: an interrupt keeps counting up from
       // here, and one diagnostic per undeliverable message is the whole point.
       if (attempts === maxAttempts) {
+        // Written whatever the event channel does with the report beside it.
+        // That channel is refused outright once the run is terminal and the
+        // rejection is dropped below, and an operator's instruction being
+        // discarded is not something this may fail to record.
+        process.stderr.write(steerUndeliverableLog(message.id, attempts, caught));
         await handlers
           .emit([
             {
@@ -1684,7 +1725,9 @@ export async function applyControlMessages(
           ])
           .catch(() => undefined);
       }
-      // A retired message is acked so the server stops serving it. An interrupt
+      // A retired message is acked so the server stops serving it: the second
+      // of the two places an id reaches the ack with nothing applied, the
+      // re-ack of an already-retired copy above being the first. An interrupt
       // stays out of the ack whatever its count, which is what keeps it pending
       // and retried for the life of the run.
       if (retirable && attempts >= maxAttempts) handled.push(message.id);
@@ -1776,8 +1819,7 @@ export async function awaitCommandStreams(
     const code = await exit;
     // Wait for both stream readers to finish draining before returning, so no
     // output line is emitted AFTER the caller records the run's result (a late
-    // event would be dropped as post-terminal). Previously these loops were
-    // fire-and-forget and could lose or reorder trailing output.
+    // event would be dropped as post-terminal).
     await Promise.all(drains);
     return code;
   } finally {
@@ -2249,36 +2291,85 @@ export function deliveryStatusEvent(
 // turn this record into a wall of agent-influenced text in the container log.
 const DISCARD_LOG_FIELD_MAX_CHARS = 512;
 
+// One field of a container-log record, shared by the three built below. A
+// missing or non-string value renders as "-" so the record keeps its field count
+// and never prints the literal "undefined" or "null" — four of postResult's five
+// call sites pass no git object at all. Whitespace collapses because these
+// values are captured error text that can span lines, and a record split across
+// lines defeats a single-line operator grep.
+function discardLogField(value: unknown, secrets: Iterable<string>) {
+  if (typeof value !== "string" || !value.trim()) return "-";
+  // Redact before bounding, never after: a secret straddling the cut would
+  // leave the prefix the bound kept, and no later redaction pass can match a
+  // token it only has half of. The line-level pass in each caller stays as it
+  // was.
+  const collapsed = redactSecrets(value.replace(/\s+/g, " ").trim(), secrets);
+  // The marker carries no space, so the record keeps parsing as one field per
+  // token, and it is in the output rather than truncating silently — an
+  // operator reading the line can tell the message continued.
+  return collapsed.length > DISCARD_LOG_FIELD_MAX_CHARS
+    ? `${collapsed.slice(0, DISCARD_LOG_FIELD_MAX_CHARS)}...[truncated]`
+    : collapsed;
+}
+
 export function runTerminalDiscardLog(
   status: "succeeded" | "failed" | "canceled",
   git: Record<string, unknown> | undefined,
   secrets: Iterable<string> = secretsToRedact,
 ): string {
-  // A missing or non-string coordinate renders as "-" so the record keeps its
-  // field count and never prints the literal "undefined" or "null" — four of
-  // postResult's five call sites pass no git object at all. Whitespace collapses
-  // because a push error is a captured Git stderr message that can span lines,
-  // and a record split across lines defeats a single-line operator grep.
-  const coordinate = (value: unknown) => {
-    if (typeof value !== "string" || !value.trim()) return "-";
-    // Redact before bounding, never after: a secret straddling the cut would
-    // leave the prefix the bound kept, and no later redaction pass can match a
-    // token it only has half of. The line-level pass below stays as it was.
-    const collapsed = redactSecrets(value.replace(/\s+/g, " ").trim(), secrets);
-    // The marker carries no space, so the record keeps parsing as one field per
-    // token, and it is in the output rather than truncating silently — an
-    // operator reading the line can tell the message continued.
-    return collapsed.length > DISCARD_LOG_FIELD_MAX_CHARS
-      ? `${collapsed.slice(0, DISCARD_LOG_FIELD_MAX_CHARS)}...[truncated]`
-      : collapsed;
-  };
+  const coordinate = (value: unknown) => discardLogField(value, secrets);
   const line = [
     "result_discarded_run_terminal",
     `attempted_status=${status}`,
+    // Not a coordinate: this one is a boolean, so a git object that never
+    // arrived renders changed=false, which reads the same as a delivery that
+    // genuinely changed nothing.
     `changed=${git?.changed === true}`,
     `branch=${coordinate(git?.branch)}`,
     `head_sha=${coordinate(git?.headSha)}`,
     `push_error=${coordinate(git?.pushError)}`,
+  ].join(" ");
+  return `${redactSecrets(line, secrets)}\n`;
+}
+
+// The record of a steer this runner gave up on. Its steer_undeliverable event
+// goes out over /events, which the control plane refuses with 409 run_terminal
+// once the run is terminal — authenticate refuses every /internal/runs/:runId
+// route that way — and applyControlMessages drops that rejection. The id is
+// acknowledged whatever happens to the event, so the route marks the row
+// delivered either way; without this line an operator's instruction could be
+// discarded with nothing recording it anywhere. Bounded and redacted like the
+// discarded result above: the error is whatever the durable action threw, of no
+// bounded length, and it lands in the same container log.
+function steerUndeliverableLog(
+  id: string,
+  attempts: number,
+  error: unknown,
+  secrets: Iterable<string> = secretsToRedact,
+): string {
+  const line = [
+    "steer_undeliverable",
+    `id=${discardLogField(id, secrets)}`,
+    `attempts=${attempts}`,
+    `error=${discardLogField(errorMessage(error), secrets)}`,
+  ].join(" ");
+  return `${redactSecrets(line, secrets)}\n`;
+}
+
+// The record of a steer channel that stopped answering. steer_poll_degraded is
+// emitted from steeringPollLoop's success path, after a poll resolves, so a
+// channel whose polls all fail from here on emits nothing at all — a refused ack
+// is re-sent unchanged by every later poll, which makes a permanent 4xx exactly
+// that case. Bounded and redacted like the records above for the same reason.
+function steerPollUnreachableLog(
+  failures: number,
+  error: unknown,
+  secrets: Iterable<string> = secretsToRedact,
+): string {
+  const line = [
+    "steer_poll_unreachable",
+    `failures=${failures}`,
+    `error=${discardLogField(errorMessage(error), secrets)}`,
   ].join(" ");
   return `${redactSecrets(line, secrets)}\n`;
 }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -55,6 +55,37 @@ const SESSION_CHECKPOINT_INTERVAL_MS = 60_000;
 const RATE_LIMIT_RETRY_LIMIT = 8;
 const DEFAULT_RETRY_AFTER_MS = 1_000;
 const MAX_RETRY_AFTER_MS = 60_000;
+// A control-plane restart (dev watch, deploy) must not kill an in-flight run:
+// the sandbox is an independent container and the API is stateless per request,
+// so the runner rides out the outage and resumes where it left off. The budget
+// bounds each call, so a genuinely dead control plane is abandoned after a
+// handful of budgeted calls rather than holding the sandbox indefinitely.
+const TRANSIENT_RETRY_BUDGET_MS = 3 * 60_000;
+const TRANSIENT_RETRY_BASE_DELAY_MS = 500;
+const TRANSIENT_RETRY_MAX_DELAY_MS = 10_000;
+// The terminal result is the run's only record of its outcome — give it a
+// longer budget than ordinary calls before abandoning the control plane.
+const RESULT_RETRY_BUDGET_MS = 5 * 60_000;
+const STEER_POLL_RETRY_DELAY_MS = 5_000;
+const TRANSIENT_HTTP_STATUSES = new Set([500, 502, 503, 504]);
+const TRANSIENT_NETWORK_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "EPIPE",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  // A containerized control plane deregisters its DNS name while restarting
+  // (compose service names, K8s services), so name resolution loss is part of
+  // the same outage class as a refused connection.
+  "ENOTFOUND",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
 const GIT_COMMAND_TIMEOUT_MS = 2 * 60_000;
 const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 const EVENT_BATCH_MAX = 50;
@@ -604,25 +635,47 @@ function startSteeringPoll() {
   let stopped = false;
   void (async () => {
     let afterId: string | undefined;
+    let failedPolls = 0;
     while (!stopped) {
-      const query = afterId ? `?afterId=${encodeURIComponent(afterId)}` : "";
-      const messages = await api<Array<{ id: string; body: string; kind?: string }>>(
-        `/internal/runs/${currentRunId()}/steer${query}`,
-      );
-      for (const message of messages) {
-        afterId = message.id;
-        await handleControlMessage(message, {
-          appendSteer: async (body) => {
-            await appendFile(steerFile, `\n\n## ${new Date().toISOString()}\n${body}\n`);
-          },
-          emit,
-          interrupt: async () => {
-            interruptRequested = true;
-            if (activeEngineChild && !clearInterruptEscalation) {
-              clearInterruptEscalation = terminateChild(activeEngineChild);
-            }
-          },
-        });
+      try {
+        const query = afterId ? `?afterId=${encodeURIComponent(afterId)}` : "";
+        const messages = await api<Array<{ id: string; body: string; kind?: string }>>(
+          `/internal/runs/${currentRunId()}/steer${query}`,
+        );
+        if (failedPolls > 0) {
+          // The transport was down while the polls failed, so the degradation
+          // can only be reported after the fact: steering messages sent in
+          // that window may have been delayed.
+          await emit([
+            {
+              type: "artifact_error",
+              data: { kind: "steer_poll_degraded", failures: failedPolls },
+            },
+          ]).catch(() => undefined);
+          failedPolls = 0;
+        }
+        for (const message of messages) {
+          afterId = message.id;
+          await handleControlMessage(message, {
+            appendSteer: async (body) => {
+              await appendFile(steerFile, `\n\n## ${new Date().toISOString()}\n${body}\n`);
+            },
+            emit,
+            interrupt: async () => {
+              interruptRequested = true;
+              if (activeEngineChild && !clearInterruptEscalation) {
+                clearInterruptEscalation = terminateChild(activeEngineChild);
+              }
+            },
+          });
+        }
+      } catch (error) {
+        // Steering and interrupts must survive the run: one poll exhausting
+        // its outage budget cannot be allowed to silence the channel for the
+        // rest of a possibly hours-long run. Only a terminal run ends it.
+        if (isRunTerminalConflict(error) || stopped) return;
+        failedPolls += 1;
+        await new Promise((resolve) => setTimeout(resolve, STEER_POLL_RETRY_DELAY_MS));
       }
     }
   })().catch(() => undefined);
@@ -1301,14 +1354,24 @@ type ControlHandlers = {
 };
 
 export async function handleControlMessage(message: ControlMessage, handlers: ControlHandlers) {
+  // The server marks a control message delivered when it is fetched, so it is
+  // never re-delivered. The durable action — the kill, the steer-file append —
+  // must land before, and regardless of, any ack the event transport may fail
+  // to carry mid-outage; a lost ack must not surface as a failed message.
   if (message.kind === "interrupt") {
-    await handlers.emit([{ type: "status", data: { message: "human interrupt" } }]);
     await handlers.interrupt();
-    await handlers.emit([{ type: "steer", data: { id: message.id, kind: "interrupt" } }]);
+    await handlers
+      .emit([
+        { type: "status", data: { message: "human interrupt" } },
+        { type: "steer", data: { id: message.id, kind: "interrupt" } },
+      ])
+      .catch(() => undefined);
     return "interrupt";
   }
   await handlers.appendSteer(message.body);
-  await handlers.emit([{ type: "steer", data: { id: message.id, applied: true } }]);
+  await handlers
+    .emit([{ type: "steer", data: { id: message.id, applied: true } }])
+    .catch(() => undefined);
   return "steer";
 }
 
@@ -1362,15 +1425,25 @@ async function runShell(
   });
   const clearTimers =
     timeoutMin === undefined ? () => undefined : armCommandTimeout(child, timeoutMin);
-  const drains = [child.stdout, child.stderr].map((stream) => drainLineEvents(stream, eventType));
-  const code = await exitCode(child);
-  // Wait for both stream readers to finish draining before returning, so no
-  // output line is emitted AFTER the caller records the run's result (a late
-  // event would be dropped as post-terminal). Previously these loops were
-  // fire-and-forget and could lose or reorder trailing output.
-  await Promise.all(drains);
-  clearTimers();
-  return code;
+  try {
+    const drains = [child.stdout, child.stderr].map((stream) => drainLineEvents(stream, eventType));
+    // A delivery failure can reject a drain while the command is still running,
+    // long before the `await` below. Mark both promises handled now so that
+    // rejection waits for the await instead of aborting the whole process as an
+    // unhandled rejection — which would exit without posting a terminal result.
+    for (const drain of drains) drain.catch(() => undefined);
+    const code = await exitCode(child);
+    // Wait for both stream readers to finish draining before returning, so no
+    // output line is emitted AFTER the caller records the run's result (a late
+    // event would be dropped as post-terminal). Previously these loops were
+    // fire-and-forget and could lose or reorder trailing output.
+    await Promise.all(drains);
+    return code;
+  } finally {
+    // Also on a drain rejection: the armed SIGKILL escalation is a live timer
+    // handle that would keep the process alive long after the result posts.
+    clearTimers();
+  }
 }
 
 export async function drainLineEvents(
@@ -1467,6 +1540,7 @@ export async function drainLineEvents(
     }
   };
 
+  let drained = false;
   try {
     for await (const line of lines) {
       if (eventType === "shell" && isTransientContainerProgressLine(line)) {
@@ -1490,9 +1564,16 @@ export async function drainLineEvents(
       if (activeDelivery) await activeDelivery;
     }
     if (deliveryError) throw deliveryError;
+    drained = true;
   } finally {
     clearFlushTimer();
     lines.close();
+    // A failed drain must not strand the producer: readline's close() pauses
+    // the source, and a child still writing into a full pipe would block
+    // forever — its exit code never observed, the run never resolved. Keep the
+    // stream flowing (discarding) so the command can finish and the delivery
+    // error can surface through the normal await.
+    if (!drained) stream.resume();
   }
 }
 
@@ -1658,33 +1739,51 @@ async function postResult(
 ) {
   const stderrTail = await readFile(engineStderrFile, "utf8").catch(() => "");
   const activity = await runnerReceiptActivity(bundle, status);
-  await api(`/internal/runs/${currentRunId()}/result`, {
-    method: "POST",
-    body: JSON.stringify({
-      status,
-      receipt: {
-        provider: receiptProvider(bundle?.engine),
-        mode: receiptMode(bundle?.mode),
-        model: configuredModel(bundle?.engineConfig),
-        result: status,
-        activity,
-        timing: {
-          started_at: new Date(startedAt).toISOString(),
-          ended_at: new Date().toISOString(),
-          duration_ms: Date.now() - startedAt,
-        },
+  try {
+    await api(
+      `/internal/runs/${currentRunId()}/result`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          status,
+          receipt: {
+            provider: receiptProvider(bundle?.engine),
+            mode: receiptMode(bundle?.mode),
+            model: configuredModel(bundle?.engineConfig),
+            result: status,
+            activity,
+            timing: {
+              started_at: new Date(startedAt).toISOString(),
+              ended_at: new Date().toISOString(),
+              duration_ms: Date.now() - startedAt,
+            },
+          },
+          error:
+            typeof error === "string"
+              ? error
+              : error
+                ? redactSecrets(`${JSON.stringify(error)} ${stderrTail.slice(-2000)}`)
+                : undefined,
+          git,
+          engineSessionId: engineSessionId ?? undefined,
+          securityReport,
+        }),
       },
-      error:
-        typeof error === "string"
-          ? error
-          : error
-            ? redactSecrets(`${JSON.stringify(error)} ${stderrTail.slice(-2000)}`)
-            : undefined,
-      git,
-      engineSessionId: engineSessionId ?? undefined,
-      securityReport,
-    }),
-  });
+      undefined,
+      { budgetMs: RESULT_RETRY_BUDGET_MS },
+    );
+  } catch (postError) {
+    if (isRunTerminalConflict(postError)) {
+      // The control plane already holds a different terminal verdict and now
+      // rejects both /result and /events for this run, so the container log is
+      // the only place left to record what this attempt would have reported.
+      process.stderr.write(
+        `result_discarded_run_terminal attempted_status=${status} git=${JSON.stringify(git ?? null)}\n`,
+      );
+      return;
+    }
+    throw postError;
+  }
 }
 
 const FACILITY_MANAGED_REPOSITORY_FILES = new Set([
@@ -2711,6 +2810,7 @@ async function api<T>(
   path: string,
   init: RequestInit = {},
   bodyFactory?: () => RequestInit["body"],
+  retry?: TransientRetryOptions,
 ): Promise<T> {
   const headers: Record<string, string> = { authorization: `Bearer ${runnerToken()}` };
   if (init.body) headers["content-type"] = "application/json";
@@ -2724,6 +2824,7 @@ async function api<T>(
       },
     },
     bodyFactory,
+    retry,
   ) as Promise<T>;
 }
 
@@ -2744,25 +2845,149 @@ export function retryAfterMs(value: string | null, now = Date.now()) {
   return DEFAULT_RETRY_AFTER_MS;
 }
 
+export class FetchJsonError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(url: string, status: number, body: string) {
+    super(`${url} failed ${status}: ${body}`);
+    this.name = "FetchJsonError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export type TransientRetryOptions = {
+  budgetMs?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+};
+
+// Undici wraps the raising syscall error in `cause` chains (and AggregateError
+// members when it raced multiple address families), so the classification has
+// to walk the tree rather than inspect the top-level error.
+export function isTransientFetchError(error: unknown): boolean {
+  const seen = new Set<object>();
+  const pending: unknown[] = [error];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || typeof current !== "object" || seen.has(current)) continue;
+    seen.add(current);
+    const { name, code, cause, errors } = current as {
+      name?: unknown;
+      code?: unknown;
+      cause?: unknown;
+      errors?: unknown;
+    };
+    // An abort is the caller's own decision to stop waiting — never replay it.
+    if (name === "AbortError" || name === "TimeoutError") return false;
+    if (typeof code === "string" && TRANSIENT_NETWORK_CODES.has(code)) return true;
+    if (cause) pending.push(cause);
+    if (Array.isArray(errors)) pending.push(...errors);
+  }
+  return false;
+}
+
+// Exponential backoff with equal jitter: half the window is deterministic so
+// retries always spread out, half is random so concurrent runners desynchronize
+// instead of stampeding a control plane that just came back.
+export function transientRetryDelayMs(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random: () => number = Math.random,
+) {
+  const window = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+  return Math.round(window / 2 + random() * (window / 2));
+}
+
+// After a replayed result post, a 409 run_terminal means some prior attempt —
+// ours before a lost response, or an operator action — already recorded a
+// terminal state. The retry achieved its purpose, so shutdown proceeds cleanly
+// instead of reporting a spurious failure.
+export function isRunTerminalConflict(error: unknown): boolean {
+  if (!(error instanceof FetchJsonError) || error.status !== 409) return false;
+  try {
+    const parsed = JSON.parse(error.body) as { error?: { code?: unknown } };
+    return parsed.error?.code === "run_terminal";
+  } catch {
+    return false;
+  }
+}
+
 export async function fetchJson(
   url: string,
   init: RequestInit = {},
   bodyFactory?: () => RequestInit["body"],
+  retry: TransientRetryOptions = {},
 ) {
-  for (let attempt = 0; ; attempt += 1) {
-    const response = await fetch(url, bodyFactory ? { ...init, body: bodyFactory() } : init);
-    if (response.ok) return response.json();
-    const body = await response.text();
-    if (response.status !== 429 || attempt >= RATE_LIMIT_RETRY_LIMIT) {
-      throw new Error(`${url} failed ${response.status}: ${body}`);
+  const budgetMs = retry.budgetMs ?? TRANSIENT_RETRY_BUDGET_MS;
+  const baseDelayMs = retry.baseDelayMs ?? TRANSIENT_RETRY_BASE_DELAY_MS;
+  const maxDelayMs = retry.maxDelayMs ?? TRANSIENT_RETRY_MAX_DELAY_MS;
+  const deadline = Date.now() + budgetMs;
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+  let transientAttempt = 0;
+  let rateLimitAttempt = 0;
+  // Retrying makes these requests at-least-once: a request whose response was
+  // lost after the server committed can be replayed. That is safe for the
+  // terminal result (a replay answers 409 run_terminal, handled by callers via
+  // isRunTerminalConflict) and can at worst duplicate one already-accepted
+  // events batch in the narrow response-lost window — a display-level artifact,
+  // never state corruption. Connection-refused and DNS-loss replays (the whole
+  // restart case this exists for) never reached the server at all.
+  for (;;) {
+    let response: Response;
+    let body: string;
+    try {
+      response = await fetch(url, bodyFactory ? { ...init, body: bodyFactory() } : init);
+      // The body reads live inside the same classification: a control plane
+      // killed between flushing headers and body fails here, and that loss is
+      // the same outage as a reset before headers.
+      if (response.ok) return (await response.json()) as unknown;
+      body = await response.text();
+    } catch (error) {
+      // Anything without a transient cause — bad URL, aborted request, invalid
+      // JSON from a healthy server — stays fatal.
+      if (!isTransientFetchError(error)) throw error;
+      const remainingMs = deadline - Date.now();
+      // One retry is always granted: a single stalled attempt (undici's
+      // header/body timeouts run to minutes) can consume the whole budget by
+      // itself, and a slow failure must not become a guaranteed-fatal one.
+      if (remainingMs <= 0 && transientAttempt > 0) throw error;
+      const delayMs = transientRetryDelayMs(transientAttempt, baseDelayMs, maxDelayMs);
+      transientAttempt += 1;
+      // Cap the wait at the remaining budget so the declared budget is spent
+      // in full: the last attempt runs at the deadline, not before it.
+      await sleep(remainingMs > 0 ? Math.min(delayMs, remainingMs) : delayMs);
+      continue;
     }
-    // The global API limiter rejects the request before a route handler runs,
-    // so replaying the runner's JSON request after Retry-After cannot duplicate
-    // an accepted event or terminal result. Awaiting here applies backpressure
-    // to noisy child processes instead of turning a temporary 429 into a crash.
-    await new Promise((resolve) =>
-      setTimeout(resolve, retryAfterMs(response.headers.get("retry-after"))),
-    );
+    if (response.status === 429) {
+      if (rateLimitAttempt >= RATE_LIMIT_RETRY_LIMIT) {
+        throw new FetchJsonError(url, response.status, body);
+      }
+      // The global API limiter rejects the request before a route handler runs,
+      // so replaying the runner's JSON request after Retry-After cannot duplicate
+      // an accepted event or terminal result. Awaiting here applies backpressure
+      // to noisy child processes instead of turning a temporary 429 into a crash.
+      rateLimitAttempt += 1;
+      await sleep(retryAfterMs(response.headers.get("retry-after")));
+      continue;
+    }
+    if (TRANSIENT_HTTP_STATUSES.has(response.status)) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) throw new FetchJsonError(url, response.status, body);
+      const retryAfter = response.headers.get("retry-after");
+      const backoffMs = transientRetryDelayMs(transientAttempt, baseDelayMs, maxDelayMs);
+      // Honor a server-requested wait, but never let "Retry-After: 0" from a
+      // recovering proxy defeat the jitter floor — synchronized zero-delay
+      // replays from every runner would stampede the API it is protecting.
+      const delayMs =
+        retryAfter !== null ? Math.max(retryAfterMs(retryAfter), backoffMs) : backoffMs;
+      transientAttempt += 1;
+      await sleep(Math.min(delayMs, remainingMs));
+      continue;
+    }
+    throw new FetchJsonError(url, response.status, body);
   }
 }
 

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -170,10 +170,20 @@ export const ENDPOINT_RETRY_POLICIES = {
   // Same last-writer-wins upload as the transcript, and losing the archive costs
   // the next run its warm session, so the replay is worth taking.
   "session-state": { replaySafe: true },
-  // A replay that lands after a committed first post answers 409 run_terminal,
-  // which postResult absorbs, so the ambiguous case is already handled and losing
-  // the outcome entirely is the worse failure. The run's only record of its
-  // outcome also gets a longer budget than ordinary calls.
+  // The handler records the base commit once, under an is-null guard, and
+  // answers an exact replay with the recorded value: a second delivery of the
+  // same SHA lands on the same row, and a different SHA is refused rather than
+  // rewriting the provenance already bound to the run.
+  workspace: { replaySafe: true },
+  // A replay that lands after a committed first post is answered one of two
+  // ways, and postResult handles both: 200 if the control plane went down
+  // between committing the verdict and finishing the work that follows it — the
+  // route admits that replay and resumes the finalization from where it
+  // stopped, each step guarded so nothing already done is done again — or 409
+  // run_terminal once that work is complete, which postResult absorbs. Either
+  // way the ambiguous case is covered, and losing the outcome entirely is the
+  // worse failure. The run's only record of its outcome also gets a longer
+  // budget than ordinary calls.
   result: { budgetMs: RESULT_RETRY_BUDGET_MS, replaySafe: true },
   // Every call mints a fresh GitHub installation token with contents:write and
   // writes an audit row, with no idempotency guard. A replay after a lost response
@@ -2152,16 +2162,19 @@ export async function postResult(
     });
   } catch (postError) {
     if (isRunTerminalConflict(postError)) {
-      // A terminal verdict is already recorded for this run, and it is most
-      // often this very post: /result is on the replaySafe policy, so an attempt
-      // whose response was lost after the handler committed is replayed by the
-      // retry loop and answered 409 — the recorded verdict is then identical to
-      // the one below, not a different one. It can also be another party's, in
-      // which case it differs: /v1/runs/:runId/cancel records "canceled", and
-      // failRun records "failed" when the control plane concludes the sandbox is
-      // gone. Either way the run is terminal, so /events is refused from here on
-      // too and the container log is the only place left to record what this
-      // attempt carried.
+      // A terminal verdict is already recorded for this run and fully finalized,
+      // and it is most often this very post: /result is on the replaySafe
+      // policy, so an attempt whose response was lost after the handler
+      // committed is replayed by the retry loop. The route admits that replay
+      // for as long as the work after the verdict is unfinished — it resumes
+      // that work and answers 200, which never reaches this branch — and
+      // answers 409 only once it is complete, so the recorded verdict here is
+      // identical to the one below, not a different one. It can also be another
+      // party's, in which case it differs: /v1/runs/:runId/cancel records
+      // "canceled", and failRun records "failed" when the control plane
+      // concludes the sandbox is gone. Either way the run is terminal, so
+      // /events is refused from here on too and the container log is the only
+      // place left to record what this attempt carried.
       process.stderr.write(runTerminalDiscardLog(status, git));
       return;
     }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -55,11 +55,23 @@ const SESSION_CHECKPOINT_INTERVAL_MS = 60_000;
 const RATE_LIMIT_RETRY_LIMIT = 8;
 const DEFAULT_RETRY_AFTER_MS = 1_000;
 const MAX_RETRY_AFTER_MS = 60_000;
-// A control-plane restart (dev watch, deploy) must not kill an in-flight run:
-// the sandbox is an independent container and the API is stateless per request,
-// so the runner rides out the outage and resumes where it left off. The budget
-// bounds each call, so a genuinely dead control plane is abandoned after a
-// handful of budgeted calls rather than holding the sandbox indefinitely.
+// What a control-plane restart (dev watch, deploy) costs an in-flight run. The
+// sandbox is an independent container and the API is stateless per request, so
+// the runner keeps working through the gap and its next call lands on the
+// restarted process. What this budget guarantees is the restart whose failures
+// all prove nothing was delivered — a refused connection, a deregistered DNS
+// name — because those are replayed for every endpoint: such a restart, finished
+// inside the budget, does not touch the run.
+//
+// What it does not guarantee is a restart that kills a request already on the
+// wire. That loss is ambiguous, and an endpoint whose handler cannot absorb a
+// duplicate refuses to replay it: /events above all, plus /hello and
+// /push-token. A batch lost that way while a shell command's output is being
+// drained fails that drain, and the failure reaches main's catch, which posts
+// "failed" — the engine's own event stream is best-effort and survives the same
+// loss. A restart that outlasts the budget ends a run the same way. Nothing here
+// resumes a run that already failed; that is /resume, which starts a fresh run
+// id.
 const TRANSIENT_RETRY_BUDGET_MS = 3 * 60_000;
 const TRANSIENT_RETRY_BASE_DELAY_MS = 500;
 const TRANSIENT_RETRY_MAX_DELAY_MS = 10_000;
@@ -67,13 +79,23 @@ const TRANSIENT_RETRY_MAX_DELAY_MS = 10_000;
 // longer budget than ordinary calls before abandoning the control plane.
 const RESULT_RETRY_BUDGET_MS = 5 * 60_000;
 const STEER_POLL_RETRY_DELAY_MS = 5_000;
+// Pacing for the one poll that has nothing of its own to wait on: a batch the
+// steer route answers again at once because nothing in it reached the ack. The
+// delay doubles from the base and stops at the max, so a message left pending for
+// the rest of the run costs one poll every 7.5 to 15 seconds at worst, rather
+// than as many as the control plane can answer. Which cases reach that, and why
+// the handled path stays unpaced, is documented at the pacing in
+// steeringPollLoop.
+const STEER_STALLED_POLL_BASE_DELAY_MS = 1_000;
+const STEER_STALLED_POLL_MAX_DELAY_MS = 15_000;
 const TRANSIENT_HTTP_STATUSES = new Set([500, 502, 503, 504]);
-const TRANSIENT_NETWORK_CODES = new Set([
+// These codes fire before the request could reach a route handler: the name did
+// not resolve, no route to the host existed, the port refused the connection, or
+// the connection never completed at all. Nothing was committed, so a replay
+// cannot duplicate an effect and every caller gets one — this is precisely the
+// control-plane-restart case.
+const UNDELIVERED_NETWORK_CODES = new Set([
   "ECONNREFUSED",
-  "ECONNRESET",
-  "ECONNABORTED",
-  "EPIPE",
-  "ETIMEDOUT",
   "EAI_AGAIN",
   // A containerized control plane deregisters its DNS name while restarting
   // (compose service names, K8s services), so name resolution loss is part of
@@ -82,10 +104,97 @@ const TRANSIENT_NETWORK_CODES = new Set([
   "ENETUNREACH",
   "EHOSTUNREACH",
   "UND_ERR_CONNECT_TIMEOUT",
+]);
+// These codes do not prove the request was never delivered: it may have been on
+// the wire, and the handler may have run and committed before the response was
+// lost. Replaying is at-least-once delivery and only a caller whose endpoint
+// absorbs a duplicate may ask for it.
+const AMBIGUOUS_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNABORTED",
+  "EPIPE",
+  "ETIMEDOUT",
   "UND_ERR_HEADERS_TIMEOUT",
   "UND_ERR_BODY_TIMEOUT",
   "UND_ERR_SOCKET",
 ]);
+// Whether an ambiguous loss may be replayed is a property of the handler on the
+// far end, not of the code that happens to be calling it, so it is declared once
+// per endpoint here and api() looks it up from the path. Keeping it out of the
+// call sites is what makes it reviewable: api() takes no policy argument at all,
+// so every control-plane call it makes is classified by this table, and an
+// endpoint nobody has classified gets ENDPOINT_RETRY_POLICY_DEFAULT rather than
+// whatever its caller felt like.
+//
+// Keys are the endpoint's last path segment. Two calls do not go through api(),
+// and each reads its entry from this table by name rather than inventing one:
+//   - `bundle`: /hello hands back an absolute bundleUrl on the sandbox-facing
+//     origin, so it cannot resolve its path against FACILITY_API_URL the way
+//     api() does. It calls fetchJson with the entry passed as an argument.
+//   - `session-state` on the restore side: it reads a gzip archive, so it needs
+//     the byte reader instead of api()'s JSON one. fetchSessionStateArchive
+//     passes the entry the same way. (The upload half is an ordinary api() POST.)
+// So every control-plane call in this file is classified, and all of them share
+// one transport — the retry loop fetchJson and fetchSessionStateArchive both
+// wrap. What this table cannot see is a call that reaches the control plane
+// without that transport at all, which is why the derivation test in the
+// runner's retry suite also refuses any bare request beyond the loop's own.
+export const ENDPOINT_RETRY_POLICIES = {
+  // The handshake is one-shot by design: it claims the provisioning→running
+  // transition and stamps virtualKeyRevealedAt, so a replay after a lost response
+  // answers 409 virtual_key_revealed. Retrying an ambiguous loss would only turn
+  // it into a more confusing failure.
+  hello: { replaySafe: false },
+  // The handler only reads the stored bundle back, so there is no effect for a
+  // second delivery to duplicate.
+  bundle: { replaySafe: true },
+  // Delivery is marked from the ack the next poll carries, not from the select,
+  // so a poll whose response was lost leaves its messages pending and the replay
+  // serves them to this same runner again.
+  steer: { replaySafe: true },
+  // The handler overwrites one object keyed by run id and points the run row at
+  // it, so a second delivery of the same bytes lands on the same state.
+  transcript: { replaySafe: true },
+  // Same last-writer-wins upload as the transcript, and losing the archive costs
+  // the next run its warm session, so the replay is worth taking.
+  "session-state": { replaySafe: true },
+  // A replay that lands after a committed first post answers 409 run_terminal,
+  // which postResult absorbs, so the ambiguous case is already handled and losing
+  // the outcome entirely is the worse failure. The run's only record of its
+  // outcome also gets a longer budget than ordinary calls.
+  result: { budgetMs: RESULT_RETRY_BUDGET_MS, replaySafe: true },
+  // Every call mints a fresh GitHub installation token with contents:write and
+  // writes an audit row, with no idempotency guard. A replay after a lost response
+  // leaves a second live token held by nobody — nothing here revokes one, so it
+  // stays live until it expires — and two audit rows for one delivery.
+  "push-token": { replaySafe: false },
+  // Appending is unguarded, so a replay duplicates the batch. The run's receipt
+  // counts run_events rows and lists the check events among them before it is
+  // sealed with a digest chained to the previous receipt, so a duplicate is a
+  // wrong receipt rather than a cosmetic artifact — this needs server-side
+  // idempotency before it can opt in.
+  events: { replaySafe: false },
+} as const satisfies Record<string, TransientRetryOptions>;
+// An unclassified endpoint fails on an ambiguous loss instead of replaying it.
+// Every way of getting here is safe in that direction: a new route whose handler
+// nobody has read yet, or a renamed one whose entry no longer matches, degrades
+// to a lost response failing the run rather than to a duplicated effect.
+export const ENDPOINT_RETRY_POLICY_DEFAULT: TransientRetryOptions = { replaySafe: false };
+
+export function endpointRetryPolicy(path: string): TransientRetryOptions {
+  // Query and fragment are per-call arguments (the steer poll's acks), not part
+  // of the endpoint's identity. hasOwn keeps an inherited property of the table's
+  // prototype from being read as a classification.
+  const endpoint =
+    path
+      .replace(/[?#][\s\S]*$/, "")
+      .replace(/\/+$/, "")
+      .split("/")
+      .pop() ?? "";
+  return Object.hasOwn(ENDPOINT_RETRY_POLICIES, endpoint)
+    ? ENDPOINT_RETRY_POLICIES[endpoint as keyof typeof ENDPOINT_RETRY_POLICIES]
+    : ENDPOINT_RETRY_POLICY_DEFAULT;
+}
 const GIT_COMMAND_TIMEOUT_MS = 2 * 60_000;
 const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 const EVENT_BATCH_MAX = 50;
@@ -148,9 +257,12 @@ async function main() {
     const hello = await api<Record<string, unknown>>(`/internal/runs/${currentRunId()}/hello`, {
       method: "POST",
     });
-    bundle = (await fetchJson(String(hello.bundleUrl), {
-      headers: { authorization: `Bearer ${runnerToken()}` },
-    })) as RunBundle;
+    bundle = (await fetchJson(
+      String(hello.bundleUrl),
+      { headers: { authorization: `Bearer ${runnerToken()}` } },
+      undefined,
+      ENDPOINT_RETRY_POLICIES.bundle,
+    )) as RunBundle;
     const activeBundle = bundle;
     await phases.finish({ outcome: "succeeded" });
     const runtimeEvent = sandboxRuntimeEvent();
@@ -631,54 +743,189 @@ async function runEngine(bundle: RunBundle, restoredSessionState: boolean) {
   return runShell(cmd, cwdFor(bundle), "assistant");
 }
 
-function startSteeringPoll() {
-  let stopped = false;
-  void (async () => {
-    let afterId: string | undefined;
-    let failedPolls = 0;
-    while (!stopped) {
-      try {
-        const query = afterId ? `?afterId=${encodeURIComponent(afterId)}` : "";
-        const messages = await api<Array<{ id: string; body: string; kind?: string }>>(
-          `/internal/runs/${currentRunId()}/steer${query}`,
-        );
-        if (failedPolls > 0) {
-          // The transport was down while the polls failed, so the degradation
-          // can only be reported after the fact: steering messages sent in
-          // that window may have been delayed.
-          await emit([
+// The request one poll of the control channel issues, ack included. The ids the
+// runner reports handling are what the server records delivery from, so this
+// string is the runner's half of that contract and is built here, apart from the
+// loop, to be driven by a test on its own.
+//
+// The server splits `ack` on commas and refuses the whole request unless every
+// id matches its ACK_ID shape, so each id is encoded individually: the separator
+// has to stay literal between ids while a comma or an `&` inside one is escaped
+// rather than read as another id or another query parameter.
+export function steerPollPath(runId: string, ack: string[]) {
+  const query = ack.length > 0 ? `?ack=${ack.map(encodeURIComponent).join(",")}` : "";
+  return `/internal/runs/${runId}/steer${query}`;
+}
+
+// The shape the steer route's ack accepts, which is exactly what newId("evt")
+// produces. The route refuses an ack whole unless every id in it matches, so an
+// id of any other shape has to be kept out of the ack rather than echoed back:
+// one refused ack takes the good ids in the same request down with it, and every
+// later ack this runner sends carries them again, so the channel stays refused
+// for the rest of the run. Nothing writes a steer row with another shape today —
+// the filter exists so one row could not do that, and a test pins this literal
+// against the route's own, because a filter disagreeing with the route would
+// wedge the channel exactly the way it is here to prevent.
+export const ACKABLE_STEER_ID = /^evt_[0-9a-f]{32}$/;
+
+export function ackableSteerIds(ids: string[]) {
+  return ids.filter((id) => ACKABLE_STEER_ID.test(id));
+}
+
+type SteeringPollLoopOptions = {
+  poll: (ack: string[]) => Promise<ControlMessage[]>;
+  handlers: ControlHandlers;
+  isStopped: () => boolean;
+  sleep?: (ms: number) => Promise<unknown>;
+  random?: () => number;
+};
+
+// One poll of the control channel, applied, acked, repeated until the run ends.
+// Separate from startSteeringPoll — which owns the process-wide engine state the
+// interrupt handler touches — so the orderings that matter can be driven by a
+// test: a batch nothing in it could ack, an id the ack cannot carry, and a poll
+// that failed on the transport.
+export async function steeringPollLoop({
+  poll,
+  handlers,
+  isStopped,
+  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+  random = Math.random,
+}: SteeringPollLoopOptions) {
+  // The ids handled but not yet known to be recorded. Cleared only once a poll
+  // carrying them came back, so an ack whose response was lost is re-sent
+  // rather than assumed.
+  let ack: string[] = [];
+  const failures = new Map<string, number>();
+  // Ids served in a shape the ack cannot carry: reported once each, and — for a
+  // steer, whose append is not idempotent — applied once each, because the route
+  // has no ack that would retire them and keeps serving them.
+  const reportedUnackable = new Set<string>();
+  const appliedUnackable = new Set<string>();
+  let failedPolls = 0;
+  let stalledPolls = 0;
+  while (!isStopped()) {
+    try {
+      const messages = await poll(ack);
+      ack = [];
+      if (failedPolls > 0) {
+        // The transport was down while the polls failed, so the degradation
+        // can only be reported after the fact: steering messages sent in
+        // that window may have been delayed.
+        await handlers
+          .emit([
             {
               type: "artifact_error",
               data: { kind: "steer_poll_degraded", failures: failedPolls },
             },
-          ]).catch(() => undefined);
-          failedPolls = 0;
-        }
-        for (const message of messages) {
-          afterId = message.id;
-          await handleControlMessage(message, {
-            appendSteer: async (body) => {
-              await appendFile(steerFile, `\n\n## ${new Date().toISOString()}\n${body}\n`);
-            },
-            emit,
-            interrupt: async () => {
-              interruptRequested = true;
-              if (activeEngineChild && !clearInterruptEscalation) {
-                clearInterruptEscalation = terminateChild(activeEngineChild);
-              }
-            },
-          });
-        }
-      } catch (error) {
-        // Steering and interrupts must survive the run: one poll exhausting
-        // its outage budget cannot be allowed to silence the channel for the
-        // rest of a possibly hours-long run. Only a terminal run ends it.
-        if (isRunTerminalConflict(error) || stopped) return;
-        failedPolls += 1;
-        await new Promise((resolve) => setTimeout(resolve, STEER_POLL_RETRY_DELAY_MS));
+          ])
+          .catch(() => undefined);
+        failedPolls = 0;
       }
+      const deliverable: ControlMessage[] = [];
+      for (const message of messages) {
+        if (ACKABLE_STEER_ID.test(message.id)) {
+          deliverable.push(message);
+          continue;
+        }
+        if (!reportedUnackable.has(message.id)) {
+          reportedUnackable.add(message.id);
+          await handlers
+            .emit([
+              {
+                type: "artifact_error",
+                data: { kind: "steer_ack_id_unacceptable", id: message.id },
+              },
+            ])
+            .catch(() => undefined);
+        }
+        // An interrupt is applied on every redelivery: an operator's stop must
+        // not be dropped over the shape of an id, and the handler absorbs a
+        // repeat. A steer's append is not idempotent, so once its action landed
+        // the redeliveries are skipped instead of appending the same body to the
+        // steer file for the rest of the run. The row stays pending either way,
+        // since only an ack retires one, and the route serves the oldest pending
+        // rows up to its batch limit — so enough such rows would crowd newer
+        // messages out of every batch. Nothing this side can fix that; what it
+        // can do is keep the channel working for every other message.
+        if (message.kind === "interrupt" || !appliedUnackable.has(message.id)) {
+          deliverable.push(message);
+        }
+      }
+      const applied = await applyControlMessages(deliverable, handlers, failures);
+      for (const id of applied.handled) {
+        if (!ACKABLE_STEER_ID.test(id)) appliedUnackable.add(id);
+      }
+      ack = ackableSteerIds(applied.handled);
+      // applied.error is deliberately not rethrown. A durable action that
+      // failed is not a transport outage, so it must not be counted into the
+      // degraded-poll report; the message stays unacked and the next poll is
+      // served it again. A steer that keeps failing is reported and retired
+      // after CONTROL_MESSAGE_MAX_ATTEMPTS; an interrupt is retried for as long
+      // as the run lasts, which the handler above absorbs — it re-sets the flag
+      // and starts the escalation only while none is pending, so a second
+      // application signals nothing twice.
+      //
+      // Pacing, and only for the batch that made no progress. The route
+      // long-polls while nothing is pending and answers the instant something
+      // is, so a batch no id of which reached the ack is served again on the
+      // next poll immediately: without this the loop would poll as fast as the
+      // control plane can answer, for the rest of the run. Reachable two ways —
+      // an interrupt whose kill keeps throwing, which is deliberately never
+      // retired, and a message whose id the ack cannot carry. The counter resets
+      // as soon as any id newly reaches the ack, so the poll that follows a batch
+      // which made progress is not delayed. The sleep is not free, though: it
+      // runs before the next poll, so anything created while the loop is stalled
+      // — an interrupt included — waits out the rest of it before the poll that
+      // would fetch it even starts. The window doubles from
+      // STEER_STALLED_POLL_BASE_DELAY_MS and stops at
+      // STEER_STALLED_POLL_MAX_DELAY_MS, and each delay is drawn from the top
+      // half of its window, so that wait is at most 15 seconds, and 7.5 to 15
+      // seconds from the fifth consecutive stalled poll on. That is what not
+      // hammering the control plane costs while a message it will keep serving
+      // cannot be retired.
+      if (messages.length > 0 && ack.length === 0) {
+        stalledPolls += 1;
+        await sleep(
+          transientRetryDelayMs(
+            stalledPolls - 1,
+            STEER_STALLED_POLL_BASE_DELAY_MS,
+            STEER_STALLED_POLL_MAX_DELAY_MS,
+            random,
+          ),
+        );
+      } else {
+        stalledPolls = 0;
+      }
+    } catch (error) {
+      // Steering and interrupts must survive the run: one poll exhausting
+      // its outage budget cannot be allowed to silence the channel for the
+      // rest of a possibly hours-long run. Only a terminal run ends it.
+      if (isRunTerminalConflict(error) || isStopped()) return;
+      failedPolls += 1;
+      await sleep(STEER_POLL_RETRY_DELAY_MS);
     }
-  })().catch(() => undefined);
+  }
+}
+
+function startSteeringPoll() {
+  let stopped = false;
+  void steeringPollLoop({
+    poll: (ack) => api<ControlMessage[]>(steerPollPath(currentRunId(), ack)),
+    handlers: {
+      appendSteer: async (body) => {
+        await appendFile(steerFile, `\n\n## ${new Date().toISOString()}\n${body}\n`);
+      },
+      emit,
+      interrupt: async () => {
+        interruptRequested = true;
+        if (activeEngineChild && !clearInterruptEscalation) {
+          clearInterruptEscalation = terminateChild(activeEngineChild);
+        }
+      },
+    },
+    isStopped: () => stopped,
+  }).catch(() => undefined);
   return () => {
     stopped = true;
   };
@@ -1140,13 +1387,11 @@ export async function restoreWorkspaceCheckpoint(
 async function restoreSessionState(bundle: RunBundle) {
   if (bundle.engine !== "claude_code" || !bundle.resume) return false;
   try {
-    const response = await fetch(`${apiUrl()}/internal/runs/${currentRunId()}/session-state`, {
-      headers: { authorization: `Bearer ${runnerToken()}` },
-    });
-    if (!response.ok) {
-      throw new Error(`session state restore failed ${response.status}`);
-    }
-    await writeFile(sessionStateArchive, Buffer.from(await response.arrayBuffer()));
+    // A pure GET read of one stored object: no handler effect exists for a
+    // replay to duplicate, so it takes the classified path like every other
+    // control-plane call. A run with no archive answers 404, which is a cold
+    // start rather than an outage and surfaces below without spending a budget.
+    await writeFile(sessionStateArchive, await fetchSessionStateArchive(currentRunId()));
     await rm(sessionStateDir, { recursive: true, force: true });
     await rm(resumeStateDir, { recursive: true, force: true });
     await mkdir(workRoot, { recursive: true });
@@ -1354,10 +1599,11 @@ type ControlHandlers = {
 };
 
 export async function handleControlMessage(message: ControlMessage, handlers: ControlHandlers) {
-  // The server marks a control message delivered when it is fetched, so it is
-  // never re-delivered. The durable action — the kill, the steer-file append —
-  // must land before, and regardless of, any ack the event transport may fail
-  // to carry mid-outage; a lost ack must not surface as a failed message.
+  // The durable action — the kill, the steer-file append — must land before,
+  // and regardless of, any ack the event transport may fail to carry
+  // mid-outage; a lost ack must not surface as a failed message. The steer
+  // event is observability; the id this message is acked under on the next poll
+  // is what records delivery.
   if (message.kind === "interrupt") {
     await handlers.interrupt();
     await handlers
@@ -1373,6 +1619,88 @@ export async function handleControlMessage(message: ControlMessage, handlers: Co
     .emit([{ type: "steer", data: { id: message.id, applied: true } }])
     .catch(() => undefined);
   return "steer";
+}
+
+// How many times a steer whose durable action keeps throwing — an appendSteer
+// onto a full workspace disk is the reachable case — is retried before it is
+// acked anyway. Were it left unacked instead, the select would keep returning it
+// as the oldest pending row of every batch, so the poll loop would retry it for
+// the rest of the run.
+//
+// The bound retires a steer only. An interrupt is the message this channel
+// exists to not lose: it is retried for the life of the run, however many times
+// its kill fails, so a broken attempt can never retire an operator's stop. What
+// the bound does for it is fire the diagnostic once — the attempt counter keeps
+// climbing past it, so the report lands on the attempt that reaches it and never
+// repeats.
+export const CONTROL_MESSAGE_MAX_ATTEMPTS = 3;
+
+export async function applyControlMessages(
+  messages: ControlMessage[],
+  handlers: ControlHandlers,
+  // Consecutive failures per message id, owned by the caller so the count
+  // survives the redeliveries that produce it. A handled id is dropped from it;
+  // a failing one keeps counting up, which is what makes the diagnostic below
+  // fire on one attempt only.
+  failures: Map<string, number> = new Map(),
+  maxAttempts = CONTROL_MESSAGE_MAX_ATTEMPTS,
+): Promise<{ handled: string[]; error?: unknown }> {
+  const handled: string[] = [];
+  let error: unknown;
+  for (const message of messages) {
+    // An interrupt is never retired, so the bound governs its diagnostic only.
+    const retirable = message.kind !== "interrupt";
+    const attempted = failures.get(message.id) ?? 0;
+    if (retirable && attempted >= maxAttempts) {
+      // Already retired and reported; this copy exists because the ack that
+      // retired it was lost. Re-ack without retrying the action or re-emitting.
+      handled.push(message.id);
+      continue;
+    }
+    try {
+      await handleControlMessage(message, handlers);
+      failures.delete(message.id);
+      // Only an id whose durable action landed goes into the ack, so anything
+      // else is served again on the next poll.
+      handled.push(message.id);
+    } catch (caught) {
+      error = caught;
+      const attempts = attempted + 1;
+      failures.set(message.id, attempts);
+      // Exactly at the bound, never past it: an interrupt keeps counting up from
+      // here, and one diagnostic per undeliverable message is the whole point.
+      if (attempts === maxAttempts) {
+        await handlers
+          .emit([
+            {
+              type: "artifact_error",
+              data: {
+                kind: "steer_undeliverable",
+                id: message.id,
+                attempts,
+                error: errorMessage(caught),
+              },
+            },
+          ])
+          .catch(() => undefined);
+      }
+      // A retired message is acked so the server stops serving it. An interrupt
+      // stays out of the ack whatever its count, which is what keeps it pending
+      // and retried for the life of the run.
+      if (retirable && attempts >= maxAttempts) handled.push(message.id);
+    }
+    // Deliberately no early return: a message that cannot be applied must not
+    // hold the line in front of the rest of the batch. An operator's interrupt
+    // sitting behind a steer that will never land has to reach the engine now,
+    // not after that steer starts succeeding — which it may never do.
+  }
+  // Handling is exactly-once in the ordinary case and at-least-once whenever a
+  // message comes back — a poll response lost after the batch was applied, or an
+  // interrupt this never acks — so the same runner re-applies it. There is no
+  // second runner in this picture — dispatch claims the run before launching a
+  // sandbox, a confirmed sandbox loss fails the run outright, and /resume starts
+  // a fresh run id whose steer rows are its own.
+  return error === undefined ? { handled } : { handled, error };
 }
 
 export function terminateChild(
@@ -1425,14 +1753,27 @@ async function runShell(
   });
   const clearTimers =
     timeoutMin === undefined ? () => undefined : armCommandTimeout(child, timeoutMin);
+  const drains = [child.stdout, child.stderr].map((stream) => drainLineEvents(stream, eventType));
+  return awaitCommandStreams(exitCode(child), drains, clearTimers);
+}
+
+// Waits out one command: its exit first, then both stream drains. Separate from
+// runShell — which owns a real child process nothing can inject into — so the two
+// orderings this exists for can be driven directly by a test: a drain that
+// rejects while the command is still running, and a timer that has to be disarmed
+// on that rejection as well as on a clean exit.
+export async function awaitCommandStreams(
+  exit: Promise<number>,
+  drains: Promise<unknown>[],
+  clearTimers: () => void,
+) {
+  // A delivery failure can reject a drain while the command is still running,
+  // long before the `await` below. Mark both promises handled now so that
+  // rejection waits for the await instead of aborting the whole process as an
+  // unhandled rejection — which would exit without posting a terminal result.
+  for (const drain of drains) drain.catch(() => undefined);
   try {
-    const drains = [child.stdout, child.stderr].map((stream) => drainLineEvents(stream, eventType));
-    // A delivery failure can reject a drain while the command is still running,
-    // long before the `await` below. Mark both promises handled now so that
-    // rejection waits for the await instead of aborting the whole process as an
-    // unhandled rejection — which would exit without posting a terminal result.
-    for (const drain of drains) drain.catch(() => undefined);
-    const code = await exitCode(child);
+    const code = await exit;
     // Wait for both stream readers to finish draining before returning, so no
     // output line is emitted AFTER the caller records the run's result (a late
     // event would be dropped as post-terminal). Previously these loops were
@@ -1729,7 +2070,7 @@ export async function runCheckCommand(
   return { code, tail: tail.trim() };
 }
 
-async function postResult(
+export async function postResult(
   bundle: RunBundle | null,
   status: "succeeded" | "failed" | "canceled",
   startedAt: number,
@@ -1740,46 +2081,46 @@ async function postResult(
   const stderrTail = await readFile(engineStderrFile, "utf8").catch(() => "");
   const activity = await runnerReceiptActivity(bundle, status);
   try {
-    await api(
-      `/internal/runs/${currentRunId()}/result`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          status,
-          receipt: {
-            provider: receiptProvider(bundle?.engine),
-            mode: receiptMode(bundle?.mode),
-            model: configuredModel(bundle?.engineConfig),
-            result: status,
-            activity,
-            timing: {
-              started_at: new Date(startedAt).toISOString(),
-              ended_at: new Date().toISOString(),
-              duration_ms: Date.now() - startedAt,
-            },
+    await api(`/internal/runs/${currentRunId()}/result`, {
+      method: "POST",
+      body: JSON.stringify({
+        status,
+        receipt: {
+          provider: receiptProvider(bundle?.engine),
+          mode: receiptMode(bundle?.mode),
+          model: configuredModel(bundle?.engineConfig),
+          result: status,
+          activity,
+          timing: {
+            started_at: new Date(startedAt).toISOString(),
+            ended_at: new Date().toISOString(),
+            duration_ms: Date.now() - startedAt,
           },
-          error:
-            typeof error === "string"
-              ? error
-              : error
-                ? redactSecrets(`${JSON.stringify(error)} ${stderrTail.slice(-2000)}`)
-                : undefined,
-          git,
-          engineSessionId: engineSessionId ?? undefined,
-          securityReport,
-        }),
-      },
-      undefined,
-      { budgetMs: RESULT_RETRY_BUDGET_MS },
-    );
+        },
+        error:
+          typeof error === "string"
+            ? error
+            : error
+              ? redactSecrets(`${JSON.stringify(error)} ${stderrTail.slice(-2000)}`)
+              : undefined,
+        git,
+        engineSessionId: engineSessionId ?? undefined,
+        securityReport,
+      }),
+    });
   } catch (postError) {
     if (isRunTerminalConflict(postError)) {
-      // The control plane already holds a different terminal verdict and now
-      // rejects both /result and /events for this run, so the container log is
-      // the only place left to record what this attempt would have reported.
-      process.stderr.write(
-        `result_discarded_run_terminal attempted_status=${status} git=${JSON.stringify(git ?? null)}\n`,
-      );
+      // A terminal verdict is already recorded for this run, and it is most
+      // often this very post: /result is on the replaySafe policy, so an attempt
+      // whose response was lost after the handler committed is replayed by the
+      // retry loop and answered 409 — the recorded verdict is then identical to
+      // the one below, not a different one. It can also be another party's, in
+      // which case it differs: /v1/runs/:runId/cancel records "canceled", and
+      // failRun records "failed" when the control plane concludes the sandbox is
+      // gone. Either way the run is terminal, so /events is refused from here on
+      // too and the container log is the only place left to record what this
+      // attempt carried.
+      process.stderr.write(runTerminalDiscardLog(status, git));
       return;
     }
     throw postError;
@@ -1880,6 +2221,68 @@ export function deliveryStatusEvent(
   };
 }
 
+// shipGitChanges' return value carries pullRequestTitle and pullRequestBody
+// copied verbatim out of the agent-written .agent-sdlc/delivery.json, which
+// readAgentDeliveryMetadata admits at up to 256 and 60000 characters of prose.
+// Serializing that object whole would push both into the container's stderr —
+// Docker logs, CloudWatch — where infrastructure log access replaces the
+// runs:read gate that gets run_events, and where none of the central redaction in
+// emit() applies. So the record is assembled from an allowlist of scalar
+// coordinates: enough to say which delivery lost the race, with the two unbounded
+// agent-authored fields left out.
+//
+// That is the whole of the claim. push_error is in the allowlist and is
+// errorMessage over captured Git stderr, so it can quote text the agent chose —
+// the branch or path it named comes back inside Git's own message. What holds it
+// is that shipGitChanges already assigns it as redactSecrets(errorMessage),
+// DISCARD_LOG_FIELD_MAX_CHARS below bounds it rather than trusting Git's message
+// to be short, and once the run is terminal the control plane refuses /events
+// too, so this line is the last place a failed push can be recorded at all.
+//
+// The finished string passes through redactSecrets again as defense in depth.
+// Every coordinate here is data the agent had a hand in: in repair mode the
+// branch is whatever existingGithubBranch accepted, which admits any ref name up
+// to 255 characters that avoids Git's own metacharacters — a branch named after a
+// token qualifies.
+//
+// Enough of a message to identify the failure, and short enough that no field can
+// turn this record into a wall of agent-influenced text in the container log.
+const DISCARD_LOG_FIELD_MAX_CHARS = 512;
+
+export function runTerminalDiscardLog(
+  status: "succeeded" | "failed" | "canceled",
+  git: Record<string, unknown> | undefined,
+  secrets: Iterable<string> = secretsToRedact,
+): string {
+  // A missing or non-string coordinate renders as "-" so the record keeps its
+  // field count and never prints the literal "undefined" or "null" — four of
+  // postResult's five call sites pass no git object at all. Whitespace collapses
+  // because a push error is a captured Git stderr message that can span lines,
+  // and a record split across lines defeats a single-line operator grep.
+  const coordinate = (value: unknown) => {
+    if (typeof value !== "string" || !value.trim()) return "-";
+    // Redact before bounding, never after: a secret straddling the cut would
+    // leave the prefix the bound kept, and no later redaction pass can match a
+    // token it only has half of. The line-level pass below stays as it was.
+    const collapsed = redactSecrets(value.replace(/\s+/g, " ").trim(), secrets);
+    // The marker carries no space, so the record keeps parsing as one field per
+    // token, and it is in the output rather than truncating silently — an
+    // operator reading the line can tell the message continued.
+    return collapsed.length > DISCARD_LOG_FIELD_MAX_CHARS
+      ? `${collapsed.slice(0, DISCARD_LOG_FIELD_MAX_CHARS)}...[truncated]`
+      : collapsed;
+  };
+  const line = [
+    "result_discarded_run_terminal",
+    `attempted_status=${status}`,
+    `changed=${git?.changed === true}`,
+    `branch=${coordinate(git?.branch)}`,
+    `head_sha=${coordinate(git?.headSha)}`,
+    `push_error=${coordinate(git?.pushError)}`,
+  ].join(" ");
+  return `${redactSecrets(line, secrets)}\n`;
+}
+
 function isSecurityMode(mode: string) {
   return ["security", "security_sweep"].includes(normalizedMode(mode));
 }
@@ -1941,6 +2344,19 @@ export function deliveryFailure(
     return "delivery_pr_body_missing";
   }
   return null;
+}
+
+// The only place a GitHub push token is acquired. It is a named function rather
+// than a line inside shipGitChanges so the request — and therefore the policy
+// api() resolves for it — can be driven by a test without a git fixture. Each
+// call mints a live contents:write token, and nothing in this codebase revokes an
+// installation token, so a second delivery has to be a test failure and not a
+// code review's job.
+export async function requestPushToken(runId: string): Promise<string> {
+  const { token } = await api<{ token: string }>(`/internal/runs/${runId}/push-token`, {
+    method: "POST",
+  });
+  return token;
 }
 
 export type ShipGitOptions = {
@@ -2007,9 +2423,7 @@ export async function shipGitChanges(
         runId,
       );
     }
-    const { token } = await api<{ token: string }>(`/internal/runs/${runId}/push-token`, {
-      method: "POST",
-    });
+    const token = await requestPushToken(runId);
     secretsToRedact.add(token);
     const published = repairRepositoryMode(mode)
       ? await publishVerifiedGithubBranchUpdate({
@@ -2806,11 +3220,13 @@ async function emit(events: RunEvent[]) {
 
 export { emit as emitRunEvents };
 
+// The retry policy is deliberately not a parameter: it belongs to the endpoint
+// being called, ENDPOINT_RETRY_POLICIES declares it, and resolving it here means
+// no call site can hand this function a policy of its own.
 async function api<T>(
   path: string,
   init: RequestInit = {},
   bodyFactory?: () => RequestInit["body"],
-  retry?: TransientRetryOptions,
 ): Promise<T> {
   const headers: Record<string, string> = { authorization: `Bearer ${runnerToken()}` };
   if (init.body) headers["content-type"] = "application/json";
@@ -2824,7 +3240,7 @@ async function api<T>(
       },
     },
     bodyFactory,
-    retry,
+    endpointRetryPolicy(path),
   ) as Promise<T>;
 }
 
@@ -2861,12 +3277,18 @@ export type TransientRetryOptions = {
   budgetMs?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
+  // Whether this endpoint absorbs a second delivery of the same request, set per
+  // endpoint in ENDPOINT_RETRY_POLICIES. It defaults to false so an endpoint
+  // nobody has classified is conservative until someone has read its handler:
+  // opting in wrongly duplicates an already-committed effect, and the only cost
+  // of leaving it off is a lost response failing the run.
+  replaySafe?: boolean;
 };
 
 // Undici wraps the raising syscall error in `cause` chains (and AggregateError
 // members when it raced multiple address families), so the classification has
 // to walk the tree rather than inspect the top-level error.
-export function isTransientFetchError(error: unknown): boolean {
+export function isTransientFetchError(error: unknown, replaySafe = false): boolean {
   const seen = new Set<object>();
   const pending: unknown[] = [error];
   while (pending.length > 0) {
@@ -2881,7 +3303,10 @@ export function isTransientFetchError(error: unknown): boolean {
     };
     // An abort is the caller's own decision to stop waiting — never replay it.
     if (name === "AbortError" || name === "TimeoutError") return false;
-    if (typeof code === "string" && TRANSIENT_NETWORK_CODES.has(code)) return true;
+    if (typeof code === "string") {
+      if (UNDELIVERED_NETWORK_CODES.has(code)) return true;
+      if (replaySafe && AMBIGUOUS_NETWORK_CODES.has(code)) return true;
+    }
     if (cause) pending.push(cause);
     if (Array.isArray(errors)) pending.push(...errors);
   }
@@ -2920,21 +3345,54 @@ export async function fetchJson(
   init: RequestInit = {},
   bodyFactory?: () => RequestInit["body"],
   retry: TransientRetryOptions = {},
-) {
+): Promise<unknown> {
+  return await fetchWithTransientRetry(url, init, bodyFactory, retry, (response) =>
+    response.json(),
+  );
+}
+
+// The session-state restore, the one control-plane read whose response is bytes
+// rather than JSON. It shares the loop below so it shares the classification:
+// the policy is the table's own session-state entry, passed as an argument
+// because this call cannot go through api()'s JSON reader.
+export async function fetchSessionStateArchive(runId: string) {
+  return await fetchWithTransientRetry(
+    `${apiUrl()}/internal/runs/${runId}/session-state`,
+    { headers: { authorization: `Bearer ${runnerToken()}` } },
+    undefined,
+    ENDPOINT_RETRY_POLICIES["session-state"],
+    async (response) => Buffer.from(await response.arrayBuffer()),
+  );
+}
+
+// The one place the runner reaches the control plane. Reading the response is a
+// parameter so a caller that needs bytes does not need a transport of its own:
+// a second transport would be a second retry policy nobody classified.
+async function fetchWithTransientRetry<T>(
+  url: string,
+  init: RequestInit,
+  bodyFactory: (() => RequestInit["body"]) | undefined,
+  retry: TransientRetryOptions,
+  read: (response: Response) => Promise<T>,
+): Promise<T> {
   const budgetMs = retry.budgetMs ?? TRANSIENT_RETRY_BUDGET_MS;
   const baseDelayMs = retry.baseDelayMs ?? TRANSIENT_RETRY_BASE_DELAY_MS;
   const maxDelayMs = retry.maxDelayMs ?? TRANSIENT_RETRY_MAX_DELAY_MS;
+  const replaySafe = retry.replaySafe ?? false;
   const deadline = Date.now() + budgetMs;
   const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   let transientAttempt = 0;
   let rateLimitAttempt = 0;
-  // Retrying makes these requests at-least-once: a request whose response was
-  // lost after the server committed can be replayed. That is safe for the
-  // terminal result (a replay answers 409 run_terminal, handled by callers via
-  // isRunTerminalConflict) and can at worst duplicate one already-accepted
-  // events batch in the narrow response-lost window — a display-level artifact,
-  // never state corruption. Connection-refused and DNS-loss replays (the whole
-  // restart case this exists for) never reached the server at all.
+  // Retrying makes a request at-least-once, so the replay rule follows what the
+  // failure proves. A refused connection or a lost DNS name proves no handler
+  // ran — the whole restart case this exists for — so replaying costs nothing
+  // and every caller gets it. Anything that leaves delivery open (a reset, a
+  // stall timeout, a 5xx) may have committed before the response was lost, so
+  // replaying it is a decision per endpoint, which
+  // ENDPOINT_RETRY_POLICIES records as replaySafe. Left off, a lost response
+  // fails the run; turned on where the handler is not idempotent, a replayed
+  // /push-token mints a second live contents:write token that nobody holds and
+  // nothing here revokes.
   for (;;) {
     let response: Response;
     let body: string;
@@ -2943,12 +3401,13 @@ export async function fetchJson(
       // The body reads live inside the same classification: a control plane
       // killed between flushing headers and body fails here, and that loss is
       // the same outage as a reset before headers.
-      if (response.ok) return (await response.json()) as unknown;
+      if (response.ok) return await read(response);
       body = await response.text();
     } catch (error) {
       // Anything without a transient cause — bad URL, aborted request, invalid
-      // JSON from a healthy server — stays fatal.
-      if (!isTransientFetchError(error)) throw error;
+      // JSON from a healthy server, or an ambiguous loss this caller did not
+      // declare replay-safe — stays fatal.
+      if (!isTransientFetchError(error, replaySafe)) throw error;
       const remainingMs = deadline - Date.now();
       // One retry is always granted: a single stalled attempt (undici's
       // header/body timeouts run to minutes) can consume the whole budget by
@@ -2973,7 +3432,12 @@ export async function fetchJson(
       await sleep(retryAfterMs(response.headers.get("retry-after")));
       continue;
     }
-    if (TRANSIENT_HTTP_STATUSES.has(response.status)) {
+    // A 5xx is as ambiguous as a lost response and takes the same opt-in. The
+    // status alone does not say whether a route handler ran: a 500 can be raised
+    // after it committed, while a 502 or 503 can come from a proxy that never
+    // forwarded the request. Unable to tell those apart, a conservative caller
+    // falls through to the fatal throw below.
+    if (replaySafe && TRANSIENT_HTTP_STATUSES.has(response.status)) {
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) throw new FetchJsonError(url, response.status, body);
       const retryAfter = response.headers.get("retry-after");

--- a/runner/test/command-streams.test.ts
+++ b/runner/test/command-streams.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { awaitCommandStreams } from "../src/index.js";
+
+// A rejected promise nothing has handled raises unhandledRejection at the end of
+// the turn, which for the runner means the process aborts before it can post a
+// terminal result. Observing that takes the process listener, so the harness's
+// own listeners are lifted for the duration and put back afterwards.
+async function withUnhandledRejectionCapture(body: () => Promise<void>) {
+  const existing = process.listeners("unhandledRejection");
+  process.removeAllListeners("unhandledRejection");
+  const unhandled: unknown[] = [];
+  const capture = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", capture);
+  try {
+    await body();
+    // The event is emitted once the microtask queue has drained, so give it a
+    // macrotask to land in before the listener goes away.
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    process.off("unhandledRejection", capture);
+    for (const listener of existing) {
+      process.on("unhandledRejection", listener as (reason: unknown) => void);
+    }
+  }
+  return unhandled;
+}
+
+describe("command stream supervision", () => {
+  it("marks each drain handled before it waits on the command's exit", async () => {
+    const cleared: string[] = [];
+    const drains = [
+      Promise.reject(new Error("event delivery failed mid-command")),
+      Promise.resolve(undefined),
+    ];
+    // The command keeps running for several macrotasks after the drain has
+    // already failed: exactly the window an unhandled rejection would abort in.
+    const exit = new Promise<number>((resolve) => setTimeout(() => resolve(0), 10));
+
+    const unhandled = await withUnhandledRejectionCapture(async () => {
+      await expect(
+        awaitCommandStreams(exit, drains, () => cleared.push("cleared")),
+      ).rejects.toThrow("event delivery failed mid-command");
+    });
+
+    expect(unhandled).toEqual([]);
+    // The armed SIGKILL escalation is a live timer handle, so it has to be
+    // disarmed on the rejection path too.
+    expect(cleared).toEqual(["cleared"]);
+  });
+
+  it("returns the exit code only after both drains finish, then disarms the timer", async () => {
+    const order: string[] = [];
+    const cleared: string[] = [];
+    const settle = (name: string, ms: number) =>
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          order.push(name);
+          resolve();
+        }, ms),
+      );
+    const exit = new Promise<number>((resolve) =>
+      setTimeout(() => {
+        order.push("exit");
+        resolve(7);
+      }, 1),
+    );
+
+    const code = await awaitCommandStreams(exit, [settle("stdout", 5), settle("stderr", 10)], () =>
+      cleared.push("cleared"),
+    );
+
+    expect(code).toBe(7);
+    // No output line may be emitted after the caller records the run's result.
+    expect(order).toEqual(["exit", "stdout", "stderr"]);
+    expect(cleared).toEqual(["cleared"]);
+  });
+});

--- a/runner/test/github-delivery.integration.test.ts
+++ b/runner/test/github-delivery.integration.test.ts
@@ -5,7 +5,13 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { deliveryFailure, emitRunEvents, prepareWorkspace, shipGitChanges } from "../src/index.js";
+import {
+  deliveryFailure,
+  emitRunEvents,
+  postResult,
+  prepareWorkspace,
+  shipGitChanges,
+} from "../src/index.js";
 import { RunPhaseRecorder } from "../src/phases.js";
 import type { RunBundle } from "../src/types.js";
 
@@ -129,7 +135,7 @@ async function startJsonServer(
   };
 }
 
-async function startFacilityServer(token: string) {
+async function startFacilityServer(token: string, resultReply?: JsonReply) {
   return startJsonServer((request) => {
     if (request.method === "POST" && request.path === "/internal/runs/run_integration/push-token") {
       if (request.headers.authorization !== "Bearer runner-integration-token") {
@@ -143,8 +149,31 @@ async function startFacilityServer(token: string) {
       }
       return { body: {} };
     }
+    if (request.method === "POST" && request.path === "/internal/runs/run_integration/result") {
+      if (request.headers.authorization !== "Bearer runner-integration-token") {
+        return { status: 401, body: { message: "invalid runner token" } };
+      }
+      return resultReply ?? { body: {} };
+    }
     return { status: 404, body: { message: `unexpected Facility route ${request.path}` } };
   });
+}
+
+// The discard log is the runner's last resort once the control plane refuses both
+// /result and /events, so the assertions below read the real stderr stream rather
+// than a return value. Restoring the original write is registered as a fixture
+// cleanup so a failing expectation cannot leave the reporter's output captured.
+function captureStderr() {
+  const written: string[] = [];
+  const original = process.stderr.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    written.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    return true;
+  }) as typeof process.stderr.write;
+  cleanups.push(async () => {
+    process.stderr.write = original;
+  });
+  return written;
 }
 
 type GithubScenario =
@@ -747,6 +776,50 @@ describe.sequential("signed GitHub delivery integration", () => {
     expect(failureEvent(facility.requests)).toContain("missing_commit_oid");
     expect(facility.handlerErrors).toEqual([]);
     expect(github.handlerErrors).toEqual([]);
+  });
+
+  it("logs only the conflict coordinates when the control plane holds a terminal verdict", async () => {
+    const facility = await startFacilityServer("installation-token-run-terminal", {
+      status: 409,
+      body: { error: { code: "run_terminal", message: "Run is terminal" } },
+    });
+    configureRunner(facility.origin);
+    const stderr = captureStderr();
+
+    await postResult(null, "succeeded", Date.now(), undefined, {
+      changed: true,
+      branch: "feature/task",
+      headSha: "signed_sha",
+      pullRequestTitle: "fix: rewrite the auth handler",
+      pullRequestBody: "## Summary\n\n- Deliver the signed task.",
+    });
+
+    expect(facilityRequests(facility.requests, "/result")).toHaveLength(1);
+    expect(stderr).toHaveLength(1);
+    expect(stderr[0]).toContain("result_discarded_run_terminal attempted_status=succeeded");
+    expect(stderr[0]).toContain("branch=feature/task");
+    expect(stderr[0]).toContain("head_sha=signed_sha");
+    expect(stderr[0]).not.toContain("Summary");
+    expect(stderr[0]).not.toContain("Deliver the signed task");
+    expect(stderr[0]).not.toContain("rewrite the auth handler");
+    expect(facility.handlerErrors).toEqual([]);
+  });
+
+  it("still raises a result conflict that is not the terminal-run verdict", async () => {
+    const facility = await startFacilityServer("installation-token-other-conflict", {
+      status: 409,
+      body: { error: { code: "virtual_key_revealed", message: "Virtual key already revealed" } },
+    });
+    configureRunner(facility.origin);
+    const stderr = captureStderr();
+
+    await expect(postResult(null, "failed", Date.now(), { code: "checks_failed" })).rejects.toThrow(
+      /failed 409/,
+    );
+
+    expect(facilityRequests(facility.requests, "/result")).toHaveLength(1);
+    expect(stderr).toEqual([]);
+    expect(facility.handlerErrors).toEqual([]);
   });
 
   it("keeps the delivery manifest excluded from the repository diff", async () => {

--- a/runner/test/http-retry.integration.test.ts
+++ b/runner/test/http-retry.integration.test.ts
@@ -1,22 +1,47 @@
+import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { PassThrough, Readable } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  applyControlMessages,
   drainLineEvents,
+  ENDPOINT_RETRY_POLICIES,
+  ENDPOINT_RETRY_POLICY_DEFAULT,
+  emitRunEvents,
+  endpointRetryPolicy,
   FetchJsonError,
   fetchJson,
+  fetchSessionStateArchive,
   isRunTerminalConflict,
   isTransientFetchError,
+  postResult,
+  requestPushToken,
   retryAfterMs,
+  steerPollPath,
   transientRetryDelayMs,
 } from "../src/index.js";
 import type { RunEvent } from "../src/types.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
 
+// The production call paths below read the API origin and the run's credentials
+// from the environment, so a test that drives one has to point them at its own
+// server and put the process back as it found it.
+const RUNNER_ENV_KEYS = ["FACILITY_API_URL", "RUN_ID", "RUNNER_TOKEN"] as const;
+let previousRunnerEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  previousRunnerEnv = Object.fromEntries(RUNNER_ENV_KEYS.map((key) => [key, process.env[key]]));
+});
+
 afterEach(async () => {
+  for (const key of RUNNER_ENV_KEYS) {
+    const value = previousRunnerEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   await Promise.all(
     servers
       .splice(0)
@@ -28,6 +53,53 @@ afterEach(async () => {
       ),
   );
 });
+
+function configureRunner(origin: string) {
+  process.env.FACILITY_API_URL = origin;
+  process.env.RUN_ID = "run_test";
+  process.env.RUNNER_TOKEN = "runner-test-token";
+}
+
+// Flushes response headers and a truncated body, then kills the socket: the
+// shape of a control plane dying after a route handler may already have
+// committed. undici surfaces it as a socket-level loss, the class of failure
+// that only an endpoint absorbing a duplicate may replay. The request body is
+// drained first so the loss lands on the response rather than on an upload the
+// server never read.
+async function startAmbiguousLossServer(reply: unknown, failures = 1) {
+  const attempts: string[] = [];
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      attempts.push(request.url ?? "");
+      response.setHeader("content-type", "application/json");
+      if (attempts.length <= failures) {
+        response.setHeader("content-length", "100");
+        response.write("{");
+        response.destroy();
+        return;
+      }
+      response.end(JSON.stringify(reply));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { attempts, origin: `http://127.0.0.1:${port}` };
+}
+
+// Binds an ephemeral port and releases it, so the next connect to it is refused
+// by the kernel — the provably-undelivered failure a restarting control plane
+// produces.
+async function reserveClosedPort() {
+  const probe = createServer();
+  await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+  const { port } = probe.address() as AddressInfo;
+  await new Promise<void>((resolve, reject) =>
+    probe.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
 
 describe("runner HTTP rate-limit recovery", () => {
   it("parses numeric and HTTP-date Retry-After values with a bounded fallback", () => {
@@ -149,16 +221,21 @@ describe("runner transient-failure classification", () => {
     expect(isTransientFetchError(refused)).toBe(true);
   });
 
-  it("classifies containerized-DNS loss and undici stall timeouts as transient", () => {
+  it("separates provably-undelivered failures from ambiguous ones", () => {
     const notFound = Object.assign(new Error("getaddrinfo ENOTFOUND api"), { code: "ENOTFOUND" });
     expect(isTransientFetchError(new TypeError("fetch failed", { cause: notFound }))).toBe(true);
+    // An undici stall timeout leaves the request on the wire, so it is retryable
+    // only where a second delivery of the same request is harmless.
     const headersTimeout = Object.assign(new Error("Headers Timeout Error"), {
       name: "HeadersTimeoutError",
       code: "UND_ERR_HEADERS_TIMEOUT",
     });
     expect(isTransientFetchError(new TypeError("fetch failed", { cause: headersTimeout }))).toBe(
-      true,
+      false,
     );
+    expect(
+      isTransientFetchError(new TypeError("fetch failed", { cause: headersTimeout }), true),
+    ).toBe(true);
   });
 
   it("keeps aborts, timeouts, and unknown failures fatal", () => {
@@ -261,6 +338,7 @@ describe("runner control-plane outage recovery", () => {
         budgetMs: 5_000,
         baseDelayMs: 1,
         maxDelayMs: 4,
+        replaySafe: true,
       }),
     ).resolves.toEqual({ ok: true });
     expect(attempts).toBe(3);
@@ -279,7 +357,10 @@ describe("runner control-plane outage recovery", () => {
     const { port } = server.address() as AddressInfo;
 
     await expect(
-      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, { budgetMs: 0 }),
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 0,
+        replaySafe: true,
+      }),
     ).rejects.toThrow("failed 503");
     expect(attempts).toBe(1);
   });
@@ -301,6 +382,7 @@ describe("runner control-plane outage recovery", () => {
         budgetMs: 150,
         baseDelayMs: 1,
         maxDelayMs: 4,
+        replaySafe: true,
       }),
     ).rejects.toThrow("failed 503");
     expect(attempts).toBeGreaterThan(1);
@@ -405,13 +487,14 @@ describe("runner control-plane outage recovery", () => {
         budgetMs: 5_000,
         baseDelayMs: 1,
         maxDelayMs: 4,
+        replaySafe: true,
       }),
     ).resolves.toEqual({ ok: true });
     expect(attempts).toBe(2);
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900);
   });
 
-  it("retries when the control plane dies between headers and body", async () => {
+  it("retries a replay-safe call when the control plane dies between headers and body", async () => {
     let attempts = 0;
     const server = createServer((_request, response) => {
       attempts += 1;
@@ -433,9 +516,65 @@ describe("runner control-plane outage recovery", () => {
         budgetMs: 5_000,
         baseDelayMs: 1,
         maxDelayMs: 4,
+        replaySafe: true,
       }),
     ).resolves.toEqual({ ok: true });
     expect(attempts).toBe(2);
+  });
+
+  it("applies an interrupt exactly once when the control plane dies mid-response", async () => {
+    const message = { id: "evt_interrupt", kind: "interrupt", body: "human_interrupt" };
+    let attempts = 0;
+    const delivered = new Set<string>();
+    const server = createServer((request, response) => {
+      attempts += 1;
+      const polled = new URL(request.url ?? "/", "http://127.0.0.1");
+      for (const id of polled.searchParams.get("ack")?.split(",") ?? []) delivered.add(id);
+      response.setHeader("content-type", "application/json");
+      if (attempts === 1) {
+        response.setHeader("content-length", "100");
+        response.write("[");
+        response.destroy();
+        return;
+      }
+      // Delivery is recorded from the ack the next poll carries, not from the
+      // select, so a lost response leaves the interrupt pending and the replay
+      // serves it again.
+      response.end(JSON.stringify(delivered.has(message.id) ? [] : [message]));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    let interrupts = 0;
+    const handlers = {
+      appendSteer: async () => {
+        throw new Error("an interrupt must never reach the steer file");
+      },
+      emit: async () => undefined,
+      interrupt: async () => {
+        interrupts += 1;
+      },
+    };
+    let ack: string[] = [];
+    for (let poll = 0; poll < 2; poll += 1) {
+      const messages = (await fetchJson(
+        `http://127.0.0.1:${port}${steerPollPath("run_test", ack)}`,
+        {},
+        undefined,
+        { budgetMs: 5_000, baseDelayMs: 1, maxDelayMs: 4, replaySafe: true },
+      )) as Array<{ id: string; kind?: string; body: string }>;
+      const applied = await applyControlMessages(messages, handlers);
+      expect(applied.error).toBeUndefined();
+      ack = applied.handled;
+    }
+
+    // Three requests: the destroyed one, its replay carrying the same message,
+    // and the acknowledged poll that comes back empty.
+    expect(attempts).toBe(3);
+    expect(interrupts).toBe(1);
+    expect(ack).toEqual([]);
+    expect(delivered).toEqual(new Set([message.id]));
   });
 
   it("keeps a failing 5xx retry loop paced even when Retry-After asks for zero delay", async () => {
@@ -461,12 +600,145 @@ describe("runner control-plane outage recovery", () => {
         budgetMs: 5_000,
         baseDelayMs: 40,
         maxDelayMs: 40,
+        replaySafe: true,
       }),
     ).resolves.toEqual({ ok: true });
     expect(attempts).toBe(2);
     // 20ms is half the 40ms jitter window — the floor Retry-After: 0 must not
     // defeat.
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(20);
+  });
+
+  it("replays a connection-refused call even when the caller is not replay-safe", async () => {
+    const probe = createServer();
+    servers.push(probe);
+    await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+    const { port } = probe.address() as AddressInfo;
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve())),
+    );
+    servers.splice(servers.indexOf(probe), 1);
+
+    const revivedRequests: string[] = [];
+    const revival = new Promise<void>((resolve) => setTimeout(resolve, 50)).then(async () => {
+      const revived = createServer((request, response) => {
+        revivedRequests.push(request.url ?? "");
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ token: "ghs_replayed" }));
+      });
+      servers.push(revived);
+      await new Promise<void>((resolve) => revived.listen(port, "127.0.0.1", resolve));
+    });
+
+    // A refused connection proves no route handler ran, so even the endpoints
+    // that must never be replayed after a lost response still ride out the
+    // restart this whole mechanism exists for.
+    await expect(
+      fetchJson(
+        `http://127.0.0.1:${port}/internal/runs/run_test/push-token`,
+        { method: "POST" },
+        undefined,
+        { budgetMs: 5_000, baseDelayMs: 5, maxDelayMs: 20 },
+      ),
+    ).resolves.toEqual({ token: "ghs_replayed" });
+    await revival;
+    expect(revivedRequests).toEqual(["/internal/runs/run_test/push-token"]);
+  });
+
+  it("never replays an ambiguous mid-flight failure for a call that is not replay-safe", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      response.setHeader("content-length", "100");
+      response.write("{");
+      response.destroy();
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    // The handler may already have minted the installation token and written its
+    // audit row before the socket died, so the loss has to surface as a failure.
+    // A replay here leaves a second live contents:write token that nobody holds.
+    await expect(
+      fetchJson(
+        `http://127.0.0.1:${port}/internal/runs/run_test/push-token`,
+        { method: "POST" },
+        undefined,
+        { budgetMs: 5_000, baseDelayMs: 1, maxDelayMs: 4 },
+      ),
+    ).rejects.toThrow();
+    expect(attempts).toBe(1);
+  });
+
+  it("replays an ambiguous mid-flight failure when the caller opts in", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts === 1) {
+        response.setHeader("content-length", "100");
+        response.write("{");
+        response.destroy();
+        return;
+      }
+      response.end(JSON.stringify({ uri: "s3://transcripts/run_test" }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    // The transcript upload overwrites one object keyed by run id, so a second
+    // delivery of the same bytes is indistinguishable from the first.
+    await expect(
+      fetchJson(
+        `http://127.0.0.1:${port}/internal/runs/run_test/transcript`,
+        { method: "POST" },
+        undefined,
+        { budgetMs: 5_000, baseDelayMs: 1, maxDelayMs: 4, replaySafe: true },
+      ),
+    ).resolves.toEqual({ uri: "s3://transcripts/run_test" });
+    expect(attempts).toBe(2);
+  });
+
+  it("replays a transient 5xx only for the caller that opts in", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts < 3) {
+        response.statusCode = 503;
+        response.end(JSON.stringify({ error: "restarting" }));
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    // A 5xx may have been raised after the handler committed, so recovering from
+    // it is the same ambiguous replay: the conservative caller fails on its first
+    // answer.
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/internal/runs/run_test/events`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 1,
+        maxDelayMs: 4,
+      }),
+    ).rejects.toThrow("failed 503");
+    expect(attempts).toBe(1);
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/internal/runs/run_test/result`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 1,
+        maxDelayMs: 4,
+        replaySafe: true,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(3);
   });
 
   it("resumes the stream when event delivery fails for good, so the child can exit", async () => {
@@ -507,6 +779,11 @@ describe("runner control-plane outage recovery", () => {
         batches.push(JSON.parse(body) as RunEvent[]);
         firstBatchArrived();
         response.setHeader("content-type", "application/json");
+        // Refuse keep-alive so the restart is observed as a refused connection.
+        // A pooled socket dispatched in the same tick the API's FIN arrives fails
+        // with UND_ERR_SOCKET instead, and that loss is ambiguous — the events
+        // POST does not opt into replaying it, which would make this a race.
+        response.setHeader("connection", "close");
         response.end(JSON.stringify({ count: 1 }));
       });
     };
@@ -556,5 +833,312 @@ describe("runner control-plane outage recovery", () => {
       "three",
       "four",
     ]);
+  });
+});
+
+// The ack is the runner's half of the delivery record: /internal/runs/:runId/steer
+// marks a message delivered from the ids the NEXT poll names, so a batch the
+// runner mishandles or an ack lost on the wire must both come back. The ids
+// travel in the query string, and the server refuses the whole request unless
+// each one matches its ACK_ID (services/api/src/routes/internal.ts), so the
+// construction is part of the contract rather than a detail.
+const ACK_ID = /^evt_[0-9a-f]{32}$/;
+const ackId = (hex: string) => `evt_${hex.repeat(32).slice(0, 32)}`;
+
+describe("runner steer poll acknowledgement", () => {
+  it("names every acked id in the query and encodes each one on its own", () => {
+    const first = ackId("a");
+    const second = ackId("b");
+    expect(steerPollPath("run_test", [])).toBe("/internal/runs/run_test/steer");
+    expect(steerPollPath("run_test", [first, second])).toBe(
+      `/internal/runs/run_test/steer?ack=${first},${second}`,
+    );
+
+    // The comma is the server's separator, so it stays literal between ids and
+    // is escaped inside one: an id carrying its own comma or an ampersand has to
+    // arrive as a single off-shape value the server refuses, never as extra ids
+    // or a second query parameter.
+    const hostile = "evt_1,&ack=evt_2";
+    const query = new URL(steerPollPath("run_test", [hostile]), "http://api.invalid").searchParams;
+    expect(query.getAll("ack")).toEqual([hostile]);
+    expect([...query.keys()]).toEqual(["ack"]);
+  });
+
+  it("acks only the ids it handled and is served the rest again", async () => {
+    const unwritable = ackId("a");
+    const applied = ackId("b");
+    const polled: string[][] = [];
+    const served: string[][] = [];
+    const pending = new Set([unwritable, applied]);
+    const server = createServer((request, response) => {
+      // The server's own parse: comma-separated ids, each refused unless it is
+      // shaped like a message id, and delivery recorded from the ack alone.
+      const query = new URL(request.url ?? "/", "http://127.0.0.1").searchParams;
+      const ack = query.get("ack")?.split(",") ?? [];
+      if (!ack.every((id) => ACK_ID.test(id))) {
+        response.statusCode = 400;
+        response.end("{}");
+        return;
+      }
+      polled.push(ack);
+      for (const id of ack) pending.delete(id);
+      const batch = [...pending].map((id) => ({
+        id,
+        kind: "steer",
+        body: id === unwritable ? "onto a full disk" : "tighten the diff",
+      }));
+      served.push(batch.map((message) => message.id));
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(batch));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    let diskFull = true;
+    const steers: string[] = [];
+    const handlers = {
+      appendSteer: async (body: string) => {
+        if (diskFull && body === "onto a full disk") throw new Error("no space left on device");
+        steers.push(body);
+      },
+      emit: async () => undefined,
+      interrupt: async () => {
+        throw new Error("no interrupt was sent");
+      },
+    };
+
+    let ack: string[] = [];
+    for (let poll = 0; poll < 3; poll += 1) {
+      const messages = (await fetchJson(
+        `http://127.0.0.1:${port}${steerPollPath("run_test", ack)}`,
+        {},
+        undefined,
+        { budgetMs: 5_000, baseDelayMs: 1, maxDelayMs: 4, ...ENDPOINT_RETRY_POLICIES.steer },
+      )) as Array<{ id: string; kind?: string; body: string }>;
+      ack = (await applyControlMessages(messages, handlers)).handled;
+      // The disk clears between the first and second poll, so the message the
+      // first poll could not write is the one the redelivery lands.
+      diskFull = false;
+    }
+
+    // First poll acks only what it applied, so the unwritable message stays
+    // pending and the second poll is served it again.
+    expect(polled).toEqual([[], [applied], [unwritable]]);
+    expect(served).toEqual([[unwritable, applied], [unwritable], []]);
+    expect(steers).toEqual(["tighten the diff", "onto a full disk"]);
+    // Nothing else acknowledged either message, and the run's whole ack traffic
+    // stays inside the 32-id cap the server enforces on one poll.
+    expect(polled.flat().sort()).toEqual([applied, unwritable].sort());
+    for (const ids of polled) expect(ids.length).toBeLessThanOrEqual(32);
+  });
+});
+
+// Whether an ambiguous mid-flight loss may be replayed is the whole security
+// content of the retry work, and it lives in one declaration per endpoint. The
+// tests below therefore assert the declaration and then drive the production
+// functions that own the calls: a call site that stopped agreeing with the table
+// would leave the table assertion green and has to fail something.
+describe("runner per-endpoint replay policy", () => {
+  it("declares a replay policy for every endpoint the runner calls", () => {
+    // Derived from the runner's own source rather than restated here, so a call
+    // site added later cannot pick up the default in silence: it has to be
+    // classified or fail this test. Two forms name an endpoint — a control-plane
+    // path built from a run id, which api() classifies by its last segment, and
+    // an entry read from the table by name, which is how the two calls that do
+    // not go through api() pass their policy on.
+    //
+    // This reads text, so it sees every literal path in the file, a mention
+    // inside a comment included, and it cannot see a path whose last segment is
+    // itself interpolated. Both directions of that are the safe one: an
+    // unclassified endpoint fails here, and only a call site written to hide
+    // its own endpoint escapes.
+    const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+    const patterns = [
+      /\/internal\/runs\/\$\{[^}]*\}\/([a-z][a-z-]*(?:\/[a-z][a-z-]*)*)/g,
+      /ENDPOINT_RETRY_POLICIES(?:\.([a-z][\w$]*)|\["([a-z][a-z-]*)"\])/g,
+    ];
+    const called = new Set<string>();
+    for (const pattern of patterns) {
+      for (const match of source.matchAll(pattern)) {
+        // Last segment, because that is the part api() classifies by.
+        called.add((match[1] ?? match[2] ?? "").split("/").pop() ?? "");
+      }
+    }
+    const declared = Object.keys(ENDPOINT_RETRY_POLICIES);
+    // Both directions, which together also keep the derivation honest: an
+    // expression that stopped matching anything would leave every declared
+    // endpoint unaccounted for instead of passing vacuously.
+    expect([...called].filter((endpoint) => !declared.includes(endpoint))).toEqual([]);
+    expect(declared.filter((endpoint) => !called.has(endpoint))).toEqual([]);
+
+    // Naming an endpoint is not the same as being classified by the table. A
+    // path spelled out at a raw `fetch` reaches the control plane with no policy
+    // at all while still counting as "called" above, which is how the
+    // session-state restore stayed unclassified with this test green. So the
+    // forms are pinned too: every classified call goes through fetchJson or the
+    // shared retry loop, which leaves exactly one bare `fetch` in the file — the
+    // loop's own, on a URL it was handed as an argument. A second one, whatever
+    // it points at, has to fail here and be justified.
+    const bareFetches = [...source.matchAll(/(?<![\w$])fetch\(([^\n]*)/g)];
+    expect(bareFetches).toHaveLength(1);
+    for (const [, args] of bareFetches) {
+      expect(args).not.toMatch(/apiUrl\(\)|\/internal\//);
+    }
+
+    // The decision each endpoint carries is the reviewable part, so it is still
+    // spelled out — a flip from false to true has to be deliberate.
+    expect(ENDPOINT_RETRY_POLICIES).toEqual({
+      hello: { replaySafe: false },
+      bundle: { replaySafe: true },
+      steer: { replaySafe: true },
+      transcript: { replaySafe: true },
+      "session-state": { replaySafe: true },
+      result: { budgetMs: 5 * 60_000, replaySafe: true },
+      "push-token": { replaySafe: false },
+      events: { replaySafe: false },
+    });
+    expect(ENDPOINT_RETRY_POLICY_DEFAULT).toEqual({ replaySafe: false });
+  });
+
+  it("resolves an endpoint path to its declared policy and anything else conservatively", () => {
+    expect(endpointRetryPolicy("/internal/runs/run_test/push-token")).toBe(
+      ENDPOINT_RETRY_POLICIES["push-token"],
+    );
+    // The steer poll carries its acks in the query string, which is not part of
+    // the endpoint's identity.
+    expect(endpointRetryPolicy("/internal/runs/run_test/steer?ack=evt_1,evt_2")).toBe(
+      ENDPOINT_RETRY_POLICIES.steer,
+    );
+    // An endpoint nobody has classified, and an inherited property of the table's
+    // own prototype that must never be mistaken for a classification, both fall
+    // back to failing rather than replaying.
+    expect(endpointRetryPolicy("/internal/runs/run_test/unclassified")).toEqual({
+      replaySafe: false,
+    });
+    expect(endpointRetryPolicy("/internal/runs/run_test/__proto__")).toEqual({
+      replaySafe: false,
+    });
+  });
+
+  it("requests a push token exactly once when the control plane dies mid-response", async () => {
+    const control = await startAmbiguousLossServer({ token: "ghs_minted" });
+    configureRunner(control.origin);
+
+    // The handler may already have minted the installation token and written its
+    // audit row before the socket died. Replaying would leave a second live
+    // contents:write token that nobody holds and nothing revokes, so the lost
+    // response has to surface as a failed delivery instead.
+    await expect(requestPushToken("run_test")).rejects.toThrow();
+    expect(control.attempts).toEqual(["/internal/runs/run_test/push-token"]);
+  });
+
+  it("delivers an event batch exactly once when the control plane dies mid-response", async () => {
+    const control = await startAmbiguousLossServer({ count: 1 });
+    configureRunner(control.origin);
+
+    // Appending to run_events is unguarded, so a replay duplicates the batch and
+    // with it the check events the platform's signed receipt is derived from.
+    await expect(emitRunEvents([{ type: "shell", data: { text: "installed" } }])).rejects.toThrow();
+    expect(control.attempts).toEqual(["/internal/runs/run_test/events"]);
+  });
+
+  it("replays the terminal result through the very failure the conservative calls refuse", async () => {
+    const control = await startAmbiguousLossServer({ ok: true });
+    configureRunner(control.origin);
+
+    // Same fixture, opposite outcome: losing the run's verdict entirely is worse
+    // than a duplicate post, which the control plane answers 409 run_terminal.
+    // Pinning both sides keeps this about the per-endpoint decision rather than
+    // about retries existing at all.
+    await expect(postResult(null, "succeeded", Date.now() - 1_000)).resolves.toBeUndefined();
+    expect(control.attempts).toEqual([
+      "/internal/runs/run_test/result",
+      "/internal/runs/run_test/result",
+    ]);
+  });
+
+  it("replays the session-state restore, which reads bytes rather than JSON", async () => {
+    const archive = Buffer.from("facility-session-state-archive");
+    const attempts: string[] = [];
+    const authorizations: (string | undefined)[] = [];
+    const server = createServer((request, response) => {
+      attempts.push(request.url ?? "");
+      authorizations.push(request.headers.authorization);
+      response.setHeader("content-type", "application/gzip");
+      if (attempts.length === 1) {
+        // Headers and a truncated body, then the socket dies: a control plane
+        // killed mid-response. The restore is a pure GET read, so replaying it
+        // cannot duplicate an effect, and losing it costs the resumed run its
+        // warm session and its workspace checkpoint.
+        response.setHeader("content-length", String(archive.length));
+        response.write(archive.subarray(0, 4));
+        response.destroy();
+        return;
+      }
+      response.end(archive);
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    configureRunner(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
+
+    await expect(fetchSessionStateArchive("run_test")).resolves.toEqual(archive);
+    expect(attempts).toEqual([
+      "/internal/runs/run_test/session-state",
+      "/internal/runs/run_test/session-state",
+    ]);
+    expect(authorizations).toEqual(["Bearer runner-test-token", "Bearer runner-test-token"]);
+  });
+
+  it("surfaces a refused session-state restore instead of retrying it", async () => {
+    const attempts: string[] = [];
+    const server = createServer((request, response) => {
+      attempts.push(request.url ?? "");
+      response.statusCode = 404;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: { code: "not_found" } }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    configureRunner(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
+
+    // A run with no stored archive is a cold start, not an outage, so it has to
+    // reach restoreSessionState's own reporting rather than spend the budget.
+    await expect(fetchSessionStateArchive("run_test")).rejects.toBeInstanceOf(FetchJsonError);
+    expect(attempts).toEqual(["/internal/runs/run_test/session-state"]);
+  });
+
+  it("replays a provably-undelivered failure under every policy, conservative ones included", async () => {
+    for (const [endpoint, policy] of Object.entries(ENDPOINT_RETRY_POLICIES)) {
+      const port = await reserveClosedPort();
+      // The path is synthesized from the table's key so a policy added later is
+      // covered without editing this test. What is under test is the policy
+      // object, not the route, so the bundle entry — whose real request goes to
+      // the absolute URL /hello hands back — is exercised the same way.
+      const path = `/internal/runs/run_test/${endpoint}`;
+      const requests: string[] = [];
+      const revival = new Promise<void>((resolve) => setTimeout(resolve, 30)).then(async () => {
+        const revived = createServer((request, response) => {
+          requests.push(request.url ?? "");
+          response.setHeader("content-type", "application/json");
+          response.end(JSON.stringify({ ok: true }));
+        });
+        servers.push(revived);
+        await new Promise<void>((resolve) => revived.listen(port, "127.0.0.1", resolve));
+      });
+
+      // Only the pacing is overridden. replaySafe — the decision under test — is
+      // whatever the endpoint declares, and a refused connection proves no
+      // handler ran, so every endpoint must ride the restart out.
+      await expect(
+        fetchJson(`http://127.0.0.1:${port}${path}`, {}, undefined, {
+          ...policy,
+          baseDelayMs: 5,
+          maxDelayMs: 20,
+        }),
+      ).resolves.toEqual({ ok: true });
+      await revival;
+      expect(requests).toEqual([path]);
+    }
   });
 });

--- a/runner/test/http-retry.integration.test.ts
+++ b/runner/test/http-retry.integration.test.ts
@@ -1,8 +1,18 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
-import { fetchJson, retryAfterMs } from "../src/index.js";
+import {
+  drainLineEvents,
+  FetchJsonError,
+  fetchJson,
+  isRunTerminalConflict,
+  isTransientFetchError,
+  retryAfterMs,
+  transientRetryDelayMs,
+} from "../src/index.js";
+import type { RunEvent } from "../src/types.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
 
@@ -127,5 +137,424 @@ describe("runner HTTP rate-limit recovery", () => {
 
     await expect(fetchJson(`http://127.0.0.1:${port}/events`)).rejects.toThrow("failed 429");
     expect(attempts).toBe(9);
+  });
+});
+
+describe("runner transient-failure classification", () => {
+  it("classifies syscall-level network failures as transient wherever undici nests them", () => {
+    const refused = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    expect(isTransientFetchError(new TypeError("fetch failed", { cause: refused }))).toBe(true);
+    const aggregate = new AggregateError([refused], "connect failed");
+    expect(isTransientFetchError(new TypeError("fetch failed", { cause: aggregate }))).toBe(true);
+    expect(isTransientFetchError(refused)).toBe(true);
+  });
+
+  it("classifies containerized-DNS loss and undici stall timeouts as transient", () => {
+    const notFound = Object.assign(new Error("getaddrinfo ENOTFOUND api"), { code: "ENOTFOUND" });
+    expect(isTransientFetchError(new TypeError("fetch failed", { cause: notFound }))).toBe(true);
+    const headersTimeout = Object.assign(new Error("Headers Timeout Error"), {
+      name: "HeadersTimeoutError",
+      code: "UND_ERR_HEADERS_TIMEOUT",
+    });
+    expect(isTransientFetchError(new TypeError("fetch failed", { cause: headersTimeout }))).toBe(
+      true,
+    );
+  });
+
+  it("keeps aborts, timeouts, and unknown failures fatal", () => {
+    const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(isTransientFetchError(abort)).toBe(false);
+    const timeout = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+    expect(isTransientFetchError(timeout)).toBe(false);
+    expect(isTransientFetchError(new TypeError("Invalid URL"))).toBe(false);
+    expect(isTransientFetchError(new Error("boom"))).toBe(false);
+    expect(isTransientFetchError(undefined)).toBe(false);
+  });
+
+  it("spreads retry delays inside a bounded, growing jitter window", () => {
+    expect(transientRetryDelayMs(0, 500, 10_000, () => 0)).toBe(250);
+    expect(transientRetryDelayMs(0, 500, 10_000, () => 1)).toBe(500);
+    expect(transientRetryDelayMs(2, 500, 10_000, () => 0)).toBe(1_000);
+    expect(transientRetryDelayMs(2, 500, 10_000, () => 1)).toBe(2_000);
+    expect(transientRetryDelayMs(10, 500, 10_000, () => 1)).toBe(10_000);
+  });
+
+  it("recognizes a run-terminal conflict as an already-recorded result", () => {
+    const terminal = new FetchJsonError(
+      "http://127.0.0.1/internal/runs/run_test/result",
+      409,
+      JSON.stringify({ error: { code: "run_terminal", message: "Run is terminal" } }),
+    );
+    expect(isRunTerminalConflict(terminal)).toBe(true);
+    const otherConflict = new FetchJsonError(
+      "http://127.0.0.1/internal/runs/run_test/result",
+      409,
+      JSON.stringify({ error: { code: "different_conflict", message: "no" } }),
+    );
+    expect(isRunTerminalConflict(otherConflict)).toBe(false);
+    const wrongStatus = new FetchJsonError(
+      "http://127.0.0.1/internal/runs/run_test/result",
+      503,
+      JSON.stringify({ error: { code: "run_terminal", message: "no" } }),
+    );
+    expect(isRunTerminalConflict(wrongStatus)).toBe(false);
+    const unparseable = new FetchJsonError("http://127.0.0.1/result", 409, "run_terminal");
+    expect(isRunTerminalConflict(unparseable)).toBe(false);
+    expect(isRunTerminalConflict(new Error("run_terminal"))).toBe(false);
+  });
+});
+
+describe("runner control-plane outage recovery", () => {
+  it("retries a connection-refused call until the control plane comes back", async () => {
+    const probe = createServer();
+    servers.push(probe);
+    await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+    const { port } = probe.address() as AddressInfo;
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve())),
+    );
+    servers.splice(servers.indexOf(probe), 1);
+
+    const revivedRequests: string[] = [];
+    // Restart the control plane on the same port mid-retry, like a dev watch
+    // or deploy restart of the API while the runner is in flight.
+    const revival = new Promise<void>((resolve) => setTimeout(resolve, 50)).then(async () => {
+      const revived = createServer((request, response) => {
+        revivedRequests.push(request.url ?? "");
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ ok: true }));
+      });
+      servers.push(revived);
+      await new Promise<void>((resolve) => revived.listen(port, "127.0.0.1", resolve));
+    });
+
+    await expect(
+      fetchJson(
+        `http://127.0.0.1:${port}/internal/runs/run_test/events`,
+        { method: "POST", headers: { "content-type": "application/json" }, body: "[]" },
+        undefined,
+        { budgetMs: 5_000, baseDelayMs: 5, maxDelayMs: 20 },
+      ),
+    ).resolves.toEqual({ ok: true });
+    await revival;
+    expect(revivedRequests).toEqual(["/internal/runs/run_test/events"]);
+  });
+
+  it("retries transient 5xx responses and succeeds when the API recovers", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts < 3) {
+        response.statusCode = 503;
+        response.end(JSON.stringify({ error: "restarting" }));
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/internal/runs/run_test/result`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 1,
+        maxDelayMs: 4,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(3);
+  });
+
+  it("does not spend the outage budget on a single failing attempt", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.statusCode = 503;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: "restarting" }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, { budgetMs: 0 }),
+    ).rejects.toThrow("failed 503");
+    expect(attempts).toBe(1);
+  });
+
+  it("gives up once the outage budget is exhausted", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.statusCode = 503;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: "still_down" }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 150,
+        baseDelayMs: 1,
+        maxDelayMs: 4,
+      }),
+    ).rejects.toThrow("failed 503");
+    expect(attempts).toBeGreaterThan(1);
+  });
+
+  it("does not retry non-transient client errors", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.statusCode = 400;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: "bad_request" }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 1,
+      }),
+    ).rejects.toThrow("failed 400");
+    expect(attempts).toBe(1);
+  });
+
+  it("grants one retry even when a slow failure consumed the whole budget", async () => {
+    const probe = createServer();
+    servers.push(probe);
+    await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+    const { port } = probe.address() as AddressInfo;
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve())),
+    );
+    servers.splice(servers.indexOf(probe), 1);
+
+    const revivedRequests: string[] = [];
+    const revival = new Promise<void>((resolve) => setTimeout(resolve, 10)).then(async () => {
+      const revived = createServer((request, response) => {
+        revivedRequests.push(request.url ?? "");
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ ok: true }));
+      });
+      servers.push(revived);
+      await new Promise<void>((resolve) => revived.listen(port, "127.0.0.1", resolve));
+    });
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 0,
+        baseDelayMs: 60,
+        maxDelayMs: 60,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await revival;
+    expect(revivedRequests).toEqual(["/events"]);
+  });
+
+  it("keeps rate-limit retries outside the transient outage budget", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts === 1) {
+        response.statusCode = 429;
+        response.setHeader("retry-after", "0");
+        response.end(JSON.stringify({ error: "rate_limited" }));
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, { budgetMs: 0 }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(2);
+  });
+
+  it("honors a server-requested Retry-After beyond the backoff", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts === 1) {
+        response.statusCode = 503;
+        response.setHeader("retry-after", "1");
+        response.end(JSON.stringify({ error: "recovering" }));
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const startedAt = Date.now();
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 1,
+        maxDelayMs: 4,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(2);
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900);
+  });
+
+  it("retries when the control plane dies between headers and body", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts === 1) {
+        response.setHeader("content-length", "100");
+        response.write("{");
+        response.destroy();
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 1,
+        maxDelayMs: 4,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(2);
+  });
+
+  it("keeps a failing 5xx retry loop paced even when Retry-After asks for zero delay", async () => {
+    let attempts = 0;
+    const server = createServer((_request, response) => {
+      attempts += 1;
+      response.setHeader("content-type", "application/json");
+      if (attempts < 2) {
+        response.statusCode = 503;
+        response.setHeader("retry-after", "0");
+        response.end(JSON.stringify({ error: "recovering" }));
+        return;
+      }
+      response.end(JSON.stringify({ ok: true }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const startedAt = Date.now();
+    await expect(
+      fetchJson(`http://127.0.0.1:${port}/events`, {}, undefined, {
+        budgetMs: 5_000,
+        baseDelayMs: 40,
+        maxDelayMs: 40,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(2);
+    // 20ms is half the 40ms jitter window — the floor Retry-After: 0 must not
+    // defeat.
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(20);
+  });
+
+  it("resumes the stream when event delivery fails for good, so the child can exit", async () => {
+    const stream = new PassThrough({ highWaterMark: 16 });
+    const draining = drainLineEvents(
+      stream,
+      "shell",
+      async () => {
+        throw new Error("delivery_failed");
+      },
+      { flushMs: 1 },
+    );
+    stream.write("first line\n");
+    await expect(draining).rejects.toThrow("delivery_failed");
+
+    // The write callback fires only if the resumed stream consumes the chunk;
+    // the guard timer wins if the failed drain left the pipe paused.
+    const flushed = new Promise<boolean>((resolve) => {
+      stream.write("x".repeat(1_024), () => resolve(true));
+    });
+    const guard = new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 500));
+    await expect(Promise.race([flushed, guard])).resolves.toBe(true);
+  });
+
+  it("buffers shell events during a control-plane restart and delivers them once, in order", async () => {
+    const batches: RunEvent[][] = [];
+    let firstBatchArrived: () => void = () => undefined;
+    const firstBatch = new Promise<void>((resolve) => {
+      firstBatchArrived = resolve;
+    });
+    const handler = (request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        batches.push(JSON.parse(body) as RunEvent[]);
+        firstBatchArrived();
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ count: 1 }));
+      });
+    };
+    const server = createServer(handler);
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const stream = new PassThrough();
+    const draining = drainLineEvents(
+      stream,
+      "shell",
+      (events) =>
+        fetchJson(
+          `http://127.0.0.1:${port}/internal/runs/run_test/events`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(events),
+          },
+          undefined,
+          { budgetMs: 5_000, baseDelayMs: 5, maxDelayMs: 20 },
+        ),
+      { flushMs: 1 },
+    );
+
+    stream.write("one\n");
+    await firstBatch;
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+    servers.splice(servers.indexOf(server), 1);
+
+    stream.write("two\n");
+    stream.write("three\n");
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    const revived = createServer(handler);
+    servers.push(revived);
+    await new Promise<void>((resolve) => revived.listen(port, "127.0.0.1", resolve));
+    stream.write("four\n");
+    stream.end();
+
+    await expect(draining).resolves.toBeUndefined();
+    expect(batches.flat().map((event) => event.data?.text)).toEqual([
+      "one",
+      "two",
+      "three",
+      "four",
+    ]);
   });
 });

--- a/runner/test/http-retry.integration.test.ts
+++ b/runner/test/http-retry.integration.test.ts
@@ -529,7 +529,9 @@ describe("runner control-plane outage recovery", () => {
     const server = createServer((request, response) => {
       attempts += 1;
       const polled = new URL(request.url ?? "/", "http://127.0.0.1");
-      for (const id of polled.searchParams.get("ack")?.split(",") ?? []) delivered.add(id);
+      // Every poll carries the parameter; only a non-empty value names ids.
+      const acked = polled.searchParams.get("ack");
+      for (const id of acked ? acked.split(",") : []) delivered.add(id);
       response.setHeader("content-type", "application/json");
       if (attempts === 1) {
         response.setHeader("content-length", "100");
@@ -849,7 +851,10 @@ describe("runner steer poll acknowledgement", () => {
   it("names every acked id in the query and encodes each one on its own", () => {
     const first = ackId("a");
     const second = ackId("b");
-    expect(steerPollPath("run_test", [])).toBe("/internal/runs/run_test/steer");
+    // The parameter is emitted even with nothing to acknowledge: its presence is
+    // what tells this protocol apart from the one that predates the ack, and a
+    // runner's first poll has nothing to name.
+    expect(steerPollPath("run_test", [])).toBe("/internal/runs/run_test/steer?ack=");
     expect(steerPollPath("run_test", [first, second])).toBe(
       `/internal/runs/run_test/steer?ack=${first},${second}`,
     );
@@ -871,10 +876,14 @@ describe("runner steer poll acknowledgement", () => {
     const served: string[][] = [];
     const pending = new Set([unwritable, applied]);
     const server = createServer((request, response) => {
-      // The server's own parse: comma-separated ids, each refused unless it is
-      // shaped like a message id, and delivery recorded from the ack alone.
+      // A stand-in for the route, not a copy of it: it splits the ack on commas
+      // and refuses anything not shaped like a message id, which is the part the
+      // path construction has to satisfy. It leaves out the route's ack cap, its
+      // run and org scope, its batch limit, and the protocol split that reads
+      // whether the parameter is there at all.
       const query = new URL(request.url ?? "/", "http://127.0.0.1").searchParams;
-      const ack = query.get("ack")?.split(",") ?? [];
+      const acked = query.get("ack");
+      const ack = acked ? acked.split(",") : [];
       if (!ack.every((id) => ACK_ID.test(id))) {
         response.statusCode = 400;
         response.end("{}");
@@ -927,10 +936,8 @@ describe("runner steer poll acknowledgement", () => {
     expect(polled).toEqual([[], [applied], [unwritable]]);
     expect(served).toEqual([[unwritable, applied], [unwritable], []]);
     expect(steers).toEqual(["tighten the diff", "onto a full disk"]);
-    // Nothing else acknowledged either message, and the run's whole ack traffic
-    // stays inside the 32-id cap the server enforces on one poll.
+    // Nothing else acknowledged either message.
     expect(polled.flat().sort()).toEqual([applied, unwritable].sort());
-    for (const ids of polled) expect(ids.length).toBeLessThanOrEqual(32);
   });
 });
 

--- a/runner/test/http-retry.integration.test.ts
+++ b/runner/test/http-retry.integration.test.ts
@@ -1001,6 +1001,7 @@ describe("runner per-endpoint replay policy", () => {
       steer: { replaySafe: true },
       transcript: { replaySafe: true },
       "session-state": { replaySafe: true },
+      workspace: { replaySafe: true },
       result: { budgetMs: 5 * 60_000, replaySafe: true },
       "push-token": { replaySafe: false },
       events: { replaySafe: false },

--- a/runner/test/steering-loop.test.ts
+++ b/runner/test/steering-loop.test.ts
@@ -1,0 +1,244 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ACKABLE_STEER_ID, ackableSteerIds, steeringPollLoop } from "../src/index.js";
+import type { RunEvent } from "../src/types.js";
+
+type ControlMessage = { id: string; body: string; kind?: string };
+
+// The shape the steer route's ack accepts, built the way newId("evt") builds it.
+const ackable = (suffix: string) => `evt_${suffix.padStart(32, "0")}`;
+
+// Stands in for the steer route: it records delivery from the ack, serves
+// whatever is still pending, and answers the moment anything is — so a message
+// that never reaches the ack is served again on every poll. That is the shape
+// the loop has to pace itself against.
+function fakeControlPlane(rows: ControlMessage[]) {
+  const pending = [...rows];
+  return {
+    add(row: ControlMessage) {
+      pending.push(row);
+    },
+    poll(ack: string[]) {
+      for (const id of ack) {
+        const index = pending.findIndex((row) => row.id === id);
+        if (index >= 0) pending.splice(index, 1);
+      }
+      return [...pending];
+    },
+  };
+}
+
+function harness(options: {
+  poll: (ack: string[], poll: number) => ControlMessage[] | Promise<ControlMessage[]>;
+  polls: number;
+  onSteer?: (body: string) => Promise<void>;
+  onInterrupt?: () => Promise<void>;
+  random?: () => number;
+}) {
+  const acks: string[][] = [];
+  const sleeps: number[] = [];
+  const steers: string[] = [];
+  const events: RunEvent[] = [];
+  const interrupts: number[] = [];
+  let polls = 0;
+  const done = steeringPollLoop({
+    poll: async (ack) => {
+      acks.push([...ack]);
+      polls += 1;
+      return await options.poll(ack, polls);
+    },
+    handlers: {
+      appendSteer: async (body) => {
+        steers.push(body);
+        await options.onSteer?.(body);
+      },
+      emit: async (batch) => {
+        events.push(...batch);
+      },
+      interrupt: async () => {
+        interrupts.push(polls);
+        await options.onInterrupt?.();
+      },
+    },
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+    isStopped: () => polls >= options.polls,
+    random: options.random ?? (() => 0),
+  });
+  return { done, acks, sleeps, steers, events, interrupts };
+}
+
+describe("steering poll pacing", () => {
+  it("backs off when a served batch reaches the ack with nothing new", async () => {
+    // An interrupt is never retired, so a kill that keeps throwing leaves the row
+    // pending for the rest of the run and the route serves it on every poll.
+    const control = fakeControlPlane([{ id: ackable("a1"), kind: "interrupt", body: "" }]);
+    const run = harness({
+      polls: 4,
+      poll: (ack) => control.poll(ack),
+      onInterrupt: async () => {
+        throw new Error("engine already gone");
+      },
+    });
+
+    await run.done;
+
+    expect(run.acks).toEqual([[], [], [], []]);
+    // Bounded exponential pacing, with the jitter pinned by random() === 0.
+    expect(run.sleeps).toEqual([500, 1_000, 2_000, 4_000]);
+    // The interrupt is still retried on every poll — pacing the channel must not
+    // retire an operator's stop.
+    expect(run.interrupts).toEqual([1, 2, 3, 4]);
+  });
+
+  it("keeps the stalled backoff bounded however long the message stays pending", async () => {
+    const control = fakeControlPlane([{ id: ackable("a2"), kind: "interrupt", body: "" }]);
+    const run = harness({
+      polls: 8,
+      poll: (ack) => control.poll(ack),
+      // The top of the jitter window, so each delay is the whole window.
+      random: () => 1,
+      onInterrupt: async () => {
+        throw new Error("engine already gone");
+      },
+    });
+
+    await run.done;
+
+    expect(run.sleeps).toEqual([1_000, 2_000, 4_000, 8_000, 15_000, 15_000, 15_000, 15_000]);
+  });
+
+  it("does not delay a poll whose message was handled", async () => {
+    // Interrupt latency is the reason this channel exists, so the ordinary path
+    // re-polls immediately.
+    const control = fakeControlPlane([]);
+    const run = harness({
+      polls: 3,
+      poll: (ack, poll) => {
+        control.add({ id: ackable(`${poll}`), body: `steer ${poll}` });
+        return control.poll(ack);
+      },
+    });
+
+    await run.done;
+
+    expect(run.sleeps).toEqual([]);
+    expect(run.acks).toEqual([[], [ackable("1")], [ackable("2")]]);
+    expect(run.steers).toEqual(["steer 1", "steer 2", "steer 3"]);
+  });
+
+  it("does not pace a poll the route answered with nothing", async () => {
+    const run = harness({ polls: 3, poll: () => [] });
+
+    await run.done;
+
+    // An empty answer already cost the route's own long-poll window.
+    expect(run.sleeps).toEqual([]);
+  });
+
+  it("reports the degraded window once the transport comes back", async () => {
+    const control = fakeControlPlane([{ id: ackable("a3"), body: "tighten the diff" }]);
+    const run = harness({
+      polls: 3,
+      poll: (ack, poll) => {
+        if (poll === 1) throw new Error("ECONNREFUSED");
+        return control.poll(ack);
+      },
+    });
+
+    await run.done;
+
+    expect(run.sleeps[0]).toBe(5_000);
+    expect(run.events).toContainEqual({
+      type: "artifact_error",
+      data: { kind: "steer_poll_degraded", failures: 1 },
+    });
+    expect(run.steers).toEqual(["tighten the diff"]);
+  });
+});
+
+describe("steer ack id filtering", () => {
+  it("accepts only the shape the steer route's ack accepts", () => {
+    expect(
+      ackableSteerIds([
+        ackable("ab"),
+        // Too short, wrong prefix, uppercase hex, and an id carrying the
+        // separator the runner encodes ids with.
+        "evt_",
+        `run_${"a".repeat(32)}`,
+        `evt_${"A".repeat(32)}`,
+        `${ackable("ab")},evt_second`,
+        `${ackable("ab")}&ack=evt_second`,
+      ]),
+    ).toEqual([ackable("ab")]);
+  });
+
+  it("matches the shape the route enforces, read from the route itself", () => {
+    // The wedge this filter closes is a disagreement between the two shapes, so
+    // the route's own literal is the only honest thing to compare against.
+    const route = readFileSync(
+      new URL("../../services/api/src/routes/internal.ts", import.meta.url),
+      "utf8",
+    );
+    const declared = /^(?:export )?const ACK_ID = (\/.+\/);$/m.exec(route);
+    // A route that stopped declaring the shape this way fails here rather than
+    // passing on an undefined match: the filter would then be guarding against
+    // a rule nobody can point at.
+    expect(declared?.[1]).toBe(String(ACKABLE_STEER_ID));
+  });
+
+  it("keeps the channel alive when a served id cannot be acked", async () => {
+    // Nothing writes a steer row with an id of another shape today; a row that
+    // had one would make every ack this runner sends get refused whole, and the
+    // channel would be dead for the rest of the run.
+    const legacy = { id: "steer_legacy", body: "read the runbook" };
+    const control = fakeControlPlane([legacy]);
+    const run = harness({
+      polls: 4,
+      poll: (ack, poll) => {
+        if (poll === 3) control.add({ id: ackable("b2"), body: "tighten the diff" });
+        return control.poll(ack);
+      },
+    });
+
+    await run.done;
+
+    // The unackable id never reaches the ack, so the ack that carries the good
+    // message is accepted instead of being refused along with it.
+    expect(run.acks).toEqual([[], [], [], [ackable("b2")]]);
+    // Its durable action landed once. Since the route keeps serving it, applying
+    // it again on every poll would append the same body to the steer file for the
+    // rest of the run, so it is applied once and then skipped locally.
+    expect(run.steers).toEqual(["read the runbook", "tighten the diff"]);
+    // Not silent: reported once, not once per redelivery.
+    expect(
+      run.events.filter(
+        (event) => (event.data as { kind?: string })?.kind === "steer_ack_id_unacceptable",
+      ),
+    ).toEqual([
+      { type: "artifact_error", data: { kind: "steer_ack_id_unacceptable", id: "steer_legacy" } },
+    ]);
+    // Paced, not spun: the two polls that ended with nothing acked backed off,
+    // and the poll that acked the good message did not.
+    expect(run.sleeps).toEqual([500, 1_000, 500]);
+  });
+
+  it("re-applies an interrupt whose id cannot be acked", async () => {
+    // An operator's stop must not be dropped for the shape of an id, and the
+    // handler absorbs a repeat: it re-sets the flag and starts the escalation
+    // only while none is pending.
+    const control = fakeControlPlane([{ id: "int_legacy", kind: "interrupt", body: "" }]);
+    const run = harness({ polls: 3, poll: (ack) => control.poll(ack) });
+
+    await run.done;
+
+    expect(run.interrupts).toEqual([1, 2, 3]);
+    expect(run.acks).toEqual([[], [], []]);
+    expect(
+      run.events.filter(
+        (event) => (event.data as { kind?: string })?.kind === "steer_ack_id_unacceptable",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/runner/test/steering-loop.test.ts
+++ b/runner/test/steering-loop.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ACKABLE_STEER_ID, ackableSteerIds, steeringPollLoop } from "../src/index.js";
 import type { RunEvent } from "../src/types.js";
 
@@ -156,6 +156,42 @@ describe("steering poll pacing", () => {
     });
     expect(run.steers).toEqual(["tighten the diff"]);
   });
+
+  it("records a steer channel that never comes back, once", async () => {
+    // A refused ack is re-sent unchanged on every later poll, so a 4xx the route
+    // answers to it never clears. Nothing in the loop reports that: the degraded
+    // event is emitted on the success path, after a poll resolves, so a channel
+    // that never resolves again emits nothing at all.
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const run = harness({
+      polls: 20,
+      poll: (_ack, poll) => {
+        throw new Error(`steer ack refused ${poll}`);
+      },
+    });
+    let records: string[] = [];
+    try {
+      await run.done;
+    } finally {
+      // Read before restoring: mockRestore clears the recorded calls with it.
+      records = stderr.mock.calls
+        .map(([chunk]) => String(chunk))
+        .filter((line) => line.startsWith("steer_poll_unreachable"));
+      stderr.mockRestore();
+    }
+
+    // One record per outage, not one per poll: 20 polls failed and the operator
+    // gets a single line naming how many and what the last one said.
+    expect(records).toHaveLength(1);
+    expect(records[0]).toContain("failures=12");
+    expect(records[0]).toContain("error=steer ack refused 12");
+    // The event path is untouched — it still has nothing to say while no poll
+    // resolves, which is the hole this record covers.
+    expect(run.events).toEqual([]);
+    // Nor is the retry pacing touched: every failed poll still waits out the
+    // fixed retry delay.
+    expect(new Set(run.sleeps)).toEqual(new Set([5_000]));
+  });
 });
 
 describe("steer ack id filtering", () => {
@@ -163,8 +199,9 @@ describe("steer ack id filtering", () => {
     expect(
       ackableSteerIds([
         ackable("ab"),
-        // Too short, wrong prefix, uppercase hex, and an id carrying the
-        // separator the runner encodes ids with.
+        // Too short, wrong prefix, uppercase hex, an id carrying the comma the
+        // runner separates ids with, and one carrying the ampersand that would
+        // otherwise open a second query parameter.
         "evt_",
         `run_${"a".repeat(32)}`,
         `evt_${"A".repeat(32)}`,
@@ -219,8 +256,11 @@ describe("steer ack id filtering", () => {
     ).toEqual([
       { type: "artifact_error", data: { kind: "steer_ack_id_unacceptable", id: "steer_legacy" } },
     ]);
-    // Paced, not spun: the two polls that ended with nothing acked backed off,
-    // and the poll that acked the good message did not.
+    // Paced, not spun, and the backoff belongs to the streak rather than to the
+    // run: the first two polls acked nothing and backed off, the poll that acked
+    // the good message was not delayed at all, and the fourth — served the
+    // unackable row again — starts the backoff over at the base delay, because
+    // that ack reset the counter.
     expect(run.sleeps).toEqual([500, 1_000, 500]);
   });
 

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -1364,7 +1364,9 @@ describe("discarded result logging", () => {
     // Truncation is visible, so an operator reading the line knows the message
     // continues rather than believing Git said only this much.
     expect(line).toContain("...[truncated]");
-    // Still one greppable line whose later fields survive the bound.
+    // Still one greppable line: push_error is the last field, so nothing follows
+    // it to survive — what the bound must leave intact is the fields ahead of it
+    // and the single trailing newline.
     expect(line.endsWith("\n")).toBe(true);
     expect(line.trimEnd()).not.toContain("\n");
     expect(line).toContain("branch=-");
@@ -1887,6 +1889,58 @@ describe("Claude resume controls", () => {
     expect(again.handled).toEqual(["msg_9"]);
     expect(again.error).toBeUndefined();
     expect(events).toHaveLength(1);
+  });
+
+  it("records a retired steer on stderr even when the event never gets out", async () => {
+    const emitted: string[] = [];
+    const handlers = {
+      appendSteer: async () => {
+        throw new Error(`no space left on device ${"x".repeat(60_000)}`);
+      },
+      emit: async () => {
+        // What the control plane answers once the run is terminal: authenticate
+        // refuses every /internal/runs/:runId route with 409 run_terminal, and
+        // applyControlMessages drops that rejection.
+        emitted.push("refused");
+        throw new Error("run_terminal");
+      },
+      interrupt: async () => undefined,
+    };
+    const messages = [{ id: "msg_12", kind: "steer", body: "tighten the diff" }];
+    const failures = new Map<string, number>();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    let records: string[] = [];
+    let handled: string[] = [];
+    try {
+      for (let attempt = 0; attempt < CONTROL_MESSAGE_MAX_ATTEMPTS + 2; attempt += 1) {
+        handled = (await applyControlMessages(messages, handlers, failures)).handled;
+      }
+    } finally {
+      // Read before restoring: mockRestore clears the recorded calls with it.
+      records = stderr.mock.calls
+        .map(([chunk]) => String(chunk))
+        .filter((line) => line.startsWith("steer_undeliverable"));
+      stderr.mockRestore();
+    }
+
+    // The operator's instruction was thrown away and its id acked anyway, so the
+    // route marks the row delivered. Every attempt at the event that would have
+    // said so was refused, which leaves the container log as the only record.
+    expect(handled).toEqual(["msg_12"]);
+    expect(emitted.length).toBeGreaterThan(0);
+    expect(records).toHaveLength(1);
+    const [record = ""] = records;
+    expect(record).toContain("id=msg_12");
+    expect(record).toContain(`attempts=${CONTROL_MESSAGE_MAX_ATTEMPTS}`);
+    expect(record).toContain("error=no space left on device xxx");
+    // Bounded like the discarded-result record: the error is whatever the
+    // durable action threw, so it may not turn the container log into a wall of
+    // text, and the truncation is visible rather than silent.
+    expect(record).toContain("...[truncated]");
+    expect(record.length).toBeLessThan(1_000);
+    expect(record.endsWith("\n")).toBe(true);
+    expect(record.trimEnd()).not.toContain("\n");
   });
 
   it("never gives up on an interrupt, and still reports it once", async () => {

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -15,8 +15,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyControlMessages,
   buildClaudeCodeArgs,
   buildCodexArgs,
+  CONTROL_MESSAGE_MAX_ATTEMPTS,
   claudeDeliverySettings,
   composedPrompt,
   createWorkspaceCheckpoint,
@@ -50,6 +52,7 @@ import {
   resumeRecoveryPrompt,
   runnerReceiptActivity,
   runPackageInstall,
+  runTerminalDiscardLog,
   semanticDeliveryBranch,
   terminateChild,
   trustClaudeWorkspace,
@@ -1298,6 +1301,103 @@ describe("delivery phase reporting", () => {
   });
 });
 
+describe("discarded result logging", () => {
+  it("records the conflict coordinates without the pull request title or body", () => {
+    const line = runTerminalDiscardLog("succeeded", {
+      changed: true,
+      branch: "feature/task",
+      headSha: "signed_sha",
+      pullRequestTitle: "fix: rewrite the auth handler",
+      pullRequestBody:
+        "## Summary\n\n- The staging login uses sb_secret_pastedbytheagent to reach the sandbox.",
+    });
+
+    expect(line).toContain("result_discarded_run_terminal");
+    expect(line).toContain("attempted_status=succeeded");
+    expect(line).toContain("changed=true");
+    expect(line).toContain("branch=feature/task");
+    expect(line).toContain("head_sha=signed_sha");
+    expect(line).not.toContain("rewrite the auth handler");
+    expect(line).not.toContain("Summary");
+    expect(line).not.toContain("staging login");
+    expect(line).not.toContain("sb_secret_");
+  });
+
+  it("redacts an injected secret that reaches the push error", () => {
+    const line = runTerminalDiscardLog(
+      "failed",
+      { changed: true, pushError: "github request rejected ghs_pushtokenvalue" },
+      ["ghs_pushtokenvalue"],
+    );
+
+    expect(line).not.toContain("ghs_pushtokenvalue");
+    expect(line).toBe(
+      "result_discarded_run_terminal attempted_status=failed changed=true branch=- head_sha=- push_error=github request rejected «redacted»\n",
+    );
+  });
+
+  it("redacts a token-shaped repair branch", () => {
+    const line = runTerminalDiscardLog(
+      "failed",
+      { changed: true, branch: "ghs_BranchNamedAfterAToken", headSha: "signed_sha" },
+      ["ghs_BranchNamedAfterAToken"],
+    );
+
+    expect(line).not.toContain("ghs_BranchNamedAfterAToken");
+    expect(line).toContain("branch=«redacted»");
+    expect(line).toContain("head_sha=signed_sha");
+  });
+
+  it("bounds a push error instead of copying a whole Git stderr into the container log", () => {
+    // readAgentDeliveryMetadata admits 60000 characters of agent prose, and a
+    // captured Git stderr can quote the branch and path the agent named, so the
+    // claim that this record carries "one bounded field" has to be enforced here
+    // rather than assumed of Git.
+    const line = runTerminalDiscardLog(
+      "failed",
+      { changed: true, pushError: "x".repeat(60_000) },
+      [],
+    );
+
+    expect(line.length).toBeLessThan(1_000);
+    expect(line).toContain("push_error=xxx");
+    // Truncation is visible, so an operator reading the line knows the message
+    // continues rather than believing Git said only this much.
+    expect(line).toContain("...[truncated]");
+    // Still one greppable line whose later fields survive the bound.
+    expect(line.endsWith("\n")).toBe(true);
+    expect(line.trimEnd()).not.toContain("\n");
+    expect(line).toContain("branch=-");
+  });
+
+  it("redacts before bounding so a secret straddling the cut leaves no prefix behind", () => {
+    const secret = `ghs_${"s".repeat(40)}`;
+    const line = runTerminalDiscardLog(
+      "failed",
+      { changed: true, pushError: `${"x".repeat(500)}${secret} rejected` },
+      [secret],
+    );
+
+    // Truncating first would cut the token in half and publish the half the
+    // bound left behind, which no later redaction pass can match.
+    expect(line).not.toContain("ghs_");
+    expect(line).toContain("«redacted»");
+  });
+
+  it.each([
+    { name: "no git object at all", git: undefined },
+    { name: "a git object without changes", git: { changed: false } },
+  ])("renders one parseable line for $name", ({ git }) => {
+    const line = runTerminalDiscardLog("canceled", git);
+
+    expect(line).toBe(
+      "result_discarded_run_terminal attempted_status=canceled changed=false branch=- head_sha=- push_error=-\n",
+    );
+    expect(line).not.toContain("undefined");
+    expect(line).not.toContain("null");
+  });
+});
+
 async function expectProcessToExit(pid: number) {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     try {
@@ -1666,8 +1766,8 @@ describe("Claude resume controls", () => {
         },
       ),
     ).resolves.toBe("interrupt");
-    // The server marks a control message delivered on fetch, so it is never
-    // re-delivered: the kill must land before, and regardless of, the ack.
+    // The steer event is observability, not the delivery ack: the kill must
+    // land before, and regardless of, it.
     expect(calls[0]).toBe("interrupt");
   });
 
@@ -1688,6 +1788,155 @@ describe("Claude resume controls", () => {
       ),
     ).resolves.toBe("steer");
     expect(steers).toEqual(["adjust"]);
+  });
+
+  it("acknowledges only the control messages whose durable action landed", async () => {
+    const applied: string[] = [];
+    const handlers = (failOn?: string) => ({
+      appendSteer: async (body: string) => {
+        if (body === failOn) throw new Error("steer file unwritable");
+        applied.push(body);
+      },
+      emit: async () => undefined,
+      interrupt: async () => undefined,
+    });
+    const messages = [
+      { id: "msg_5", kind: "steer", body: "first" },
+      { id: "msg_6", kind: "steer", body: "second" },
+    ];
+
+    // The acked ids are the server-side delivery record, so a message whose
+    // durable action threw must stay out of them and come back on the next poll.
+    const partial = await applyControlMessages(messages, handlers("second"));
+    expect(partial.handled).toEqual(["msg_5"]);
+    expect(partial.error).toBeInstanceOf(Error);
+    expect(applied).toEqual(["first"]);
+
+    const complete = await applyControlMessages(messages, handlers());
+    expect(complete).toEqual({ handled: ["msg_5", "msg_6"] });
+    expect(applied).toEqual(["first", "first", "second"]);
+  });
+
+  it("applies an interrupt queued behind a message it cannot handle", async () => {
+    let interrupted = false;
+    const handlers = {
+      appendSteer: async () => {
+        throw new Error("no space left on device");
+      },
+      emit: async () => undefined,
+      interrupt: async () => {
+        interrupted = true;
+      },
+    };
+
+    const applied = await applyControlMessages(
+      [
+        { id: "msg_7", kind: "steer", body: "tighten the diff" },
+        { id: "msg_8", kind: "interrupt", body: "human_interrupt" },
+      ],
+      handlers,
+    );
+
+    // A steer that can never land must not hold the line in front of a kill:
+    // the operator pressed stop and the batch it arrived in is irrelevant.
+    expect(interrupted).toBe(true);
+    expect(applied.handled).toEqual(["msg_8"]);
+    expect(applied.error).toBeInstanceOf(Error);
+  });
+
+  it("gives up on a steer that keeps failing, with one diagnostic", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handlers = {
+      appendSteer: async () => {
+        throw new Error("no space left on device");
+      },
+      emit: async (batch: Array<{ type: string; data?: Record<string, unknown> }>) => {
+        events.push(...batch.map((event) => ({ type: event.type, ...event.data })));
+      },
+      interrupt: async () => undefined,
+    };
+    const messages = [{ id: "msg_9", kind: "steer", body: "tighten the diff" }];
+    const failures = new Map<string, number>();
+
+    // Attempts short of the bound leave the message unacked, so the server
+    // serves it again — the poll loop is what retries it.
+    const first = await applyControlMessages(messages, handlers, failures, 3);
+    const second = await applyControlMessages(messages, handlers, failures, 3);
+    expect(first.handled).toEqual([]);
+    expect(second.handled).toEqual([]);
+    expect(events).toEqual([]);
+
+    // At the bound it is acked anyway: an unappliable message may not keep the
+    // channel and the artifact_error stream looping on it forever.
+    const third = await applyControlMessages(messages, handlers, failures, 3);
+    expect(third.handled).toEqual(["msg_9"]);
+    expect(events).toEqual([
+      {
+        type: "artifact_error",
+        kind: "steer_undeliverable",
+        id: "msg_9",
+        attempts: 3,
+        error: "no space left on device",
+      },
+    ]);
+
+    // If that ack is the one lost on the wire the message comes back. It is
+    // re-acked so the server stops serving it, but the handler is not retried
+    // and the diagnostic is not emitted twice.
+    const again = await applyControlMessages(messages, handlers, failures, 3);
+    expect(again.handled).toEqual(["msg_9"]);
+    expect(again.error).toBeUndefined();
+    expect(events).toHaveLength(1);
+  });
+
+  it("never gives up on an interrupt, and still reports it once", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    let interruptAttempts = 0;
+    const handlers = {
+      appendSteer: async () => undefined,
+      emit: async (batch: Array<{ type: string; data?: Record<string, unknown> }>) => {
+        events.push(...batch.map((event) => ({ type: event.type, ...event.data })));
+      },
+      interrupt: async () => {
+        interruptAttempts += 1;
+        throw new Error("engine child unreachable");
+      },
+    };
+    const messages = [
+      { id: "msg_10", kind: "interrupt", body: "human_interrupt" },
+      { id: "msg_11", kind: "steer", body: "tighten the diff" },
+    ];
+    const failures = new Map<string, number>();
+
+    // An operator's stop is the message this whole channel exists to not lose,
+    // so the attempt bound that retires a steer must never retire it: past the
+    // bound it is still absent from the ack, so the server keeps serving it and
+    // every poll retries the kill.
+    const polls = CONTROL_MESSAGE_MAX_ATTEMPTS + 2;
+    for (let poll = 0; poll < polls; poll += 1) {
+      const applied = await applyControlMessages(messages, handlers, failures);
+      // The steer behind it still lands on every poll: no early return, so a
+      // message that cannot be applied never holds the line in front of the
+      // rest of the batch.
+      expect(applied.handled).toEqual(["msg_11"]);
+      expect(applied.error).toBeInstanceOf(Error);
+    }
+    expect(interruptAttempts).toBe(polls);
+
+    // The failures map is what keeps the diagnostic single: the count still
+    // climbs past the bound, so the report fires on the attempt that reaches it
+    // and never again.
+    expect(events.filter((event) => event.type === "artifact_error")).toEqual([
+      {
+        type: "artifact_error",
+        kind: "steer_undeliverable",
+        id: "msg_10",
+        attempts: CONTROL_MESSAGE_MAX_ATTEMPTS,
+        error: "engine child unreachable",
+      },
+    ]);
+    expect(events.filter((event) => event.type === "steer")).toHaveLength(polls);
+    expect(failures.get("msg_10")).toBe(polls);
   });
 
   it("signals SIGTERM before SIGKILL on interrupt termination", () => {

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -1649,6 +1649,47 @@ describe("Claude resume controls", () => {
     );
   });
 
+  it("interrupts before any ack, even when the event transport is down", async () => {
+    const calls: string[] = [];
+    await expect(
+      handleControlMessage(
+        { id: "msg_3", kind: "interrupt", body: "stop" },
+        {
+          appendSteer: async () => undefined,
+          emit: async () => {
+            calls.push("emit");
+            throw new Error("control plane down");
+          },
+          interrupt: async () => {
+            calls.push("interrupt");
+          },
+        },
+      ),
+    ).resolves.toBe("interrupt");
+    // The server marks a control message delivered on fetch, so it is never
+    // re-delivered: the kill must land before, and regardless of, the ack.
+    expect(calls[0]).toBe("interrupt");
+  });
+
+  it("applies a steer even when its ack cannot be delivered", async () => {
+    const steers: string[] = [];
+    await expect(
+      handleControlMessage(
+        { id: "msg_4", kind: "steer", body: "adjust" },
+        {
+          appendSteer: async (body) => {
+            steers.push(body);
+          },
+          emit: async () => {
+            throw new Error("control plane down");
+          },
+          interrupt: async () => undefined,
+        },
+      ),
+    ).resolves.toBe("steer");
+    expect(steers).toEqual(["adjust"]);
+  });
+
   it("signals SIGTERM before SIGKILL on interrupt termination", () => {
     const signals: string[] = [];
     const timers: Array<() => void> = [];

--- a/services/api/src/github/security-findings.ts
+++ b/services/api/src/github/security-findings.ts
@@ -63,9 +63,16 @@ export async function syncSecurityFindings(
   client: FacilityGithubClient,
   report: SecurityReport,
   source: { runId: string },
+  assertOwnership?: () => Promise<void>,
 ) {
   const synced = [];
   for (const finding of qualifyingSecurityFindings(report)) {
+    // Each finding costs several GitHub calls, so a long report is where a
+    // finalization attempt outlives its lease. The caller's assertion re-proves
+    // ownership before every finding, not only between finalization steps: an
+    // attempt that stalled and was superseded stops here, before it can race
+    // the winning attempt's ensureTrackedIssue into a duplicate issue.
+    await assertOwnership?.();
     const issue = await ensureTrackedIssue(client, {
       kind: "security",
       fingerprint: finding.fingerprint,

--- a/services/api/src/routes/internal.ts
+++ b/services/api/src/routes/internal.ts
@@ -29,30 +29,45 @@ const GitCommitSha = z.string().regex(/^[0-9a-f]{40}$/i);
 // route takes only ids it could have issued: a list carrying anything else is
 // refused whole, before any of it reaches a query.
 const ACK_ID = /^evt_[0-9a-f]{32}$/;
-// An ack can only name ids from a batch this route served, and STEER_BATCH caps
-// a batch. The bound stays above that so it remains a sanity limit on the query
-// rather than something a change to the batch size silently invalidates.
+// How many ids one request may name. A caller is expected to name ids from a
+// batch this route served — STEER_BATCH caps a batch — but that is the caller's
+// convention and nothing here checks it: what this route enforces is the id
+// shape, this length, and the run and org the update runs under, so an id that
+// never reached this caller is simply an id the update matches no row for. The
+// bound has to stay at or above STEER_BATCH, which a steer-ack test pins,
+// because an ack of a full batch past it is refused whole and the runner
+// re-sends that same list on every later poll.
 export const STEER_ACK_MAX = 32;
-const STEER_BATCH = 10;
-// One ack parameter, or several, each holding a comma-separated list. Exported
-// so the id rule can be tested as a rule: from outside the route every refusal
-// is the same 400, which says nothing about which shapes the rule refuses.
+// The most rows one poll is answered with. Exported for the test that keeps it
+// inside the bound above.
+export const STEER_BATCH = 10;
+// One ack parameter, or several, each holding a comma-separated list. The
+// parameter absent stays undefined rather than becoming an empty list: presence
+// is what tells this route which protocol the caller speaks, and a poll with
+// nothing to acknowledge still carries the parameter, empty. Exported so the id
+// rule can be tested as a rule: from outside the route every refusal is the same
+// 400, which says nothing about which shapes the rule refuses.
 export const SteerAck = z
   .union([z.string(), z.array(z.string())])
   .optional()
-  .transform((value) =>
-    value === undefined
-      ? []
-      : (Array.isArray(value) ? value : [value]).flatMap((entry) => entry.split(",")),
-  )
+  .transform((value) => {
+    if (value === undefined) return undefined;
+    // Joined before splitting so that a wholly empty parameter — and only that —
+    // is the acknowledgment of nothing. An empty entry beside others survives
+    // into the list and fails the id rule below, which refuses the request whole.
+    const joined = Array.isArray(value) ? value.join(",") : value;
+    return joined === "" ? [] : joined.split(",");
+  })
   .refine(
-    (ids) => ids.length <= STEER_ACK_MAX && ids.every((id) => ACK_ID.test(id)),
+    (ids) =>
+      ids === undefined || (ids.length <= STEER_ACK_MAX && ids.every((id) => ACK_ID.test(id))),
     `ack takes up to ${STEER_ACK_MAX} comma-separated message ids`,
   );
-// The cursor this route took before the ack. A request carrying it marks rows
-// delivered, so it is held to the same id rule for the same reason: only an id
-// this route could have issued reaches a query, and a list — which the cursor
-// never was — is refused outright.
+// The cursor this route took before the ack. A request this route reads the
+// cursor from marks rows delivered from the select that served them, so the
+// cursor is held to the same id rule for the same reason: only an id this route
+// could have issued reaches a query, and a list — which the cursor never was —
+// is refused outright.
 const SteerAfterId = z.string().regex(ACK_ID).optional();
 const TRANSCRIPT_MAX_BYTES = 50 * 1024 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
@@ -301,8 +316,8 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     async (request) => {
       const run = (request as RunnerRequest).runnerRun;
       if (!run) throw notFound("Run not found");
-      const { ack, afterId } = request.query as { ack: string[]; afterId?: string };
-      if (ack.length > 0) {
+      const { ack, afterId } = request.query as { ack?: string[]; afterId?: string };
+      if (ack !== undefined && ack.length > 0) {
         // Delivery is recorded from the ack, not from the select that served the
         // batch: marking on the select loses a message whenever the response
         // drops on the wire — an operator's stop goes with it, and no error
@@ -325,6 +340,12 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
             and(
               eq(steerMessages.orgId, run.orgId),
               eq(steerMessages.runId, run.id),
+              // A delivery is written once. The runner re-sends an ack whose
+              // response it never saw, and that replay names rows this statement
+              // already marked: without this clause the replay would move their
+              // timestamps, with it the update matches nothing at all. Applying
+              // the same request twice therefore leaves the same rows in the same
+              // state, which is what lets the runner retry an ambiguous poll.
               isNull(steerMessages.deliveredAt),
               inArray(steerMessages.id, ack),
             ),
@@ -334,18 +355,20 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
       // shipped can still be polling. A run keeps the runner image dispatch
       // launched its sandbox with, so during the deploy that ships this route
       // every run already in flight speaks the protocol this branch replaced: it
-      // polls with afterId, applies what comes back, and starts the next poll
-      // with no delay of its own, relying on the response to have retired the
-      // rows it just applied. Served by the ack path alone, that poll marks
-      // nothing, so it is handed the same rows again on every iteration — one
-      // more copy of the same steer body appended per iteration, as fast as this
-      // route can answer. So a request that names no ack and does carry the
-      // cursor — which no runner built after this change sends — gets the
-      // previous semantics back for that request: rows above the cursor, marked
-      // delivered by the select that served them. Anything carrying an ack is a
-      // runner that retires its own rows by id and takes the path above, cursor
-      // beside it or not.
-      const cursor = ack.length > 0 ? undefined : afterId;
+      // polls, applies what comes back, and starts the next poll with no delay of
+      // its own, relying on the response to have retired the rows it just
+      // applied. Its cursor cannot identify it — it has none until a batch gives
+      // it one, so its first poll carries no parameter at all and looks exactly
+      // like a poll acknowledging nothing. The ack parameter can: a runner built
+      // after this change sends it on every poll, empty when it has nothing to
+      // name, and one built before this change sends it at no point in its life.
+      // So a request carrying no ack parameter gets the previous semantics for
+      // that request — rows above the cursor when one came with it, marked
+      // delivered by the select that served them — and a request carrying the
+      // parameter, empty or not, is a runner that retires its own rows by id and
+      // takes the path above, cursor beside it or not.
+      const legacyPoll = ack === undefined;
+      const cursor = legacyPoll ? afterId : undefined;
       const deadline = Date.now() + 25_000;
       while (Date.now() < deadline) {
         const messages = await db
@@ -353,7 +376,12 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
           .from(steerMessages)
           // Served under the same org scope the ack mutates: a row this run's
           // org cannot acknowledge is a row it must not be handed either, or the
-          // channel wedges on a message that returns on every poll.
+          // channel wedges on a message that returns on every poll. No writer
+          // makes such a row today: there are four — steer and interrupt over
+          // /v1, and the two matching agent tools — and each resolves the run
+          // inside the caller's org before stamping the row with that same org.
+          // So this predicate is defence against a mis-scoped writer rather than
+          // a hazard anything currently produces.
           .where(
             and(
               eq(steerMessages.orgId, run.orgId),
@@ -373,11 +401,13 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
           .orderBy(asc(steerMessages.createdAt), asc(steerMessages.id))
           .limit(STEER_BATCH);
         if (messages.length > 0) {
-          if (cursor) {
+          if (legacyPoll) {
             // The compatibility path's mark-on-select, scoped exactly like the
-            // ack update above. A poll that predates the ack has no other way to
-            // say what it handled, so this response is the only thing that can
-            // retire these rows for it.
+            // ack update above, and run whether or not a cursor came with the
+            // request: the first poll of a runner that predates the ack has no
+            // cursor yet, and it needs its rows retired as much as any later one.
+            // Such a poll has no way of its own to say what it handled, so this
+            // response is the only thing that can retire these rows for it.
             await db
               .update(steerMessages)
               .set({ deliveredAt: new Date() })

--- a/services/api/src/routes/internal.ts
+++ b/services/api/src/routes/internal.ts
@@ -14,11 +14,16 @@ import {
   createGithubInstallationTokenFactory,
 } from "../github/client.js";
 import { collectGithubSecuritySweepEvidence } from "../github/security-sweep.js";
-import { finishRun, updateGithubRunProgress } from "../sandbox/orchestrator.js";
+import {
+  FinalizationInProgressError,
+  finishRun,
+  updateGithubRunProgress,
+} from "../sandbox/orchestrator.js";
 import {
   appendRunEvents,
   type RunSandboxState,
   readSandbox,
+  resultFinalizationPending,
   terminalStatus,
 } from "../sandbox/state.js";
 import type { AppConfig } from "../types.js";
@@ -101,19 +106,35 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     );
   }
 
-  async function authenticate(request: FastifyRequest) {
+  async function authenticateRunner(
+    request: FastifyRequest,
+    // Whether a terminal run is still admitted while the finalization its
+    // /result claim started has not been recorded complete. Only /result asks
+    // for it: that is the request the runner replays after a lost response, and
+    // the one finishRun knows how to resume. Every other route stays refused
+    // the moment the run is terminal — an event or a steer poll has nothing
+    // left to do for a run whose verdict is committed.
+    resumesFinalization: boolean,
+  ) {
     const { runId } = request.params as { runId: string };
     const token = bearer(request.headers.authorization);
     if (!token) throw new ApiError(401, "unauthorized", "Runner token required");
     const run = (await db.select().from(runs).where(eq(runs.id, runId)).limit(1))[0];
     if (!run) throw notFound("Run not found");
-    if (terminalStatus(run.status)) throw new ApiError(409, "run_terminal", "Run is terminal");
     const sandbox = readSandbox(run.sandbox);
+    if (
+      terminalStatus(run.status) &&
+      !(resumesFinalization && resultFinalizationPending(sandbox))
+    ) {
+      throw new ApiError(409, "run_terminal", "Run is terminal");
+    }
     if (!sandbox.runnerTokenHash || !(await verifyKey(token, sandbox.runnerTokenHash))) {
       throw new ApiError(401, "unauthorized", "Invalid runner token");
     }
     (request as RunnerRequest).runnerRun = run;
   }
+  const authenticate = (request: FastifyRequest) => authenticateRunner(request, false);
+  const authenticateResult = (request: FastifyRequest) => authenticateRunner(request, true);
 
   app.post(
     "/internal/runs/:runId/hello",
@@ -582,7 +603,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     "/internal/runs/:runId/result",
     {
       config: { public: true },
-      preHandler: authenticate,
+      preHandler: authenticateResult,
       schema: {
         params: Params,
         body: z.object({
@@ -606,7 +627,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         response: { 200: z.record(z.string(), z.unknown()) },
       },
     },
-    async (request) => {
+    async (request, reply) => {
       const run = (request as RunnerRequest).runnerRun;
       if (!run) throw notFound("Run not found");
       const body = request.body as {
@@ -625,11 +646,27 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         engineSessionId?: string;
         securityReport?: unknown;
       };
-      return (await finishRun(db, run, body, {
-        config,
-        githubClientFactory: app.githubClientFactory,
-        enqueue: app.enqueue,
-      })) as unknown as Record<string, unknown>;
+      try {
+        return (await finishRun(db, run, body, {
+          config,
+          githubClientFactory: app.githubClientFactory,
+          enqueue: app.enqueue,
+        })) as unknown as Record<string, unknown>;
+      } catch (error) {
+        if (!(error instanceof FinalizationInProgressError)) throw error;
+        // A replay while another attempt holds the finalization: the runner
+        // retries a 503 on this endpoint and honors the wait, and the code is
+        // exposed so the reply says what is being waited on rather than
+        // masking it as an internal error.
+        reply.header("retry-after", String(Math.ceil(error.retryAfterMs / 1000)));
+        throw new ApiError(
+          503,
+          "finalization_in_progress",
+          "Run finalization is in progress; retry after the lease expires",
+          undefined,
+          true,
+        );
+      }
     },
   );
 

--- a/services/api/src/routes/internal.ts
+++ b/services/api/src/routes/internal.ts
@@ -25,6 +25,35 @@ import type { AppConfig } from "../types.js";
 
 const Params = z.object({ runId: z.string() });
 const GitCommitSha = z.string().regex(/^[0-9a-f]{40}$/i);
+// Exactly what newId("evt") produces. An ack names rows to mutate, so this
+// route takes only ids it could have issued: a list carrying anything else is
+// refused whole, before any of it reaches a query.
+const ACK_ID = /^evt_[0-9a-f]{32}$/;
+// An ack can only name ids from a batch this route served, and STEER_BATCH caps
+// a batch. The bound stays above that so it remains a sanity limit on the query
+// rather than something a change to the batch size silently invalidates.
+export const STEER_ACK_MAX = 32;
+const STEER_BATCH = 10;
+// One ack parameter, or several, each holding a comma-separated list. Exported
+// so the id rule can be tested as a rule: from outside the route every refusal
+// is the same 400, which says nothing about which shapes the rule refuses.
+export const SteerAck = z
+  .union([z.string(), z.array(z.string())])
+  .optional()
+  .transform((value) =>
+    value === undefined
+      ? []
+      : (Array.isArray(value) ? value : [value]).flatMap((entry) => entry.split(",")),
+  )
+  .refine(
+    (ids) => ids.length <= STEER_ACK_MAX && ids.every((id) => ACK_ID.test(id)),
+    `ack takes up to ${STEER_ACK_MAX} comma-separated message ids`,
+  );
+// The cursor this route took before the ack. A request carrying it marks rows
+// delivered, so it is held to the same id rule for the same reason: only an id
+// this route could have issued reaches a query, and a list — which the cursor
+// never was — is refused outright.
+const SteerAfterId = z.string().regex(ACK_ID).optional();
 const TRANSCRIPT_MAX_BYTES = 50 * 1024 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
 const EventBatch = z.array(
@@ -265,37 +294,105 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
       preHandler: authenticate,
       schema: {
         params: Params,
-        querystring: z.object({ afterId: z.string().optional() }),
+        querystring: z.object({ ack: SteerAck, afterId: SteerAfterId }),
         response: { 200: z.array(z.record(z.string(), z.unknown())) },
       },
     },
     async (request) => {
       const run = (request as RunnerRequest).runnerRun;
       if (!run) throw notFound("Run not found");
-      const { afterId } = request.query as { afterId?: string };
+      const { ack, afterId } = request.query as { ack: string[]; afterId?: string };
+      if (ack.length > 0) {
+        // Delivery is recorded from the ack, not from the select that served the
+        // batch: marking on the select loses a message whenever the response
+        // drops on the wire — an operator's stop goes with it, and no error
+        // surfaces anywhere. What the server enforces is exactly this much — a
+        // row flips to delivered when a poll authenticated for its run names its
+        // exact id inside that run's org. That the runner names an id only once
+        // the message's durable action landed is the runner's half of the
+        // contract: assumed here, not checked. Redelivery reaches that same
+        // runner, because dispatch claims a run out of "queued" before launching
+        // one sandbox for it, and /resume starts a new run id whose steer rows
+        // are separate. Exact ids also spare a row that became visible only
+        // after this ack was earned: ids come from per-process uuidv7 counters,
+        // so two API tasks can commit one run's messages in an order that
+        // disagrees with their id order, and a range ack would mark such a row
+        // delivered without ever serving it.
+        await db
+          .update(steerMessages)
+          .set({ deliveredAt: new Date() })
+          .where(
+            and(
+              eq(steerMessages.orgId, run.orgId),
+              eq(steerMessages.runId, run.id),
+              isNull(steerMessages.deliveredAt),
+              inArray(steerMessages.id, ack),
+            ),
+          );
+      }
+      // Transitional, and deletable once no sandbox launched before this change
+      // shipped can still be polling. A run keeps the runner image dispatch
+      // launched its sandbox with, so during the deploy that ships this route
+      // every run already in flight speaks the protocol this branch replaced: it
+      // polls with afterId, applies what comes back, and starts the next poll
+      // with no delay of its own, relying on the response to have retired the
+      // rows it just applied. Served by the ack path alone, that poll marks
+      // nothing, so it is handed the same rows again on every iteration — one
+      // more copy of the same steer body appended per iteration, as fast as this
+      // route can answer. So a request that names no ack and does carry the
+      // cursor — which no runner built after this change sends — gets the
+      // previous semantics back for that request: rows above the cursor, marked
+      // delivered by the select that served them. Anything carrying an ack is a
+      // runner that retires its own rows by id and takes the path above, cursor
+      // beside it or not.
+      const cursor = ack.length > 0 ? undefined : afterId;
       const deadline = Date.now() + 25_000;
       while (Date.now() < deadline) {
-        const clauses = [eq(steerMessages.runId, run.id), isNull(steerMessages.deliveredAt)];
-        if (afterId) clauses.push(gt(steerMessages.id, afterId));
         const messages = await db
           .select()
           .from(steerMessages)
-          .where(and(...clauses))
-          .orderBy(asc(steerMessages.createdAt))
-          .limit(10);
+          // Served under the same org scope the ack mutates: a row this run's
+          // org cannot acknowledge is a row it must not be handed either, or the
+          // channel wedges on a message that returns on every poll.
+          .where(
+            and(
+              eq(steerMessages.orgId, run.orgId),
+              eq(steerMessages.runId, run.id),
+              isNull(steerMessages.deliveredAt),
+              // Where the pre-ack route's id comparison lives now: on the
+              // compatibility path and nowhere else, so what an ack poll is
+              // served still depends on delivery alone.
+              ...(cursor ? [gt(steerMessages.id, cursor)] : []),
+            ),
+          )
+          // Send order, which is the order the agent must read them in. An ack
+          // poll filters on deliveredAt alone, so the ordering no longer has to
+          // double as a delivery filter. createdAt comes from now(), which rows
+          // committed by a single transaction share exactly; id breaks that tie
+          // so a batch at the limit below is deterministic.
+          .orderBy(asc(steerMessages.createdAt), asc(steerMessages.id))
+          .limit(STEER_BATCH);
         if (messages.length > 0) {
-          await db
-            .update(steerMessages)
-            .set({ deliveredAt: new Date() })
-            .where(
-              and(
-                eq(steerMessages.runId, run.id),
-                inArray(
-                  steerMessages.id,
-                  messages.map((message) => message.id),
+          if (cursor) {
+            // The compatibility path's mark-on-select, scoped exactly like the
+            // ack update above. A poll that predates the ack has no other way to
+            // say what it handled, so this response is the only thing that can
+            // retire these rows for it.
+            await db
+              .update(steerMessages)
+              .set({ deliveredAt: new Date() })
+              .where(
+                and(
+                  eq(steerMessages.orgId, run.orgId),
+                  eq(steerMessages.runId, run.id),
+                  isNull(steerMessages.deliveredAt),
+                  inArray(
+                    steerMessages.id,
+                    messages.map((message) => message.id),
+                  ),
                 ),
-              ),
-            );
+              );
+          }
           return messages;
         }
         await new Promise((resolve) => setTimeout(resolve, 500));

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -2410,8 +2410,8 @@ async function ensureRunAgentRole(
 // terminal result still in flight when the container exits, and a provider
 // status misreport on a single probe. With the 2-minute reconcile cron this
 // confirms on the next tick after the window, keeping genuinely dead sandboxes
-// visible within ~4 minutes. A worker that was down also cannot fail runs on
-// its first tick back: the first observation only starts the window.
+// visible within ~4 minutes. A returning worker cannot fail a run it never
+// observed lost: a first observation only starts the window.
 export const SANDBOX_LOSS_GRACE_MS = 90_000;
 
 export function sandboxLossConfirmed(
@@ -2489,10 +2489,11 @@ export async function reconcileSandboxes(
             await updateGithubRunProgress(db, run.id, "failed", { config }).catch(() => undefined);
           } else if (!Number.isFinite(Date.parse(sandbox.lossObservedAt ?? ""))) {
             // First (or unreadable) observation: start the grace window. The
-            // guarded jsonb_set leaves concurrent terminal transitions — a
-            // result landing right now — untouched, and the SQL-level null
-            // check keeps an overlapping tick holding a pre-stamp snapshot
-            // from moving an existing stamp later.
+            // guards leave concurrent terminal transitions — a result landing
+            // right now — untouched, and the compare-and-set against the value
+            // this tick read keeps an overlapping tick holding a stale
+            // snapshot from moving an existing stamp later, while still
+            // letting a corrupt stamp (which could never confirm) be replaced.
             await db
               .update(runs)
               .set({
@@ -2503,7 +2504,7 @@ export async function reconcileSandboxes(
                 and(
                   eq(runs.id, run.id),
                   inArray(runs.status, ["provisioning", "running"]),
-                  sql`${runs.sandbox}->>'lossObservedAt' is null`,
+                  sql`${runs.sandbox}->>'lossObservedAt' is not distinct from ${sandbox.lossObservedAt ?? null}`,
                 ),
               );
           }

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -40,7 +40,7 @@ import {
   virtualKeys,
 } from "@facility/db";
 import { isBuilderMode } from "@facility/run-objective";
-import { and, asc, desc, eq, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, notInArray, or, type SQL, sql } from "drizzle-orm";
 import {
   type BuilderPlanFreshnessOptions,
   resolveBuilderPlanFreshnessForRun,
@@ -2404,14 +2404,26 @@ async function ensureRunAgentRole(
 }
 
 // How long an exited/lost observation must persist before reconcile declares
-// the run sandbox_lost. The verdict is irreversible — it revokes the run's keys
-// and 409s every later runner call — so it must survive the situations issue
-// #35 hit: an API/worker restart while the runner rides out the outage, a
-// terminal result still in flight when the container exits, and a provider
-// status misreport on a single probe. With the 2-minute reconcile cron this
-// confirms on the next tick after the window, keeping genuinely dead sandboxes
-// visible within ~4 minutes. A returning worker cannot fail a run it never
-// observed lost: a first observation only starts the window.
+// the run sandbox_lost. That verdict is irreversible: failRun takes the run
+// terminal and revokes its keys, and every later runner call then fails the
+// terminal check in the internal routes with a 409. So a single probe must not
+// decide it — a provider status misreport, a worker restart while the runner
+// rides out a control-plane outage, and a terminal result still in flight as the
+// container exits all look alike on one tick. The reconcile cron runs every two
+// minutes (worker.ts schedules "sandbox.reconcile" at */2), and a window shorter
+// than that interval confirms on the tick after the one that stamped it: a
+// genuinely dead sandbox goes terminal within two ticks, so ~4 minutes.
+// The window is paid for in key lifetime. While it is open the run is still
+// non-terminal, so no terminal path has revoked its virtual key (gateway spend)
+// or its run-scoped platform key: both authenticate on a null revokedAt, neither
+// is minted with a wall-clock expiry, and the orphaned-key sweep below only
+// reaches runs already terminal. Measured against a verdict on the first probe,
+// that leaves a genuinely dead sandbox's two keys live 120s longer at worst —
+// one reconcile interval, because confirmation is only ever evaluated on a tick
+// and the next tick lands 120s after the one that stamped — and 90s longer at
+// best, which takes offset overlapping ticks to put one right at the edge of the
+// window. A returning worker cannot fail a run it never observed lost, because a
+// first observation only starts the window.
 export const SANDBOX_LOSS_GRACE_MS = 90_000;
 
 export function sandboxLossConfirmed(
@@ -2425,6 +2437,7 @@ export function sandboxLossConfirmed(
 
 type ReconcileSandboxesDeps = {
   sandboxDriver?: (name: SandboxDriverName) => Promise<SandboxDriver>;
+  githubClientFactory?: GithubClientFactory;
 };
 
 export async function reconcileSandboxes(
@@ -2482,18 +2495,45 @@ export async function reconcileSandboxes(
         }
         if (!sandbox.driver || !sandbox.ref) continue;
         const driver = await resolveDriver(sandbox.driver);
+        // Every write below compare-and-sets on the stamp exactly as this tick
+        // read it. driver.status() is a provider round trip, and nothing
+        // serializes reconcile ticks — the queue carries no singleton policy and
+        // more than one worker task can be live at once (a rolling deploy
+        // overlaps them) — so an overlapping tick can clear the stamp,
+        // certifying the sandbox alive, or record a fresher loss while this one
+        // waits inside the probe. Without the predicate this tick would then act
+        // on a snapshot the row no longer holds, and failRun's own notInArray
+        // guard cannot catch that: a run the other tick just certified is still
+        // "running".
+        const stampUnchanged = sql`${runs.sandbox}->>'lossObservedAt' is not distinct from ${sandbox.lossObservedAt ?? null}`;
         const status = await driver.status(sandbox.ref);
         if (status === "exited" || status === "lost") {
           if (sandboxLossConfirmed(sandbox, new Date())) {
-            await failRun(db, run.orgId, run.id, "sandbox_lost", "sandbox_lost");
-            await updateGithubRunProgress(db, run.id, "failed", { config }).catch(() => undefined);
+            const failed = await failRun(
+              db,
+              run.orgId,
+              run.id,
+              "sandbox_lost",
+              "sandbox_lost",
+              stampUnchanged,
+            );
+            // Only the tick that actually claimed the failure may rewrite the
+            // progress comment: the comment is the issue thread's public record
+            // of the run, so posting "Failed" on a lost claim would contradict a
+            // run that is still live.
+            if (failed) {
+              await updateGithubRunProgress(db, run.id, "failed", {
+                config,
+                githubClientFactory: deps.githubClientFactory,
+              }).catch(() => undefined);
+            }
           } else if (!Number.isFinite(Date.parse(sandbox.lossObservedAt ?? ""))) {
             // First (or unreadable) observation: start the grace window. The
             // guards leave concurrent terminal transitions — a result landing
-            // right now — untouched, and the compare-and-set against the value
-            // this tick read keeps an overlapping tick holding a stale
-            // snapshot from moving an existing stamp later, while still
-            // letting a corrupt stamp (which could never confirm) be replaced.
+            // right now — untouched, and the compare-and-set keeps an
+            // overlapping tick holding a stale snapshot from moving an existing
+            // stamp later, while still letting a corrupt stamp (which could
+            // never confirm) be replaced.
             await db
               .update(runs)
               .set({
@@ -2504,20 +2544,36 @@ export async function reconcileSandboxes(
                 and(
                   eq(runs.id, run.id),
                   inArray(runs.status, ["provisioning", "running"]),
-                  sql`${runs.sandbox}->>'lossObservedAt' is not distinct from ${sandbox.lossObservedAt ?? null}`,
+                  stampUnchanged,
                 ),
               );
           }
         } else if (sandbox.lossObservedAt !== undefined) {
           // The sandbox came back (or the probe misreported): reset the window
-          // so an unrelated later loss starts its own grace period.
+          // so an unrelated later loss starts its own grace period. The
+          // compare-and-set keeps this clear from erasing a loss another tick
+          // observed after this one read the row. That takes more than any two
+          // overlapping ticks: this tick's probe has to report the sandbox alive,
+          // and the branch above writes only over an absent or unparseable stamp,
+          // so the value this tick read has to have left the row before another
+          // tick could put a fresher one there. Declining the clear then leaves
+          // that fresher stamp for the next tick, which clears it if the sandbox
+          // is still up, whereas clearing unconditionally would discard the
+          // observation the window runs on and push the verdict out by another
+          // window each time the interleaving recurs.
           await db
             .update(runs)
             .set({
               sandbox: sql`coalesce(${runs.sandbox}, '{}'::jsonb) - 'lossObservedAt'`,
               updatedAt: new Date(),
             })
-            .where(and(eq(runs.id, run.id), inArray(runs.status, ["provisioning", "running"])));
+            .where(
+              and(
+                eq(runs.id, run.id),
+                inArray(runs.status, ["provisioning", "running"]),
+                stampUnchanged,
+              ),
+            );
         }
       } catch {
         // Driver unreachable for this run; leave it for the next tick.
@@ -2981,7 +3037,12 @@ export async function failRun(
   runId: string,
   message: string,
   kind: string,
-) {
+  // Extra condition ANDed into the atomic claim, for callers whose decision to
+  // fail rests on state they read earlier: the run being non-terminal proves
+  // nothing about that state still holding. Returns whether the claim landed so
+  // the caller can skip the side effects that only the winner owns.
+  guard?: SQL,
+): Promise<boolean> {
   // Claim the failure atomically: only a non-terminal run transitions, so a
   // concurrent finish/cancel/fail cannot be clobbered and cleanup runs once.
   const [failed] = await db
@@ -2992,10 +3053,14 @@ export async function failRun(
         eq(runs.orgId, orgId),
         eq(runs.id, runId),
         notInArray(runs.status, [...TERMINAL_RUN_STATUSES]),
+        ...(guard ? [guard] : []),
       ),
     )
     .returning({ projectId: runs.projectId, sandbox: runs.sandbox, trigger: runs.trigger });
-  if (!failed) return; // already terminal — another path handled it.
+  // Already terminal, or the caller's guard no longer holds — another path owns
+  // this run, so touch nothing: revoking the keys of a run that is still live
+  // would strand the path still driving it.
+  if (!failed) return false;
   // Reclaim the run's credentials + sandbox so a failed run can't keep calling
   // the gateway or the platform API.
   await revokeRunKeys(db, readSandbox(failed.sandbox));
@@ -3021,6 +3086,7 @@ export async function failRun(
   await appendRunEvents(db, orgId, runId, [
     { type: "result", data: { status: "failed", kind, error: message } },
   ]);
+  return true;
 }
 
 /** Free a conversation's turn lock when its run failed before finishRun ran. */

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -15,6 +15,7 @@ import {
   actionTypes,
   agentDefs,
   apiKeys,
+  auditEvents,
   conversationMessages,
   conversations,
   createDb,
@@ -95,10 +96,12 @@ import type { LaunchSpec, SandboxDriver, SandboxDriverName } from "./driver.js";
 import { sandboxDriver } from "./driver.js";
 import {
   appendRunEvents,
+  RESULT_FINALIZATION_LEASE_MS,
   type RunBundle,
   type RunnerEngine,
   type RunSandboxState,
   readSandbox,
+  resultFinalizationPending,
   TERMINAL_RUN_STATUSES,
   terminalStatus,
 } from "./state.js";
@@ -111,7 +114,28 @@ type FinishRunDeps = {
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>;
   /** Test seam for proving terminal run + proposal commit atomicity. */
   afterArchitectPlanOutboxWrite?: () => Promise<void> | void;
+  /**
+   * Test seam for proving finalization resumes after the terminal claim: called
+   * after the claim commits and after each step that follows it, so a test can
+   * interrupt at any depth and replay the result.
+   */
+  afterFinalizationStep?: (step: FinalizationStep) => Promise<void> | void;
 };
+// The steps finishRun runs once the terminal status is committed, in order.
+// Each is guarded against its own repetition, which is what lets a replayed
+// /result resume from wherever an earlier attempt was interrupted.
+export type FinalizationStep =
+  | "claim"
+  | "sandbox"
+  | "keys"
+  | "delivery"
+  | "pull_request"
+  | "architect_plan"
+  | "security_findings"
+  | "result_event"
+  | "github_progress"
+  | "audit"
+  | "conversation";
 type DispatchRunDeps = {
   sandboxDriver?: (name: SandboxDriverName) => Promise<SandboxDriver>;
   githubFactory?: GithubClientFactory;
@@ -488,6 +512,15 @@ export async function finishRun(
   deps?: FinishRunDeps,
 ) {
   if (terminalStatus(run.status)) {
+    // The terminal status is committed but the work after it never finished: the
+    // control plane went down, or a step threw, between the claim and the
+    // finalizedAt marker. The runner replays /result into that window, the route
+    // admits it, and it lands here. Everything is re-derived from the row the
+    // claim wrote — the replayed body is the same request, but the row is what
+    // was committed.
+    if (resultFinalizationPending(readSandbox(run.sandbox))) {
+      return resumeRunFinalization(db, run, input, deps);
+    }
     // Current writes commit Architect success and its Gate 1 proposal together.
     // Keep this repair path for legacy/incomplete rows and missing canonical
     // origin events; network delivery remains the cron reconciler's job.
@@ -550,7 +583,7 @@ export async function finishRun(
   // A delivery receipt names the published range. Runs without a delivery
   // still expose the prepared workspace base they actually inspected.
   const receiptBaseSha = input.git?.baseSha ?? run.workspaceBaseSha;
-  let receipt = await canonicalRunReceipt(
+  const receipt = await canonicalRunReceipt(
     db,
     run,
     input.receipt,
@@ -570,7 +603,11 @@ export async function finishRun(
           gh: persistedGh,
           engineSessionId: input.engineSessionId,
           endedAt: new Date(),
-          sandbox: { ...sandbox, finishedAt: new Date().toISOString() },
+          sandbox: {
+            ...sandbox,
+            finishedAt: new Date().toISOString(),
+            finalizingAt: new Date().toISOString(),
+          },
           updatedAt: new Date(),
         })
         // Terminal status, durable PR delivery intent, and the Architect Gate
@@ -592,8 +629,193 @@ export async function finishRun(
     return { run: terminal, architectProposalId: architectProposal?.id };
   });
   if (!claim) return run;
-  const claimed = claim.run;
-  if (sandbox.driver && sandbox.ref) {
+  await deps?.afterFinalizationStep?.("claim");
+  return finalizeRun(
+    db,
+    claim.run,
+    {
+      status,
+      error,
+      receipt,
+      aggregate,
+      receiptBaseSha,
+      input,
+      securityReport,
+      hasDelivery: status === "succeeded" && deliveryPlan !== null,
+      architectProposalId: claim.architectProposalId,
+    },
+    deps,
+  );
+}
+
+type FinishRunInput = Parameters<typeof finishRun>[2];
+type TerminalRunStatus = FinishRunInput["status"];
+type FinalizationContext = {
+  status: TerminalRunStatus;
+  error: string | undefined;
+  receipt: FacilityReceipt;
+  aggregate: Awaited<ReturnType<typeof gatewayAggregate>>;
+  receiptBaseSha: string | null | undefined;
+  input: FinishRunInput;
+  securityReport: SecurityReport | undefined;
+  hasDelivery: boolean;
+  architectProposalId: string | undefined;
+};
+
+// Thrown to a replayed /result while another attempt still holds the run's
+// finalization lease. The route answers it with a 503 the runner retries after
+// retryAfterMs, by which time the lease has either been released by a completed
+// finalization — the next replay is then refused as run_terminal — or expired
+// under a dead attempt, which the next replay takes over.
+export class FinalizationInProgressError extends Error {
+  constructor(public readonly retryAfterMs: number) {
+    super("Run finalization is in progress");
+  }
+}
+
+// Rebuilds the context finalizeRun needs from a run whose claim is committed,
+// for a replayed /result. The row is authoritative for what the claim decided —
+// status, error, receipt, and the delivery and proposal rows it committed
+// beside them. The body supplies only what the claim never persisted: the git
+// coordinates a repair run's PR update names, and the security report.
+async function resumeRunFinalization(
+  db: ReturnType<typeof createDb>["db"],
+  pending: RunRow,
+  input: FinishRunInput,
+  deps?: FinishRunDeps,
+) {
+  // Take the lease over atomically, and only from an attempt that has had
+  // longer than the lease to finish: the guards below keep sequential attempts
+  // from repeating a step, not concurrent ones. The row this returns carries
+  // whatever the earlier attempt recorded — its destroyedAt, its downgraded
+  // status — which is what the rest of this reads.
+  const now = new Date();
+  const staleBefore = new Date(now.getTime() - RESULT_FINALIZATION_LEASE_MS).toISOString();
+  const [run] = await db
+    .update(runs)
+    .set({
+      sandbox: sql`${runs.sandbox} || ${JSON.stringify({ finalizingAt: now.toISOString() })}::jsonb`,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(runs.orgId, pending.orgId),
+        eq(runs.id, pending.id),
+        inArray(runs.status, [...TERMINAL_RUN_STATUSES]),
+        sql`${runs.sandbox}->>'finishedAt' is not null`,
+        sql`${runs.sandbox}->>'finalizedAt' is null`,
+        sql`(${runs.sandbox}->>'finalizingAt' is null or (${runs.sandbox}->>'finalizingAt')::timestamptz <= ${staleBefore}::timestamptz)`,
+      ),
+    )
+    .returning();
+  if (!run) {
+    const [current] = await db
+      .select({ sandbox: runs.sandbox })
+      .from(runs)
+      .where(and(eq(runs.orgId, pending.orgId), eq(runs.id, pending.id)))
+      .limit(1);
+    const state = readSandbox(current?.sandbox);
+    // Finalized between the route's admission and this takeover: the run is
+    // terminal to this request like any other.
+    if (!resultFinalizationPending(state))
+      throw new ApiError(409, "run_terminal", "Run is terminal");
+    const held = Date.parse(state.finalizingAt ?? "");
+    const remainingMs = Number.isFinite(held)
+      ? Math.max(0, held + RESULT_FINALIZATION_LEASE_MS - now.getTime())
+      : RESULT_FINALIZATION_LEASE_MS;
+    throw new FinalizationInProgressError(remainingMs);
+  }
+  const status = run.status as TerminalRunStatus;
+  const error = run.error ?? undefined;
+  const aggregate = await gatewayAggregate(db, run.id);
+  const receiptBaseSha = input.git?.baseSha ?? run.workspaceBaseSha;
+  const stored = FacilityReceiptSchema.safeParse(run.receipt);
+  const receipt = stored.success
+    ? stored.data
+    : await canonicalRunReceipt(db, run, input.receipt, aggregate, status, receiptBaseSha);
+  let securityReport: SecurityReport | undefined;
+  if (status === "succeeded" && isSecurityMode(run.mode)) {
+    // The claim only records "succeeded" for a security run whose report was
+    // valid, so the runner's replay of that same body parses again. A body that
+    // does not is not that replay, and the sync it would drive has no report.
+    const parsed = SecurityReportSchema.safeParse(input.securityReport);
+    if (!parsed.success) throw new Error("security_report_invalid");
+    securityReport = sanitizeSecurityReport(parsed.data);
+  }
+  const hasDelivery =
+    status === "succeeded" &&
+    (
+      await db
+        .select({ runId: runDeliveries.runId })
+        .from(runDeliveries)
+        .where(and(eq(runDeliveries.orgId, run.orgId), eq(runDeliveries.runId, run.id)))
+        .limit(1)
+    ).length > 0;
+  const architectProposalId =
+    status === "succeeded" && isArchitectMode(run.mode)
+      ? (
+          await db
+            .select({ id: proposals.id })
+            .from(proposals)
+            .innerJoin(
+              actionTypes,
+              and(
+                eq(actionTypes.id, proposals.actionTypeId),
+                eq(actionTypes.orgId, proposals.orgId),
+              ),
+            )
+            .where(
+              and(
+                eq(proposals.orgId, run.orgId),
+                eq(proposals.projectId, run.projectId),
+                eq(proposals.runId, run.id),
+                eq(actionTypes.name, "plan_acceptance"),
+              ),
+            )
+            .orderBy(desc(proposals.createdAt))
+            .limit(1)
+        )[0]?.id
+      : undefined;
+  return finalizeRun(
+    db,
+    run,
+    {
+      status,
+      error,
+      receipt,
+      aggregate,
+      receiptBaseSha,
+      input,
+      securityReport,
+      hasDelivery,
+      architectProposalId,
+    },
+    deps,
+  );
+}
+
+// Everything finishRun does after the terminal claim. Runs to completion once
+// for a run whatever the number of attempts: each step is guarded by the durable
+// trace its own effect leaves — the sandbox's destroyedAt, a key's revokedAt, an
+// event of its type, an audit row for its action, the conversation message that
+// carries this run's id — rather than by a ledger written beside the effect,
+// which would leave a crash between the two to repeat it. A step re-entered on
+// a resumed attempt therefore finds its work done and moves on, and the marker
+// written last admits no further replay.
+async function finalizeRun(
+  db: ReturnType<typeof createDb>["db"],
+  claimed: RunRow,
+  context: FinalizationContext,
+  deps?: FinishRunDeps,
+) {
+  const run = claimed;
+  const { input, aggregate, receiptBaseSha, securityReport } = context;
+  let { status, error, receipt } = context;
+  const step = async (name: FinalizationStep) => {
+    await deps?.afterFinalizationStep?.(name);
+  };
+  const sandbox = readSandbox(run.sandbox);
+  if (sandbox.driver && sandbox.ref && !sandbox.destroyedAt) {
     const driver = await sandboxDriver(sandbox.driver);
     const destroyed = await driver
       .destroy(sandbox.ref)
@@ -601,37 +823,28 @@ export async function finishRun(
       .catch(() => false);
     if (destroyed) await markSandboxDestroyed(db, run.id);
   }
+  await step("sandbox");
   await revokeRunKeys(db, sandbox);
-  if (status === "succeeded" && deliveryPlan) {
+  await step("keys");
+  if (status === "succeeded" && context.hasDelivery) {
+    // The delivery worker owns its own idempotency and is also scheduled every
+    // minute, so a second enqueue for the same run is a no-op there.
     await deps?.enqueue?.("deliveries.deliver", { runId: run.id }).catch(() => undefined);
-  } else if (deliveryPreparationError) {
-    await appendRunEvents(db, run.orgId, run.id, [
-      {
-        type: "artifact_error",
-        data: { kind: "delivery_repo_unresolvable", error: deliveryPreparationError },
-      },
-    ]);
-    await raisePlatformIssue(db, {
-      orgId: run.orgId,
-      projectId: run.projectId,
-      kind: "delivery_repo_unresolvable",
-      severity: "error",
-      fingerprint: `delivery_repo_unresolvable:${run.id}`,
-      title: "Run delivery repository is unavailable",
-      bodyMd: `Run ${run.id} pushed ${input.git?.branch}, but Facility could not bind the delivery to its tenant-scoped repository.\n\n${deliveryPreparationError}`,
-    });
   }
+  await step("delivery");
   if (
     status === "succeeded" &&
     input.git?.changed === true &&
     input.git.branch &&
-    repairPullRequestMode(run.mode)
+    repairPullRequestMode(run.mode) &&
+    !(await hasAuditEvent(db, run.orgId, "github.pr.updated", run.id))
   ) {
-    await recordRunPullRequestUpdate(db, claimed, input.git.branch, input.git.headSha);
+    await recordRunPullRequestUpdate(db, run, input.git.branch, input.git.headSha);
   }
-  if (status === "succeeded" && claim.architectProposalId) {
+  await step("pull_request");
+  if (status === "succeeded" && context.architectProposalId) {
     try {
-      await publishArchitectPlanAcceptance(db, run.orgId, claim.architectProposalId, deps);
+      await publishArchitectPlanAcceptance(db, run.orgId, context.architectProposalId, deps);
     } catch (planError) {
       // The sealed Architect work and canonical proposal are already durable.
       // A transient GitHub publication failure is an artifact-delivery error,
@@ -641,14 +854,19 @@ export async function finishRun(
         orgId: run.orgId,
         projectId: run.projectId,
         runId: run.id,
-        proposalId: claim.architectProposalId,
+        proposalId: context.architectProposalId,
         error: planError,
       });
     }
   }
-  if (status === "succeeded" && securityReport) {
+  await step("architect_plan");
+  if (
+    status === "succeeded" &&
+    securityReport &&
+    !(await hasRunEvent(db, run.orgId, run.id, "security_findings"))
+  ) {
     try {
-      const sync = await publishSecurityFindings(db, claimed, securityReport, deps);
+      const sync = await publishSecurityFindings(db, run, securityReport, deps);
       await appendRunEvents(db, run.orgId, run.id, [
         {
           type: "security_findings",
@@ -665,9 +883,8 @@ export async function finishRun(
         },
       ]);
     } catch (syncError) {
-      const message = errorMessage(syncError);
       status = "failed";
-      error = `security_issue_sync_failed:${message}`;
+      error = `security_issue_sync_failed:${errorMessage(syncError)}`;
       receipt = await canonicalRunReceipt(
         db,
         run,
@@ -680,56 +897,93 @@ export async function finishRun(
         .update(runs)
         .set({ status, receipt, error, updatedAt: new Date() })
         .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id)));
-      await appendRunEvents(db, run.orgId, run.id, [
-        { type: "artifact_error", data: { kind: "security_issue_sync_failed", error: message } },
-      ]);
-      await raisePlatformIssue(db, {
-        orgId: run.orgId,
-        projectId: run.projectId,
-        kind: "security_issue_sync_failed",
-        severity: "error",
-        fingerprint: `security_issue_sync_failed:${run.id}`,
-        title: "Failed to synchronize security findings",
-        bodyMd: `Security run ${run.id} completed its audit, but Facility could not synchronize qualifying findings to GitHub.\n\n${message}`,
-      });
     }
   }
-  await appendRunEvents(db, run.orgId, run.id, [{ type: "result", data: { status, error } }]);
+  await step("security_findings");
+  // The record of a failure the claim, or the sync above, wrote into the run's
+  // error. Derived from the error rather than from which branch ran, so an
+  // attempt interrupted between the status update and this record still leaves
+  // it on the next one.
+  const failure = finalizationFailure(run, error, input);
+  if (failure) {
+    if (!(await hasRunEvent(db, run.orgId, run.id, "artifact_error", failure.kind))) {
+      await appendRunEvents(db, run.orgId, run.id, [
+        { type: "artifact_error", data: { kind: failure.kind, error: failure.detail } },
+      ]);
+    }
+    // Upserted on its fingerprint, so a repeat is a no-op.
+    await raisePlatformIssue(db, {
+      orgId: run.orgId,
+      projectId: run.projectId,
+      kind: failure.kind,
+      severity: "error",
+      fingerprint: `${failure.kind}:${run.id}`,
+      title: failure.title,
+      bodyMd: failure.bodyMd,
+    });
+  }
+  if (!(await hasRunEvent(db, run.orgId, run.id, "result"))) {
+    await appendRunEvents(db, run.orgId, run.id, [{ type: "result", data: { status, error } }]);
+  }
+  await step("result_event");
   // Architect Gate 1 publication owns the succeeded progress comment. A
   // second generic update could race a publication_closed reconciliation and
-  // resurrect an approval CTA after the proposal became terminal.
-  if (!(status === "succeeded" && claim.architectProposalId)) {
+  // resurrect an approval CTA after the proposal became terminal. The update
+  // itself rewrites one comment, so a repeat lands on the same text.
+  if (!(status === "succeeded" && context.architectProposalId)) {
     await updateGithubRunProgress(db, run.id, status, deps).catch(() => undefined);
   }
-  await insertAuditEvent(db, {
-    orgId: run.orgId,
-    projectId: run.projectId,
-    actor: { type: "agent", id: run.id },
-    action: "run.finished",
-    target: { type: "run", id: run.id },
-    payload: {
-      status,
-      error,
-      receipt_sha256: receipt.integrity?.payload_sha256 ?? receiptContentDigest(receipt),
-    },
-  });
-  await finishConversationTurn(db, claimed, input.engineSessionId).catch(
-    async (conversationError) => {
-      const message = errorMessage(conversationError);
+  await step("github_progress");
+  if (!(await hasAuditEvent(db, run.orgId, "run.finished", run.id))) {
+    await insertAuditEvent(db, {
+      orgId: run.orgId,
+      projectId: run.projectId,
+      actor: { type: "agent", id: run.id },
+      action: "run.finished",
+      target: { type: "run", id: run.id },
+      payload: {
+        status,
+        error,
+        receipt_sha256: receipt.integrity?.payload_sha256 ?? receiptContentDigest(receipt),
+      },
+    });
+  }
+  await step("audit");
+  await finishConversationTurn(db, run, input.engineSessionId).catch(async (conversationError) => {
+    const message = errorMessage(conversationError);
+    if (
+      !(await hasRunEvent(
+        db,
+        run.orgId,
+        run.id,
+        "artifact_error",
+        "conversation_finish_failed",
+      ).catch(() => false))
+    ) {
       await appendRunEvents(db, run.orgId, run.id, [
         { type: "artifact_error", data: { kind: "conversation_finish_failed", error: message } },
       ]).catch(() => undefined);
-      await raisePlatformIssue(db, {
-        orgId: run.orgId,
-        projectId: run.projectId,
-        kind: "conversation_finish_failed",
-        severity: "error",
-        fingerprint: `conversation_finish_failed:${run.id}`,
-        title: "Failed to finalize conversation turn",
-        bodyMd: `Run ${run.id} finished, but Facility could not append the conversation reply.\n\n${message}`,
-      }).catch(() => undefined);
-    },
-  );
+    }
+    await raisePlatformIssue(db, {
+      orgId: run.orgId,
+      projectId: run.projectId,
+      kind: "conversation_finish_failed",
+      severity: "error",
+      fingerprint: `conversation_finish_failed:${run.id}`,
+      title: "Failed to finalize conversation turn",
+      bodyMd: `Run ${run.id} finished, but Facility could not append the conversation reply.\n\n${message}`,
+    }).catch(() => undefined);
+  });
+  await step("conversation");
+  // Merged rather than assigned, so a destroyedAt the reconciler wrote in the
+  // meantime survives. From here a replayed /result is refused as run_terminal.
+  await db
+    .update(runs)
+    .set({
+      sandbox: sql`${runs.sandbox} || ${JSON.stringify({ finalizedAt: new Date().toISOString() })}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id)));
   return { ...claimed, status, receipt, error };
 }
 
@@ -765,6 +1019,21 @@ export async function finishConversationTurn(
   const reply = await lastAssistantText(db, run);
   await db.transaction(async (tx) => {
     await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${conversationId}))`);
+    // The reply carries the run's id, so under the lock it is the record of this
+    // turn having been finalized: a resumed finalization that finds it appends
+    // nothing and leaves the thread as the first attempt left it.
+    const appended = await tx
+      .select({ id: conversationMessages.id })
+      .from(conversationMessages)
+      .where(
+        and(
+          eq(conversationMessages.conversationId, conversationId),
+          eq(conversationMessages.runId, run.id),
+          eq(conversationMessages.role, "agent"),
+        ),
+      )
+      .limit(1);
+    if (appended.length > 0) return;
     const rows = await tx
       .select({ max: sql<number>`coalesce(max(seq), 0)` })
       .from(conversationMessages)
@@ -789,6 +1058,78 @@ export async function finishConversationTurn(
       })
       .where(and(eq(conversations.orgId, run.orgId), eq(conversations.id, conversationId)));
   });
+}
+
+// The two failures finishRun records as an artifact_error and a platform issue
+// after the claim, keyed on the error the run carries so an interrupted attempt
+// can tell what it still owes. Anything else in the error — a KB checkpoint, an
+// invalid security report, a push failure — is recorded by the result event
+// alone, as before.
+function finalizationFailure(run: RunRow, error: string | undefined, input: FinishRunInput) {
+  const detailAfter = (prefix: string) =>
+    error?.startsWith(prefix) ? error.slice(prefix.length) : null;
+  const unresolvable = detailAfter("delivery_repo_unresolvable:");
+  if (unresolvable !== null) {
+    return {
+      kind: "delivery_repo_unresolvable",
+      detail: unresolvable,
+      title: "Run delivery repository is unavailable",
+      bodyMd: `Run ${run.id} pushed ${input.git?.branch}, but Facility could not bind the delivery to its tenant-scoped repository.\n\n${unresolvable}`,
+    };
+  }
+  const sync = detailAfter("security_issue_sync_failed:");
+  if (sync !== null) {
+    return {
+      kind: "security_issue_sync_failed",
+      detail: sync,
+      title: "Failed to synchronize security findings",
+      bodyMd: `Security run ${run.id} completed its audit, but Facility could not synchronize qualifying findings to GitHub.\n\n${sync}`,
+    };
+  }
+  return null;
+}
+
+async function hasRunEvent(
+  db: ReturnType<typeof createDb>["db"],
+  orgId: string,
+  runId: string,
+  type: string,
+  kind?: string,
+) {
+  const rows = await db
+    .select({ seq: runEvents.seq })
+    .from(runEvents)
+    .where(
+      and(
+        eq(runEvents.orgId, orgId),
+        eq(runEvents.runId, runId),
+        eq(runEvents.type, type),
+        ...(kind ? [sql`${runEvents.data}->>'kind' = ${kind}`] : []),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function hasAuditEvent(
+  db: ReturnType<typeof createDb>["db"],
+  orgId: string,
+  action: string,
+  runId: string,
+) {
+  const rows = await db
+    .select({ id: auditEvents.id })
+    .from(auditEvents)
+    .where(
+      and(
+        eq(auditEvents.orgId, orgId),
+        eq(auditEvents.action, action),
+        sql`${auditEvents.target}->>'type' = 'run'`,
+        sql`${auditEvents.target}->>'id' = ${runId}`,
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
 }
 
 async function lastAssistantText(db: ReturnType<typeof createDb>["db"], run: RunRow) {

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -2403,10 +2403,36 @@ async function ensureRunAgentRole(
   return row?.id ?? id;
 }
 
+// How long an exited/lost observation must persist before reconcile declares
+// the run sandbox_lost. The verdict is irreversible — it revokes the run's keys
+// and 409s every later runner call — so it must survive the situations issue
+// #35 hit: an API/worker restart while the runner rides out the outage, a
+// terminal result still in flight when the container exits, and a provider
+// status misreport on a single probe. With the 2-minute reconcile cron this
+// confirms on the next tick after the window, keeping genuinely dead sandboxes
+// visible within ~4 minutes. A worker that was down also cannot fail runs on
+// its first tick back: the first observation only starts the window.
+export const SANDBOX_LOSS_GRACE_MS = 90_000;
+
+export function sandboxLossConfirmed(
+  sandbox: RunSandboxState,
+  now: Date,
+  graceMs = SANDBOX_LOSS_GRACE_MS,
+) {
+  const observedAt = sandbox.lossObservedAt ? Date.parse(sandbox.lossObservedAt) : Number.NaN;
+  return Number.isFinite(observedAt) && now.getTime() - observedAt >= graceMs;
+}
+
+type ReconcileSandboxesDeps = {
+  sandboxDriver?: (name: SandboxDriverName) => Promise<SandboxDriver>;
+};
+
 export async function reconcileSandboxes(
   config: AppConfig,
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>,
+  deps: ReconcileSandboxesDeps = {},
 ) {
+  const resolveDriver = deps.sandboxDriver ?? sandboxDriver;
   const { db, client } = createDb(config.databaseUrl);
   try {
     // Dispatch-loss backstop: run rows are committed BEFORE their pg-boss
@@ -2455,11 +2481,42 @@ export async function reconcileSandboxes(
           continue;
         }
         if (!sandbox.driver || !sandbox.ref) continue;
-        const driver = await sandboxDriver(sandbox.driver);
+        const driver = await resolveDriver(sandbox.driver);
         const status = await driver.status(sandbox.ref);
         if (status === "exited" || status === "lost") {
-          await failRun(db, run.orgId, run.id, "sandbox_lost", "sandbox_lost");
-          await updateGithubRunProgress(db, run.id, "failed", { config }).catch(() => undefined);
+          if (sandboxLossConfirmed(sandbox, new Date())) {
+            await failRun(db, run.orgId, run.id, "sandbox_lost", "sandbox_lost");
+            await updateGithubRunProgress(db, run.id, "failed", { config }).catch(() => undefined);
+          } else if (!Number.isFinite(Date.parse(sandbox.lossObservedAt ?? ""))) {
+            // First (or unreadable) observation: start the grace window. The
+            // guarded jsonb_set leaves concurrent terminal transitions — a
+            // result landing right now — untouched, and the SQL-level null
+            // check keeps an overlapping tick holding a pre-stamp snapshot
+            // from moving an existing stamp later.
+            await db
+              .update(runs)
+              .set({
+                sandbox: sql`jsonb_set(coalesce(${runs.sandbox}, '{}'::jsonb), '{lossObservedAt}', to_jsonb(${new Date().toISOString()}::text))`,
+                updatedAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(runs.id, run.id),
+                  inArray(runs.status, ["provisioning", "running"]),
+                  sql`${runs.sandbox}->>'lossObservedAt' is null`,
+                ),
+              );
+          }
+        } else if (sandbox.lossObservedAt !== undefined) {
+          // The sandbox came back (or the probe misreported): reset the window
+          // so an unrelated later loss starts its own grace period.
+          await db
+            .update(runs)
+            .set({
+              sandbox: sql`coalesce(${runs.sandbox}, '{}'::jsonb) - 'lossObservedAt'`,
+              updatedAt: new Date(),
+            })
+            .where(and(eq(runs.id, run.id), inArray(runs.status, ["provisioning", "running"])));
         }
       } catch {
         // Driver unreachable for this run; leave it for the next tick.
@@ -2487,7 +2544,7 @@ export async function reconcileSandboxes(
       try {
         const sandbox = readSandbox(run.sandbox);
         if (!sandbox.driver || !sandbox.ref) continue;
-        const driver = await sandboxDriver(sandbox.driver);
+        const driver = await resolveDriver(sandbox.driver);
         await driver.destroy(sandbox.ref);
         await markSandboxDestroyed(db, run.id);
       } catch {

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -97,6 +97,7 @@ import { sandboxDriver } from "./driver.js";
 import {
   appendRunEvents,
   RESULT_FINALIZATION_LEASE_MS,
+  RESULT_FINALIZATION_RENEW_MS,
   type RunBundle,
   type RunnerEngine,
   type RunSandboxState,
@@ -120,6 +121,12 @@ type FinishRunDeps = {
    * interrupt at any depth and replay the result.
    */
   afterFinalizationStep?: (step: FinalizationStep) => Promise<void> | void;
+  /**
+   * Test seam for the mid-step lease renewal cadence: shortened to observe a
+   * renewal without waiting a real tick, or stretched past the test to simulate
+   * an attempt whose process stalled and stopped renewing.
+   */
+  finalizationLeaseRenewMs?: number;
 };
 // The steps finishRun runs once the terminal status is committed, in order.
 // Each is guarded against its own repetition, which is what lets a replayed
@@ -607,6 +614,7 @@ export async function finishRun(
             ...sandbox,
             finishedAt: new Date().toISOString(),
             finalizingAt: new Date().toISOString(),
+            finalizingToken: crypto.randomUUID(),
           },
           updatedAt: new Date(),
         })
@@ -684,17 +692,21 @@ async function resumeRunFinalization(
   input: FinishRunInput,
   deps?: FinishRunDeps,
 ) {
-  // Take the lease over atomically, and only from an attempt that has had
-  // longer than the lease to finish: the guards below keep sequential attempts
-  // from repeating a step, not concurrent ones. The row this returns carries
-  // whatever the earlier attempt recorded — its destroyedAt, its downgraded
-  // status — which is what the rest of this reads.
+  // Take the lease over atomically, and only from an attempt that has stopped
+  // renewing for a whole lease — a live one renews at every step and on a
+  // timer inside long ones, so an expired lease means its holder is dead or
+  // stalled: the guards below keep sequential attempts from repeating a step,
+  // not concurrent ones. The takeover mints its own token, which is what a
+  // stalled holder's next renewal fails against, forcing it to abort. The row
+  // this returns carries whatever the earlier attempt recorded — its
+  // destroyedAt, its downgraded status — which is what the rest of this reads.
   const now = new Date();
   const staleBefore = new Date(now.getTime() - RESULT_FINALIZATION_LEASE_MS).toISOString();
+  const takeover = { finalizingAt: now.toISOString(), finalizingToken: crypto.randomUUID() };
   const [run] = await db
     .update(runs)
     .set({
-      sandbox: sql`${runs.sandbox} || ${JSON.stringify({ finalizingAt: now.toISOString() })}::jsonb`,
+      sandbox: sql`${runs.sandbox} || ${JSON.stringify(takeover)}::jsonb`,
       updatedAt: now,
     })
     .where(
@@ -802,16 +814,82 @@ async function resumeRunFinalization(
 // which would leave a crash between the two to repeat it. A step re-entered on
 // a resumed attempt therefore finds its work done and moves on, and the marker
 // written last admits no further replay.
+//
+// Those guards are idempotency guards, not mutual exclusion: two attempts
+// running the steps at once could each observe an effect missing and create it
+// twice. Mutual exclusion is the lease's job, and this wrapper is what keeps it
+// held for the whole finalization rather than for its first sixty seconds: the
+// attempt renews its finalizingAt at every step boundary and on a timer inside
+// long steps (a security sync can spend minutes on GitHub), each renewal a
+// compare-and-set on the finalizingToken its claim or takeover minted. A live
+// attempt therefore never looks expired to a replay — the replay waits on a 503
+// instead of taking over — and an attempt that did stall past the lease finds
+// the winner's token at its next renewal and aborts before its next effect.
 async function finalizeRun(
   db: ReturnType<typeof createDb>["db"],
   claimed: RunRow,
   context: FinalizationContext,
   deps?: FinishRunDeps,
 ) {
+  const leaseToken = readSandbox(claimed.sandbox).finalizingToken;
+  // A row claimed before tokens existed (a rolling restart's old process wrote
+  // it) can only be renewed, never lost — the pre-token behaviour. Every claim
+  // and takeover in this code mints one.
+  const holdsLease = leaseToken
+    ? sql`${runs.sandbox}->>'finalizingToken' = ${leaseToken}`
+    : sql`${runs.sandbox}->>'finalizingToken' is null`;
+  const renewLease = async () => {
+    const now = new Date();
+    const renewed = await db
+      .update(runs)
+      .set({
+        sandbox: sql`${runs.sandbox} || ${JSON.stringify({ finalizingAt: now.toISOString() })}::jsonb`,
+        updatedAt: now,
+      })
+      .where(and(eq(runs.orgId, claimed.orgId), eq(runs.id, claimed.id), holdsLease))
+      .returning({ id: runs.id });
+    return renewed.length > 0;
+  };
+  // A tick that fails transiently is absorbed — the step-boundary renewal is
+  // the authoritative check, and it throws on the same unreachable database. A
+  // tick that finds the token gone stops renewing; the boundary aborts the
+  // attempt.
+  const heartbeat = setInterval(() => {
+    void renewLease()
+      .then((held) => {
+        if (!held) clearInterval(heartbeat);
+      })
+      .catch(() => undefined);
+  }, deps?.finalizationLeaseRenewMs ?? RESULT_FINALIZATION_RENEW_MS);
+  heartbeat.unref?.();
+  try {
+    return await finalizeRunSteps(db, claimed, context, { renewLease, holdsLease }, deps);
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+type FinalizationLease = {
+  renewLease: () => Promise<boolean>;
+  holdsLease: SQL;
+};
+
+async function finalizeRunSteps(
+  db: ReturnType<typeof createDb>["db"],
+  claimed: RunRow,
+  context: FinalizationContext,
+  lease: FinalizationLease,
+  deps?: FinishRunDeps,
+) {
   const run = claimed;
   const { input, aggregate, receiptBaseSha, securityReport } = context;
   let { status, error, receipt } = context;
   const step = async (name: FinalizationStep) => {
+    // The renewal doubles as the fence: an attempt another one superseded
+    // fails the compare-and-set here and stops before its next effect, and the
+    // runner's retry of its 503 lands on the winner's outcome.
+    if (!(await lease.renewLease()))
+      throw new FinalizationInProgressError(RESULT_FINALIZATION_LEASE_MS);
     await deps?.afterFinalizationStep?.(name);
   };
   const sandbox = readSandbox(run.sandbox);
@@ -866,7 +944,14 @@ async function finalizeRun(
     !(await hasRunEvent(db, run.orgId, run.id, "security_findings"))
   ) {
     try {
-      const sync = await publishSecurityFindings(db, run, securityReport, deps);
+      // The one step whose length scales with the run's output — up to twenty
+      // findings, several GitHub calls each — so ownership is re-proved (and
+      // with it the lease renewed) before every finding, not only at the step
+      // boundaries around it.
+      const sync = await publishSecurityFindings(db, run, securityReport, deps, async () => {
+        if (!(await lease.renewLease()))
+          throw new FinalizationInProgressError(RESULT_FINALIZATION_LEASE_MS);
+      });
       await appendRunEvents(db, run.orgId, run.id, [
         {
           type: "security_findings",
@@ -883,6 +968,9 @@ async function finalizeRun(
         },
       ]);
     } catch (syncError) {
+      // Losing the lease is not a sync failure: the winner owns the run's
+      // outcome now, and this attempt's job is to stop, not to downgrade it.
+      if (syncError instanceof FinalizationInProgressError) throw syncError;
       status = "failed";
       error = `security_issue_sync_failed:${errorMessage(syncError)}`;
       receipt = await canonicalRunReceipt(
@@ -893,10 +981,13 @@ async function finalizeRun(
         status,
         receiptBaseSha,
       );
+      // Fenced on the lease: a superseded attempt must not rewrite the status
+      // the winning one is finalizing. The boundary below aborts it anyway;
+      // this keeps the row untouched in the meantime.
       await db
         .update(runs)
         .set({ status, receipt, error, updatedAt: new Date() })
-        .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id)));
+        .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id), lease.holdsLease));
     }
   }
   await step("security_findings");
@@ -977,13 +1068,19 @@ async function finalizeRun(
   await step("conversation");
   // Merged rather than assigned, so a destroyedAt the reconciler wrote in the
   // meantime survives. From here a replayed /result is refused as run_terminal.
-  await db
+  // Fenced on the lease: only the attempt that owns the finalization may
+  // declare it complete — one superseded mid-flight reports the 503 the
+  // runner retries into the winner's outcome, never a success over work the
+  // winner is still doing.
+  const [finalized] = await db
     .update(runs)
     .set({
       sandbox: sql`${runs.sandbox} || ${JSON.stringify({ finalizedAt: new Date().toISOString() })}::jsonb`,
       updatedAt: new Date(),
     })
-    .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id)));
+    .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id), lease.holdsLease))
+    .returning({ id: runs.id });
+  if (!finalized) throw new FinalizationInProgressError(RESULT_FINALIZATION_LEASE_MS);
   return { ...claimed, status, receipt, error };
 }
 
@@ -2027,6 +2124,7 @@ async function publishSecurityFindings(
   run: RunRow,
   report: SecurityReport,
   deps?: FinishRunDeps,
+  assertOwnership?: () => Promise<void>,
 ) {
   const repo = await repoForGithubRun(db, run);
   if (!repo?.installationId) throw new Error("run_repo_missing_installation");
@@ -2054,7 +2152,7 @@ async function publishSecurityFindings(
     repo: repo.name,
     defaultBranch: repo.defaultBranch,
   });
-  const result = await syncSecurityFindings(client, report, { runId: run.id });
+  const result = await syncSecurityFindings(client, report, { runId: run.id }, assertOwnership);
   await insertAuditEvent(db, {
     orgId: run.orgId,
     projectId: run.projectId,

--- a/services/api/src/sandbox/state.ts
+++ b/services/api/src/sandbox/state.ts
@@ -53,9 +53,8 @@ export type RunSandboxState = {
   destroyedAt?: string;
   lastStatus?: string;
   // First reconcile tick that observed the sandbox exited/lost while the run
-  // was still live. The verdict is only confirmed once the loss persists past
-  // the grace window — a single probe can race a restarting control plane, an
-  // in-flight terminal result, or a transient provider misreport.
+  // was still live. Cleared when a later probe sees the sandbox alive;
+  // confirmation rules live at SANDBOX_LOSS_GRACE_MS.
   lossObservedAt?: string;
   // True for in-process assistant turns: no container, no driver — the key
   // lifecycle and orphan sweeps still apply through virtualKeyId.

--- a/services/api/src/sandbox/state.ts
+++ b/services/api/src/sandbox/state.ts
@@ -52,6 +52,11 @@ export type RunSandboxState = {
   finishedAt?: string;
   destroyedAt?: string;
   lastStatus?: string;
+  // First reconcile tick that observed the sandbox exited/lost while the run
+  // was still live. The verdict is only confirmed once the loss persists past
+  // the grace window — a single probe can race a restarting control plane, an
+  // in-flight terminal result, or a transient provider misreport.
+  lossObservedAt?: string;
   // True for in-process assistant turns: no container, no driver — the key
   // lifecycle and orphan sweeps still apply through virtualKeyId.
   inline?: boolean;

--- a/services/api/src/sandbox/state.ts
+++ b/services/api/src/sandbox/state.ts
@@ -49,7 +49,19 @@ export type RunSandboxState = {
   projectId?: string;
   bundle?: RunBundle;
   launchedAt?: string;
+  // Written by finishRun's terminal claim, in the same commit as the status.
   finishedAt?: string;
+  // Written once every step that follows that claim — resource reclamation,
+  // delivery, events, audit, the conversation turn — has landed. Until it is,
+  // the /result route admits a replay so an interrupted finalization resumes;
+  // see resultFinalizationPending.
+  finalizedAt?: string;
+  // The lease on that finalization: written by the claim and taken over by a
+  // replayed /result only once it is RESULT_FINALIZATION_LEASE_MS old, so two
+  // attempts never run the steps at once — the attempt a rolling restart cut
+  // the runner off from may still be running on the old process while the
+  // runner replays to the new one.
+  finalizingAt?: string;
   destroyedAt?: string;
   lastStatus?: string;
   // First reconcile tick that observed the sandbox exited/lost while the run
@@ -74,6 +86,23 @@ export const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "canceled"] as cons
 export function terminalStatus(status: string) {
   return (TERMINAL_RUN_STATUSES as readonly string[]).includes(status);
 }
+
+// A run whose terminal status finishRun committed but whose finalization it
+// never recorded as complete: the control plane went down, or a step threw,
+// between the claim and finalizedAt. Only that claim writes finishedAt — a
+// cancel or a failRun leaves it unset — so this is exactly the window a
+// replayed /result is admitted to close. A run finalized before finalizedAt
+// existed reads as pending too; resuming one re-runs guarded steps that all
+// find their work done and then records the marker.
+export function resultFinalizationPending(sandbox: RunSandboxState) {
+  return Boolean(sandbox.finishedAt) && !sandbox.finalizedAt;
+}
+
+// How long one attempt at finalization holds the run before a replay may take
+// it over. Longer than a finalization takes — a few GitHub calls at most — and
+// short against the runner's five-minute result budget, which has to cover a
+// control-plane restart plus this wait.
+export const RESULT_FINALIZATION_LEASE_MS = 60_000;
 
 export async function appendRunEvents(
   db: FacilityDb,

--- a/services/api/src/sandbox/state.ts
+++ b/services/api/src/sandbox/state.ts
@@ -60,8 +60,15 @@ export type RunSandboxState = {
   // replayed /result only once it is RESULT_FINALIZATION_LEASE_MS old, so two
   // attempts never run the steps at once — the attempt a rolling restart cut
   // the runner off from may still be running on the old process while the
-  // runner replays to the new one.
+  // runner replays to the new one. A live attempt renews it for as long as it
+  // works (between steps and on a timer inside long ones), so expiry means the
+  // holder is dead or stalled, not merely slow.
   finalizingAt?: string;
+  // Which attempt holds that lease: minted by the claim, replaced by a
+  // takeover. Renewal compare-and-sets on it, so a stalled attempt that was
+  // taken over discovers the loss atomically at its next step and aborts
+  // instead of running beside — and duplicating the effects of — the winner.
+  finalizingToken?: string;
   destroyedAt?: string;
   lastStatus?: string;
   // First reconcile tick that observed the sandbox exited/lost while the run
@@ -98,11 +105,17 @@ export function resultFinalizationPending(sandbox: RunSandboxState) {
   return Boolean(sandbox.finishedAt) && !sandbox.finalizedAt;
 }
 
-// How long one attempt at finalization holds the run before a replay may take
-// it over. Longer than a finalization takes — a few GitHub calls at most — and
-// short against the runner's five-minute result budget, which has to cover a
-// control-plane restart plus this wait.
+// How long one attempt at finalization holds the run without renewing before a
+// replay may take it over. Not a bound on how long a finalization may take —
+// a security sync can spend minutes on GitHub — but on how long a live attempt
+// goes between renewals, which happen at every step boundary and on a
+// RESULT_FINALIZATION_RENEW_MS timer inside a step. Short against the runner's
+// five-minute result budget, which has to cover a control-plane restart plus
+// this wait.
 export const RESULT_FINALIZATION_LEASE_MS = 60_000;
+// How often an attempt renews mid-step. A third of the lease, so a takeover
+// needs several missed renewals, not one late timer tick.
+export const RESULT_FINALIZATION_RENEW_MS = RESULT_FINALIZATION_LEASE_MS / 3;
 
 export async function appendRunEvents(
   db: FacilityDb,

--- a/services/api/test/orchestrator-checks.test.ts
+++ b/services/api/test/orchestrator-checks.test.ts
@@ -11,6 +11,8 @@ import {
   resolveRepoEngineConfig,
   resumeFallbackScopeValue,
   runSafePermissions,
+  SANDBOX_LOSS_GRACE_MS,
+  sandboxLossConfirmed,
 } from "../src/sandbox/orchestrator.js";
 
 describe("platform delivery boundaries", () => {
@@ -286,5 +288,27 @@ describe("harness and resume bundle boundaries", () => {
         },
       ),
     ).toEqual(original);
+  });
+});
+
+describe("sandbox loss grace", () => {
+  const now = new Date("2026-08-15T10:00:00.000Z");
+
+  it("never confirms a loss that was not observed on a previous tick", () => {
+    expect(sandboxLossConfirmed({}, now)).toBe(false);
+  });
+
+  it("holds the verdict while the observation is inside the grace window", () => {
+    const observed = new Date(now.getTime() - SANDBOX_LOSS_GRACE_MS + 1_000).toISOString();
+    expect(sandboxLossConfirmed({ lossObservedAt: observed }, now)).toBe(false);
+  });
+
+  it("confirms a loss that persisted past the grace window", () => {
+    const observed = new Date(now.getTime() - SANDBOX_LOSS_GRACE_MS).toISOString();
+    expect(sandboxLossConfirmed({ lossObservedAt: observed }, now)).toBe(true);
+  });
+
+  it("treats an unreadable observation stamp as not yet observed", () => {
+    expect(sandboxLossConfirmed({ lossObservedAt: "not-a-date" }, now)).toBe(false);
   });
 });

--- a/services/api/test/result-finalization.test.ts
+++ b/services/api/test/result-finalization.test.ts
@@ -413,6 +413,122 @@ describe("result finalization after an interrupted terminal claim", async () => 
     });
   });
 
+  // A first attempt paused inside the named step, and the promise that lets
+  // the test resume it. The two lease tests below both hold an attempt open
+  // past the lease; they differ in whether its heartbeat is running.
+  function attemptHeldAt(
+    step: FinalizationStep,
+    run: (typeof runs)["$inferSelect"],
+    renewMs: number,
+  ) {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let blocked!: () => void;
+    const reached = new Promise<void>((resolve) => {
+      blocked = resolve;
+    });
+    const attempt = finishRun(db, run, body, {
+      finalizationLeaseRenewMs: renewMs,
+      afterFinalizationStep: async (at) => {
+        if (at !== step) return;
+        blocked();
+        await held;
+      },
+    });
+    return { attempt, reached, release };
+  }
+
+  async function storedFinalizingAt(runId: string) {
+    const [stored] = await db
+      .select({ sandbox: runs.sandbox })
+      .from(runs)
+      .where(eq(runs.id, runId));
+    return Date.parse(readSandbox(stored?.sandbox).finalizingAt ?? "");
+  }
+
+  it("renews the lease under a live attempt that outlasts it, so a replay waits instead of taking over", async () => {
+    // Finalization can legitimately run longer than the lease — a security
+    // sync can spend minutes on GitHub — so an attempt renews for as long as
+    // it works. An attempt alive past the lease therefore still looks held to
+    // the runner's replay, which waits on a 503 rather than running the steps
+    // beside it and duplicating their effects.
+    const { run, token, conversationId, virtualKeyId } = await conversationRun("renewal");
+    const first = attemptHeldAt("keys", run, 25);
+    await first.reached;
+    // Age the lease past expiry under the working attempt — standing in for
+    // the wait the test cannot spend — and watch the heartbeat re-freshen it.
+    await expireFinalizationLease(run.id);
+    let renewed = false;
+    for (let i = 0; i < 500 && !renewed; i++) {
+      const at = await storedFinalizingAt(run.id);
+      renewed = Number.isFinite(at) && Date.now() - at < RESULT_FINALIZATION_LEASE_MS;
+      if (!renewed) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(renewed).toBe(true);
+    const replay = await postResult(run.id, token);
+    expect(replay.statusCode).toBe(503);
+    expect(replay.json().error.code).toBe("finalization_in_progress");
+    // No takeover: nothing past the step the attempt is paused in has run.
+    expect(await finalizationState(run.id, conversationId, virtualKeyId)).toMatchObject({
+      keyRevoked: true,
+      resultEvents: 0,
+      finishedAudits: 0,
+      replies: 0,
+    });
+    first.release();
+    await expect(first.attempt).resolves.toMatchObject({ id: run.id, status: "succeeded" });
+    const finalized = await finalizationState(run.id, conversationId, virtualKeyId);
+    expect(finalized).toMatchObject({
+      status: "succeeded",
+      keyRevoked: true,
+      resultEvents: 1,
+      finishedAudits: 1,
+      replies: 1,
+      conversationStatus: "idle",
+    });
+    expect(finalized.sandbox.finalizedAt).toEqual(expect.any(String));
+    const again = await postResult(run.id, token);
+    expect(again.statusCode).toBe(409);
+    expect(again.json().error.code).toBe("run_terminal");
+  });
+
+  it("aborts a stalled attempt a replay superseded before it repeats an effect", async () => {
+    // The other half of the fence: an attempt that really did stop renewing —
+    // its process stalled — loses the lease to the replay. When it wakes it
+    // must discover that at its next step boundary and abort, not run the
+    // remaining steps beside the winner: the per-step guards are idempotency
+    // guards, and two concurrent attempts could each see an effect missing and
+    // create it twice.
+    const { run, token, conversationId, virtualKeyId } = await conversationRun("superseded");
+    // A renewal cadence far past the test stands in for the stall.
+    const first = attemptHeldAt("keys", run, 600_000);
+    await first.reached;
+    await expireFinalizationLease(run.id);
+    // The replay takes the expired lease over and finalizes everything.
+    const replay = await postResult(run.id, token);
+    expect(replay.statusCode).toBe(200);
+    const won = await finalizationState(run.id, conversationId, virtualKeyId);
+    expect(won).toMatchObject({
+      status: "succeeded",
+      keyRevoked: true,
+      resultEvents: 1,
+      finishedAudits: 1,
+      replies: 1,
+      conversationStatus: "idle",
+    });
+    expect(won.sandbox.finalizedAt).toEqual(expect.any(String));
+    // The stalled attempt wakes into a lease it no longer holds: the renewal
+    // compare-and-set at its next boundary fails against the winner's token,
+    // and it surfaces the same 503 a waiting replay gets — whose retry the
+    // finished run then refuses as run_terminal — with every effect counted
+    // exactly once.
+    first.release();
+    await expect(first.attempt).rejects.toThrow("Run finalization is in progress");
+    expect(await finalizationState(run.id, conversationId, virtualKeyId)).toEqual(won);
+  });
+
   it("refuses a result for a run another path made terminal", async () => {
     // A failRun or a cancel commits its terminal status without finishRun's
     // claim, so the run carries no finishedAt: there is no finalization of a

--- a/services/api/test/result-finalization.test.ts
+++ b/services/api/test/result-finalization.test.ts
@@ -1,0 +1,453 @@
+import { hashKey, newId } from "@facility/core";
+import {
+  agentDefs,
+  auditEvents,
+  conversationMessages,
+  conversations,
+  createDb,
+  migrate,
+  projects,
+  registryItems,
+  runEvents,
+  runs,
+  seed,
+  virtualKeys,
+} from "@facility/db";
+import { and, eq, sql } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../src/app.js";
+import { type FinalizationStep, finishRun } from "../src/sandbox/orchestrator.js";
+import {
+  appendRunEvents,
+  RESULT_FINALIZATION_LEASE_MS,
+  readSandbox,
+} from "../src/sandbox/state.js";
+import type { AppConfig } from "../src/types.js";
+
+const databaseUrl =
+  process.env.DATABASE_URL ?? "postgres://facility:facility@localhost:5461/facility_test";
+const masterKey = Buffer.alloc(32, 8).toString("base64");
+
+async function canConnect() {
+  const sqlClient = postgres(databaseUrl, { max: 1, connect_timeout: 10 });
+  try {
+    await sqlClient`select 1`;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await sqlClient.end().catch(() => undefined);
+  }
+}
+
+// finishRun commits the terminal status first and only then does the work that
+// follows it: reclaiming the sandbox and keys, the result and audit events, the
+// conversation reply. A control plane that goes down inside that window has a
+// run whose verdict is recorded and whose finalization is not, and the runner's
+// replay of /result is the only party that comes back for it. These tests cut
+// the first attempt at each depth of that window, replay the result through the
+// route, and check that every effect lands exactly once — and that once it has,
+// the route refuses the run as terminal like any other.
+describe("result finalization after an interrupted terminal claim", async () => {
+  const reachable = await canConnect();
+  if (!reachable) {
+    it.skip("Postgres is unreachable at DATABASE_URL; finalization tests skipped", () => undefined);
+    return;
+  }
+
+  const config: AppConfig = {
+    databaseUrl,
+    secretMasterKey: masterKey,
+    port: 4402,
+    publicUrl: "http://127.0.0.1:0",
+    sandboxApiUrl: "http://127.0.0.1:0",
+    sandboxGatewayUrl: "http://127.0.0.1:0",
+    gatewayUrl: "http://localhost:4410",
+    sandboxRunnerImage: "facility-runner:dev",
+    sandboxDriver: "docker",
+    webUrl: "http://localhost:3000",
+    facilityInsecureDev: true,
+    packageRegistryToken: "package-token",
+    logLevel: "silent",
+  };
+  const { db, client } = createDb(databaseUrl);
+  const app = await buildApp(config);
+  let orgId = "";
+  let projectId = "";
+  let agentDefId = "";
+
+  beforeAll(async () => {
+    await migrate(databaseUrl);
+    await seed(databaseUrl);
+    await app.ready();
+    const login = await app.inject({
+      method: "POST",
+      url: "/__test/session",
+      payload: { email: `finalization-${Date.now()}@example.com` },
+    });
+    orgId = login.json().orgId;
+    const project = (
+      await db
+        .insert(projects)
+        .values({
+          id: newId("proj"),
+          orgId,
+          name: "Finalization Test Project",
+          slug: `finalization-${Date.now()}`,
+          settings: {},
+        })
+        .returning()
+    )[0];
+    projectId = project?.id ?? "";
+    const contract = (
+      await db
+        .insert(registryItems)
+        .values({
+          id: newId("item"),
+          orgId,
+          scope: "project",
+          projectId,
+          kind: "agent_contract",
+          name: `finalization-contract-${Date.now()}`,
+        })
+        .returning()
+    )[0];
+    if (!contract) throw new Error("contract fixture missing");
+    const agent = (
+      await db
+        .insert(agentDefs)
+        .values({
+          id: newId("agent"),
+          orgId,
+          projectId,
+          name: `finalization-agent-${Date.now()}`,
+          engine: "claude_code",
+          model: {},
+          contractItemId: contract.id,
+          triggers: [],
+          permissions: [],
+          enabled: true,
+        })
+        .returning()
+    )[0];
+    if (!agent) throw new Error("agent fixture missing");
+    agentDefId = agent.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await client.end();
+  });
+
+  // A conversation run with a live virtual key: the fixture that touches the
+  // most steps after the claim — key revocation, the result event, the audit
+  // row, and the conversation reply that unlocks the thread.
+  async function conversationRun(label: string) {
+    const token = `frt_${label}_${Date.now()}`;
+    const runId = newId("run");
+    const virtualKeyId = newId("vkey");
+    const conversationId = newId("evt");
+    const run = (
+      await db
+        .insert(runs)
+        .values({
+          id: runId,
+          orgId,
+          projectId,
+          agentDefId,
+          mode: "conversation",
+          engine: "claude_code",
+          status: "running",
+          trigger: { type: "conversation", conversationId, message: "hello" },
+          sandbox: { runnerTokenHash: await hashKey(token), virtualKeyId },
+          createdBy: { type: "user", id: "test" },
+        })
+        .returning()
+    )[0];
+    if (!run) throw new Error("run fixture missing");
+    await db.insert(virtualKeys).values({
+      id: virtualKeyId,
+      orgId,
+      projectId,
+      runId,
+      name: `${label} run key`,
+      prefix: `${label}_${Date.now()}`,
+      last4: "0000",
+      hash: `${label}-hash`,
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    // Pinned to the run the way the message handler pins it at dispatch:
+    // finishConversationTurn finalizes only the run the thread points at.
+    await db.insert(conversations).values({
+      id: conversationId,
+      orgId,
+      projectId,
+      agentDefId,
+      status: "running",
+      lastRunId: runId,
+      createdBy: { type: "user", id: "test" },
+    });
+    await appendRunEvents(db, orgId, run.id, [{ type: "assistant", data: { text: "the reply" } }]);
+    return { run, token, conversationId, virtualKeyId };
+  }
+
+  async function finalizationState(runId: string, conversationId: string, virtualKeyId: string) {
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    const results = await db
+      .select({ seq: runEvents.seq })
+      .from(runEvents)
+      .where(and(eq(runEvents.runId, runId), eq(runEvents.type, "result")));
+    const finished = await db
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.orgId, orgId),
+          eq(auditEvents.action, "run.finished"),
+          sql`${auditEvents.target}->>'id' = ${runId}`,
+        ),
+      );
+    const replies = await db
+      .select({ id: conversationMessages.id })
+      .from(conversationMessages)
+      .where(eq(conversationMessages.runId, runId));
+    const [conversation] = await db
+      .select({ status: conversations.status })
+      .from(conversations)
+      .where(eq(conversations.id, conversationId));
+    const [key] = await db
+      .select({ revokedAt: virtualKeys.revokedAt })
+      .from(virtualKeys)
+      .where(eq(virtualKeys.id, virtualKeyId));
+    return {
+      status: stored?.status,
+      sandbox: readSandbox(stored?.sandbox),
+      resultEvents: results.length,
+      finishedAudits: finished.length,
+      replies: replies.length,
+      conversationStatus: conversation?.status,
+      keyRevoked: key?.revokedAt !== null,
+    };
+  }
+
+  const body = { status: "succeeded" as const, engineSessionId: "sess_finalization" };
+
+  // The wait the runner would have spent: the lease the dead attempt took at
+  // its claim is moved back past its own length, so the next replay may take
+  // it over.
+  async function expireFinalizationLease(runId: string) {
+    const expired = new Date(Date.now() - RESULT_FINALIZATION_LEASE_MS - 1_000).toISOString();
+    await db
+      .update(runs)
+      .set({ sandbox: sql`${runs.sandbox} || ${JSON.stringify({ finalizingAt: expired })}::jsonb` })
+      .where(eq(runs.id, runId));
+  }
+
+  async function postResult(runId: string, token: string) {
+    return app.inject({
+      method: "POST",
+      url: `/internal/runs/${runId}/result`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: body,
+    });
+  }
+
+  // One case per depth of the window: the attempt is cut right after the claim,
+  // after the keys are revoked, after the result event, and after the audit row
+  // — so a resumed attempt has to skip a different prefix of the work each time.
+  it.each<{ interruptAfter: FinalizationStep; before: Record<string, unknown> }>([
+    {
+      interruptAfter: "claim",
+      before: { keyRevoked: false, resultEvents: 0, finishedAudits: 0, replies: 0 },
+    },
+    {
+      interruptAfter: "keys",
+      before: { keyRevoked: true, resultEvents: 0, finishedAudits: 0, replies: 0 },
+    },
+    {
+      interruptAfter: "result_event",
+      before: { keyRevoked: true, resultEvents: 1, finishedAudits: 0, replies: 0 },
+    },
+    {
+      interruptAfter: "audit",
+      before: { keyRevoked: true, resultEvents: 1, finishedAudits: 1, replies: 0 },
+    },
+  ])("resumes a finalization interrupted after $interruptAfter and completes it exactly once", async ({
+    interruptAfter,
+    before,
+  }) => {
+    const { run, token, conversationId, virtualKeyId } = await conversationRun(
+      `resume_${interruptAfter}`,
+    );
+
+    // The first attempt: the control plane dies at the chosen step. The claim
+    // is committed, whatever came after it is not.
+    await expect(
+      finishRun(db, run, body, {
+        afterFinalizationStep: (step) => {
+          if (step === interruptAfter) throw new Error("control plane restarted");
+        },
+      }),
+    ).rejects.toThrow("control plane restarted");
+    const interrupted = await finalizationState(run.id, conversationId, virtualKeyId);
+    expect(interrupted).toMatchObject({ status: "succeeded", ...before });
+    expect(interrupted.sandbox.finishedAt).toEqual(expect.any(String));
+    expect(interrupted.sandbox.finalizedAt).toBeUndefined();
+    expect(interrupted.conversationStatus).toBe("running");
+
+    // The runner's replay of the same result, through the route. Admitted
+    // although the run is terminal, because its finalization is pending — but
+    // not before the dead attempt's lease has run out.
+    const early = await postResult(run.id, token);
+    expect(early.statusCode).toBe(503);
+    expect(early.json().error.code).toBe("finalization_in_progress");
+    expect(Number(early.headers["retry-after"])).toBeGreaterThan(0);
+    expect(await finalizationState(run.id, conversationId, virtualKeyId)).toMatchObject(before);
+    await expireFinalizationLease(run.id);
+    const replay = await postResult(run.id, token);
+    expect(replay.statusCode).toBe(200);
+    expect(replay.json()).toMatchObject({ id: run.id, status: "succeeded" });
+    const resumed = await finalizationState(run.id, conversationId, virtualKeyId);
+    expect(resumed).toMatchObject({
+      status: "succeeded",
+      keyRevoked: true,
+      resultEvents: 1,
+      finishedAudits: 1,
+      replies: 1,
+      conversationStatus: "idle",
+    });
+    expect(resumed.sandbox.finalizedAt).toEqual(expect.any(String));
+
+    // Finalized, the run is terminal to every request, this one included, and
+    // a further replay changes nothing.
+    const again = await postResult(run.id, token);
+    expect(again.statusCode).toBe(409);
+    expect(again.json().error.code).toBe("run_terminal");
+    expect(await finalizationState(run.id, conversationId, virtualKeyId)).toEqual(resumed);
+  });
+
+  it("finalizes an uninterrupted result once and refuses its replay", async () => {
+    const { run, token, conversationId, virtualKeyId } = await conversationRun("uninterrupted");
+    const first = await postResult(run.id, token);
+    expect(first.statusCode).toBe(200);
+    const finalized = await finalizationState(run.id, conversationId, virtualKeyId);
+    expect(finalized).toMatchObject({
+      status: "succeeded",
+      keyRevoked: true,
+      resultEvents: 1,
+      finishedAudits: 1,
+      replies: 1,
+      conversationStatus: "idle",
+    });
+    expect(finalized.sandbox.finalizedAt).toEqual(expect.any(String));
+    const replay = await postResult(run.id, token);
+    expect(replay.statusCode).toBe(409);
+    expect(replay.json().error.code).toBe("run_terminal");
+    expect(await finalizationState(run.id, conversationId, virtualKeyId)).toEqual(finalized);
+  });
+
+  it("admits only /result into the pending window, and only with the run's token", async () => {
+    const { run, token } = await conversationRun("window");
+    await expect(
+      finishRun(db, run, body, {
+        afterFinalizationStep: (step) => {
+          if (step === "claim") throw new Error("control plane restarted");
+        },
+      }),
+    ).rejects.toThrow("control plane restarted");
+
+    // Every other runner route has nothing left to do for a run whose verdict
+    // is committed, pending finalization or not.
+    const events = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/events`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: [{ type: "log", data: { line: "late" } }],
+    });
+    expect(events.statusCode).toBe(409);
+    expect(events.json().error.code).toBe("run_terminal");
+
+    // The admission is a narrowing of the terminal refusal, not of the token
+    // check: a replay with the wrong token is refused like any other request.
+    const forged = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/result`,
+      headers: { authorization: "Bearer frt_not_this_run" },
+      payload: body,
+    });
+    expect(forged.statusCode).toBe(401);
+    const [stored] = await db.select().from(runs).where(eq(runs.id, run.id));
+    expect(readSandbox(stored?.sandbox).finalizedAt).toBeUndefined();
+  });
+
+  it("lets one replay take over an expired lease and holds the rest off", async () => {
+    // The attempt a rolling restart cut the runner off from may still be
+    // running on the old process while the runner replays to the new one, so
+    // a replay never runs the steps beside another attempt: it waits the lease
+    // out, and of two replays that arrive on an expired lease only one runs.
+    const { run, token, conversationId, virtualKeyId } = await conversationRun("lease");
+    await expect(
+      finishRun(db, run, body, {
+        afterFinalizationStep: (step) => {
+          if (step === "claim") throw new Error("control plane restarted");
+        },
+      }),
+    ).rejects.toThrow("control plane restarted");
+    await expireFinalizationLease(run.id);
+    // Two replays on the expired lease at once: the takeover is one atomic
+    // update, so exactly one wins it, and the other sees a lease just renewed.
+    const [first, second] = await Promise.all([
+      postResult(run.id, token),
+      postResult(run.id, token),
+    ]);
+    expect([first.statusCode, second.statusCode].sort()).toEqual([200, 503]);
+    const held = first.statusCode === 503 ? first : second;
+    expect(held.json().error.code).toBe("finalization_in_progress");
+    expect(await finalizationState(run.id, conversationId, virtualKeyId)).toMatchObject({
+      keyRevoked: true,
+      resultEvents: 1,
+      finishedAudits: 1,
+      replies: 1,
+      conversationStatus: "idle",
+    });
+  });
+
+  it("refuses a result for a run another path made terminal", async () => {
+    // A failRun or a cancel commits its terminal status without finishRun's
+    // claim, so the run carries no finishedAt: there is no finalization of a
+    // result to resume, and the runner's late verdict is refused as before.
+    const token = `frt_failed_${Date.now()}`;
+    const run = (
+      await db
+        .insert(runs)
+        .values({
+          id: newId("run"),
+          orgId,
+          projectId,
+          mode: "builder",
+          engine: "byo",
+          status: "failed",
+          error: "sandbox_lost",
+          trigger: {},
+          sandbox: { runnerTokenHash: await hashKey(token) },
+          createdBy: { type: "user", id: "test" },
+        })
+        .returning()
+    )[0];
+    if (!run) throw new Error("run fixture missing");
+    const response = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/result`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: body,
+    });
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("run_terminal");
+    const results = await db
+      .select({ seq: runEvents.seq })
+      .from(runEvents)
+      .where(and(eq(runEvents.runId, run.id), eq(runEvents.type, "result")));
+    expect(results).toHaveLength(0);
+  });
+});

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -35,6 +35,7 @@ import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../src/app.js";
 import { verifyStoredReceipts } from "../src/receipt-integrity.js";
+import { STEER_ACK_MAX, STEER_BATCH } from "../src/routes/internal.js";
 import { AwsSandboxDriver } from "../src/sandbox/aws.js";
 import { sandboxCachePartition, sandboxNamespace } from "../src/sandbox/cache.js";
 import { DockerSandboxDriver } from "../src/sandbox/docker.js";
@@ -1125,7 +1126,10 @@ describe("sandbox api", async () => {
     const message = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
     const poll = {
       method: "GET" as const,
-      url: `/internal/runs/${run.id}/steer`,
+      // The ack parameter present and empty: a runner that speaks this protocol
+      // sends it on every poll, its first included, and empty whenever it has
+      // nothing to name.
+      url: `/internal/runs/${run.id}/steer?ack=`,
       headers: { authorization: `Bearer ${token}` },
     };
 
@@ -1152,7 +1156,11 @@ describe("sandbox api", async () => {
       method: "GET",
       // Two acked ids straddling an unacked one: the runner handled the first
       // and the third and could not apply the second. Only an exact-id ack can
-      // express that, and the runner's poison-message bound produces it.
+      // express that, and the runner produces it by applying the rest of a batch
+      // rather than stopping at the message that failed, and leaving that
+      // message's id out of the ack. Its poison-message bound is what ends the
+      // straddle: past enough attempts a steer that keeps failing joins the ack
+      // anyway, so the route stops serving it.
       url: `/internal/runs/${run.id}/steer?ack=${handled.id},${alsoHandled.id}`,
       headers: { authorization: `Bearer ${token}` },
     });
@@ -1213,12 +1221,12 @@ describe("sandbox api", async () => {
     });
     expect(ack.statusCode).toBe(200);
 
-    // The runner polls again carrying no ack — the shape of the poll that
-    // follows an ack whose response arrived. The recorded delivery is the only
-    // thing keeping the already-applied interrupt from being applied twice.
+    // The runner polls again with the ack parameter empty — the shape of the poll
+    // that follows an ack whose response arrived. The recorded delivery is the
+    // only thing keeping the already-applied interrupt from being applied twice.
     const restarted = await app.inject({
       method: "GET",
-      url: `/internal/runs/${run.id}/steer`,
+      url: `/internal/runs/${run.id}/steer?ack=`,
       headers: { authorization: `Bearer ${token}` },
     });
 
@@ -1229,20 +1237,22 @@ describe("sandbox api", async () => {
     const token = "frt_steer_bad_ack";
     const run = await insertRunnerRun(token, "running");
     const pending = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
-    // The shapes a buggy or hostile caller reaches for: a prefix with no id
-    // ('evt_z' also sorts above every real id under this database's en_US.utf8
-    // collation), an empty entry, a non-id, a real id with a suffix, a real id
-    // upper-cased, a valid id with one bad entry beside it, and a list longer
-    // than a served batch can be. The route takes only ids it could have issued,
-    // so each list is refused whole and nothing is marked delivered.
+    // The shapes a buggy or hostile caller reaches for. All but the last name
+    // something this route could not have issued — a prefix with no id ('evt_z'
+    // also sorts above every real id under this database's en_US.utf8
+    // collation), an empty entry beside a real one, a non-id, a real id with a
+    // suffix, a real id upper-cased, and a valid id with one bad entry beside
+    // it. The last names nothing but ids this route could have issued and is
+    // refused for its length alone. Either way the list is refused whole and
+    // nothing is marked delivered.
     const malformed = [
       "evt_z",
-      "",
+      `,${pending.id}`,
       "not-an-id",
       `${pending.id}x`,
       pending.id.toUpperCase(),
       `${pending.id},evt_z`,
-      Array.from({ length: 33 }, () => pending.id).join(","),
+      Array.from({ length: STEER_ACK_MAX + 1 }, () => pending.id).join(","),
     ];
     for (const ack of malformed) {
       const rejected = await app.inject({
@@ -1256,7 +1266,7 @@ describe("sandbox api", async () => {
 
     const response = await app.inject({
       method: "GET",
-      url: `/internal/runs/${run.id}/steer`,
+      url: `/internal/runs/${run.id}/steer?ack=`,
       headers: { authorization: `Bearer ${token}` },
     });
     expect(steerIds(response)).toEqual([pending.id]);
@@ -1319,7 +1329,10 @@ describe("sandbox api", async () => {
     // steer_messages carries its own org_id and no constraint ties it to the
     // org of the run it names, so a row like this one is reachable through a
     // mis-scoped writer. Both statements on this route stay inside the polling
-    // run's org, like every other runner-scoped query in this file.
+    // run's org, which is not true of every runner-scoped query on these
+    // internal routes: /hello claims the run's credentials on the run id and
+    // status alone, and two of the three installation lookups match on
+    // installation id alone.
     const foreignOrg = (
       await db
         .insert(steerMessages)
@@ -1370,10 +1383,15 @@ describe("sandbox api", async () => {
     expect(response.statusCode).toBe(200);
     expect(steerIds(response)).toEqual([next.id]);
     // A runner started before the ack existed polls with this cursor, applies
-    // whatever comes back and starts the next poll with no delay of its own. The
-    // delivery this response records is the only thing that retires the row for
-    // it: without it the same body is served again on the very next poll, and on
-    // every poll after that for the rest of the run.
+    // whatever comes back and starts the next poll with no delay of its own,
+    // having no ack to retire anything with. What this test replays is one poll
+    // object — the same cursor twice — so the delivery recorded here is what
+    // keeps the same body out of the second response. That runner does not
+    // repeat a cursor: it moves it to each message it applies. What the delivery
+    // buys it is the row the cursor alone would hand it twice, since a batch is
+    // ordered by createdAt while the cursor filters on id, and ids come from
+    // per-process counters — so a row of that same batch can sort above the
+    // cursor the runner ends up with and be applied a second time.
     expect(await steerDeliveries(run.id)).toEqual([
       { id: seen.id, deliveredAt: null },
       { id: next.id, deliveredAt: expect.any(Date) },
@@ -1445,6 +1463,118 @@ describe("sandbox api", async () => {
       { id: handled.id, deliveredAt: expect.any(Date) },
       { id: served.id, deliveredAt: null },
     ]);
+  });
+
+  it("records delivery from the select for a poll carrying no ack parameter at all", async () => {
+    const token = "frt_steer_legacy_first_poll";
+    const run = await insertRunnerRun(token, "running");
+    const first = await insertSteerMessage(run.id, "steer", "tighten the diff");
+
+    // A runner that predates the ack opens its loop with a bare poll: it has no
+    // cursor until a batch gives it one, so its first poll carries no parameter
+    // of any kind. The presence of the ack parameter is the only thing that
+    // tells that runner apart from one that speaks this protocol, since the
+    // latter sends the parameter empty rather than omitting it.
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(steerIds(response)).toEqual([first.id]);
+    // That runner applies what comes back and never names an id, so this
+    // response is the only thing that can retire the row. Left pending, the row
+    // is served again on a later poll whenever its id sorts above the cursor
+    // that runner ends up with — it takes the cursor from the last message of
+    // the batch in this route's order, which is createdAt first, while the
+    // compatibility select filters on id — and the steer body is appended a
+    // second time.
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: first.id, deliveredAt: expect.any(Date) },
+    ]);
+  });
+
+  it("leaves another org's message unserved on a poll carrying no ack parameter", async () => {
+    const token = "frt_steer_legacy_cross_org";
+    const run = await insertRunnerRun(token, "running");
+    const otherOrgId = newId("org");
+    await db.insert(orgs).values({
+      id: otherOrgId,
+      name: "Steer Legacy Other Org",
+      slug: `steer-legacy-${Date.now()}`,
+    });
+    // Inserted first, so it is the oldest pending row on this run and the batch
+    // would open with it. steer_messages carries its own org_id and no
+    // constraint ties it to the org of the run it names.
+    const foreignOrg = (
+      await db
+        .insert(steerMessages)
+        .values({
+          id: newId("evt"),
+          orgId: otherOrgId,
+          runId: run.id,
+          kind: "interrupt",
+          body: "human_interrupt",
+        })
+        .returning()
+    )[0];
+    if (!foreignOrg) throw new Error("failed to insert cross-org steer message");
+    const pending = await insertSteerMessage(run.id, "steer", "keep going");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // The compatibility path serves and marks in one exchange, so the org scope
+    // on its select is what keeps the foreign row out of both: never handed to
+    // this run, and therefore never among the ids its response retires.
+    expect(steerIds(response)).toEqual([pending.id]);
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: foreignOrg.id, deliveredAt: null },
+      { id: pending.id, deliveredAt: expect.any(Date) },
+    ]);
+  });
+
+  it("acknowledges a whole served batch in one request", async () => {
+    const token = "frt_steer_full_batch";
+    const run = await insertRunnerRun(token, "running");
+    const inserted = [];
+    // One past the batch limit, so the batch comes back full and the poll that
+    // acknowledges it still has a pending row to answer with at once.
+    for (let i = 0; i <= STEER_BATCH; i += 1) {
+      inserted.push(await insertSteerMessage(run.id, "steer", `tighten the diff ${i}`));
+    }
+    const batch = inserted.slice(0, STEER_BATCH);
+
+    const served = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(served.statusCode).toBe(200);
+    expect(steerIds(served)).toEqual(batch.map((message) => message.id));
+
+    // The whole batch acknowledged in one request, which is what a runner does
+    // after applying it. Refused, this ack would take every id in it down
+    // together and the runner would re-send the same list on every later poll.
+    const acked = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${batch.map((message) => message.id).join(",")}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(acked.statusCode).toBe(200);
+    expect(await steerDeliveries(run.id)).toEqual(
+      inserted.map((message) => ({
+        id: message.id,
+        deliveredAt: batch.includes(message) ? expect.any(Date) : null,
+      })),
+    );
   });
 
   it("aws driver fails loudly as not_configured when env is missing", async () => {
@@ -2452,8 +2582,10 @@ describe("sandbox api", async () => {
       prefix: `lossrace_${Date.now()}`,
       last4: "0000",
       hash: "loss-race-hash",
-      // Far-future expiry, so a null revokedAt proves nothing revoked the key
-      // rather than proving it merely outlived its own lifetime.
+      // Nothing but an explicit revoke writes revokedAt, so the null asserted
+      // below holds whatever this date says. What a far-future expiry buys is a
+      // key the surviving run can still use: authentication turns away an
+      // expired key as firmly as a revoked one.
       expiresAt: new Date(Date.now() + 3_600_000),
     });
     // driver.status() is a provider round trip, so an overlapping tick can see

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -1977,8 +1977,6 @@ describe("sandbox api", async () => {
     await reconcileSandboxes(config, undefined, { sandboxDriver: async () => exitedDriver });
 
     const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
-    // A single "exited" probe must not fail the run: the runner may be riding
-    // out a control-plane restart, or the result may already be in flight.
     expect(stored?.status).toBe("running");
     expect(Number.isFinite(Date.parse(readSandbox(stored?.sandbox).lossObservedAt ?? ""))).toBe(
       true,
@@ -2012,6 +2010,69 @@ describe("sandbox api", async () => {
     expect(stored?.status).toBe("failed");
     expect(stored?.error).toBe("sandbox_lost");
     await db.update(runs).set({ sandbox: {} }).where(eq(runs.id, runId));
+  });
+
+  it("does not move an in-window loss stamp on a repeat observation", async () => {
+    const runId = newId("run");
+    const stamp = new Date(Date.now() - 30_000).toISOString();
+    await insertRunnerRun("frt_grace_hold", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_grace_hold"),
+      lossObservedAt: stamp,
+    });
+    const exitedDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async () => "exited",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => exitedDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    // Restamping on every tick would keep resetting the window and a genuinely
+    // dead sandbox could never be confirmed lost.
+    expect(readSandbox(stored?.sandbox).lossObservedAt).toBe(stamp);
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
+      .where(eq(runs.id, runId));
+  });
+
+  it("replaces an unreadable loss stamp so the grace window can still run", async () => {
+    const runId = newId("run");
+    await insertRunnerRun("frt_grace_corrupt", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_grace_corrupt"),
+      lossObservedAt: "not-a-date",
+    });
+    const exitedDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async () => "exited",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => exitedDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    const lossObservedAt = readSandbox(stored?.sandbox).lossObservedAt;
+    // A stamp that cannot be parsed can never confirm; leaving it in place
+    // would wedge the run live forever with a dead sandbox.
+    expect(lossObservedAt).not.toBe("not-a-date");
+    expect(Number.isFinite(Date.parse(lossObservedAt ?? ""))).toBe(true);
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
+      .where(eq(runs.id, runId));
   });
 
   it("clears the loss observation when the sandbox is seen alive again", async () => {

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -44,6 +44,7 @@ import {
   reconcileSandboxes,
   repairExpectedHeadSha,
   runDeliveryRefMismatch,
+  SANDBOX_LOSS_GRACE_MS,
 } from "../src/sandbox/orchestrator.js";
 import { appendRunEvents, readSandbox } from "../src/sandbox/state.js";
 import type { AppConfig } from "../src/types.js";
@@ -1954,6 +1955,90 @@ describe("sandbox api", async () => {
     await db
       .update(runs)
       .set({ status: "canceled", endedAt: new Date() })
+      .where(eq(runs.id, runId));
+  });
+
+  it("gives a lost-looking sandbox a reconcile grace window before failing the run", async () => {
+    const runId = newId("run");
+    await insertRunnerRun("frt_grace_first", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_grace_first"),
+    });
+    const exitedDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async () => "exited",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => exitedDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    // A single "exited" probe must not fail the run: the runner may be riding
+    // out a control-plane restart, or the result may already be in flight.
+    expect(stored?.status).toBe("running");
+    expect(Number.isFinite(Date.parse(readSandbox(stored?.sandbox).lossObservedAt ?? ""))).toBe(
+      true,
+    );
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
+      .where(eq(runs.id, runId));
+  });
+
+  it("fails a run as sandbox_lost once the loss persists past the grace window", async () => {
+    const runId = newId("run");
+    await insertRunnerRun("frt_grace_confirm", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_grace_confirm"),
+      lossObservedAt: new Date(Date.now() - SANDBOX_LOSS_GRACE_MS - 60_000).toISOString(),
+    });
+    const exitedDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async () => "exited",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => exitedDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("failed");
+    expect(stored?.error).toBe("sandbox_lost");
+    await db.update(runs).set({ sandbox: {} }).where(eq(runs.id, runId));
+  });
+
+  it("clears the loss observation when the sandbox is seen alive again", async () => {
+    const runId = newId("run");
+    await insertRunnerRun("frt_grace_recover", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_grace_recover"),
+      lossObservedAt: new Date(Date.now() - 30_000).toISOString(),
+    });
+    const runningDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async () => "running",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => runningDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    expect(readSandbox(stored?.sandbox).lossObservedAt).toBeUndefined();
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
       .where(eq(runs.id, runId));
   });
 

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -16,6 +16,7 @@ import {
   githubInstallations,
   kbSpaces,
   migrate,
+  orgs,
   projects,
   providerCredentials,
   registryItems,
@@ -26,9 +27,10 @@ import {
   runs,
   sandboxProfiles,
   seed,
+  steerMessages,
   virtualKeys,
 } from "@facility/db";
-import { and, eq, sql } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../src/app.js";
@@ -1117,6 +1119,334 @@ describe("sandbox api", async () => {
     expect(stored?.ts).toBeInstanceOf(Date);
   });
 
+  it("returns a control message without marking it delivered", async () => {
+    const token = "frt_steer_pending";
+    const run = await insertRunnerRun(token, "running");
+    const message = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
+    const poll = {
+      method: "GET" as const,
+      url: `/internal/runs/${run.id}/steer`,
+      headers: { authorization: `Bearer ${token}` },
+    };
+
+    const first = await app.inject(poll);
+
+    expect(first.statusCode).toBe(200);
+    expect(steerIds(first)).toEqual([message.id]);
+    // A response lost on the wire must leave the row pending, otherwise the
+    // retry filters out a message the runner never saw and the operator's
+    // interrupt disappears with no error surfaced anywhere.
+    expect(await steerDeliveries(run.id)).toEqual([{ id: message.id, deliveredAt: null }]);
+    const retry = await app.inject(poll);
+    expect(steerIds(retry)).toEqual([message.id]);
+  });
+
+  it("marks delivered exactly the acknowledged ids", async () => {
+    const token = "frt_steer_ack";
+    const run = await insertRunnerRun(token, "running");
+    const handled = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const skipped = await insertSteerMessage(run.id, "steer", "and rerun the checks");
+    const alsoHandled = await insertSteerMessage(run.id, "steer", "then push");
+
+    const response = await app.inject({
+      method: "GET",
+      // Two acked ids straddling an unacked one: the runner handled the first
+      // and the third and could not apply the second. Only an exact-id ack can
+      // express that, and the runner's poison-message bound produces it.
+      url: `/internal/runs/${run.id}/steer?ack=${handled.id},${alsoHandled.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: handled.id, deliveredAt: expect.any(Date) },
+      { id: skipped.id, deliveredAt: null },
+      { id: alsoHandled.id, deliveredAt: expect.any(Date) },
+    ]);
+    // Delivery, not an id comparison, is what filters the next batch, so the
+    // unacked message keeps coming back until the runner acknowledges it.
+    expect(steerIds(response)).toEqual([skipped.id]);
+  });
+
+  it("does not mark delivered a message it never returned", async () => {
+    const token = "frt_steer_below_cursor";
+    const run = await insertRunnerRun(token, "running");
+    // Two API tasks generate ids from independent uuidv7 counters, so a message
+    // committed second can still sort first. `late` stands in for that row: it
+    // becomes visible only after the runner already handled `handled`. A shared
+    // stem with hand-picked last bytes fixes that order, which newId() cannot
+    // express, while keeping each id unique and shaped like a real one.
+    const stem = newId("evt").slice(0, -2);
+    const handled = await insertSteerMessage(run.id, "steer", "tighten", `${stem}b2`);
+    const late = await insertSteerMessage(run.id, "interrupt", "stop", `${stem}a1`);
+    const later = await insertSteerMessage(run.id, "steer", "rerun", `${stem}c3`);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${handled.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // An ack covers the ids the runner handled, nothing else. Matching exact ids
+    // rather than a cursor is what leaves `late` alone: a range ack would mark it
+    // delivered without it ever having been served to anyone, which is the
+    // silently dropped interrupt this route exists to prevent.
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: late.id, deliveredAt: null },
+      { id: handled.id, deliveredAt: expect.any(Date) },
+      { id: later.id, deliveredAt: null },
+    ]);
+    expect(steerIds(response)).toEqual([late.id, later.id]);
+  });
+
+  it("does not resurrect an acknowledged message", async () => {
+    const token = "frt_steer_acked";
+    const run = await insertRunnerRun(token, "running");
+    const acked = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
+    const pending = await insertSteerMessage(run.id, "steer", "keep going");
+
+    const ack = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${acked.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(ack.statusCode).toBe(200);
+
+    // The runner polls again carrying no ack — the shape of the poll that
+    // follows an ack whose response arrived. The recorded delivery is the only
+    // thing keeping the already-applied interrupt from being applied twice.
+    const restarted = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(steerIds(restarted)).toEqual([pending.id]);
+  });
+
+  it("rejects a malformed acknowledgment without mutating deliveries", async () => {
+    const token = "frt_steer_bad_ack";
+    const run = await insertRunnerRun(token, "running");
+    const pending = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
+    // The shapes a buggy or hostile caller reaches for: a prefix with no id
+    // ('evt_z' also sorts above every real id under this database's en_US.utf8
+    // collation), an empty entry, a non-id, a real id with a suffix, a real id
+    // upper-cased, a valid id with one bad entry beside it, and a list longer
+    // than a served batch can be. The route takes only ids it could have issued,
+    // so each list is refused whole and nothing is marked delivered.
+    const malformed = [
+      "evt_z",
+      "",
+      "not-an-id",
+      `${pending.id}x`,
+      pending.id.toUpperCase(),
+      `${pending.id},evt_z`,
+      Array.from({ length: 33 }, () => pending.id).join(","),
+    ];
+    for (const ack of malformed) {
+      const rejected = await app.inject({
+        method: "GET",
+        url: `/internal/runs/${run.id}/steer?ack=${encodeURIComponent(ack)}`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(rejected.statusCode).toBe(400);
+      expect(await steerDeliveries(run.id)).toEqual([{ id: pending.id, deliveredAt: null }]);
+    }
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(steerIds(response)).toEqual([pending.id]);
+  });
+
+  it("accepts a repeated ack parameter", async () => {
+    const token = "frt_steer_repeated_ack";
+    const run = await insertRunnerRun(token, "running");
+    const first = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const second = await insertSteerMessage(run.id, "steer", "and rerun the checks");
+    const pending = await insertSteerMessage(run.id, "steer", "then push");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${first.id}&ack=${second.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(steerIds(response)).toEqual([pending.id]);
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: first.id, deliveredAt: expect.any(Date) },
+      { id: second.id, deliveredAt: expect.any(Date) },
+      { id: pending.id, deliveredAt: null },
+    ]);
+  });
+
+  it("ignores an acknowledgment for another run's message", async () => {
+    const token = "frt_steer_foreign_ack";
+    const run = await insertRunnerRun(token, "running");
+    const other = await insertRunnerRun("frt_steer_foreign_other", "running");
+    const foreign = await insertSteerMessage(other.id, "interrupt", "human_interrupt");
+    const handled = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const pending = await insertSteerMessage(run.id, "steer", "keep going");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${foreign.id},${handled.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(steerIds(response)).toEqual([pending.id]);
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: handled.id, deliveredAt: expect.any(Date) },
+      { id: pending.id, deliveredAt: null },
+    ]);
+    // The ack is scoped to the polling run, so one runner's token can never
+    // burn another run's interrupt even when it names a well-formed id.
+    expect(await steerDeliveries(other.id)).toEqual([{ id: foreign.id, deliveredAt: null }]);
+  });
+
+  it("leaves another org's message on this run untouched and unserved", async () => {
+    const token = "frt_steer_cross_org_ack";
+    const run = await insertRunnerRun(token, "running");
+    const otherOrgId = newId("org");
+    await db
+      .insert(orgs)
+      .values({ id: otherOrgId, name: "Steer Ack Other Org", slug: `steer-ack-${Date.now()}` });
+    // steer_messages carries its own org_id and no constraint ties it to the
+    // org of the run it names, so a row like this one is reachable through a
+    // mis-scoped writer. Both statements on this route stay inside the polling
+    // run's org, like every other runner-scoped query in this file.
+    const foreignOrg = (
+      await db
+        .insert(steerMessages)
+        .values({
+          id: newId("evt"),
+          orgId: otherOrgId,
+          runId: run.id,
+          kind: "interrupt",
+          body: "human_interrupt",
+        })
+        .returning()
+    )[0];
+    if (!foreignOrg) throw new Error("failed to insert cross-org steer message");
+    const handled = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const pending = await insertSteerMessage(run.id, "steer", "keep going");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${foreignOrg.id},${handled.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: foreignOrg.id, deliveredAt: null },
+      { id: handled.id, deliveredAt: expect.any(Date) },
+      { id: pending.id, deliveredAt: null },
+    ]);
+    // Never served either: a message this run's org cannot be shown is also a
+    // message it can never acknowledge, so serving it would wedge the channel
+    // on a row that comes back on every poll.
+    expect(steerIds(response)).toEqual([pending.id]);
+  });
+
+  it("records delivery from the select for a poll carrying only the retired cursor", async () => {
+    const token = "frt_steer_cursor";
+    const run = await insertRunnerRun(token, "running");
+    const seen = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const next = await insertSteerMessage(run.id, "steer", "and rerun the checks");
+    const poll = {
+      method: "GET" as const,
+      url: `/internal/runs/${run.id}/steer?afterId=${seen.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    };
+
+    const response = await app.inject(poll);
+
+    expect(response.statusCode).toBe(200);
+    expect(steerIds(response)).toEqual([next.id]);
+    // A runner started before the ack existed polls with this cursor, applies
+    // whatever comes back and starts the next poll with no delay of its own. The
+    // delivery this response records is the only thing that retires the row for
+    // it: without it the same body is served again on the very next poll, and on
+    // every poll after that for the rest of the run.
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: seen.id, deliveredAt: null },
+      { id: next.id, deliveredAt: expect.any(Date) },
+    ]);
+    const later = await insertSteerMessage(run.id, "steer", "then push");
+    const second = await app.inject(poll);
+    expect(steerIds(second)).toEqual([later.id]);
+  });
+
+  it("does not record delivery from the select when a poll carries an acknowledgment", async () => {
+    const token = "frt_steer_ack_select";
+    const run = await insertRunnerRun(token, "running");
+    const handled = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const served = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${handled.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(steerIds(response)).toEqual([served.id]);
+    // The served interrupt stays pending until its own ack: a runner that speaks
+    // the ack protocol must lose nothing to a response that drops on the wire.
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: handled.id, deliveredAt: expect.any(Date) },
+      { id: served.id, deliveredAt: null },
+    ]);
+  });
+
+  it("rejects a malformed cursor without mutating deliveries", async () => {
+    const token = "frt_steer_bad_cursor";
+    const run = await insertRunnerRun(token, "running");
+    const pending = await insertSteerMessage(run.id, "interrupt", "human_interrupt");
+    // A request carrying the cursor marks rows delivered, so the cursor is held
+    // to the same rule as an ack: only an id this route could have issued, and a
+    // refusal touches nothing.
+    const malformed = ["evt_z", "", "not-an-id", `${pending.id}x`, pending.id.toUpperCase()];
+    for (const afterId of malformed) {
+      const rejected = await app.inject({
+        method: "GET",
+        url: `/internal/runs/${run.id}/steer?afterId=${encodeURIComponent(afterId)}`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(rejected.statusCode).toBe(400);
+      expect(await steerDeliveries(run.id)).toEqual([{ id: pending.id, deliveredAt: null }]);
+    }
+  });
+
+  it("takes the acknowledgment path when a poll carries both", async () => {
+    const token = "frt_steer_ack_and_cursor";
+    const run = await insertRunnerRun(token, "running");
+    const handled = await insertSteerMessage(run.id, "steer", "tighten the diff");
+    const served = await insertSteerMessage(run.id, "steer", "and rerun the checks");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/internal/runs/${run.id}/steer?ack=${handled.id}&afterId=${handled.id}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(steerIds(response)).toEqual([served.id]);
+    // An ack names a runner that handles the acked ids itself, so the cursor
+    // beside it changes nothing: the served row is not marked from the select,
+    // which a cursor poll would have done.
+    expect(await steerDeliveries(run.id)).toEqual([
+      { id: handled.id, deliveredAt: expect.any(Date) },
+      { id: served.id, deliveredAt: null },
+    ]);
+  });
+
   it("aws driver fails loudly as not_configured when env is missing", async () => {
     await expect(
       new AwsSandboxDriver().launch({
@@ -2103,6 +2433,236 @@ describe("sandbox api", async () => {
       .where(eq(runs.id, runId));
   });
 
+  it("does not fail a run whose loss stamp was cleared while the probe was in flight", async () => {
+    const runId = newId("run");
+    const virtualKeyId = newId("vkey");
+    await insertRunnerRun("frt_loss_race", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_loss_race"),
+      virtualKeyId,
+      lossObservedAt: new Date(Date.now() - SANDBOX_LOSS_GRACE_MS - 60_000).toISOString(),
+    });
+    await db.insert(virtualKeys).values({
+      id: virtualKeyId,
+      orgId,
+      projectId,
+      runId,
+      name: "loss race run key",
+      prefix: `lossrace_${Date.now()}`,
+      last4: "0000",
+      hash: "loss-race-hash",
+      // Far-future expiry, so a null revokedAt proves nothing revoked the key
+      // rather than proving it merely outlived its own lifetime.
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    // driver.status() is a provider round trip, so an overlapping tick can see
+    // the sandbox alive and clear the stamp while this tick waits inside it.
+    // Keyed on the ref because the tick probes every live run through this same
+    // driver, and only this run's probe may move this run's row.
+    const recoveringDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async (ref) => {
+        if (ref !== `fake-${runId}`) return "running";
+        await db
+          .update(runs)
+          .set({ sandbox: sql`coalesce(${runs.sandbox}, '{}'::jsonb) - 'lossObservedAt'` })
+          .where(eq(runs.id, runId));
+        return "lost";
+      },
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => recoveringDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    // sandbox_lost is irreversible: the run goes terminal and its keys are
+    // revoked, so a stale verdict must not land on a recovered sandbox.
+    const [vkey] = await db.select().from(virtualKeys).where(eq(virtualKeys.id, virtualKeyId));
+    expect(vkey?.revokedAt).toBeNull();
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
+      .where(eq(runs.id, runId));
+  });
+
+  it("does not delete a loss stamp written after this tick read the run", async () => {
+    const runId = newId("run");
+    const newerStamp = new Date(Date.now() - 5_000).toISOString();
+    await insertRunnerRun("frt_clear_race", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_clear_race"),
+      lossObservedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    // Keyed on the ref: the tick probes every live run through this driver, so
+    // an unkeyed hook would let a later run's probe restamp this row and hide a
+    // clear that did land.
+    const restampingDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async (ref) => {
+        if (ref !== `fake-${runId}`) return "running";
+        await db
+          .update(runs)
+          .set({
+            sandbox: sql`jsonb_set(coalesce(${runs.sandbox}, '{}'::jsonb), '{lossObservedAt}', to_jsonb(${newerStamp}::text))`,
+          })
+          .where(eq(runs.id, runId));
+        return "running";
+      },
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => restampingDriver });
+
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    // Erasing a newer observation with this tick's stale snapshot would discard
+    // the one the grace window runs on, pushing the verdict out by another window
+    // each time this interleaving recurs.
+    expect(readSandbox(stored?.sandbox).lossObservedAt).toBe(newerStamp);
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
+      .where(eq(runs.id, runId));
+  });
+
+  it("still fails a run whose loss stamp is unchanged past the grace window", async () => {
+    const runId = newId("run");
+    const virtualKeyId = newId("vkey");
+    await insertRunnerRun("frt_loss_unchanged", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_loss_unchanged"),
+      virtualKeyId,
+      lossObservedAt: new Date(Date.now() - SANDBOX_LOSS_GRACE_MS - 60_000).toISOString(),
+    });
+    await db.insert(virtualKeys).values({
+      id: virtualKeyId,
+      orgId,
+      projectId,
+      runId,
+      name: "loss unchanged run key",
+      prefix: `lossdead_${Date.now()}`,
+      last4: "0000",
+      hash: "loss-unchanged-hash",
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    // Keyed on the ref, like the sibling races above: the tick probes every live
+    // run through this driver, so reporting one status for all of them would let
+    // this run's verdict rest on another run's probe.
+    const lostDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async (ref) => (ref === `fake-${runId}` ? "lost" : "running"),
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, { sandboxDriver: async () => lostDriver });
+
+    // Guards the compare-and-set from the opposite failure: matching the stamp
+    // it read must still let a genuinely dead sandbox reach the verdict.
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("failed");
+    expect(stored?.error).toBe("sandbox_lost");
+    const [vkey] = await db.select().from(virtualKeys).where(eq(virtualKeys.id, virtualKeyId));
+    expect(vkey?.revokedAt).not.toBeNull();
+    await db.update(runs).set({ sandbox: {} }).where(eq(runs.id, runId));
+  });
+
+  it("does not mark GitHub progress failed when the failure claim is lost", async () => {
+    const suffix = Date.now();
+    const installation = (
+      await db
+        .insert(githubInstallations)
+        .values({
+          id: newId("int"),
+          orgId,
+          installationId: Math.floor(Math.random() * 2_000_000_000) + 1,
+          accountLogin: `progress-${suffix}`,
+          targetType: "Organization",
+        })
+        .returning()
+    )[0];
+    await db.insert(repos).values({
+      id: newId("repo"),
+      orgId,
+      projectId,
+      installationId: installation?.id,
+      owner: `progress-${suffix}`,
+      name: "repo",
+      defaultBranch: "main",
+    });
+    const runId = newId("run");
+    const commentId = 424_242;
+    await insertRunnerRun("frt_progress_race", "running", runId, {
+      driver: "docker",
+      ref: `fake-${runId}`,
+      runnerTokenHash: await hashKey("frt_progress_race"),
+      lossObservedAt: new Date(Date.now() - SANDBOX_LOSS_GRACE_MS - 60_000).toISOString(),
+    });
+    await db
+      .update(runs)
+      .set({
+        gh: {
+          owner: `progress-${suffix}`,
+          repo: "repo",
+          progressComment: { id: commentId },
+        },
+      })
+      .where(eq(runs.id, runId));
+    const updates: Array<{ comment_id: number; body: string }> = [];
+    const githubClientFactory = (async () => ({
+      rest: {
+        issues: {
+          updateComment: async (input: { comment_id: number; body: string }) => {
+            updates.push(input);
+            return { data: {} };
+          },
+        },
+      },
+    })) as never;
+    const recoveringDriver: SandboxDriver = {
+      name: "docker",
+      launch: async () => ({ ref: `fake-${runId}` }),
+      status: async (ref) => {
+        if (ref !== `fake-${runId}`) return "running";
+        await db
+          .update(runs)
+          .set({ sandbox: sql`coalesce(${runs.sandbox}, '{}'::jsonb) - 'lossObservedAt'` })
+          .where(eq(runs.id, runId));
+        return "lost";
+      },
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+
+    await reconcileSandboxes(config, undefined, {
+      sandboxDriver: async () => recoveringDriver,
+      githubClientFactory,
+    });
+
+    // The progress comment is the issue thread's public record of the run;
+    // rewriting it to Failed on a lost claim contradicts a live run.
+    expect(updates.filter((update) => update.comment_id === commentId)).toEqual([]);
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(stored?.status).toBe("running");
+    await db
+      .update(runs)
+      .set({ status: "canceled", endedAt: new Date(), sandbox: {} })
+      .where(eq(runs.id, runId));
+  });
+
   it("rejects an expired run-scoped platform key at authentication", async () => {
     const roleId = newId("key");
     await db
@@ -2295,5 +2855,28 @@ describe("sandbox api", async () => {
     )[0];
     if (!row) throw new Error("failed to insert runner run");
     return row;
+  }
+
+  async function insertSteerMessage(runId: string, kind: string, body: string, id?: string) {
+    const row = (
+      await db
+        .insert(steerMessages)
+        .values({ id: id ?? newId("evt"), orgId, runId, kind, body })
+        .returning()
+    )[0];
+    if (!row) throw new Error("failed to insert steer message");
+    return row;
+  }
+
+  async function steerDeliveries(runId: string) {
+    return await db
+      .select({ id: steerMessages.id, deliveredAt: steerMessages.deliveredAt })
+      .from(steerMessages)
+      .where(eq(steerMessages.runId, runId))
+      .orderBy(asc(steerMessages.id));
+  }
+
+  function steerIds(response: Awaited<ReturnType<typeof app.inject>>) {
+    return (response.json() as Array<{ id: string }>).map((message) => message.id);
   }
 });

--- a/services/api/test/steer-ack.test.ts
+++ b/services/api/test/steer-ack.test.ts
@@ -1,0 +1,46 @@
+import { newId } from "@facility/core";
+import { describe, expect, it } from "vitest";
+import { STEER_ACK_MAX, SteerAck } from "../src/routes/internal.js";
+
+// The steer poll's own tests drive this validation through a live route, where a
+// rejected list is observable only as a 400. These exercise the schema itself, so
+// the boundary between "an id this route could have issued" and everything else
+// is pinned to the validator rather than to what the surrounding query does with
+// what it is handed.
+describe("steer acknowledgment ids", () => {
+  it("normalizes the shapes a poll can arrive in", () => {
+    const first = newId("evt");
+    const second = newId("evt");
+    // No ack at all is a plain poll: an empty list mutates nothing.
+    expect(SteerAck.parse(undefined)).toEqual([]);
+    expect(SteerAck.parse(first)).toEqual([first]);
+    expect(SteerAck.parse(`${first},${second}`)).toEqual([first, second]);
+    // A repeated query parameter arrives as an array, and each entry may still
+    // carry a comma-separated list of its own.
+    expect(SteerAck.parse([first, second])).toEqual([first, second]);
+    expect(SteerAck.parse([`${first},${second}`])).toEqual([first, second]);
+  });
+
+  it("accepts a list at the bound and refuses one past it", () => {
+    const ids = Array.from({ length: STEER_ACK_MAX }, () => newId("evt"));
+    expect(SteerAck.parse(ids.join(","))).toEqual(ids);
+    expect(SteerAck.safeParse([...ids, newId("evt")].join(",")).success).toBe(false);
+  });
+
+  it("refuses a list carrying anything this route could not have issued", () => {
+    const valid = newId("evt");
+    const malformed = [
+      "", // an entry that names no row at all
+      "evt_z", // the prefix with no id behind it
+      "not-an-id",
+      `${valid}x`, // a real id with a suffix
+      valid.toUpperCase(),
+      valid.replace("evt_", "run_"), // an id of another kind, right length
+      `${valid},evt_z`, // one bad entry refuses the whole list
+      `${valid}, ${valid}`, // entries are not trimmed, so a spaced list is refused
+    ];
+    for (const ack of malformed) {
+      expect(SteerAck.safeParse(ack).success).toBe(false);
+    }
+  });
+});

--- a/services/api/test/steer-ack.test.ts
+++ b/services/api/test/steer-ack.test.ts
@@ -1,6 +1,6 @@
 import { newId } from "@facility/core";
 import { describe, expect, it } from "vitest";
-import { STEER_ACK_MAX, SteerAck } from "../src/routes/internal.js";
+import { STEER_ACK_MAX, STEER_BATCH, SteerAck } from "../src/routes/internal.js";
 
 // The steer poll's own tests drive this validation through a live route, where a
 // rejected list is observable only as a 400. These exercise the schema itself, so
@@ -11,8 +11,13 @@ describe("steer acknowledgment ids", () => {
   it("normalizes the shapes a poll can arrive in", () => {
     const first = newId("evt");
     const second = newId("evt");
-    // No ack at all is a plain poll: an empty list mutates nothing.
-    expect(SteerAck.parse(undefined)).toEqual([]);
+    // The parameter absent, which is the poll of a runner that predates the ack.
+    // The route tells that protocol from the current one by presence alone, so
+    // absence has to survive the transform instead of collapsing into a list.
+    expect(SteerAck.parse(undefined)).toBeUndefined();
+    // The parameter present and empty: an acknowledgment naming no row, which is
+    // what a runner sends whenever the last batch left it nothing to name.
+    expect(SteerAck.parse("")).toEqual([]);
     expect(SteerAck.parse(first)).toEqual([first]);
     expect(SteerAck.parse(`${first},${second}`)).toEqual([first, second]);
     // A repeated query parameter arrives as an array, and each entry may still
@@ -27,10 +32,19 @@ describe("steer acknowledgment ids", () => {
     expect(SteerAck.safeParse([...ids, newId("evt")].join(",")).success).toBe(false);
   });
 
+  it("keeps a whole served batch inside the acknowledgment bound", () => {
+    // A runner acknowledges the ids of one batch in one request, so a batch
+    // larger than the bound would be refused whole every time. The runner re-sends
+    // an unrecorded ack unchanged, so that refusal would repeat for the rest of
+    // the run and no row would ever be retired, with no error surfaced anywhere.
+    expect(STEER_BATCH).toBeLessThanOrEqual(STEER_ACK_MAX);
+  });
+
   it("refuses a list carrying anything this route could not have issued", () => {
     const valid = newId("evt");
     const malformed = [
-      "", // an entry that names no row at all
+      `,${valid}`, // an entry that names no row at all: only a wholly empty
+      `${valid},,${valid}`, // parameter is the empty ack, an empty entry is not
       "evt_z", // the prefix with no id behind it
       "not-an-id",
       `${valid}x`, // a real id with a suffix

--- a/services/api/test/tracked-issues.test.ts
+++ b/services/api/test/tracked-issues.test.ts
@@ -4,6 +4,7 @@ import {
   qualifyingSecurityFindings,
   redactSecurityText,
   SecurityReportSchema,
+  syncSecurityFindings,
 } from "../src/github/security-findings.js";
 import { ensureTrackedIssue, trackedIssueMarker } from "../src/github/tracked-issues.js";
 
@@ -120,5 +121,55 @@ describe("trusted GitHub issue projection", () => {
     expect(redactSecurityText("credential ghp_abcdefghijklmnopqrstuvwxyz123456")).toBe(
       "credential «redacted»",
     );
+  });
+
+  it("re-proves finalization ownership before each finding it syncs", async () => {
+    // The sync is the long tail of run finalization — several GitHub calls per
+    // finding — so ownership of the finalization lease is asserted per finding,
+    // not only around the whole step: an attempt superseded mid-report must
+    // stop before it races the winner into a duplicate tracked issue.
+    const finding = {
+      fingerprint: "auth-bypass",
+      title: "Authorization bypass",
+      severity: "high" as const,
+      confidence: "high" as const,
+      actionable: true,
+      risk: "Reachable admin path",
+      locations: ["src/admin.ts:4"],
+      smallest_fix: "Apply the authorization guard",
+      evidence: [],
+    };
+    const report = SecurityReportSchema.parse({
+      schema: "facility.security.findings.v1",
+      findings: [finding, { ...finding, fingerprint: "second" }],
+    });
+    let created = 0;
+    const client = new FacilityGithubClient(
+      {
+        rest: {
+          issues: {
+            listForRepo: async () => ({ data: [] }),
+            createLabel: async () => ({ data: {} }),
+            create: async () => {
+              created += 1;
+              return {
+                data: { number: created, html_url: `https://github.test/issues/${created}` },
+              };
+            },
+          },
+        },
+      } as unknown as Octokit,
+      { owner: "acme", repo: "app", defaultBranch: "main" },
+    );
+    let assertionsLeft = 1;
+    await expect(
+      syncSecurityFindings(client, report, { runId: "run_test" }, async () => {
+        assertionsLeft -= 1;
+        if (assertionsLeft < 0) throw new Error("finalization superseded");
+      }),
+    ).rejects.toThrow("finalization superseded");
+    // The report carries two qualifying findings; ownership held for the first
+    // and was lost before the second, so exactly one issue was created.
+    expect(created).toBe(1);
   });
 });


### PR DESCRIPTION
## What changes

An API or worker restart no longer kills in-flight runs (#35).

**Runner.** `fetchJson` used to retry only on HTTP 429. It now separates two failure classes. Codes that fire before the request could reach a route handler (connection refused, name resolution loss when a containerized API restarts, no route to host, connect timeout) prove nothing was committed, so every caller replays them: this is the control-plane-restart case. Codes where the request was already on the wire (reset, broken pipe, header and body timeouts) and transient 5xx do not prove that, so replaying them is at-least-once delivery and only an endpoint whose handler absorbs a duplicate opts in. Retries use exponential backoff with jitter under a bounded budget: 3 minutes for ordinary calls, 5 minutes for the terminal result. The runner spends the whole budget and always grants one retry, so a single stalled attempt cannot eat the budget by itself. On 5xx it honors `Retry-After` but keeps the backoff as a floor, so a proxy answering `Retry-After: 0` cannot make every runner hammer it at once. The 429 path keeps its old semantics and stays exempt from the budget.

Whether an ambiguous loss may be replayed is a property of the handler on the far end, not of the caller, so it is declared once per endpoint in `ENDPOINT_RETRY_POLICIES` and `api()` looks it up from the path. `api()` takes no policy argument, so a call site cannot invent one, and an endpoint nobody has classified gets the conservative default rather than whatever its caller felt like. The two calls that do not go through `api()` read their entry from the same table by name. `bundle`, `steer`, `transcript`, `session-state` and `result` replay; `hello`, `push-token` and `events` do not. Each entry carries the handler behaviour that justifies it.

The session-state restore used to call `fetch` directly and got no outage tolerance at all. It now shares the same transport through a byte-reading caller, so it is classified like everything else.

Related runner changes:

- Event batches keep buffering through an outage. The existing single-flight batcher already applies backpressure; retry turns delivery failure into delivery delay, so order holds and no line is dropped.
- When delivery fails for good, the drain now resumes its source stream. Before, readline left the stream paused, a child writing into a full pipe blocked forever, and the failure aborted the process as an unhandled rejection before the result could post. The command timeout timer is cleared on that path too.
- Control messages are handled before they are acknowledged, and the acknowledgment names the ids whose durable action landed. A message whose response died on the wire, or whose handling threw, is served again.
- An interrupt is never retired. A steer that keeps failing is retired after `CONTROL_MESSAGE_MAX_ATTEMPTS` (3) with one `steer_undeliverable` event, because leaving it unacked would make it the oldest pending row of every batch forever. An operator's stop does not get that treatment: it keeps being retried for the life of the run. Nothing in the batch holds the line in front of anything else.
- The steering poll survives failed iterations, emits a `steer_poll_degraded` event once the transport returns, and exits only on a terminal run. When a served batch produces no new acknowledgment, the poll backs off (1 s doubling to 15 s, equal jitter) so a message that can never be acknowledged cannot spin the loop against the control plane.
- A replayed result post that gets `409 run_terminal` counts as already recorded. The discarded outcome is written to the container log, the one channel still open at that point, from an allowlist of scalar coordinates: attempted status, changed, branch, head sha, and push error. Each field is bounded at 512 characters and the finished line passes through `redactSecrets()`, so the generated pull request title and body never reach a log store that sits outside the run event redaction boundary.

**Control plane.** Reconcile used to declare `sandbox_lost` from a single `driver.status()` probe. That verdict is irreversible: it revokes the run's keys, and every later runner call gets a 409. Now the first exited/lost observation only stamps `lossObservedAt` in the sandbox state, and the run fails only when the loss persists past `SANDBOX_LOSS_GRACE_MS` (90 s; with the 2-minute cron that means the next tick). A later probe that sees the sandbox alive clears the stamp.

Every write in that path compare-and-sets against the stamp the tick read, including the failure itself: the tick's snapshot is taken before a network probe per live run, so a concurrent tick that saw the sandbox alive and cleared the stamp must win. `failRun` takes an optional guard folded into its existing atomic claim and reports whether it claimed the row; `updateGithubRunProgress` is gated on that, which also stops a lost claim from rewriting a live run's progress comment to failed. `reconcileSandboxes` takes an injectable driver resolver for tests, mirroring `DispatchRunDeps`.

`GET /internal/runs/:runId/steer` no longer marks a message delivered because it was fetched. It marks exactly the ids the next poll acknowledges, scoped to the run and its org, and refuses an acknowledgment whole unless every id matches what `newId("evt")` produces, up to `STEER_ACK_MAX` (32). A runner launched before this change keeps its image for the life of its run, so a transitional branch answers a poll carrying only the old `afterId` cursor with the previous mark-on-select behaviour: without it, such a runner would be served the same row on every iteration and re-apply the same steer in a loop with no delay. An acknowledgment always takes precedence, and the cursor is validated the same way. That branch can be deleted once no sandbox launched before this change can still be polling.

## Why

Three architect runs died as `sandbox_lost` in one day of dogfooding (#35). A `tsx watch` restart of the API made the runner's next call fail, the runner treated that as fatal and exited, and reconcile recorded the loss. A production API deploy does the same. The sandbox container is an independent process and the API is stateless per request, so the runs were recoverable the whole time. Two things made the loss real: the runner gave up, and reconcile judged from one probe.

## Verification

- `pnpm verify` passes end to end: lint, typecheck, clean build, DB-backed suites with skips forbidden, guards, audit.
- The runner tests drive the real code against real `node:http` servers, no fake timers. Covered: a server killed and re-listened on the same port mid-call, 503-503-200 recovery, a 200 whose body is cut mid-flight, `Retry-After` honored when large and floored at zero, budget bounds plus the one guaranteed retry, 429 exempt from the budget, no retry on 4xx, transient classification of nested undici causes, and the per-endpoint policy split: an ambiguous mid-flight failure is replayed for a caller that opts in and rejected after exactly one attempt for one that does not. The policy table is not merely snapshotted: the suite derives the endpoints the runner actually calls from the source and fails if one is unclassified, or if a control-plane request bypasses the shared transport.
- The control channel is covered on both sides: an acknowledgment marks exactly the ids it names and nothing that was never served, a malformed or oversized acknowledgment mutates nothing, another run's and another org's messages are untouched, a lost response redelivers, an interrupt survives a control plane that dies mid-response and is applied exactly once, an interrupt is never retired while a steer is, and a stalled poll backs off.
- Two tiers cover reconcile grace: the pure predicate in `orchestrator-checks.test.ts`, and `sandbox.test.ts` against real Postgres, including a run whose stamp is cleared while its probe is in flight, which must not be failed and must keep its keys.
- The tests bite: with each source change reverted and the tests kept, the corresponding tests fail.
- The Docker sandbox E2E (`FACILITY_E2E_DOCKER=1 pnpm test:e2e-sandbox`) passes against a `facility-runner:dev` image built from this branch.

Known limits, on purpose:

- `/events` does not replay an ambiguous loss, because appending is unguarded and the run's receipt counts event rows and lists check events before it is sealed with a chained digest, so a duplicate is a wrong receipt rather than a cosmetic artifact. A control plane that dies mid-POST therefore still fails the run, and behind a proxy a restart surfaces as 502 or 503 rather than a refused connection, so that path behaves as it does on `main` today. A client batch key with server-side dedupe would let it opt in. I am happy to file or take that follow-up.
- `/push-token` is conservative for the same reason: every call mints a fresh contents:write installation token with no idempotency guard, so a lost response now fails the delivery rather than leaving a second live token that nothing revokes.
- `/hello` is a one-shot credential claim, so a restart landing between its commit and its response still fails the run at bootstrap. Making `/hello` replay-safe is a server-side follow-up.
- An outage longer than the result budget still loses the run's outcome, breadcrumbed to the container log as coordinates only.
- Control-message delivery is at-least-once across a lost response: a steer can be applied twice. Within a live runner the in-memory cursor keeps it exactly once.
- The grace window delays surfacing a dead sandbox by up to one extra tick, which also means its keys stay live that much longer. That is the cost of not failing runs from one observation.
- A failed session-state restore is still swallowed, so a resume degrades to a cold start rather than failing the run.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how): revert-the-fix mutation checks, plus the Docker sandbox E2E on an image built from this branch. Both described above.
- [x] Documentation updated, or no user-facing change: no user-facing surface changed; constants carry their rationale at their definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
