### PR TITLE
fix(dev): start pnpm through a shell on Windows

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -185,13 +185,22 @@ export function developmentServiceEnvironment(prepared, base = process.env) {
   return environment;
 }
 
+export function usesWindowsCmdShell(command, platform = process.platform) {
+  return platform === "win32" && /\.(cmd|bat)$/i.test(command);
+}
+
 export function run(
   command,
   args,
   { cwd = repoRoot, label = [command, ...args].join(" "), environment = process.env } = {},
 ) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, env: environment, stdio: "inherit" });
+    const child = spawn(command, args, {
+      cwd,
+      env: environment,
+      stdio: "inherit",
+      shell: usesWindowsCmdShell(command),
+    });
     child.once("error", (error) => {
       const hint =
         error.code === "ENOENT"

--- a/scripts/dev.test.mjs
+++ b/scripts/dev.test.mjs
@@ -10,6 +10,7 @@ import {
   prepareDevEnv,
   setEnvIfBlank,
   usesLocalStorage,
+  usesWindowsCmdShell,
 } from "./dev.mjs";
 
 const example = [
@@ -279,4 +280,12 @@ test("an exported development origin overrides the env file, and a blank one is 
     environment: { FACILITY_DEV_ORIGINS: "   " },
   });
   assert.equal(blank.devOrigins, "from-file.example.dev");
+});
+
+test("Windows .cmd/.bat spawns use a shell so Node does not throw EINVAL", () => {
+  assert.equal(usesWindowsCmdShell("pnpm.cmd", "win32"), true);
+  assert.equal(usesWindowsCmdShell("pnpm.bat", "win32"), true);
+  assert.equal(usesWindowsCmdShell("pnpm", "win32"), false);
+  assert.equal(usesWindowsCmdShell("docker", "win32"), false);
+  assert.equal(usesWindowsCmdShell("pnpm.cmd", "linux"), false);
 });


### PR DESCRIPTION
## Summary

Fixes `pnpm dev` on Windows, where it aborted with `Error: spawn EINVAL` before any service started.

`scripts/dev.mjs` resolves the package manager to `pnpm.cmd` on `win32`, but `run()` spawned it without a shell. Since the fix for CVE-2024-27980 (Node 18.20 / 20.12), `child_process.spawn` refuses to launch a `.cmd` or `.bat` file unless `shell` is set. Every `pnpm` step in the script was affected — install, the shared-package build, `migrate`, `seed` and `dev:services` — and the first one ended the run.

The throw is also **synchronous**, so the existing `child.once("error", ...)` handler never ran and the friendly `Could not start <label>` hint was replaced by a raw stack trace.

`shell` is applied only to `.cmd` and `.bat` commands on `win32`, so real executables such as `docker` keep their current argument handling and POSIX platforms are unchanged. The predicate is exported so the behavior is testable without spawning processes.

Closes #182

## Test plan

- [x] `node --test scripts/dev.test.mjs` — new `usesWindowsCmdShell` assertions cover `.cmd` and `.bat` on `win32`, plain commands on `win32`, and `.cmd` on `linux`
- [x] Verified on Windows 10 / Node v22.23.2 that spawning `pnpm.cmd` without a shell throws `EINVAL` synchronously, and succeeds with `shell: true`
- [x] Verified `docker` still spawns without a shell, so the compose steps are unaffected
- [x] `pnpm dev` now brings up Postgres, MinIO, API (`:4400`), worker, gateway (`:4410`), web (`:3400`) and docs (`:3500`) on Windows
- [ ] Confirm on macOS/Linux that `usesWindowsCmdShell` returns `false` and behavior is byte-for-byte unchanged

### Note for reviewers

`scripts/dev.test.mjs` has one failure on Windows that is **pre-existing and unrelated** to this change: the test asserting the generated `.env` mode is `0o600` sees `0o666` (`expected: 384, actual: 438`), because Windows does not honor POSIX file modes. That assertion is present on `main`. I left it alone to keep this PR focused, but I'm happy to address it here or in a separate issue if you prefer.
