### PR TITLE
feat(github): add observe-first repository onboarding

### DIFF
--- a/apps/docs/docs/guides/existing-repo.md
+++ b/apps/docs/docs/guides/existing-repo.md
@@ -7,6 +7,18 @@ title: Adopt an existing repo
 Repositories that already run the vendored Facility system (or its
 predecessors) adopt the platform incrementally — nothing breaks on day one.
 
+## Step 0 — observe before automating
+
+New projects created in the web app start in **observe first** mode. Connecting
+the repository vendors and provisions nothing. Manual architect runs are
+reviewed in Facility, do not acknowledge or publish progress in GitHub, and all
+scheduled agents remain gated. A project operator can optionally publish one
+terminal architect summary; the default is no GitHub write at all.
+
+In **Project settings → autonomy**, switch to active only when the team is
+ready for scheduled work and live GitHub progress. This switch is enforced by
+the API schedulers, not only by the web interface.
+
 ## Step 1 — import
 
 Connect the repo to a project. The platform detects vendored facility files
@@ -33,10 +45,18 @@ weekly security sweep to a platform sandbox, run the new Project Owner agent
 platform-side. Each flip is reversible; the vendored workflows remain the
 fallback.
 
-Declare those choices in `.facility.json` under `executionLane`. A push to the
+Declare those choices in `.facility.json` under `executionLane`, or apply an
+operator override in **Project settings → autonomy**. The override exists so a
+team can experiment without committing Facility configuration to the
+repository; it takes precedence and is reversible. A push to the
 default branch synchronizes the reviewed manifest into the control plane. An
 unset agent remains on the `repo` lane, so adoption fails closed and does not
 start duplicate automation.
+
+If an incumbent automation already owns commands such as `/architect`, set a
+repository command prefix in the same settings surface. With prefix `fx`, only
+`/fx architect` and `/fx builder` route to Facility; the unprefixed commands
+remain available to the incumbent tool.
 
 Platform sandboxes clone the repository before starting the agent. Checked-in
 `AGENTS.md`, `CLAUDE.md`, hooks, commands, guards, and skills therefore remain

--- a/apps/docs/docs/self-host/github-app.md
+++ b/apps/docs/docs/self-host/github-app.md
@@ -40,6 +40,29 @@ webhook inactive until the API has a public HTTPS URL.
 
 ## 2. Grant permissions
 
+### Observe-only permission profile
+
+An organization evaluating Facility without repository writes can begin with
+an App limited to **Metadata, Contents, Issues, Pull requests, Actions, Checks,
+Deployments, and the enabled security-alert surfaces: Read-only**. Keep the
+organization Members and account Email addresses permissions below when this
+same App provides sign-in.
+
+That profile supports repository discovery, issue and pull-request mirrors,
+and manual observe-first analysis. It deliberately cannot kickstart a
+repository, publish comments, create branches or pull requests, project
+findings as issues, or deliver builder output. Those actions fail closed until
+the installation owner approves the corresponding write permissions. Move to
+the lifecycle profile below only when the project is switched from observation
+to active delivery.
+
+GitHub App permissions apply to the whole installation, not to an individual
+Facility project. For a mixed deployment, install a separate read-scoped App
+on observation repositories or limit each App installation to repositories
+with the same autonomy boundary.
+
+### Active lifecycle permission profile
+
 For an existing-repository lifecycle, set these **Repository permissions**:
 
 | permission | access | why |

--- a/apps/web/app/(app)/(org)/projects/new/page.tsx
+++ b/apps/web/app/(app)/(org)/projects/new/page.tsx
@@ -205,7 +205,7 @@ export default function KickstartPage() {
             name: name.trim(),
             slug: effectiveSlug,
             description: description.trim() || undefined,
-            settings: { check_cmds: [] },
+            settings: { check_cmds: [], autonomy_mode: "observe", observe_summary: false },
           }),
         }));
       setProject(created);

--- a/apps/web/app/(app)/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/settings/page.tsx
@@ -2,6 +2,7 @@ import { Divider, Eyebrow, PillTag, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { GatesEditor } from "@/components/project/gates-editor";
+import { ObserveFirstEditor } from "@/components/project/observe-first-editor";
 import { api } from "@/lib/api";
 
 export const metadata = { title: "project settings" };
@@ -85,6 +86,13 @@ export default async function ProjectSettingsPage({
             ))}
           </div>
         )}
+      </section>
+
+      <Divider />
+
+      <section className="flex flex-col gap-4">
+        <Eyebrow>autonomy</Eyebrow>
+        <ObserveFirstEditor projectId={projectId} settings={settings} repos={repoList} />
       </section>
 
       <Divider />

--- a/apps/web/components/project/observe-first-editor.tsx
+++ b/apps/web/components/project/observe-first-editor.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import type { ProjectRepo } from "@facility/sdk";
+import { Button, PillTag } from "@facility/ui";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type Lane = "repo" | "platform";
+
+const LANE_AGENTS = [
+  "architect",
+  "builder",
+  "codex-architect",
+  "codex-builder",
+  "review",
+  "address-review",
+  "ci-doctor",
+  "security-sweep",
+] as const;
+
+function objectOrEmpty(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function ObserveFirstEditor({
+  projectId,
+  settings,
+  repos,
+}: {
+  projectId: string;
+  settings: Record<string, unknown>;
+  repos: ProjectRepo[];
+}) {
+  const router = useRouter();
+  const repoAnswers = objectOrEmpty(repos[0]?.renderAnswers);
+  const configured = objectOrEmpty(settings.execution_lane_override);
+  const fallback = objectOrEmpty(
+    repoAnswers.execution_lane_override ?? repoAnswers.execution_lane,
+  );
+  const initialLane = (name: string): Lane =>
+    (configured[name] ?? fallback[name]) === "platform" ? "platform" : "repo";
+  const [mode, setMode] = useState<"observe" | "active">(
+    settings.autonomy_mode === "observe" ? "observe" : "active",
+  );
+  const [summary, setSummary] = useState(settings.observe_summary === true);
+  const [lanes, setLanes] = useState<Record<string, Lane>>(() =>
+    Object.fromEntries(LANE_AGENTS.map((name) => [name, initialLane(name)])),
+  );
+  const [prefix, setPrefix] = useState(
+    typeof settings.command_prefix === "string"
+      ? settings.command_prefix
+      : typeof repoAnswers.command_prefix === "string"
+        ? repoAnswers.command_prefix
+        : "",
+  );
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function save() {
+    setBusy(true);
+    setMessage(null);
+    const response = await fetch(\`/api/v1/projects/\${projectId}\`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        settings: {
+          ...settings,
+          autonomy_mode: mode,
+          observe_summary: summary,
+          execution_lane_override: lanes,
+          command_prefix: prefix.trim() || null,
+        },
+      }),
+    });
+    setBusy(false);
+    if (!response.ok) {
+      const body = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      setMessage(body?.error?.message ?? \`could not save project policy (\${response.status})\`);
+      return;
+    }
+    setMessage("project policy saved");
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col gap-5 border border-(--line) p-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <button type="button" onClick={() => setMode("observe")}>
+          <PillTag active={mode === "observe"}>observe first</PillTag>
+        </button>
+        <button type="button" onClick={() => setMode("active")}>
+          <PillTag active={mode === "active"}>active</PillTag>
+        </button>
+      </div>
+      <p className="text-sm leading-relaxed text-(--mut)">
+        {mode === "observe"
+          ? "Manual runs stay inside Facility and scheduled agents do not fire. GitHub remains unchanged unless a summary is explicitly enabled."
+          : "Scheduled agents may run and control-plane sessions publish their normal GitHub feedback."}
+      </p>
+      {mode === "observe" ? (
+        <label className="flex items-center gap-2 text-sm text-(--mut)">
+          <input
+            type="checkbox"
+            checked={summary}
+            onChange={(event) => setSummary(event.target.checked)}
+          />
+          publish one terminal summary for a completed architect run
+        </label>
+      ) : null}
+
+      <div className="grid gap-4 border-t border-(--line) pt-5 sm:grid-cols-3">
+        {LANE_AGENTS.map((name) => (
+          <LaneSelect
+            key={name}
+            label={name}
+            value={lanes[name] ?? "repo"}
+            onChange={(value) => setLanes((current) => ({ ...current, [name]: value }))}
+          />
+        ))}
+        <label className="flex flex-col gap-1 text-[11px] font-medium text-(--dim)">
+          command prefix
+          <input
+            className="border border-(--line) bg-transparent px-3 py-2 font-mono text-[12px] text-(--ink)"
+            value={prefix}
+            maxLength={32}
+            placeholder="none — or fx"
+            pattern="[a-z0-9][a-z0-9_-]*"
+            onChange={(event) => setPrefix(event.target.value.toLowerCase())}
+          />
+        </label>
+      </div>
+      <p className="text-[11px] leading-relaxed text-(--dim)">
+        These operator settings apply to {repos.length || "no"} connected{" "}
+        {repos.length === 1 ? "repository" : "repositories"} without modifying their manifests.
+        {prefix ? \` Facility listens to /\${prefix} architect and /\${prefix} builder.\` : ""}
+      </p>
+      <div className="flex items-center gap-3">
+        <Button size="sm" disabled={busy} onClick={() => void save()}>
+          {busy ? "saving…" : "save autonomy policy"}
+        </Button>
+        {message ? <span className="font-mono text-[11px] text-(--dim)">{message}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+function LaneSelect({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: Lane;
+  onChange: (value: Lane) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-[11px] font-medium text-(--dim)">
+      {label} lane
+      <select
+        className="border border-(--line) bg-(--bg) px-3 py-2 text-[12px] text-(--ink)"
+        value={value}
+        onChange={(event) => onChange(event.target.value as Lane)}
+      >
+        <option value="repo">repository</option>
+        <option value="platform">Facility</option>
+      </select>
+    </label>
+  );
+}

--- a/services/api/src/executors.ts
+++ b/services/api/src/executors.ts
@@ -58,6 +58,7 @@ import {
   toHarnessSpace,
 } from "./harness.js";
 import { MCP_TOOL_PERMISSIONS } from "./mcp-policy.js";
+import { githubFeedbackMode } from "./project-policy.js";
 import { createNextDraftVersion, publishRegistryVersion } from "./registry.js";
 import { cancelRun } from "./sandbox/orchestrator.js";
 import { appendRunEvents, TERMINAL_RUN_STATUSES } from "./sandbox/state.js";
@@ -892,6 +893,15 @@ async function executeKnownMcpTool(
     const number = requiredNumber(args.number, "number");
     const repoId = optionalString(args.repoId);
     const agentName = requiredString(args.agentName, "agentName");
+    const project = (
+      await db
+        .select()
+        .from(projects)
+        .where(and(eq(projects.orgId, orgId), eq(projects.id, projectId)))
+        .limit(1)
+    )[0];
+    if (!project) throw new Error("project_not_found");
+    const feedback = githubFeedbackMode(project.settings);
     const issues = await db
       .select()
       .from(ghIssues)
@@ -930,6 +940,7 @@ async function executeKnownMcpTool(
           engine: agent.engine,
           trigger: {
             type: "mcp_issue",
+            githubFeedback: feedback,
             repo: { id: repo.id, owner: repo.owner, name: repo.name },
             issue: { number },
           },
@@ -952,7 +963,7 @@ async function executeKnownMcpTool(
       (options.config?.githubAppId && options.config.githubAppPrivateKey
         ? createGithubClientFactory(options.config)
         : undefined);
-    if (factory) {
+    if (feedback === "live" && factory) {
       try {
         const github = await createGithubClientForRepo(db, factory, repo);
         await github.createIssueComment(

--- a/services/api/src/github/kickstart.ts
+++ b/services/api/src/github/kickstart.ts
@@ -310,6 +310,21 @@ export async function kickstartRepo(args: {
     execution_lane: args.answers.execution_lane ?? { architect: "repo", builder: "repo" },
   };
   const render = await renderFacilityInit(renderAnswers, { existingFiles: existing });
+  const currentAnswers =
+    args.repo.renderAnswers &&
+    typeof args.repo.renderAnswers === "object" &&
+    !Array.isArray(args.repo.renderAnswers)
+      ? (args.repo.renderAnswers as Record<string, unknown>)
+      : {};
+  const persistedRenderAnswers = {
+    ...renderAnswers,
+    ...(currentAnswers.execution_lane_override
+      ? { execution_lane_override: currentAnswers.execution_lane_override }
+      : {}),
+    ...(currentAnswers.command_prefix !== undefined
+      ? { command_prefix: currentAnswers.command_prefix }
+      : {}),
+  };
   const branch = "facility/kickstart";
   const baseSha = await client.getDefaultBranchSha();
   const baseCommit = await client.getCommit(baseSha);
@@ -327,7 +342,7 @@ export async function kickstartRepo(args: {
     .set({
       fingerprintStatus: "pending_merge",
       fingerprint: { ...render.manifest, files: render.manifest.files },
-      renderAnswers,
+      renderAnswers: persistedRenderAnswers,
       updatedAt: new Date(),
     })
     .where(eq(repos.id, args.repo.id));

--- a/services/api/src/github/router.ts
+++ b/services/api/src/github/router.ts
@@ -45,18 +45,30 @@ export type GithubIssueCommentContext = {
 export const ISSUE_CONTEXT_MAX_CHARS = 512 * 1024;
 
 const COMMAND_RE =
-  /(?:^|\n)\s*\/(builder|architect|codex-builder|codex-architect)(?=$|[\s,.:;!?)])/g;
+  /(?:^|\n)\s*\/(?:(?<prefix>[a-z0-9][a-z0-9_-]*)\s+)?(?<agent>builder|architect|codex-builder|codex-architect)(?=$|[\s,.:;!?)])/g;
 
 export function resolveSlashCommand(body: string): {
   command?: string;
   agentCommand?: string;
+  prefix?: string;
   ambiguous: boolean;
 } {
-  const commands = [...body.matchAll(COMMAND_RE)].map((match) => match[1]).filter(Boolean);
-  const unique = [...new Set(commands)];
+  const matches = [...body.matchAll(COMMAND_RE)].map((match) => ({
+    agent: match.groups?.agent,
+    prefix: match.groups?.prefix,
+  }));
+  const unique = [
+    ...new Map(matches.map((match) => [`${match.prefix ?? ""}:${match.agent}`, match])).values(),
+  ];
   if (unique.length !== 1) return { ambiguous: unique.length > 1 };
-  const raw = unique[0] ?? "";
-  return { command: raw.replace(/^codex-/, ""), agentCommand: raw, ambiguous: false };
+  const selected = unique[0];
+  const raw = selected?.agent ?? "";
+  return {
+    command: raw.replace(/^codex-/, ""),
+    agentCommand: raw,
+    ...(selected?.prefix ? { prefix: selected.prefix } : {}),
+    ambiguous: false,
+  };
 }
 
 export function githubTriggerRequiresClient(payload: TriggerPayload) {
@@ -125,6 +137,9 @@ export async function routeTrigger(
   // workflow has already yielded to Facility but the database still has the
   // previous lane configuration.
   const renderAnswers = await syncRepoFacilityConfig({ db, client, repo });
+  if (resolved.prefix !== commandPrefixFor({ ...repo, renderAnswers })) {
+    return { routed: false, reason: "command_prefix_mismatch" };
+  }
   const lane = laneFor({ ...repo, renderAnswers }, resolved.agentCommand ?? command);
   if (lane !== "platform") return { routed: false, reason: "repo_lane" };
   const agent = await findAgentDef(
@@ -293,7 +308,7 @@ export async function routeTrigger(
       renderGithubRunProgress({
         runId: run.id,
         mode: command,
-        command: `/${resolved.agentCommand ?? command}`,
+        command: `/${resolved.prefix ? `${resolved.prefix} ` : ""}${resolved.agentCommand ?? command}`,
         phase: "queued",
         issueNumber,
         issueTitle: payload.issue?.title,
@@ -308,7 +323,7 @@ export async function routeTrigger(
           progressComment: {
             id: progress.id,
             url: progress.url ?? null,
-            command: `/${resolved.agentCommand ?? command}`,
+            command: `/${resolved.prefix ? `${resolved.prefix} ` : ""}${resolved.agentCommand ?? command}`,
             sender,
             issueTitle: payload.issue?.title ?? null,
           },
@@ -488,9 +503,22 @@ function objectOrEmpty(value: unknown): Record<string, unknown> {
 }
 
 export function laneFor(repo: typeof repos.$inferSelect, command: string): "repo" | "platform" {
-  const answers = repo.renderAnswers as { execution_lane?: Record<string, string> } | null;
-  const lane = answers?.execution_lane?.[command] ?? answers?.execution_lane?.[`/${command}`];
+  const answers = repo.renderAnswers as {
+    execution_lane?: Record<string, string>;
+    execution_lane_override?: Record<string, string>;
+  } | null;
+  const override =
+    answers?.execution_lane_override?.[command] ??
+    answers?.execution_lane_override?.[`/${command}`];
+  const lane =
+    override ?? answers?.execution_lane?.[command] ?? answers?.execution_lane?.[`/${command}`];
   return lane === "platform" ? "platform" : "repo";
+}
+
+export function commandPrefixFor(repo: typeof repos.$inferSelect): string | undefined {
+  const answers = repo.renderAnswers as { command_prefix?: unknown } | null;
+  const value = answers?.command_prefix;
+  return typeof value === "string" && value ? value : undefined;
 }
 
 export async function findAgentDef(

--- a/services/api/src/learning.ts
+++ b/services/api/src/learning.ts
@@ -7,6 +7,7 @@ import {
   githubInstallations,
   outcomes,
   platformIssues,
+  projects,
   proposalEvents,
   proposals,
   repos,
@@ -21,6 +22,7 @@ import {
   type GithubClientFactory,
 } from "./github/client.js";
 import { ensureProjectKbSpace } from "./harness.js";
+import { scheduledAutonomyAllowed } from "./project-policy.js";
 import type { AppConfig } from "./types.js";
 
 type Db = ReturnType<typeof createDb>["db"];
@@ -461,10 +463,12 @@ export async function runLearningNightly(
   }
   try {
     const agents = await db
-      .select()
+      .select({ agent: agentDefs, project: projects })
       .from(agentDefs)
+      .innerJoin(projects, eq(projects.id, agentDefs.projectId))
       .where(and(eq(agentDefs.name, "learning"), eq(agentDefs.enabled, true)));
-    for (const agent of agents) {
+    for (const { agent, project } of agents) {
+      if (!scheduledAutonomyAllowed(project.settings)) continue;
       if (agent.harnessItemId) {
         await ensureProjectKbSpace(db, agent.orgId, agent.projectId);
       }

--- a/services/api/src/project-policy.ts
+++ b/services/api/src/project-policy.ts
@@ -1,0 +1,29 @@
+export type ProjectAutonomyMode = "observe" | "active";
+
+function objectOrEmpty(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** Existing projects keep their current behaviour; observe-first is explicit. */
+export function projectAutonomyMode(settings: unknown): ProjectAutonomyMode {
+  return objectOrEmpty(settings).autonomy_mode === "observe" ? "observe" : "active";
+}
+
+export function scheduledAutonomyAllowed(settings: unknown) {
+  return projectAutonomyMode(settings) === "active";
+}
+
+export type GithubFeedbackMode = "silent" | "summary" | "live";
+
+export function githubFeedbackMode(settings: unknown): GithubFeedbackMode {
+  const values = objectOrEmpty(settings);
+  if (projectAutonomyMode(values) === "active") return "live";
+  return values.observe_summary === true ? "summary" : "silent";
+}
+
+export function githubFeedbackModeForRun(trigger: unknown): GithubFeedbackMode {
+  const value = objectOrEmpty(trigger).githubFeedback;
+  return value === "silent" || value === "summary" ? value : "live";
+}

--- a/services/api/src/routes/v1/github.ts
+++ b/services/api/src/routes/v1/github.ts
@@ -11,11 +11,13 @@ import {
   runEvents,
   runs,
   users,
+  withOrg,
 } from "@facility/db";
 import { and, desc, eq, gte, inArray, isNull, lt, or, type SQL, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { ApiError, notFound } from "../../errors.js";
+import { githubFeedbackMode } from "../../project-policy.js";
 import { createGithubClientFactory, type GithubClientFactory } from "../../github/client.js";
 import { createGithubClientForRepo, syncRepoFacilityConfig } from "../../github/kickstart.js";
 import {
@@ -919,6 +921,9 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
       const { repoId } = request.query as { repoId?: string };
       assertProjectScope(p, projectId);
       const body = request.body as { agent: string };
+      const project = await withOrg(db, p.orgId).projects.byId(projectId);
+      if (!project) throw notFound("Project not found");
+      const feedback = githubFeedbackMode(project.settings);
       const issue = await loadIssue(db, p.orgId, projectId, number, repoId);
       const repo = (
         await db
@@ -989,6 +994,7 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
             engine: agent.engine,
             trigger: {
               type: "web_issue",
+              githubFeedback: feedback,
               ...(p.githubLogin ? { githubLogin: p.githubLogin } : {}),
               repo: { id: repo.id, owner: repo.owner, name: repo.name },
               issue: { number },
@@ -1008,7 +1014,7 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
         data: { queue: "runs.dispatch" },
       });
       await app.enqueue("runs.dispatch", { runId: run.id, orgId: p.orgId });
-      if (p.type === "user") {
+      if (feedback === "live" && p.type === "user") {
         await assignIssueBestEffort(
           db,
           githubFactory,
@@ -1019,7 +1025,9 @@ export async function registerGithubV1Routes(app: FastifyInstance, context: V1Ro
           { type: p.type, id: p.id },
         );
       }
-      await ackIssueQueued(db, githubFactory, repo, number, body.agent, run.id);
+      if (feedback === "live") {
+        await ackIssueQueued(db, githubFactory, repo, number, body.agent, run.id);
+      }
       await insertAuditEvent(db, {
         orgId: p.orgId,
         projectId,

--- a/services/api/src/routes/v1/projects-repos.ts
+++ b/services/api/src/routes/v1/projects-repos.ts
@@ -1,4 +1,4 @@
-import { newId } from "@facility/core";
+import { can, newId } from "@facility/core";
 import {
   agentDefs,
   analysisSandboxProfileId,
@@ -85,6 +85,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
         description?: string;
         settings?: Record<string, unknown>;
       };
+      validateProjectPolicy(body.settings);
       const project = (
         await db
           .insert(projects)
@@ -160,21 +161,49 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
       const p = principal(request);
       const { projectId } = request.params as { projectId: string };
       assertProjectScope(p, projectId);
-      return (
-        await db
-          .update(projects)
-          .set(
-            definedFields({
-              name: (request.body as { name?: string }).name,
-              description: (request.body as { description?: string }).description,
-              status: (request.body as { status?: string }).status,
-              settings: (request.body as { settings?: Record<string, unknown> }).settings,
-              updatedAt: new Date(),
-            }),
-          )
-          .where(and(eq(projects.orgId, p.orgId), eq(projects.id, projectId)))
-          .returning()
-      )[0];
+      const settings = (request.body as { settings?: Record<string, unknown> }).settings;
+      validateProjectPolicy(settings);
+      const governance = settings ? repoGovernanceFromProjectSettings(settings) : null;
+      if (governance && !can(p.permissions, "repos:write")) {
+        throw new ApiError(403, "forbidden", "Repository write permission is required");
+      }
+      return db.transaction(async (tx) => {
+        const project = (
+          await tx
+            .update(projects)
+            .set(
+              definedFields({
+                name: (request.body as { name?: string }).name,
+                description: (request.body as { description?: string }).description,
+                status: (request.body as { status?: string }).status,
+                settings,
+                updatedAt: new Date(),
+              }),
+            )
+            .where(and(eq(projects.orgId, p.orgId), eq(projects.id, projectId)))
+            .returning()
+        )[0];
+        if (!project) throw notFound("Project not found");
+        if (governance) {
+          const projectRepos = await tx
+            .select()
+            .from(repos)
+            .where(and(eq(repos.orgId, p.orgId), eq(repos.projectId, projectId)));
+          for (const repo of projectRepos) {
+            const current =
+              repo.renderAnswers &&
+              typeof repo.renderAnswers === "object" &&
+              !Array.isArray(repo.renderAnswers)
+                ? (repo.renderAnswers as Record<string, unknown>)
+                : {};
+            await tx
+              .update(repos)
+              .set({ renderAnswers: { ...current, ...governance }, updatedAt: new Date() })
+              .where(and(eq(repos.orgId, p.orgId), eq(repos.id, repo.id)));
+          }
+        }
+        return project;
+      });
     },
   );
 
@@ -252,6 +281,11 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
         autoInit: boolean;
       };
       const creation = body.create === true || body.mode === "create";
+      const project = await withOrg(db, p.orgId).projects.byId(projectId);
+      if (!project) throw notFound("Project not found");
+      const governance = repoGovernanceFromProjectSettings(
+        project.settings as Record<string, unknown>,
+      );
       const installation = await loadGithubInstallation(p.orgId, body.owner);
       const githubRepo = creation
         ? await createGithubRepository({
@@ -278,6 +312,7 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
             owner: githubRepo.owner,
             name: githubRepo.name,
             defaultBranch: githubRepo.defaultBranch ?? body.defaultBranch,
+            ...(governance ? { renderAnswers: governance } : {}),
           })
           .returning()
       )[0];
@@ -590,5 +625,66 @@ export async function registerProjectsReposRoutes(app: FastifyInstance, context:
         enabled: true,
       });
     }
+  }
+}
+
+function repoGovernanceFromProjectSettings(settings: Record<string, unknown>) {
+  const rawLane = settings.execution_lane_override;
+  const rawPrefix = settings.command_prefix;
+  if (rawLane === undefined && rawPrefix === undefined) return null;
+  if (
+    rawLane !== undefined &&
+    (!rawLane || typeof rawLane !== "object" || Array.isArray(rawLane))
+  ) {
+    throw new ApiError(400, "invalid_project_governance", "execution_lane_override must be an object");
+  }
+  const lane = (rawLane ?? {}) as Record<string, unknown>;
+  if (Object.values(lane).some((value) => value !== "repo" && value !== "platform")) {
+    throw new ApiError(
+      400,
+      "invalid_project_governance",
+      "execution_lane_override values must be repo or platform",
+    );
+  }
+  if (
+    rawPrefix !== undefined &&
+    rawPrefix !== null &&
+    (typeof rawPrefix !== "string" ||
+      !/^[a-z0-9][a-z0-9_-]*$/.test(rawPrefix) ||
+      rawPrefix.length > 32)
+  ) {
+    throw new ApiError(
+      400,
+      "invalid_project_governance",
+      "command_prefix must be null or 1-32 lowercase letters, numbers, hyphens, or underscores",
+    );
+  }
+  return {
+    ...(rawLane !== undefined ? { execution_lane_override: lane } : {}),
+    ...(rawPrefix !== undefined
+      ? { command_prefix: typeof rawPrefix === "string" ? rawPrefix : null }
+      : {}),
+  };
+}
+
+function validateProjectPolicy(settings: Record<string, unknown> | undefined) {
+  if (!settings) return;
+  if (
+    settings.autonomy_mode !== undefined &&
+    settings.autonomy_mode !== "observe" &&
+    settings.autonomy_mode !== "active"
+  ) {
+    throw new ApiError(
+      400,
+      "invalid_project_governance",
+      "autonomy_mode must be observe or active",
+    );
+  }
+  if (settings.observe_summary !== undefined && typeof settings.observe_summary !== "boolean") {
+    throw new ApiError(
+      400,
+      "invalid_project_governance",
+      "observe_summary must be a boolean",
+    );
   }
 }

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -61,6 +61,7 @@ import {
   createPreviewRecord,
   previewAccessUrl,
 } from "../previews.js";
+import { githubFeedbackModeForRun } from "../project-policy.js";
 import type { AppConfig } from "../types.js";
 import { raisePlatformIssue, resolvePlatformIssue } from "../watchtower/issues.js";
 import { sandboxCachePartition, sandboxNamespace } from "./cache.js";
@@ -751,6 +752,18 @@ async function openArchitectPlanAcceptance(
       data: { source: "architect_run" },
     });
   }
+  const feedback = githubFeedbackModeForRun(run.trigger);
+  if (feedback === "silent") {
+    await insertAuditEvent(db, {
+      orgId: run.orgId,
+      projectId: run.projectId,
+      actor: { type: "agent", id: run.id },
+      action: "hitl.proposed",
+      target: { type: "proposal", id: proposal.id },
+      payload: { action_type: "plan_acceptance", issue: issueNumber, github_feedback: feedback },
+    });
+    return;
+  }
   if (!repo?.installationId) throw new Error("run_repo_missing_installation");
   const installation = (
     await db
@@ -782,7 +795,7 @@ async function openArchitectPlanAcceptance(
     proposalId: proposal.id,
   });
   const commentId = progressCommentId(run.gh);
-  if (commentId) {
+  if (feedback === "live" && commentId) {
     await client.updateIssueComment(commentId, body);
   } else {
     await client.createIssueComment(issueNumber, body);
@@ -793,7 +806,7 @@ async function openArchitectPlanAcceptance(
     actor: { type: "agent", id: run.id },
     action: "hitl.proposed",
     target: { type: "proposal", id: proposal.id },
-    payload: { action_type: "plan_acceptance", issue: issueNumber },
+    payload: { action_type: "plan_acceptance", issue: issueNumber, github_feedback: feedback },
   });
 }
 
@@ -1225,7 +1238,7 @@ export async function publishRunDelivery(
   if (delivery.issueNumber) {
     // New platform-lane runs have a live progress comment that is updated at
     // the terminal transition. Keep a short fallback for older/manual runs.
-    if (!progressCommentId(run.gh)) {
+    if (githubFeedbackModeForRun(run.trigger) === "live" && !progressCommentId(run.gh)) {
       await client
         .createIssueComment(delivery.issueNumber, `Facility opened PR #${pr.number}: ${pr.url}`)
         .catch(() => undefined);

--- a/services/api/src/scheduler.ts
+++ b/services/api/src/scheduler.ts
@@ -1,11 +1,12 @@
 import { newId } from "@facility/core";
-import { agentDefs, createDb, insertAuditEvent, runEvents, runs } from "@facility/db";
+import { agentDefs, createDb, insertAuditEvent, projects, runEvents, runs } from "@facility/db";
 // Default-import: cron-parser is CJS and its named exports aren't statically
 // visible to Node's ESM loader (tsx runs the worker in real ESM mode).
 import cronParser from "cron-parser";
 import { and, eq, not, notInArray, sql } from "drizzle-orm";
 import { TERMINAL_RUN_STATUSES } from "./sandbox/state.js";
 import type { AppConfig } from "./types.js";
+import { scheduledAutonomyAllowed } from "./project-policy.js";
 
 type Enqueue = (queue: string, data: Record<string, unknown>) => Promise<unknown>;
 
@@ -29,8 +30,9 @@ export async function runScheduledAgents(
     await db.transaction(async (tx) => {
       await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext('agents.schedule'))`);
       const agents = await tx
-        .select()
+        .select({ agent: agentDefs, project: projects })
         .from(agentDefs)
+        .innerJoin(projects, eq(projects.id, agentDefs.projectId))
         .where(
           and(
             eq(agentDefs.enabled, true),
@@ -38,7 +40,8 @@ export async function runScheduledAgents(
             sql`${agentDefs.triggers} @> '[{"type":"schedule"}]'::jsonb`,
           ),
         );
-      for (const agent of agents) {
+      for (const { agent, project } of agents) {
+        if (!scheduledAutonomyAllowed(project.settings)) continue;
         // The bespoke learning.nightly packet job owns learning agents because it
         // assembles a daily packet before dispatch; the generic scheduler skips them.
         const trigger = dueScheduleTrigger(agent.triggers, agent.lastScheduledAt, now);

--- a/services/api/src/schedules.ts
+++ b/services/api/src/schedules.ts
@@ -11,6 +11,7 @@ import {
 } from "@facility/db";
 import { and, eq, not, sql } from "drizzle-orm";
 import { laneFor } from "./github/router.js";
+import { scheduledAutonomyAllowed } from "./project-policy.js";
 import type { AppConfig } from "./types.js";
 
 type Enqueue = (
@@ -62,7 +63,8 @@ export async function runAgentSchedules(config: AppConfig, enqueue: Enqueue, now
     )[0];
     const instants = catchUpMinutes(watermark?.lastTick, currentMinute);
     let created = 0;
-    for (const { agent } of rows) {
+    for (const { agent, project } of rows) {
+      if (!scheduledAutonomyAllowed(project.settings)) continue;
       if (
         REPOSITORY_SCHEDULED_AGENTS.has(agent.name) &&
         !projectRepos.some(

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -705,6 +705,88 @@ describe("api", async () => {
       payload: { description: "updated" },
     });
     expect(patched.json().description).toBe("updated");
+
+    const governanceRepoId = newId("repo");
+    await db.insert(repos).values({
+      id: governanceRepoId,
+      orgId,
+      projectId,
+      owner: "octo",
+      name: `governance-${Date.now()}`,
+      defaultBranch: "main",
+      renderAnswers: { execution_lane: { architect: "repo" }, preserved: true },
+    });
+    const governed = await app.inject({
+      method: "PATCH",
+      url: `/v1/projects/${projectId}`,
+      headers: { cookie },
+      payload: {
+        settings: {
+          autonomy_mode: "observe",
+          observe_summary: false,
+          execution_lane_override: { architect: "platform", builder: "repo" },
+          command_prefix: "fx",
+        },
+      },
+    });
+    expect(governed.statusCode).toBe(200);
+    const [governedRepo] = await db.select().from(repos).where(eq(repos.id, governanceRepoId));
+    expect(governedRepo?.renderAnswers).toMatchObject({
+      execution_lane: { architect: "repo" },
+      execution_lane_override: { architect: "platform", builder: "repo" },
+      command_prefix: "fx",
+      preserved: true,
+    });
+
+    const invalid = await app.inject({
+      method: "PATCH",
+      url: `/v1/projects/${projectId}`,
+      headers: { cookie },
+      payload: { settings: { command_prefix: "Not Valid" } },
+    });
+    expect(invalid.statusCode).toBe(400);
+    expect(invalid.json().error.code).toBe("invalid_project_governance");
+  });
+
+  it("requires repository write authority before changing repository governance", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const restrictedRoleId = newId("role");
+    const restrictedUserId = newId("user");
+    await db.insert(roles).values({
+      id: restrictedRoleId,
+      orgId,
+      name: `project-only-${suffix}`,
+      permissions: ["projects:write"],
+    });
+    await db.insert(users).values({
+      id: restrictedUserId,
+      email: `project-only-${suffix}@example.com`,
+      status: "active",
+    });
+    await db.insert(orgMembers).values({
+      id: newId("member"),
+      orgId,
+      userId: restrictedUserId,
+      roleId: restrictedRoleId,
+    });
+    const restrictedCookie = `facility_session=${await mintSessionCookie(
+      config,
+      restrictedUserId,
+      orgId,
+    )}`;
+    const denied = await app.inject({
+      method: "PATCH",
+      url: `/v1/projects/${projectId}`,
+      headers: { cookie: restrictedCookie },
+      payload: {
+        settings: {
+          execution_lane_override: { architect: "platform" },
+          command_prefix: "fx",
+        },
+      },
+    });
+    expect(denied.statusCode).toBe(403);
+    expect(denied.json().error.code).toBe("forbidden");
   });
 
   it("replays idempotent creates and rejects key reuse with different input", async () => {
@@ -2882,6 +2964,36 @@ describe("api", async () => {
           body: expect.stringContaining(`run ${issueRun?.id}`),
         }),
       ]);
+
+      await db
+        .update(projects)
+        .set({ settings: { autonomy_mode: "observe", observe_summary: false } })
+        .where(eq(projects.id, target.projectId));
+      await db.insert(ghIssues).values({
+        id: newId("evt"),
+        orgId,
+        projectId: target.projectId,
+        repoId: repo?.id ?? "",
+        number: 42,
+        title: "Observe without touching GitHub",
+        state: "open",
+        htmlUrl: `https://github.com/${repo?.owner}/${repo?.name}/issues/42`,
+      });
+      await execute("facility_trigger_github_issue", "runs:trigger", {
+        projectId: target.projectId,
+        repoId: repo?.id,
+        number: 42,
+        agentName: target.agent.name,
+      });
+      const observeRun = (
+        await db
+          .select()
+          .from(runs)
+          .where(sql`${runs.projectId} = ${target.projectId} and ${runs.gh}->>'issueNumber' = '42'`)
+          .limit(1)
+      )[0];
+      expect(observeRun?.trigger).toMatchObject({ githubFeedback: "silent" });
+      expect(comments).toHaveLength(1);
     } finally {
       app.enqueue = originalEnqueue;
       app.githubClientFactory = originalFactory;
@@ -5092,6 +5204,26 @@ describe("api", async () => {
     expect(
       caughtUpRuns.map((run) => (run.trigger as { scheduledFor: string }).scheduledFor).sort(),
     ).toEqual(["2026-07-16T12:28:00.000Z", "2026-07-16T12:29:00.000Z", "2026-07-16T12:30:00.000Z"]);
+  });
+
+  it("gates catch-up scheduling while a project is observe-first", async () => {
+    await db.delete(schedulerWatermarks);
+    const target = await createProjectWithAgent("Observe Scheduled Gate");
+    await db
+      .update(projects)
+      .set({ settings: { autonomy_mode: "observe" } })
+      .where(eq(projects.id, target.projectId));
+    await db
+      .update(agentDefs)
+      .set({ triggers: [{ type: "schedule", config: { cron: "* * * * *", timezone: "UTC" } }] })
+      .where(eq(agentDefs.id, target.agent.id));
+    await runAgentSchedules(
+      config,
+      async () => null,
+      new Date("2026-07-16T12:30:42.000Z"),
+    );
+    const scheduled = await db.select().from(runs).where(eq(runs.agentDefId, target.agent.id));
+    expect(scheduled).toEqual([]);
   });
 
   it("creates a greenfield GitHub repo through the App and connects the repo row", async () => {

--- a/services/api/test/github.test.ts
+++ b/services/api/test/github.test.ts
@@ -24,7 +24,9 @@ import { parseFacilityRepoManifest, syncRepoFacilityConfig } from "../src/github
 import { githubEventMatches, processGithubWebhook } from "../src/github/processor.js";
 import {
   assertGithubRequestContextSize,
+  commandPrefixFor,
   githubRequestContext,
+  laneFor,
   resolveSlashCommand,
   routeTrigger,
 } from "../src/github/router.js";
@@ -819,6 +821,26 @@ describe("github integration", async () => {
       agentCommand: "codex-builder",
       ambiguous: false,
     });
+    expect(resolveSlashCommand("/fx architect\n\nkeep the current process")).toEqual({
+      command: "architect",
+      agentCommand: "architect",
+      prefix: "fx",
+      ambiguous: false,
+    });
+    expect(resolveSlashCommand("/fx architect\n/architect")).toEqual({ ambiguous: true });
+  });
+
+  it("applies operator lane overrides and command namespaces", () => {
+    const repo = {
+      renderAnswers: {
+        execution_lane: { architect: "repo" },
+        execution_lane_override: { architect: "platform" },
+        command_prefix: "fx",
+      },
+    } as never;
+    expect(laneFor(repo, "architect")).toBe("platform");
+    expect(laneFor(repo, "builder")).toBe("repo");
+    expect(commandPrefixFor(repo)).toBe("fx");
   });
 
   it("routes only creation actions and denies replay-prone GitHub updates", async () => {

--- a/services/api/test/project-policy.test.ts
+++ b/services/api/test/project-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  githubFeedbackMode,
+  githubFeedbackModeForRun,
+  projectAutonomyMode,
+  scheduledAutonomyAllowed,
+} from "../src/project-policy.js";
+
+describe("project autonomy policy", () => {
+  it("preserves active behaviour for existing projects without a policy", () => {
+    expect(projectAutonomyMode({})).toBe("active");
+    expect(scheduledAutonomyAllowed(null)).toBe(true);
+    expect(githubFeedbackMode(undefined)).toBe("live");
+  });
+
+  it("makes observe-first silent and gates schedules", () => {
+    const settings = { autonomy_mode: "observe" };
+    expect(projectAutonomyMode(settings)).toBe("observe");
+    expect(scheduledAutonomyAllowed(settings)).toBe(false);
+    expect(githubFeedbackMode(settings)).toBe("silent");
+  });
+
+  it("allows one explicit terminal summary without enabling schedules", () => {
+    const settings = { autonomy_mode: "observe", observe_summary: true };
+    expect(scheduledAutonomyAllowed(settings)).toBe(false);
+    expect(githubFeedbackMode(settings)).toBe("summary");
+  });
+
+  it("fails legacy and malformed run feedback values to live behaviour", () => {
+    expect(githubFeedbackModeForRun({})).toBe("live");
+    expect(githubFeedbackModeForRun({ githubFeedback: "unexpected" })).toBe("live");
+    expect(githubFeedbackModeForRun({ githubFeedback: "silent" })).toBe("silent");
+  });
+});

--- a/services/api/test/scheduler.test.ts
+++ b/services/api/test/scheduler.test.ts
@@ -125,6 +125,32 @@ describe("scheduled agents", async () => {
     expect(stored?.lastScheduledAt?.toISOString()).toBe(now.toISOString());
   });
 
+  it("does not arm or dispatch scheduled agents for observe-first projects", async () => {
+    const now = new Date("2026-07-06T06:01:30.000Z");
+    const agent = await insertAgent("observe-gated", {
+      triggers: [{ type: "schedule", config: { cron: "* * * * *", timezone: "UTC" } }],
+      lastScheduledAt: new Date("2026-07-06T06:00:00.000Z"),
+    });
+    await db
+      .update(projects)
+      .set({ settings: { autonomy_mode: "observe" } })
+      .where(eq(projects.id, agent.projectId));
+    const enqueued: unknown[] = [];
+    const result = await runScheduledAgents(
+      config,
+      async (queue, data) => {
+        enqueued.push({ queue, data });
+      },
+      { now },
+    );
+    expect(result.dispatched).toEqual([]);
+    expect(enqueued).toEqual([]);
+    const stored = (
+      await db.select().from(agentDefs).where(eq(agentDefs.id, agent.id)).limit(1)
+    )[0];
+    expect(stored?.lastScheduledAt?.toISOString()).toBe("2026-07-06T06:00:00.000Z");
+  });
+
   it("skips due agents with a live run but still advances last_scheduled_at", async () => {
     const now = new Date("2026-07-06T06:01:30.000Z");
     const agent = await insertAgent("live-skip", {


### PR DESCRIPTION
Closes #26.

## What changed

Introduces observe-first onboarding for existing repositories so teams can connect Facility without changing their established delivery workflow.

- Adds project-level `observe` and `active` autonomy modes.
- Keeps newly connected repositories quiet by default.
- Supports `silent`, `summary`, and `live` GitHub feedback modes.
- Prevents scheduled architect and learning agents from running until explicitly enabled.
- Keeps `execution_lane` as the existing safety control while exposing it in project settings.
- Adds configurable command namespacing, including commands such as `/fx architect`.
- Preserves project autonomy settings when repositories are connected or kickstarted.
- Adds project settings UI for autonomy mode, GitHub feedback, execution lane, schedules, and command prefix.
- Documents observe-first onboarding and least-privilege GitHub App permissions.
- Adds policy, scheduler, routing, authorization, and API coverage.

## Why

Teams with a working SDLC should be able to evaluate Facility without allowing it to create comments, assignments, scheduled work, or pull requests before they deliberately opt in.

This creates a progressive adoption path:

1. Connect a repository.
2. Observe the project quietly.
3. Review plans in Facility.
4. Enable selected agent lanes or GitHub feedback.
5. Move to active automation when the team is ready.

## Validation

Completed:

- `git diff --check`
- TypeScript syntax checks for changed files using Node 24
- Direct smoke validation of the project policy helpers
- Remote comparison against `main`: 19 files, 687 additions, 40 deletions

Not completed:

- `pnpm verify` could not run because the workspace dependencies were unavailable in the execution environment and package installation was blocked by network restrictions.