### PR TITLE
fix(sandbox): render the default branch into platform contracts

### DIFF
--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -1728,7 +1728,12 @@ async function buildRunBundle(
   );
   const checkCmds = resolveCheckCmds(profile, repo?.renderAnswers, project?.settings);
   const provisionSummary = [packageInstallCmd, provisionCmd].filter(Boolean).join(" && ") || null;
-  const contract = renderRunContract(rawContract, provisionSummary, checkCmds);
+  const contract = renderRunContract(
+    rawContract,
+    provisionSummary,
+    checkCmds,
+    repo?.defaultBranch ?? null,
+  );
   const githubBranch = typeof runGh.branch === "string" ? runGh.branch : null;
   const checkoutBranch = githubPullRequestMode(run.mode) && githubBranch ? githubBranch : null;
   const expectedHeadSha = repairExpectedHeadSha(run.mode, run.trigger);
@@ -2539,13 +2544,15 @@ export function renderRunContract(
   contract: string,
   provisionCmd: string | null,
   checkCmds: string[],
+  defaultBranch: string | null,
 ) {
   return contract
     .replaceAll("{{PROVISION_CMD}}", provisionCmd ?? "No provision command is configured.")
     .replaceAll(
       "{{CHECKS_INLINE}}",
       checkCmds.length ? checkCmds.join(" && ") : "No checks configured.",
-    );
+    )
+    .replaceAll("{{DEFAULT_BRANCH}}", defaultBranch || "main");
 }
 
 function command(value: unknown) {

--- a/services/api/test/orchestrator-checks.test.ts
+++ b/services/api/test/orchestrator-checks.test.ts
@@ -1,3 +1,6 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { harnessFragmentForBundle } from "../src/harness.js";
 import {
@@ -186,11 +189,41 @@ describe("platform run repository setup", () => {
 
   it("renders repository setup and gates into platform contracts", () => {
     expect(
-      renderRunContract("Provision: {{PROVISION_CMD}}\nChecks: {{CHECKS_INLINE}}", "pnpm install", [
-        "pnpm test",
-        "pnpm lint",
-      ]),
-    ).toBe("Provision: pnpm install\nChecks: pnpm test && pnpm lint");
+      renderRunContract(
+        "Provision: {{PROVISION_CMD}}\nChecks: {{CHECKS_INLINE}}\nBase: origin/{{DEFAULT_BRANCH}}",
+        "pnpm install",
+        ["pnpm test", "pnpm lint"],
+        "trunk",
+      ),
+    ).toBe("Provision: pnpm install\nChecks: pnpm test && pnpm lint\nBase: origin/trunk");
+  });
+
+  it("falls back to main when the repository has no recorded default branch", () => {
+    expect(renderRunContract("origin/{{DEFAULT_BRANCH}}", null, [], null)).toBe("origin/main");
+  });
+
+  // The repository lane renders these templates through packages/core/src/render.ts,
+  // which understands every placeholder. renderRunContract is a hand-written subset,
+  // so a placeholder added to a shared prompt reaches a platform agent literally
+  // unless this test fails first.
+  it("leaves no placeholder unrendered in any shared prompt template", async () => {
+    const promptsDir = fileURLToPath(
+      new URL("../../../packages/cli/templates/prompts/", import.meta.url),
+    );
+    const names = (await readdir(promptsDir)).filter((name) => name.endsWith(".md"));
+    expect(names.length).toBeGreaterThan(0);
+
+    const leftovers = new Set<string>();
+    for (const name of names) {
+      const rendered = renderRunContract(
+        await readFile(join(promptsDir, name), "utf8"),
+        "pnpm install",
+        ["pnpm test"],
+        "main",
+      );
+      for (const match of rendered.match(/\{\{[A-Z_]+\}\}/g) ?? []) leftovers.add(match);
+    }
+    expect([...leftovers]).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What's wrong

`renderRunContract()` substitutes two of the three placeholders that exist in the
shared prompt templates. The third, `{{DEFAULT_BRANCH}}`, reaches platform-lane
agents literally.

It lands inside the CI-doctor's `<security_audit_gate>` —
`packages/cli/templates/prompts/doctor.md:31`:

```
Before editing, check the failure and the PR's changed files
(`git diff --name-only origin/{{DEFAULT_BRANCH}}...HEAD`). STOP without code
changes — and say why in your PR comment — if anything touches:
`.github/workflows/`, `.github/facility/`, secrets or `.env*`, auth or access
control, migrations, dependency lockfiles, `guards/`, or the doctor policy itself.
```

So the agent is instructed to run `git diff --name-only origin/{{DEFAULT_BRANCH}}...HEAD`,
which is not a valid ref. The gate's stop-list depends on that diff to know which
paths the pull request touches.

The repository lane is unaffected: it renders the same templates through
`packages/core/src/render.ts`, which resolves every placeholder.

## How it reaches an agent

- `prompts/doctor` is a registered platform contract —
  `services/api/src/routes/v1/projects-repos.ts:503`
- seeding stores template content verbatim — `packages/db/src/seed.ts:761`
- dispatch calls `renderRunContract(...)` at
  `services/api/src/sandbox/orchestrator.ts:1731`, inside the same function that
  handles `ci_doctor` mode
- the runner performs no placeholder substitution of its own

The comment above `renderRunContract` already states the intent — *"so agents never
receive literal `{{...}}` instructions"*. The body implements two thirds of it.

## What this changes

`repo` is already selected in full at `orchestrator.ts:1691`, and
`repos.default_branch` is `notNull`, so the value was already in scope. This passes
it through and adds the third substitution, falling back to `main`.

The test worth looking at is the third one. It reads
`packages/cli/templates/prompts/*.md`, renders each through `renderRunContract`, and
fails if any `{{...}}` survives. The platform renderer is a hand-written subset of the
repo-lane engine, so this turns the next added placeholder into a red build instead of
a silent instruction. With the production change reverted it reports:

```
AssertionError: expected [ '{{DEFAULT_BRANCH}}' ] to deeply equal []
```

## Verification

```bash
pnpm --filter @facility/api exec vitest run test/orchestrator-checks.test.ts
# Test Files 1 passed (1) — Tests 24 passed (24)

pnpm --filter @facility/api exec vitest run test/sandbox.test.ts \
  test/sandbox-capabilities.test.ts test/sandbox-cache.test.ts \
  test/docker-sandbox.test.ts test/ci-doctor-policy.test.ts
# Test Files 5 passed (5) — Tests 37 passed | 1 skipped (38)

pnpm --filter @facility/api exec tsc --noEmit    # clean
pnpm exec biome lint <the two changed files>     # clean
```

I could not run the full `pnpm verify` ladder here. The database-backed tier
self-skips without Postgres on this machine, so `github-platform-lane.test.ts` and the
other DB-gated suites were skipped rather than run — CI covers them. `biome check` also
reports a formatter diff on both files, but it does so on untouched files too
(`services/api/src/previews.ts`, `executors.ts`, `learning.ts` each report one): it is
the CRLF artifact of a Windows checkout with `core.autocrlf=true`, and the committed
content is LF.

## A design question I did not decide here

This keeps the hand-written subset and guards it with a test. The alternative is to have
the platform lane reuse `packages/core/src/render.ts` outright, which removes the second
renderer instead of testing it. That is a larger change and felt like yours to make —
happy to follow up with it if you would rather go that way.
