### PR TITLE
fix(guards): resolve markdown links against a normalised repository root

### DIFF
--- a/guards/markdown-links.mjs
+++ b/guards/markdown-links.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { dirname, extname, resolve, sep } from "node:path";
+import nodePath, { extname, resolve } from "node:path";
 
 import { readText } from "./_kit.mjs";
 
@@ -122,9 +122,28 @@ function localPath(target) {
   }
 }
 
+/**
+ * Resolve a link target against the repository, or null when it escapes the
+ * repository.
+ *
+ * `root` is normalised before the containment comparison because
+ * `git rev-parse --show-toplevel` reports POSIX separators on every platform:
+ * on Windows it answers `C:/repo` while `path.resolve` produces `C:\repo`, so
+ * comparing them directly rejects every in-repo target.
+ *
+ * `path` is injectable so the platform-specific behaviour can be tested from
+ * any host.
+ */
+export function resolveWithinRoot(root, source, target, path = nodePath) {
+  const base = path.resolve(root);
+  const exact = path.resolve(base, path.dirname(source), target);
+  if (exact !== base && !exact.startsWith(`${base}${path.sep}`)) return null;
+  return exact;
+}
+
 function targetExists(root, source, target) {
-  const exact = resolve(root, dirname(source), target);
-  if (exact !== root && !exact.startsWith(`${root}${sep}`)) return false;
+  const exact = resolveWithinRoot(root, source, target);
+  if (exact === null) return false;
 
   const withoutSlash = exact.replace(/[\\/]+$/, "");
   const candidates = [exact];

--- a/scripts/markdown-links-guard.test.mjs
+++ b/scripts/markdown-links-guard.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { posix, win32 } from "node:path";
+import { test } from "node:test";
+import { resolveWithinRoot } from "../guards/markdown-links.mjs";
+
+// `git rev-parse --show-toplevel` reports POSIX separators on every platform,
+// so on Windows the guard receives `C:/repo` while `path.resolve` produces
+// `C:\repo`. Comparing the two without normalising rejected every in-repo
+// target, and the guard reported all 56 local links in this repository as
+// missing on Windows.
+test("a git-reported Windows root resolves in-repo targets", () => {
+  assert.equal(
+    resolveWithinRoot("C:/projects/facility", "README.md", "SECURITY.md", win32),
+    "C:\\projects\\facility\\SECURITY.md",
+  );
+  assert.equal(
+    resolveWithinRoot("C:/projects/facility", "apps/docs/docs/faq.md", "../index.md", win32),
+    "C:\\projects\\facility\\apps\\docs\\index.md",
+  );
+});
+
+test("a native Windows root keeps working", () => {
+  assert.equal(
+    resolveWithinRoot("C:\\projects\\facility", "README.md", "LICENSE", win32),
+    "C:\\projects\\facility\\LICENSE",
+  );
+});
+
+test("POSIX roots are unaffected", () => {
+  assert.equal(
+    resolveWithinRoot("/srv/facility", "README.md", "SECURITY.md", posix),
+    "/srv/facility/SECURITY.md",
+  );
+  assert.equal(
+    resolveWithinRoot("/srv/facility", "docs/README.md", "testing.md", posix),
+    "/srv/facility/docs/testing.md",
+  );
+});
+
+test("targets escaping the repository are still rejected on both platforms", () => {
+  assert.equal(resolveWithinRoot("C:/projects/facility", "README.md", "../outside.md", win32), null);
+  assert.equal(resolveWithinRoot("/srv/facility", "README.md", "../outside.md", posix), null);
+  assert.equal(
+    resolveWithinRoot("/srv/facility", "README.md", "../facility-sibling/x.md", posix),
+    null,
+  );
+});
+
+test("the repository root itself is inside the repository", () => {
+  assert.equal(resolveWithinRoot("C:/projects/facility", "README.md", ".", win32), "C:\\projects\\facility");
+  assert.equal(resolveWithinRoot("/srv/facility", "README.md", ".", posix), "/srv/facility");
+});


### PR DESCRIPTION
Closes #<issue number>

## The bug

`git rev-parse --show-toplevel` reports POSIX separators on every platform. On Windows it
answers `C:/repo` while `path.resolve` produces `C:\repo`, so the containment check in
`targetExists` compared

```
C:\repo\SECURITY.md   .startsWith(   "C:/repo" + "\"   )
```

which is `false`, and returned before `existsSync` was ever called. Every local link was
reported missing — on a Windows checkout `node guards/run.mjs` flags all 56 links in this
repository, `LICENSE` and `SECURITY.md` included, while `actions-pinned` passes in the same
run and the same checkout is clean on Linux.

Since `pnpm verify` runs `pnpm guards`, a Windows contributor could not get a green local
verify, and the output looks like a broken checkout rather than a platform bug.

## The fix

Normalise the root with `path.resolve` before the comparison. The containment rule is
unchanged — targets escaping the repository are still rejected.

The resolution step is extracted as an exported `resolveWithinRoot(root, source, target, path)`
with the `path` module injectable, so Windows semantics can be exercised from any host via
`node:path`'s `win32` binding. That is the only structural change; `targetExists` keeps its
behaviour and its extension/`index.md` candidates.

## Tests

`scripts/markdown-links-guard.test.mjs`, five cases, picked up by the existing
`pnpm test:dev` (`node --test scripts/*.test.mjs`):

- a git-reported Windows root (`C:/repo`) resolves in-repo targets, including a `../` hop
- a native Windows root (`C:\repo`) keeps working
- POSIX roots are unaffected
- traversal outside the repository still returns `null`, on both platforms
- the repository root itself counts as inside the repository

The traversal cases are there deliberately: the containment check is a security property, and
this change must not loosen it.

## Verification

Confirmed on a Windows host, which is where the bug is observable.

Before this change, `node guards\run.mjs` on Windows fails `markdown-links` with 56
violations — every local link in the repository, `LICENSE` and `SECURITY.md` included —
while `actions-pinned` passes in the same run. After applying this branch, same machine,
same checkout:

```
PS C:\...\facility> node guards\run.mjs
✓ actions-pinned
✓ markdown-links

2 guards ran, 0 failed.
```

```
PS C:\...\facility> node --test scripts/markdown-links-guard.test.mjs
# pass 5
# fail 0
```

On Linux:

```
node guards/run.mjs             # 2 guards ran, 0 failed
node --test scripts/*.test.mjs  # no new failures
```

## Suggested follow-up

Not in this PR, but this is the third Windows issue on the quickstart path alongside #182 and
#167. A minimal Windows CI job running `pnpm guards` and `pnpm test:dev` would have caught all
three. Happy to open that separately if it's wanted.
