### PR TITLE
docs: align CLI documentation with its PostgreSQL dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,13 @@ To delegate setup to Claude Code or Codex:
   when committing; maintainers squash and merge pull requests.
 - Add or update tests for behavior changes. Never relax, skip, or delete a test,
   guard, or check to make a change pass.
-- Keep the CLI and everything it vendors into user repositories free of runtime
-  dependencies. A new dependency becomes part of every adopter's supply chain.
+- Keep everything the CLI vendors into user repositories free of runtime
+  dependencies, and add one to the CLI package itself only when a command
+  cannot work without it. A new dependency becomes part of every adopter's
+  supply chain. The package declares exactly one today — `postgres`, which
+  `facility instance bootstrap` uses to reach the database directly, because it
+  creates the first organization and owner that the API's own authentication
+  depends on. Do not drop it without also removing that command.
 - Treat files under `packages/cli/templates/` and `packages/cli/modules/` as
   product surfaces. Comments should explain why a constraint exists, not
   narrate the code.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ pnpm exec facility instance bootstrap \
   --github-account-type organization
 ```
 
-The command connects to the local database, is idempotent for the same
+The command connects directly to PostgreSQL, is idempotent for the same
 binding, and refuses to modify a database bound to a different instance.
 
 ### 6. Sign in
@@ -265,7 +265,7 @@ For the rest of the platform, follow the
 ## Operate without the web application
 
 Every control-plane workflow is available over the versioned REST API and the
-zero-dependency CLI; AI clients use the same permissions through MCP.
+CLI; AI clients use the same permissions through MCP.
 
 ```bash
 # REST/OpenAPI

--- a/apps/docs/docs/reference/cli.md
+++ b/apps/docs/docs/reference/cli.md
@@ -15,6 +15,24 @@ node /absolute/path/to/facility/packages/cli/bin/facility.mjs <command>
 alias facility='node /absolute/path/to/facility/packages/cli/bin/facility.mjs'
 ```
 
+## Runtime requirements
+
+Node.js 20 or newer — a lower floor than the platform's, so the installer runs
+against repositories the rest of Facility could not host.
+
+The package declares exactly one runtime dependency, `postgres`. Only
+`facility instance bootstrap` uses it: that command connects directly to the
+database rather than through the API, because it creates the first organization
+and owner that the API's own authentication depends on. Every other command
+either speaks HTTP to a Facility API or writes files locally.
+
+Two external tools are used where present rather than installed as
+dependencies: `init` reads repository details with `git`, and `doctor --github`
+queries secrets, variables and branch protection with the GitHub CLI. Neither
+is an npm dependency, and both degrade rather than fail — `git` detection falls
+back to empty answers, and `doctor` reports a warning instead of a failure when
+`gh` is absent or unauthenticated.
+
 ## Vendored lane (no platform required)
 
 | command | does |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,10 @@ One binary with two jobs, and you rarely need both:
 npx @theagilemonkeys/facility --help
 ```
 
-Node.js 20 or newer. Zero configuration to read; one dependency.
+Node.js 20 or newer. Zero configuration to read; one runtime dependency —
+`postgres`, which `facility instance bootstrap` uses to connect directly to a
+Facility database. `init` also shells out to `git`, and `doctor --github` to the
+GitHub CLI, where those are on the `PATH`.
 
 **Early software.** Facility is published while it is still being built: the
 API is young, generated files change shape between `0.x` releases, and no


### PR DESCRIPTION
## What changes

Removes the zero-dependency claim from the operator CLI and states the real runtime
contract wherever the CLI is documented.

| file | change |
|---|---|
| `README.md` | drops "zero-dependency CLI"; the bootstrap paragraph now says *connects directly to PostgreSQL*, matching the authentication guide word for word |
| `CONTRIBUTING.md` | rewrites the "keep the CLI free of runtime dependencies" rule so it is true and still protective |
| `packages/cli/README.md` | names the dependency and the external tools instead of "one dependency" |
| `apps/docs/docs/reference/cli.md` | new **Runtime requirements** section |

The behaviour and the dependency are untouched: `postgres` stays, and
`facility instance bootstrap` still connects directly to the database.

## Why

Closes #45.

`packages/cli/package.json` declares `postgres@^3.4.7`, imported in
`packages/cli/src/instance.mjs` and used by `facility instance bootstrap` — while
`README.md` called the same CLI zero-dependency. The package README was already partly
correct ("one dependency"), so the genuinely false claim was in the root README alone.

The more consequential half is `CONTRIBUTING.md`, which the issue does not name directly
but which its audit clause reaches. It read:

> Keep the CLI and everything it vendors into user repositories free of runtime
> dependencies.

That is the failure mode the issue warns about — "can send future reviews toward removing
behavior the self-host bootstrap requires" — written down as a rule a reviewer is meant to
follow. It now scopes the dependency-free requirement to the vendored surface, and says
`postgres` cannot be dropped without also removing the command that needs it.

Two claims were verified against the code rather than assumed, because the point of this
change is documentation matching reality:

- `postgres` is imported in exactly one file and used by exactly one command
  (`instance.mjs:2` and `:31`) — so "only `instance bootstrap` uses it" is accurate.
- The CLI also shells out to `git` (`detect.mjs:16`) and, for `doctor --github`, to the
  GitHub CLI (`doctor.mjs:218-344`). Neither is an npm dependency, and both degrade rather
  than fail — `git` errors are caught and return empty, and `doctor` reports a warning when
  `gh` is absent or unauthenticated. The new section says so rather than claiming the CLI
  needs nothing but Node.

## Verification

Acceptance criteria, checked against the tree:

- **No public documentation calls the whole CLI zero-dependency.** Sweeping
  `zero.dependenc|dependency-free|no dependencies` across `README.md`, `CONTRIBUTING.md`,
  `packages/cli/README.md` and `apps/docs/docs/` leaves only two hits, both about the
  vendored guards runner (`README.md:79`, `reference/guards.md:12`), which genuinely has no
  dependencies. Those are accurate and were left alone.
- **`instance bootstrap` is still documented as connecting directly to PostgreSQL** —
  `README.md:215` and `self-host/authentication.md:51`, now identical in wording.
- **Package metadata and CLI documentation agree** — `engines.node: ">=20"` and
  `dependencies: {"postgres":"^3.4.7"}` are what both READMEs and the CLI reference now state.

Commands run:

```
node guards/run.mjs                              # 2 passed, 0 failed
pnpm --filter @facility/docs test                # 12 passed, 0 failed (includes the Pages build)
pnpm --filter @theagilemonkeys/facility test     # 98 passed, 0 failed
pnpm verify                                      # see below
```

### On `pnpm verify`

It completed Lint, Typecheck, the clean cache-disabled workspace build, both isolated
test-database recreations and the critical integration tests, then exited `1` in the final
stage on one test:

```
FAIL runner/test/docker-proxy.test.ts > restricted Docker API
     > forwards a Docker exec upgrade body before waiting for 101   15009ms
Tests  1 failed | 168 passed (169)
```

**Pre-existing and unrelated to this pull request.** Checking out unmodified `main` at
`ae68401` and running that file alone reproduces it identically (`1 failed | 24 passed`,
same ~15s timeout). It looks environment-dependent — a Unix-socket upgrade handshake that
never receives its `101` — so it may well be green in CI. Flagged only so the non-zero exit
is not mistaken for something this branch introduced; nothing here is reachable from
`runner/`, and the diff is four Markdown files.

- [ ] `pnpm verify` passes locally — runs green **except** the pre-existing `docker-proxy`
      timeout documented above, which also fails on clean `main`
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
