### PR TITLE
docs: document the repository settings behind the human gates

### DIFF
--- a/apps/docs/docs/guides/existing-repo.md
+++ b/apps/docs/docs/guides/existing-repo.md
@@ -13,6 +13,12 @@ Connect the repo to a project. The platform detects vendored facility files
 and records the current state as the fingerprint baseline (**adopt**), so
 integrity checking starts from reality, not from an ideal.
 
+An adopted repository has been running agents without Facility's assumptions
+being checked. Verify the
+[repository settings that back the gates](../reference/security#repository-settings-that-back-the-gates)
+now: fingerprinting records what the repository is, not whether its human gates
+can actually hold.
+
 ## Step 2 — money first
 
 Switch the repo's provider secrets to gateway virtual keys

--- a/apps/docs/docs/guides/kickstart.md
+++ b/apps/docs/docs/guides/kickstart.md
@@ -22,6 +22,10 @@ From zero to a working factory:
    `facility/kickstart` and opens a pull request. Manual steps that only you
    can do are in the PR body: create the agent token secret, protect the
    default branch, confirm App permissions, and complete preview configuration.
+   Work through the
+   [repository settings that back the gates](../reference/security#repository-settings-that-back-the-gates)
+   while you are there — several of the human gates are held up by repository
+   configuration rather than by Facility.
 6. **Configure a live PR preview.** Choose a Facility-owned preview or an
    external deployment adapter. For a native preview, provide an immutable
    image, optional command, internal port, readiness path, and TTL. Add
@@ -32,6 +36,11 @@ From zero to a working factory:
 7. **Merge it.** That's Gate 2 muscle memory from day zero. Validate the live
    preview, review the PR, and squash-merge it in GitHub. On merge the
    fingerprint baseline is recorded and the project reports **system ok**.
+
+Confirm the
+[repository settings that back the gates](../reference/security#repository-settings-that-back-the-gates)
+are in place before this point: the gates have to exist before the first agent
+run, not after the first surprise.
 
 Now open an issue and comment `/architect`. The agent's task-specific checklist
 and final plan appear in one comment. Continue entirely from GitHub: comment

--- a/apps/docs/docs/reference/cli.md
+++ b/apps/docs/docs/reference/cli.md
@@ -71,7 +71,10 @@ Actions in the repository lane and by Facility in the platform lane.
 
 Run `facility doctor --run-guards --github` after committing. It checks the
 manifest, generated workflows, configured agent models and authentication,
-preview variables/secrets, deterministic guards, and branch protection.
+preview variables/secrets, deterministic guards, and branch protection. It does
+not check every setting the human gates depend on — see
+[repository settings that back the gates](../reference/security#repository-settings-that-back-the-gates)
+for the full list and for what the command does not yet cover.
 
 ## Platform lane
 

--- a/apps/docs/docs/reference/security.md
+++ b/apps/docs/docs/reference/security.md
@@ -101,4 +101,69 @@ Agents never approve, never merge, never push to protected branches. Every
 outward action carries a named principal. Every merge carries a human
 decision.
 
+## Repository settings that back the gates
+
+Facility enforces part of the paragraph above — generated workflows declare their
+own least-privilege `permissions:` block, refuse bot-authored events, skip fork
+heads, and pin every action to a SHA. The rest is GitHub repository
+configuration, which Facility cannot enforce from inside a workflow. The split is
+invisible: a repository can run the whole loop, produce plans and pull requests
+and reviews, look completely correct, and still let an automated actor satisfy a
+human gate. Configure these before the first agent run.
+
+| setting | required value | enforced by | what skipping it costs |
+|---|---|---|---|
+| **Allow GitHub Actions to create and approve pull requests** (organization and repository) | disabled | the setting | Breaks *agents never approve*. The review workflow only comments — but that is a prompt, and the job runs with `pull-requests: write`. With this enabled, `GITHUB_TOKEN` can submit an approving review and satisfy the required human approval on its own pull request. |
+| **Workflow permissions** — the default `GITHUB_TOKEN` scope | read repository contents and packages permissions | the setting, for workflows you add later; Facility, for the ones it generates | Every generated workflow declares an explicit job-level `permissions:` block, so this default does not change what the crew receives. It governs the next workflow added without one, which otherwise gets write access to everything. |
+| **Default branch protected, pull request required** | enabled | the setting | Breaks *agents never push to protected branches* by making the sentence vacuous. Facility commits kickstart to `facility/kickstart` and builders push semantic branches, but the address-review and doctor workflows hold `contents: write`. Nothing structural stops a push to an unprotected default branch. |
+| **Required approvals** | at least 1 | the setting | Breaks *every merge carries a human decision*. The count alone is not enough: pair it with the Actions-approval setting above, or a token can satisfy it. |
+| **Dismiss stale approvals when new commits are pushed** | enabled | the setting | The address-review agent pushes commits to the pull request branch after a human reviews it. Without dismissal, an approval given for one diff silently covers code the approver never read. |
+| **Required status checks**, with branches up to date (or a merge queue) | the repository's own checks, plus the guards runner | Facility runs them; the setting makes them blocking | The agent verified the change against these checks. Unless they are required, nothing stops a merge that ignores that verification — and a green check against a stale base is not evidence about what lands. |
+| **Restrict who can push, and who can bypass required pull requests** | humans and teams only — never the Facility GitHub App | the setting | Breaks *agents never merge*. The App installation holds `Contents: Read and write`; a bypass entry converts that permission into merge authority over the default branch. |
+| **Do not allow bypassing the above settings** | enabled | the setting | An administrator, or an App acting with administrative rights, otherwise skips every row in this table. |
+
+Rulesets are the modern equivalent of branch protection and satisfy the same
+rows. Audit their **bypass list** with equal suspicion: a bypass entry is the
+setting saying "except for this actor".
+
+### Checking them through the API
+
+| setting | endpoint and field | needs |
+|---|---|---|
+| Actions may approve pull requests; default `GITHUB_TOKEN` scope | `GET /repos/{owner}/{repo}/actions/permissions/workflow` → `can_approve_pull_request_reviews` must be `false`, `default_workflow_permissions` must be `"read"` | repository admin |
+| The same two, organization-wide | `GET /orgs/{org}/actions/permissions/workflow` | organization admin, and an `admin:org` token scope |
+| Approvals, stale dismissal, required checks, push restrictions, admin enforcement | `GET /repos/{owner}/{repo}/branches/{branch}/protection` → `required_pull_request_reviews.required_approving_review_count`, `.dismiss_stale_reviews`, `required_status_checks.contexts` and `.strict`, `restrictions`, `enforce_admins` | repository admin |
+| The rules actually in force on a branch, including rulesets | `GET /repos/{owner}/{repo}/rules/branches/{branch}` | read access — no admin required |
+
+The organization setting constrains the repository one: if the organization
+disables Actions approving pull requests, a repository cannot re-enable it. Check
+both before concluding a repository is safe.
+
+Two `404` responses from the protection endpoint mean different things, and the
+message body is the difference: `Branch not protected` is an answer, `Not Found`
+means the caller is not an admin and learned nothing.
+
+### What `facility doctor --github` covers today
+
+The command verifies that the required secrets and variables exist, and that the
+default branch returns a branch-protection response at all. It does not read that
+response. Worth adding, in rough priority order — each is a field in a call the
+command already makes, or one extra call:
+
+- `can_approve_pull_request_reviews` and `default_workflow_permissions`, from a
+  single `actions/permissions/workflow` call. Neither is checked today, and the
+  first is the setting that most directly defeats an advertised gate.
+- The organization-level values of those two fields when the token carries
+  `admin:org`, reported as unknown rather than as a pass when it does not.
+- `required_approving_review_count`, `dismiss_stale_reviews`, the required check
+  contexts, `strict`, `restrictions`, and `enforce_admins` — all already present
+  in the protection response the check fetches and discards.
+- `GET /repos/{owner}/{repo}/rules/branches/{branch}` as a fallback: a branch
+  protected purely by a ruleset returns `404` from the classic endpoint, so the
+  command currently reports a correctly protected repository as a failure.
+- Distinguishing `Branch not protected` from `Not Found`, so a non-administrator
+  does not get the same failure as a genuinely unprotected branch.
+
+---
+
 Report vulnerabilities per [SECURITY.md](https://github.com/theam/facility/blob/main/SECURITY.md).


### PR DESCRIPTION
## What changes

`apps/docs/docs/reference/security.md` gains a **Repository settings that back the gates**
section, placed immediately after *The invariants that never move* — the paragraph it
qualifies. For each setting it states the required value, **whether Facility or the setting
enforces it**, and which advertised gate a skip breaks.

It covers the four areas the issue asks for — Actions approving pull requests, the default
`GITHUB_TOKEN` scope, default-branch protection and required checks, and who may merge or
bypass — plus stale-approval dismissal, which matters here specifically because the
address-review agent pushes commits to a pull request branch after a human has reviewed it.

Two subsections follow: which settings are readable through the GitHub API (endpoint and
field), and what `facility doctor --github` does **not** check yet, recorded as a follow-up
rather than implemented here.

Three guides link to it before the first agent run:

| file | where |
|---|---|
| `guides/kickstart.md` | step 5, and again immediately before the `/architect` paragraph |
| `guides/existing-repo.md` | Step 1 — import |
| `reference/cli.md` | where `doctor --run-guards --github` is described, to state the boundary of what it checks |

Documentation only. No code, no behaviour change.

## Why

Closes #48.

The gap is easy to confirm: grepping the repository for `approve pull requests`,
`can_approve`, `approving_review_count`, `enforce_admins` or `restrictions` returns nothing.
The setting *Allow GitHub Actions to create and approve pull requests* is not mentioned
anywhere, and the existing guidance ("protect the default branch, require a human review")
names no setting and assigns no ownership.

That matters because the invariants lean on repository configuration more than the docs
admit:

- `facility-review.yml` states it *"never approves or merges"* — but that is a prompt, and
  the job runs with `pull-requests: write`. The hard stop is
  `can_approve_pull_request_reviews: false`.
- *Never push to protected branches* is vacuous on an unprotected default branch, and
  `facility-address-review.yml` and `facility-doctor.yml` hold `contents: write`.
- The GitHub App installation holds `Contents: Read and write`, so a bypass entry on
  required pull requests converts that into merge authority.

So a repository can run the whole loop, look correct, and still let an automated actor
satisfy a human gate — which is exactly what the issue describes.

## Verification

Every API claim in the new section was probed against the live GitHub API rather than
written from memory:

| probe | result |
|---|---|
| `GET /repos/{owner}/{repo}/actions/permissions/workflow` | returns both settings in one call: `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}` |
| `GET /orgs/{org}/actions/permissions/workflow` | `403` without org admin and the `admin:org` scope |
| `GET /repos/{owner}/{repo}/branches/{branch}/protection` | `404 "Branch not protected"` as an admin on an unprotected branch, but `404 "Not Found"` without admin — two different meanings, same status code |
| `GET /repos/{owner}/{repo}/rules/branches/{branch}` | answers **without** admin, so it works where the protection endpoint cannot |

Those last two are why the `doctor` follow-up list is specific: the command currently treats
any non-zero exit as a failure, so a branch protected by a ruleset and a caller who simply
lacks admin both report the same way as a genuinely unprotected branch — and the protection
response it already fetches is never parsed.

Commands run:

```
node guards/run.mjs                  # actions-pinned, markdown-links — 2 passed, 0 failed
pnpm --filter @facility/docs test    # 12 passed, 0 failed (includes the Pages build)
pnpm verify                          # see below
```

The docs build runs under `onBrokenLinks: "throw"`, so the four new relative links are
verified rather than assumed. Because the guides link to an anchor and `onBrokenAnchors`
only warns, I checked the built output directly instead of trusting the slug rule:
`id="repository-settings-that-back-the-gates"` is present in `reference/security/index.html`,
and `guides/kickstart`, `guides/existing-repo` and `reference/cli` all emit links pointing at
it.

### On `pnpm verify`

It completed Lint, Typecheck, the clean cache-disabled workspace build, isolated Postgres,
both test-database recreations, and the critical integration tests, then exited `1` in the
final stage on a single test:

```
FAIL runner/test/docker-proxy.test.ts > restricted Docker API
     > forwards a Docker exec upgrade body before waiting for 101
Error: Test timed out in 5000ms.        (then afterEach: Hook timed out in 10000ms)

Test Files  1 failed | 11 passed (12)
     Tests  1 failed | 168 passed (169)
```

**This is pre-existing and unrelated to this pull request.** I confirmed it rather than
assuming: checking out unmodified `main` at `ae68401` and running that file alone reproduces
the same failure, same test, same timeout —

```
× forwards a Docker exec upgrade body before waiting for 101  15011ms
Test Files  1 failed (1)
     Tests  1 failed | 24 passed (25)
```

It looks environment-dependent (a Unix-socket upgrade handshake that never receives its
`101`), so it may well be green in CI — flagging it only so the failing run below isn't
mistaken for something this branch introduced. Nothing in this diff is reachable from
`runner/`; the change is four Markdown files under `apps/docs/`.

- [ ] `pnpm verify` passes locally — runs green **except** the pre-existing
      `docker-proxy` timeout documented above, which also fails on clean `main`
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
