### PR TITLE
fix(mcp)!: make remote OAuth path-aware and same-origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,11 +67,14 @@ OIDC_CLIENT_SECRET=
 FACILITY_INSTANCE_ID=
 
 # --- Per-instance MCP OAuth authorization server ---
-FACILITY_OAUTH_ISSUER=http://localhost:4400
+# OAuth browser endpoints use the web origin so host-only interaction, login,
+# and callback cookies remain on one origin. The web app proxies them to the API.
+FACILITY_OAUTH_ISSUER=http://localhost:3400
 # Private ES256 JWK set; `pnpm dev` generates a persistent local value when blank.
 FACILITY_OAUTH_JWKS=
+# An origin-only MCP_PUBLIC_URL remains accepted and canonicalizes to /mcp.
 MCP_PUBLIC_URL=http://localhost:4420
-MCP_AUTHORIZATION_SERVER=http://localhost:4400
+MCP_AUTHORIZATION_SERVER=http://localhost:3400
 # Comma-separated Host/Origin authorities accepted by a remote MCP bind.
 MCP_ALLOWED_HOSTS=localhost,127.0.0.1
 # Exact number of trusted right-most reverse-proxy hops for client rate limits.

--- a/apps/docs/docs/reference/mcp.md
+++ b/apps/docs/docs/reference/mcp.md
@@ -36,11 +36,42 @@ control plane. It exposes streamable HTTP at `https://<mcp-host>/mcp` with
 `Authorization: Bearer <credential>`.
 Two credential kinds are accepted: a `fak_…` API key (for non-interactive services) or a Facility
 OAuth access token (for interactive clients like Claude, Cursor, and ChatGPT). Interactive
-clients discover the flow from `/.well-known/oauth-protected-resource` (advertised on a `401` via
-`WWW-Authenticate`). Each instance publishes authorization metadata, dynamic client registration,
-PKCE authorization, revocation, and JWKS endpoints. Tokens are bound to the exact `MCP_PUBLIC_URL`;
-configure the API with `FACILITY_OAUTH_ISSUER` and `FACILITY_OAUTH_JWKS`, then point the MCP process's
-`MCP_AUTHORIZATION_SERVER` at that issuer.
+clients discover the flow from the RFC 9728 path-aware metadata URL
+`/.well-known/oauth-protected-resource/mcp` (advertised on a `401` via
+`WWW-Authenticate`). The former `/.well-known/oauth-protected-resource` URL remains a discovery
+alias during upgrades, but Facility never advertises that alias or associates it with the legacy
+`POST /` transport path. Each instance publishes authorization metadata, dynamic client registration,
+PKCE authorization, revocation, and JWKS endpoints. Tokens are bound to the canonical
+`MCP_PUBLIC_URL` resource ending in `/mcp`; an origin-only value is accepted and normalized for
+backward-compatible deployments. It must use HTTPS unless it names a loopback development host.
+Configure the API with `FACILITY_OAUTH_ISSUER` set to the web
+origin and `FACILITY_OAUTH_JWKS`, then point the MCP process's `MCP_AUTHORIZATION_SERVER` at that
+same issuer. `MCP_AUTHORIZATION_SERVER` must be an HTTPS origin; HTTP is accepted only for a
+loopback development origin. The web origin proxies `/.well-known/*` and `/oauth/*` to the API so authorization,
+interaction, GitHub login/callback, and resume retain host-only cookies on one browser origin.
+
+### Breaking upgrade: same-origin, path-aware OAuth
+
+This OAuth layout changes both token identity boundaries: the issuer moves from the API origin to
+the web origin, and the resource/audience moves from the MCP origin to the canonical `/mcp` URL.
+Treat the upgrade as breaking for interactive MCP clients.
+
+1. Update deployment configuration or Terraform **before deploying the new API, web, and MCP
+   images**. Set `WEB_URL` and `FACILITY_OAUTH_ISSUER` to the same canonical origin,
+   `AUTH_CALLBACK_URL` to exactly `<WEB_URL>/api/auth/callback`, `MCP_PUBLIC_URL` to the MCP origin
+   or `/mcp`, and `MCP_AUTHORIZATION_SERVER` to the web origin. Production endpoints require HTTPS.
+2. Deploy API, web, and MCP together. Do not leave an API-origin issuer or origin-only token
+   audience active behind only part of the new runtime.
+3. Reconnect every interactive MCP client. Existing access tokens, refresh flows, and browser OAuth
+   sessions must be treated as invalid after the issuer/audience transition; `fak_` API keys are
+   unchanged.
+
+For `pnpm dev`, inspect a pre-existing `.env`: older copies used
+`FACILITY_OAUTH_ISSUER=http://localhost:4400` and
+`MCP_AUTHORIZATION_SERVER=http://localhost:4400`. Change both to
+`http://localhost:3400`; keep `AUTH_CALLBACK_URL=http://localhost:3400/api/auth/callback`.
+Fresh `.env.example` values are already aligned. The dev launcher preserves non-empty legacy
+values rather than rewriting operator configuration.
 
 Remote binds fail closed unless `MCP_ALLOWED_HOSTS` or `MCP_PUBLIC_URL` names a
 trusted authority. Browser `Origin` is checked against the same set, request

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -181,7 +181,13 @@ request to HTTPS; it never forwards plaintext traffic to a Facility service.
 Certificate-less testing retains direct HTTP forwarding.
 In that validation-only mode, the browser-to-CloudFront hop is HTTPS but the
 CloudFront-to-ALB hop is plaintext HTTP. Configure the ALB certificate for
-production transport confidentiality.
+production transport confidentiality. The module disables interactive MCP OAuth in this mode:
+the MCP listener remains available for validation with scoped `fak_` API keys, but neither the API
+nor MCP service receives `MCP_PUBLIC_URL`, and Facility injects no `FACILITY_OAUTH_ISSUER`,
+`FACILITY_OAUTH_JWKS`, or authorization-server advertisement. Do not send real credentials or
+workloads over this plaintext validation mode. Add ACM and apply the Terraform configuration before
+deploying OAuth-capable images; then reconnect every interactive client because the web-origin
+issuer and canonical `/mcp` audience invalidate legacy OAuth sessions.
 
 Protected previews use a dedicated AWS-assigned CloudFront HTTPS origin by
 default. Keep `preview_hostname = ""`; Terraform creates the distribution,

--- a/apps/docs/docs/self-host/production.md
+++ b/apps/docs/docs/self-host/production.md
@@ -137,10 +137,24 @@ identity broker. See [Authentication modes](authentication) for the broker claim
 ### Remote MCP OAuth 2.1 (interactive clients)
 
 Each Facility instance is the authorization server for its MCP resource. Set
-`FACILITY_OAUTH_ISSUER`, a private ES256 `FACILITY_OAUTH_JWKS`, and
-`MCP_PUBLIC_URL`; point `MCP_AUTHORIZATION_SERVER` at the issuer. Interactive
+`FACILITY_OAUTH_ISSUER` to the exact `WEB_URL` origin, configure a private ES256
+`FACILITY_OAUTH_JWKS`, and set `MCP_PUBLIC_URL` to the MCP origin or its canonical
+`/mcp` endpoint; point `MCP_AUTHORIZATION_SERVER` at the issuer. The web runtime
+proxies the authorization endpoints to the API, keeping every browser cookie
+host-only and same-origin. Interactive
 clients use Authorization Code + PKCE and receive 15-minute, audience-bound JWTs
-plus rotating refresh tokens. `fak_` keys remain available for services.
+plus rotating refresh tokens. All four browser/resource URLs must use HTTPS in production; an
+all-loopback HTTP configuration is retained only for local development. `fak_` keys remain
+available for services.
+
+> **Breaking upgrade:** update configuration or Terraform before deploying the new API, web, and
+> MCP images. The issuer changes from the API origin to `WEB_URL`, and the token audience changes
+> from the MCP origin to the canonical `/mcp` resource. Deploy those three services together, then
+> reconnect interactive MCP clients and start new browser sessions; existing access/refresh flows
+> must not be reused. For old `pnpm dev` `.env` files, replace the legacy
+> `FACILITY_OAUTH_ISSUER=http://localhost:4400` and
+> `MCP_AUTHORIZATION_SERVER=http://localhost:4400` values with `http://localhost:3400`. See the
+> [MCP upgrade guide](../reference/mcp#breaking-upgrade-same-origin-path-aware-oauth).
 
 ## GitHub App
 

--- a/apps/web/app/.well-known/[[...path]]/route.ts
+++ b/apps/web/app/.well-known/[[...path]]/route.ts
@@ -1,0 +1,10 @@
+import { proxyApiRequest } from "@/lib/api-proxy";
+
+export const dynamic = "force-dynamic";
+
+const handler = (request: Request) =>
+  proxyApiRequest(request, { publicPathPrefix: "/.well-known" });
+
+export const GET = handler;
+export const HEAD = handler;
+export const OPTIONS = handler;

--- a/apps/web/app/oauth/[[...path]]/route.ts
+++ b/apps/web/app/oauth/[[...path]]/route.ts
@@ -1,0 +1,10 @@
+import { proxyApiRequest } from "@/lib/api-proxy";
+
+export const dynamic = "force-dynamic";
+
+const handler = (request: Request) => proxyApiRequest(request, { publicPathPrefix: "/oauth" });
+
+export const GET = handler;
+export const HEAD = handler;
+export const POST = handler;
+export const OPTIONS = handler;

--- a/apps/web/lib/api-proxy.ts
+++ b/apps/web/lib/api-proxy.ts
@@ -22,9 +22,10 @@ type ApiProxyOptions = {
   apiUrl?: string;
   nodeEnv?: string;
   fetchImpl?: typeof fetch;
+  publicPathPrefix?: "/api" | "/oauth" | "/.well-known";
 };
 
-export function apiTargetUrl(requestUrl: string, apiUrl: string) {
+export function apiTargetUrl(requestUrl: string, apiUrl: string, publicPathPrefix = "/api") {
   let request: URL;
   let base: URL;
   try {
@@ -43,12 +44,18 @@ export function apiTargetUrl(requestUrl: string, apiUrl: string) {
   ) {
     throw new Error("facility_api_proxy_url_invalid");
   }
-  if (request.pathname !== "/api" && !request.pathname.startsWith("/api/")) {
+  if (
+    request.pathname !== publicPathPrefix &&
+    !request.pathname.startsWith(`${publicPathPrefix}/`)
+  ) {
     throw new Error("facility_api_proxy_path_invalid");
   }
 
   const target = new URL(base);
-  target.pathname = request.pathname.slice("/api".length) || "/";
+  target.pathname =
+    publicPathPrefix === "/api"
+      ? request.pathname.slice(publicPathPrefix.length) || "/"
+      : request.pathname;
   target.search = request.search;
   return target;
 }
@@ -81,7 +88,7 @@ export async function proxyApiRequest(request: Request, options: ApiProxyOptions
 
   let target: URL;
   try {
-    target = apiTargetUrl(request.url, apiUrl);
+    target = apiTargetUrl(request.url, apiUrl, options.publicPathPrefix);
   } catch {
     return proxyError(503, "api_proxy_not_configured");
   }

--- a/apps/web/test/api-proxy.test.ts
+++ b/apps/web/test/api-proxy.test.ts
@@ -33,6 +33,26 @@ describe("runtime API proxy policy", () => {
     }
   });
 
+  it("keeps OAuth and authorization metadata on the browser's web origin", () => {
+    expect(
+      apiTargetUrl(
+        "https://app.example/oauth/authorize?client_id=codex",
+        "https://api.example",
+        "/oauth",
+      ).toString(),
+    ).toBe("https://api.example/oauth/authorize?client_id=codex");
+    expect(
+      apiTargetUrl(
+        "https://app.example/.well-known/oauth-authorization-server",
+        "https://api.example",
+        "/.well-known",
+      ).toString(),
+    ).toBe("https://api.example/.well-known/oauth-authorization-server");
+    expect(() =>
+      apiTargetUrl("https://app.example/v1/me", "https://api.example", "/oauth"),
+    ).toThrow("facility_api_proxy_path_invalid");
+  });
+
   it("preserves application headers but strips hop-by-hop and spoofed forwarding headers", () => {
     const headers = apiProxyRequestHeaders(
       new Headers({
@@ -142,6 +162,59 @@ describe("runtime API proxy integration", () => {
     expect(result.status).toBe(302);
     expect(result.headers.get("location")).toBe("/should-not-be-followed");
     expect(requests).toBe(1);
+  });
+
+  it("preserves a host-only interaction cookie across two web-origin OAuth proxy hops", async () => {
+    let hop = 0;
+    const { origin } = await listen((request, response) => {
+      hop += 1;
+      if (hop === 1) {
+        expect(request.url).toBe("/oauth/authorize?client_id=codex");
+        expect(request.headers.cookie).toBeUndefined();
+        response.writeHead(303, {
+          location: "https://app.example/oauth/interaction/interaction_1",
+          "set-cookie":
+            "_interaction=sealed; Path=/oauth/interaction/interaction_1; HttpOnly; Secure",
+        });
+        response.end();
+        return;
+      }
+      expect(request.url).toBe("/oauth/interaction/interaction_1");
+      expect(request.headers.cookie).toBe("_interaction=sealed");
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("interaction resumed");
+    });
+    const authorization = await proxyApiRequest(
+      new Request("https://app.example/oauth/authorize?client_id=codex"),
+      {
+        apiUrl: origin,
+        nodeEnv: "production",
+        publicPathPrefix: "/oauth",
+      },
+    );
+    expect(authorization.status).toBe(303);
+    expect(authorization.headers.get("location")).toBe(
+      "https://app.example/oauth/interaction/interaction_1",
+    );
+    expect(authorization.headers.getSetCookie()).toEqual([
+      "_interaction=sealed; Path=/oauth/interaction/interaction_1; HttpOnly; Secure",
+    ]);
+    const cookie = authorization.headers.getSetCookie()[0]?.split(";", 1)[0];
+    if (!cookie) throw new Error("OAuth proxy response omitted its interaction cookie");
+
+    const interaction = await proxyApiRequest(
+      new Request("https://app.example/oauth/interaction/interaction_1", {
+        headers: { cookie },
+      }),
+      {
+        apiUrl: origin,
+        nodeEnv: "production",
+        publicPathPrefix: "/oauth",
+      },
+    );
+    expect(interaction.status).toBe(200);
+    await expect(interaction.text()).resolves.toBe("interaction resumed");
+    expect(hop).toBe(2);
   });
 
   it("delivers an event-stream chunk before the upstream response completes", async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
       FACILITY_INSTANCE_ID: ${FACILITY_INSTANCE_ID:-}
-      FACILITY_OAUTH_ISSUER: ${FACILITY_OAUTH_ISSUER:-http://localhost:4400}
+      FACILITY_OAUTH_ISSUER: ${FACILITY_OAUTH_ISSUER:-http://localhost:3400}
       FACILITY_OAUTH_JWKS: ${FACILITY_OAUTH_JWKS:-}
       MCP_PUBLIC_URL: ${MCP_PUBLIC_URL:-http://localhost:4420}
       # GitHub App (repo automation): webhooks 401 and clone-token minting fail
@@ -221,7 +221,7 @@ services:
       FACILITY_API_URL: http://api:4400
       MCP_PUBLIC_URL: ${MCP_PUBLIC_URL:-http://localhost:4420}
       MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-localhost,127.0.0.1,mcp}
-      MCP_AUTHORIZATION_SERVER: ${MCP_AUTHORIZATION_SERVER:-http://localhost:4400}
+      MCP_AUTHORIZATION_SERVER: ${MCP_AUTHORIZATION_SERVER:-http://localhost:3400}
       MCP_TRUST_PROXY_HOPS: ${MCP_TRUST_PROXY_HOPS:-0}
     command:
       [

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -60,6 +60,11 @@ Edit `playground.tfvars`:
   In certificate-less validation stacks the preview viewer edge remains HTTPS,
   but CloudFront reaches the ALB over plaintext HTTP. Configure the certificate
   for production transport confidentiality.
+  Certificate-less stacks intentionally omit Facility's interactive MCP OAuth issuer, signing-key
+  injection, public resource URL, and authorization-server advertisement. The MCP listener remains
+  available for validation with `fak_` API keys, but this plaintext mode must not carry real
+  credentials or workloads. Configure ACM before enabling interactive MCP clients or using MCP
+  operationally.
 - Set `route53_zone_id` if Terraform should create alias records.
 - Set `enable_cloudfront_api_endpoint = true` to get an AWS-managed HTTPS API
   and webhook URL without a public DNS zone. This is intended for validation;
@@ -67,7 +72,7 @@ Edit `playground.tfvars`:
   certificate for production; Terraform rejects enabling both modes.
 - Use the module-owned ECR release path below.
 - Select direct `github` authentication for self-hosting or `oidc` for a SaaS
-  broker. MCP OAuth is always issued by the dedicated Facility instance.
+  broker. With ACM configured, MCP OAuth is issued by the dedicated Facility instance.
 - Set a stable `facility_instance_id` so API and worker retain one sandbox
   ownership namespace across PostgreSQL endpoint moves. For commercial OIDC it
   must match the instance id registered with the identity broker.

--- a/infra/terraform/aws/locals.tf
+++ b/infra/terraform/aws/locals.tf
@@ -11,6 +11,12 @@ locals {
   # already own a separate registered site can keep routing it through the ALB.
   managed_preview_origin = trimspace(var.preview_hostname) == ""
 
+  # Interactive MCP OAuth is browser-facing and must never be advertised over
+  # the certificate-less validation stack. That mode keeps MCP available with
+  # scoped fak_ API keys; adding ACM enables the issuer, signing key, and
+  # authorization-server advertisement as one unit.
+  interactive_mcp_oauth_enabled = trimspace(var.acm_certificate_arn) != ""
+
   tags = {
     Project     = var.project
     Environment = var.environment
@@ -92,7 +98,12 @@ locals {
     { name = "FACILITY_PREVIEW_SURFACE_TOKEN", value = random_password.preview_surface[0].result },
   ] : []
 
-  api_environment = concat(local.common_environment, local.sandbox_provider_environment, local.preview_surface_environment, [
+  api_oauth_environment = local.interactive_mcp_oauth_enabled ? [
+    { name = "FACILITY_OAUTH_ISSUER", value = local.public_urls.web },
+    { name = "MCP_PUBLIC_URL", value = local.public_urls.mcp },
+  ] : []
+
+  api_environment = concat(local.common_environment, local.sandbox_provider_environment, local.preview_surface_environment, local.api_oauth_environment, [
     { name = "PORT", value = tostring(local.ports.api) },
     { name = "PUBLIC_URL", value = local.public_urls.api },
     { name = "WEB_URL", value = local.public_urls.web },
@@ -102,8 +113,6 @@ locals {
     { name = "GITHUB_OAUTH_ALLOWED_ORGANIZATION", value = lower(trimspace(var.github_oauth_allowed_organization)) },
     { name = "OIDC_ISSUER", value = var.oidc_issuer },
     { name = "FACILITY_INSTANCE_ID", value = var.facility_instance_id },
-    { name = "FACILITY_OAUTH_ISSUER", value = local.public_urls.api },
-    { name = "MCP_PUBLIC_URL", value = local.public_urls.mcp },
     { name = "GATEWAY_URL", value = "http://${aws_service_discovery_service.gateway.name}.${aws_service_discovery_private_dns_namespace.facility.name}:${local.ports.gateway}" },
     # AWS sandboxes reach the gateway over private service discovery. Vercel
     # sandboxes use the authenticated provider paths routed through the existing
@@ -135,13 +144,16 @@ locals {
     { name = "FACILITY_API_URL", value = local.public_urls.api },
   ]
 
-  mcp_environment = [
+  mcp_oauth_environment = local.interactive_mcp_oauth_enabled ? [
+    { name = "MCP_PUBLIC_URL", value = local.public_urls.mcp },
+    { name = "MCP_AUTHORIZATION_SERVER", value = local.public_urls.web },
+  ] : []
+
+  mcp_environment = concat([
     { name = "NODE_ENV", value = "production" },
     { name = "FACILITY_API_URL", value = local.public_urls.api },
-    { name = "MCP_PUBLIC_URL", value = local.public_urls.mcp },
-    { name = "MCP_AUTHORIZATION_SERVER", value = local.public_urls.api },
     { name = "MCP_ALLOWED_HOSTS", value = var.mcp_hostname },
-  ]
+  ], local.mcp_oauth_environment)
 
   app_secret_names = toset([
     "database_url",
@@ -190,7 +202,7 @@ locals {
   api_secrets = concat(
     local.core_secrets,
     local.identity_secrets,
-    [{ name = "FACILITY_OAUTH_JWKS", valueFrom = aws_secretsmanager_secret.app["facility_oauth_jwks"].arn }],
+    local.interactive_mcp_oauth_enabled ? [{ name = "FACILITY_OAUTH_JWKS", valueFrom = aws_secretsmanager_secret.app["facility_oauth_jwks"].arn }] : [],
     var.enable_package_registry_token ? local.package_registry_secrets : [],
     local.sandbox_provider_secrets
   )

--- a/infra/terraform/aws/tests/preview_origin.tftest.hcl
+++ b/infra/terraform/aws/tests/preview_origin.tftest.hcl
@@ -134,6 +134,16 @@ run "managed_preview_needs_no_domain_or_certificate" {
     condition     = !contains(keys(aws_lb_target_group.service), "gateway") && length(aws_lb_listener_rule.http_vercel_gateway) == 0 && length(aws_lb_listener_rule.https_vercel_gateway) == 0 && length(aws_vpc_security_group_ingress_rule.gateway_from_alb) == 0
     error_message = "The AWS sandbox path must keep the model gateway private."
   }
+
+  assert {
+    condition     = !local.interactive_mcp_oauth_enabled && length([for entry in local.api_environment : entry if contains(["FACILITY_OAUTH_ISSUER", "MCP_PUBLIC_URL"], entry.name)]) == 0 && length([for entry in local.api_secrets : entry if entry.name == "FACILITY_OAUTH_JWKS"]) == 0 && length([for entry in local.mcp_environment : entry if contains(["MCP_PUBLIC_URL", "MCP_AUTHORIZATION_SERVER"], entry.name)]) == 0
+    error_message = "Certificate-less validation must not configure or advertise interactive MCP OAuth."
+  }
+
+  assert {
+    condition     = one([for entry in local.mcp_environment : entry.value if entry.name == "MCP_ALLOWED_HOSTS"]) == "mcp.example.com"
+    error_message = "Certificate-less validation must retain the MCP listener for scoped fak_ API keys without an OAuth resource."
+  }
 }
 
 run "managed_preview_uses_the_existing_https_api_origin" {
@@ -169,6 +179,11 @@ run "managed_preview_uses_the_existing_https_api_origin" {
   assert {
     condition     = length(aws_vpc_security_group_ingress_rule.alb_preview_cloudfront) == 1 && aws_vpc_security_group_ingress_rule.alb_preview_cloudfront[0].from_port == 443 && aws_vpc_security_group_ingress_rule.alb_preview_cloudfront[0].to_port == 443
     error_message = "Production managed previews must admit CloudFront only on the HTTPS origin port."
+  }
+
+  assert {
+    condition     = local.interactive_mcp_oauth_enabled && one([for entry in local.api_environment : entry.value if entry.name == "FACILITY_OAUTH_ISSUER"]) == "https://app.example.com" && one([for entry in local.api_environment : entry.value if entry.name == "MCP_PUBLIC_URL"]) == "https://mcp.example.com" && length([for entry in local.api_secrets : entry if entry.name == "FACILITY_OAUTH_JWKS"]) == 1 && one([for entry in local.mcp_environment : entry.value if entry.name == "MCP_AUTHORIZATION_SERVER"]) == "https://app.example.com" && one([for entry in local.mcp_environment : entry.value if entry.name == "MCP_PUBLIC_URL"]) == "https://mcp.example.com"
+    error_message = "Certificate-backed stacks must configure the web issuer, signing key, and MCP advertisement together."
   }
 }
 

--- a/packages/mcp/src/bin/facility-mcp.ts
+++ b/packages/mcp/src/bin/facility-mcp.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { serveHttp } from "../http.js";
+import { canonicalAuthorizationServerUrl, serveHttp } from "../http.js";
 import { createFacilityMcpServer } from "../tools.js";
 
 const [command, ...rest] = process.argv.slice(2);
@@ -19,11 +19,13 @@ if (command === "serve") {
   }
   // OAuth discovery points at this Facility instance's authorization server.
   const authRaw = process.env.MCP_AUTHORIZATION_SERVER;
-  const authorizationServer = authRaw
-    ? /^https?:\/\//.test(authRaw)
-      ? authRaw.replace(/\/+$/, "")
-      : `https://${authRaw.replace(/\/+$/, "")}`
-    : undefined;
+  let authorizationServer: string | undefined;
+  try {
+    authorizationServer = authRaw ? canonicalAuthorizationServerUrl(authRaw) : undefined;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "MCP_AUTHORIZATION_SERVER is invalid");
+    process.exit(2);
+  }
   const host = flag(rest, "--host") ?? process.env.MCP_HOST ?? "127.0.0.1";
   const server = serveHttp({
     apiUrl,

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -22,10 +22,17 @@ export type HttpServerOptions = {
 };
 
 const PROTECTED_RESOURCE_PATH = "/.well-known/oauth-protected-resource";
+const MCP_ENDPOINT_PATH = "/mcp";
 
 export function serveHttp(options: HttpServerOptions) {
   const host = options.host ?? "127.0.0.1";
-  const allowedHosts = configuredHosts(options, host);
+  const resourceUrl = options.resourceUrl
+    ? canonicalMcpResourceUrl(options.resourceUrl)
+    : undefined;
+  const protectedResourcePath = resourceUrl
+    ? protectedResourceMetadataPath(resourceUrl)
+    : PROTECTED_RESOURCE_PATH;
+  const allowedHosts = configuredHosts({ ...options, resourceUrl }, host);
   const limiter = new FixedWindowLimiter(options.maxRequestsPerMinute ?? 120, 60_000);
   const credentialValidator = new CredentialValidator(options.apiUrl, options.fetch ?? fetch);
   const trustedProxyHops = nonNegativeInteger(options.trustedProxyHops ?? 0, "trustedProxyHops");
@@ -77,7 +84,20 @@ export function serveHttp(options: HttpServerOptions) {
 
     // Public OAuth discovery document — served without auth so an interactive
     // client can bootstrap the flow before it holds a token.
-    if (request.method === "GET" && path === PROTECTED_RESOURCE_PATH) {
+    if (
+      request.method === "GET" &&
+      resourceUrl &&
+      protectedResourcePath !== PROTECTED_RESOURCE_PATH &&
+      path === PROTECTED_RESOURCE_PATH
+    ) {
+      response.writeHead(308, {
+        "content-type": "application/json",
+        location: protectedResourcePath,
+      });
+      response.end(JSON.stringify({ redirect: protectedResourcePath }));
+      return;
+    }
+    if (request.method === "GET" && path === protectedResourcePath) {
       if (!options.authorizationServer) {
         response.writeHead(404, { "content-type": "application/json" });
         response.end(JSON.stringify({ error: "oauth_not_configured" }));
@@ -86,7 +106,7 @@ export function serveHttp(options: HttpServerOptions) {
       response.writeHead(200, { "content-type": "application/json" });
       response.end(
         JSON.stringify({
-          resource: options.resourceUrl ?? "",
+          resource: resourceUrl ?? "",
           authorization_servers: [options.authorizationServer],
           bearer_methods_supported: ["header"],
         }),
@@ -104,11 +124,15 @@ export function serveHttp(options: HttpServerOptions) {
       return;
     }
 
+    // RFC 9728 metadata describes the canonical /mcp resource only. Keep the
+    // authenticated legacy POST / transport alias, but do not tell an
+    // unauthenticated client that the root path represents the /mcp resource.
+    const challengedResourceUrl = path === MCP_ENDPOINT_PATH ? resourceUrl : undefined;
     const bearer = bearerToken(request);
     if (!bearer) {
       response.writeHead(401, {
         "content-type": "application/json",
-        "www-authenticate": wwwAuthenticate(options),
+        "www-authenticate": wwwAuthenticate(challengedResourceUrl, options.authorizationServer),
       });
       response.end(JSON.stringify({ error: "missing or invalid bearer token" }));
       return;
@@ -117,7 +141,7 @@ export function serveHttp(options: HttpServerOptions) {
     if (credential === "invalid") {
       response.writeHead(401, {
         "content-type": "application/json",
-        "www-authenticate": wwwAuthenticate(options),
+        "www-authenticate": wwwAuthenticate(challengedResourceUrl, options.authorizationServer),
       });
       response.end(JSON.stringify({ error: "missing or invalid bearer token" }));
       return;
@@ -130,7 +154,7 @@ export function serveHttp(options: HttpServerOptions) {
       response.end(JSON.stringify({ error: "credential validation unavailable" }));
       return;
     }
-    if (request.method !== "POST" || !["/mcp", "/"].includes(path)) {
+    if (request.method !== "POST" || ![MCP_ENDPOINT_PATH, "/"].includes(path)) {
       response.writeHead(405, { "content-type": "application/json", allow: "POST" });
       response.end(JSON.stringify({ error: "method not allowed" }));
       return;
@@ -359,11 +383,84 @@ function nonNegativeInteger(value: number, label: string) {
   return value;
 }
 
-function wwwAuthenticate(options: HttpServerOptions): string {
-  if (options.authorizationServer && options.resourceUrl) {
-    return `Bearer resource_metadata="${options.resourceUrl}${PROTECTED_RESOURCE_PATH}"`;
+function wwwAuthenticate(resourceUrl: string | undefined, authorizationServer: string | undefined) {
+  if (authorizationServer && resourceUrl) {
+    const metadata = new URL(resourceUrl);
+    metadata.pathname = protectedResourceMetadataPath(resourceUrl);
+    metadata.search = "";
+    metadata.hash = "";
+    return `Bearer resource_metadata="${metadata.toString()}"`;
   }
   return "Bearer";
+}
+
+/**
+ * MCP_PUBLIC_URL historically accepted the MCP origin. Keep accepting that
+ * deployment shape, but turn it into the actual RFC 8707 resource identifier
+ * that clients request and the server protects.
+ */
+export function canonicalMcpResourceUrl(value: string) {
+  const resource = new URL(value);
+  if (
+    !["http:", "https:"].includes(resource.protocol) ||
+    resource.username ||
+    resource.password ||
+    resource.search ||
+    resource.hash
+  ) {
+    throw new Error(
+      "MCP resourceUrl must be an HTTP(S) URL without credentials, query, or fragment",
+    );
+  }
+  if (resource.protocol !== "https:" && !isLoopbackHostname(resource.hostname)) {
+    throw new Error("MCP resourceUrl must use HTTPS unless it is a loopback URL");
+  }
+  const path = resource.pathname.replace(/\/+$/, "");
+  if (path && path !== MCP_ENDPOINT_PATH) {
+    throw new Error(`MCP resourceUrl path must be ${MCP_ENDPOINT_PATH}`);
+  }
+  resource.pathname = MCP_ENDPOINT_PATH;
+  return resource.toString();
+}
+
+/** RFC 9728 section 3.1: insert the well-known suffix before a resource path. */
+export function protectedResourceMetadataPath(resourceUrl: string) {
+  const resource = new URL(resourceUrl);
+  const resourcePath = resource.pathname === "/" ? "" : resource.pathname.replace(/\/+$/, "");
+  return `${PROTECTED_RESOURCE_PATH}${resourcePath}`;
+}
+
+export function canonicalAuthorizationServerUrl(value: string) {
+  const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  let authorizationServer: URL;
+  try {
+    authorizationServer = new URL(candidate);
+  } catch {
+    throw new Error("MCP_AUTHORIZATION_SERVER must be a valid HTTPS origin");
+  }
+  if (
+    !["http:", "https:"].includes(authorizationServer.protocol) ||
+    authorizationServer.username ||
+    authorizationServer.password ||
+    authorizationServer.pathname !== "/" ||
+    authorizationServer.search ||
+    authorizationServer.hash
+  ) {
+    throw new Error(
+      "MCP_AUTHORIZATION_SERVER must be an origin without credentials, path, query, or fragment",
+    );
+  }
+  if (
+    authorizationServer.protocol !== "https:" &&
+    !isLoopbackHostname(authorizationServer.hostname)
+  ) {
+    throw new Error("MCP_AUTHORIZATION_SERVER must use HTTPS unless it is a loopback origin");
+  }
+  return authorizationServer.origin;
+}
+
+function isLoopbackHostname(hostname: string) {
+  return ["localhost", "127.0.0.1", "[::1]"].includes(hostname.toLowerCase());
 }
 
 function writeError(response: ServerResponse, error: unknown) {

--- a/packages/mcp/test/mcp.test.ts
+++ b/packages/mcp/test/mcp.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, test } from "vitest";
-import { serveHttp } from "../src/http.js";
+import { canonicalAuthorizationServerUrl, serveHttp } from "../src/http.js";
 import { createFacilityMcpServer, toolDefinitions } from "../src/tools.js";
 
 const acceptCredential: typeof fetch = async () =>
@@ -98,6 +98,37 @@ async function connect(stub: {
 }
 
 describe("@facility/mcp", () => {
+  test("accepts only HTTPS or loopback HTTP authorization-server origins", () => {
+    expect(canonicalAuthorizationServerUrl("auth.facility.test")).toBe(
+      "https://auth.facility.test",
+    );
+    expect(canonicalAuthorizationServerUrl("https://auth.facility.test/")).toBe(
+      "https://auth.facility.test",
+    );
+    expect(canonicalAuthorizationServerUrl("http://localhost:3400")).toBe("http://localhost:3400");
+    expect(canonicalAuthorizationServerUrl("http://127.0.0.1:3400")).toBe("http://127.0.0.1:3400");
+    expect(canonicalAuthorizationServerUrl("http://[::1]:3400")).toBe("http://[::1]:3400");
+    for (const invalid of [
+      "http://auth.facility.test",
+      "https://user:secret@auth.facility.test",
+      "https://auth.facility.test/oauth",
+      "https://auth.facility.test?tenant=one",
+      "https://auth.facility.test#fragment",
+    ]) {
+      expect(() => canonicalAuthorizationServerUrl(invalid)).toThrow(/MCP_AUTHORIZATION_SERVER/);
+    }
+  });
+
+  test("accepts HTTP MCP resources only on loopback", () => {
+    expect(() =>
+      serveHttp({
+        apiUrl: "http://facility.test",
+        port: 0,
+        resourceUrl: "http://mcp.facility.test",
+      }),
+    ).toThrow("MCP resourceUrl must use HTTPS unless it is a loopback URL");
+  });
+
   test("tools/list exposes the spec tool names and schemas", async () => {
     const { client, server } = await connect({ request: async () => ({ ok: true }) });
     const result = await client.listTools();
@@ -624,7 +655,7 @@ describe("@facility/mcp", () => {
 
     const oauthDiscovery = await requestWithAuthority({
       port,
-      path: "/.well-known/oauth-protected-resource",
+      path: "/.well-known/oauth-protected-resource/mcp",
       authority: privateAuthority,
     });
     expect(oauthDiscovery.status).toBe(421);
@@ -739,19 +770,27 @@ describe("@facility/mcp", () => {
     const server = serveHttp({
       apiUrl: "http://facility.test",
       port: 0,
-      resourceUrl: "https://mcp.facility.test",
+      resourceUrl: "https://mcp.facility.test/mcp",
       authorizationServer: "https://auth.facility.test",
     });
     await once(server, "listening");
     const port = (server.address() as AddressInfo).port;
-    const response = await fetch(`http://127.0.0.1:${port}/.well-known/oauth-protected-resource`);
+    const response = await fetch(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`,
+    );
     assert.equal(response.status, 200);
     const body = (await response.json()) as {
       resource: string;
       authorization_servers: string[];
     };
-    assert.equal(body.resource, "https://mcp.facility.test");
+    assert.equal(body.resource, "https://mcp.facility.test/mcp");
     assert.deepEqual(body.authorization_servers, ["https://auth.facility.test"]);
+    const legacyAlias = await fetch(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource`,
+      { redirect: "manual" },
+    );
+    assert.equal(legacyAlias.status, 308);
+    assert.equal(legacyAlias.headers.get("location"), "/.well-known/oauth-protected-resource/mcp");
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 
@@ -759,8 +798,10 @@ describe("@facility/mcp", () => {
     const server = serveHttp({
       apiUrl: "http://facility.test",
       port: 0,
+      // Keep the historical origin-only deployment value as an accepted input.
       resourceUrl: "https://mcp.facility.test",
       authorizationServer: "https://auth.facility.test",
+      fetch: acceptCredential,
     });
     await once(server, "listening");
     const port = (server.address() as AddressInfo).port;
@@ -768,8 +809,24 @@ describe("@facility/mcp", () => {
     assert.equal(response.status, 401);
     assert.match(
       response.headers.get("www-authenticate") ?? "",
-      /resource_metadata="https:\/\/mcp\.facility\.test\/\.well-known\/oauth-protected-resource"/,
+      /resource_metadata="https:\/\/mcp\.facility\.test\/\.well-known\/oauth-protected-resource\/mcp"/,
     );
+    const legacyUnauthenticated = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      body: "{}",
+    });
+    assert.equal(legacyUnauthenticated.status, 401);
+    assert.equal(legacyUnauthenticated.headers.get("www-authenticate"), "Bearer");
+    const legacyAuthenticated = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer fak_legacy",
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+    assert.notEqual(legacyAuthenticated.status, 401);
+    assert.notEqual(legacyAuthenticated.status, 405);
     // Metadata discovery is unconfigured (no authorization server) => 404.
     const bare = serveHttp({ apiUrl: "http://facility.test", port: 0 });
     await once(bare, "listening");

--- a/services/api/src/auth/authorization-server.ts
+++ b/services/api/src/auth/authorization-server.ts
@@ -11,6 +11,7 @@ import { oauthAdapterFactory } from "./oauth-adapter.js";
 
 export async function registerAuthorizationServer(app: FastifyInstance, config: AppConfig) {
   if (!config.oauthIssuer || !config.oauthJwks || !config.mcpPublicUrl) return;
+  const browserOrigin = oauthBrowserOrigin(config);
   const Adapter = oauthAdapterFactory(app.facilityDb, config.secretMasterKey);
   const provider = new Provider(config.oauthIssuer, {
     adapter: Adapter,
@@ -72,7 +73,7 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
       client.grantTypeAllowed("refresh_token"),
     interactions: {
       url: (_ctx: unknown, interaction: { uid: string }) =>
-        `${config.publicUrl}/oauth/interaction/${interaction.uid}`,
+        `${browserOrigin}/oauth/interaction/${interaction.uid}`,
     },
     findAccount: async (_ctx: unknown, accountId: string) => {
       const account = await activeAccount(app, accountId);
@@ -143,8 +144,9 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
     { config: { public: true }, schema: { params: z.object({ uid: z.string() }) } },
     async (request, reply) => {
       if (!request.principal?.userId) {
+        const returnTo = `/oauth/interaction/${(request.params as { uid: string }).uid}`;
         return reply.redirect(
-          `/auth/login?returnTo=${encodeURIComponent(`/oauth/interaction/${(request.params as { uid: string }).uid}`)}`,
+          `${browserOrigin}/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`,
         );
       }
       const details = await provider.interactionDetails(request.raw, reply.raw);
@@ -221,4 +223,50 @@ function escapeHtml(value: string) {
     "'": "&#39;",
   };
   return value.replace(/[&<>"']/g, (character) => entities[character] ?? character);
+}
+
+export function oauthBrowserOrigin(config: AppConfig) {
+  let issuer: URL;
+  let web: URL;
+  let callback: URL;
+  try {
+    issuer = new URL(config.oauthIssuer ?? "");
+    web = new URL(config.webUrl ?? config.publicUrl);
+    callback = new URL(config.authCallbackUrl ?? `${web.origin}/api/auth/callback`);
+  } catch {
+    throw new Error(
+      "Facility OAuth WEB_URL, issuer, and authentication callback must be valid HTTP(S) URLs",
+    );
+  }
+  if (!isOriginUrl(web) || !isOriginUrl(issuer) || issuer.origin !== web.origin) {
+    throw new Error("Facility OAuth WEB_URL and issuer must be the same canonical HTTP(S) origin");
+  }
+  if (!isExactAuthCallbackUrl(callback, web.origin)) {
+    throw new Error(
+      "Facility OAuth authentication callback must be exactly WEB_URL /api/auth/callback",
+    );
+  }
+  return web.origin;
+}
+
+function isOriginUrl(url: URL) {
+  return (
+    ["http:", "https:"].includes(url.protocol) &&
+    !url.username &&
+    !url.password &&
+    url.pathname === "/" &&
+    !url.search &&
+    !url.hash
+  );
+}
+
+function isExactAuthCallbackUrl(url: URL, webOrigin: string) {
+  return (
+    ["http:", "https:"].includes(url.protocol) &&
+    !url.username &&
+    !url.password &&
+    !url.search &&
+    !url.hash &&
+    url.toString() === `${webOrigin}/api/auth/callback`
+  );
 }

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -176,6 +176,70 @@ const EnvSchema = z
         message: "GitHub organization restriction is only supported in github mode",
       });
     }
+    if (env.MCP_PUBLIC_URL) {
+      try {
+        canonicalMcpResourceUrl(env.MCP_PUBLIC_URL);
+      } catch (error) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["MCP_PUBLIC_URL"],
+          message: error instanceof Error ? error.message : "MCP_PUBLIC_URL is invalid",
+        });
+      }
+    }
+    const interactiveOauthEnabled = Boolean(
+      env.FACILITY_OAUTH_ISSUER && env.FACILITY_OAUTH_JWKS?.trim() && env.MCP_PUBLIC_URL,
+    );
+    if (interactiveOauthEnabled) {
+      const webUrl = env.WEB_URL ?? env.PUBLIC_URL;
+      const callbackUrl =
+        env.AUTH_CALLBACK_URL ?? `${webUrl.replace(/\/+$/, "")}/api/auth/callback`;
+      const oauthUrls: Array<[string, URL]> = [
+        ["WEB_URL", new URL(webUrl)],
+        ["AUTH_CALLBACK_URL", new URL(callbackUrl)],
+        ["FACILITY_OAUTH_ISSUER", new URL(env.FACILITY_OAUTH_ISSUER ?? "")],
+        ["MCP_PUBLIC_URL", new URL(env.MCP_PUBLIC_URL ?? "")],
+      ];
+      const allLoopbackHttp = oauthUrls.every(
+        ([, url]) => url.protocol === "http:" && isLoopbackHostname(url.hostname),
+      );
+      if (env.NODE_ENV === "production" && !allLoopbackHttp) {
+        for (const [name, url] of oauthUrls) {
+          if (url.protocol === "https:") continue;
+          ctx.addIssue({
+            code: "custom",
+            path: [name],
+            message: `${name} must use HTTPS in production`,
+          });
+        }
+      }
+      const web = new URL(webUrl);
+      const issuer = new URL(env.FACILITY_OAUTH_ISSUER ?? "");
+      if (!isOriginUrl(web)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["WEB_URL"],
+          message:
+            "WEB_URL must be an HTTP(S) origin without credentials, path, query, or fragment when Facility OAuth is enabled",
+        });
+      }
+      if (!isOriginUrl(issuer) || issuer.origin !== web.origin) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["FACILITY_OAUTH_ISSUER"],
+          message:
+            "FACILITY_OAUTH_ISSUER must be the WEB_URL origin so OAuth browser cookies remain host-only and same-origin",
+        });
+      }
+      const callback = new URL(callbackUrl);
+      if (!isExactAuthCallbackUrl(callback, web.origin)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["AUTH_CALLBACK_URL"],
+          message: "AUTH_CALLBACK_URL must be exactly the WEB_URL /api/auth/callback URL",
+        });
+      }
+    }
   });
 
 function isExactBase64Key(value: string) {
@@ -213,7 +277,9 @@ export function readConfig(env = process.env): AppConfig {
     facilityInstanceId: parsed.FACILITY_INSTANCE_ID,
     oauthIssuer: parsed.FACILITY_OAUTH_ISSUER?.replace(/\/$/, ""),
     oauthJwks: parseJwks(parsed.FACILITY_OAUTH_JWKS),
-    mcpPublicUrl: parsed.MCP_PUBLIC_URL?.replace(/\/$/, ""),
+    mcpPublicUrl: parsed.MCP_PUBLIC_URL
+      ? canonicalMcpResourceUrl(parsed.MCP_PUBLIC_URL)
+      : undefined,
     facilityInsecureDev: parsed.FACILITY_INSECURE_DEV === "1",
     s3Endpoint: parsed.S3_ENDPOINT,
     s3AccessKey: parsed.S3_ACCESS_KEY,
@@ -263,4 +329,53 @@ function parseJwks(value: string | undefined): { keys: Record<string, unknown>[]
     throw new Error("FACILITY_OAUTH_JWKS key ids must be unique");
   }
   return { keys: keys as Record<string, unknown>[] };
+}
+
+function canonicalMcpResourceUrl(value: string) {
+  const resource = new URL(value);
+  if (
+    !["http:", "https:"].includes(resource.protocol) ||
+    resource.username ||
+    resource.password ||
+    resource.search ||
+    resource.hash
+  ) {
+    throw new Error(
+      "MCP_PUBLIC_URL must be an HTTP(S) URL without credentials, query, or fragment",
+    );
+  }
+  if (resource.protocol !== "https:" && !isLoopbackHostname(resource.hostname)) {
+    throw new Error("MCP_PUBLIC_URL must use HTTPS unless it is a loopback URL");
+  }
+  const path = resource.pathname.replace(/\/+$/, "");
+  if (path && path !== "/mcp") throw new Error("MCP_PUBLIC_URL path must be /mcp");
+  resource.pathname = "/mcp";
+  return resource.toString();
+}
+
+function isOriginUrl(url: URL) {
+  return (
+    ["http:", "https:"].includes(url.protocol) &&
+    !url.username &&
+    !url.password &&
+    url.pathname === "/" &&
+    !url.search &&
+    !url.hash
+  );
+}
+
+function isExactAuthCallbackUrl(url: URL, webOrigin: string) {
+  return (
+    ["http:", "https:"].includes(url.protocol) &&
+    !url.username &&
+    !url.password &&
+    !url.search &&
+    !url.hash &&
+    url.toString() === `${webOrigin}/api/auth/callback`
+  );
+}
+
+function isLoopbackHostname(hostname: string) {
+  const normalized = hostname.toLowerCase();
+  return ["localhost", "127.0.0.1", "[::1]"].includes(normalized);
 }

--- a/services/api/test/config.test.ts
+++ b/services/api/test/config.test.ts
@@ -6,6 +6,26 @@ const validEnv = {
   SECRET_MASTER_KEY: Buffer.alloc(32, 9).toString("base64"),
 };
 
+const validOauthJwks = JSON.stringify({
+  keys: [{ kty: "EC", crv: "P-256", x: "x", y: "y", d: "d", kid: "oauth-key" }],
+});
+
+const enabledOauthEnv = {
+  FACILITY_OAUTH_JWKS: validOauthJwks,
+  MCP_PUBLIC_URL: "https://mcp.example.org/mcp",
+};
+
+const validProductionOauthEnv = {
+  ...validEnv,
+  NODE_ENV: "production",
+  PUBLIC_URL: "https://api.example.com",
+  WEB_URL: "https://app.example.com",
+  FACILITY_PREVIEW_URL: "https://facility-previews.example.net",
+  AUTH_CALLBACK_URL: "https://app.example.com/api/auth/callback",
+  FACILITY_OAUTH_ISSUER: "https://app.example.com",
+  ...enabledOauthEnv,
+};
+
 describe("API configuration", () => {
   it("accepts a master key that decodes to exactly 32 bytes", () => {
     expect(readConfig(validEnv).secretMasterKey).toBe(validEnv.SECRET_MASTER_KEY);
@@ -206,14 +226,173 @@ describe("API configuration", () => {
     expect(
       readConfig({
         ...validEnv,
-        FACILITY_OAUTH_ISSUER: "https://api.example.com/",
+        PUBLIC_URL: "https://api.example.com/",
+        WEB_URL: "https://app.example.com/",
+        AUTH_CALLBACK_URL: "https://app.example.com/api/auth/callback",
+        FACILITY_OAUTH_ISSUER: "https://app.example.com/",
         MCP_PUBLIC_URL: "https://mcp.example.com/",
         FACILITY_OAUTH_JWKS: JSON.stringify({ keys: [privateKey] }),
       }),
     ).toMatchObject({
-      oauthIssuer: "https://api.example.com",
-      mcpPublicUrl: "https://mcp.example.com",
+      oauthIssuer: "https://app.example.com",
+      mcpPublicUrl: "https://mcp.example.com/mcp",
       oauthJwks: { keys: [privateKey] },
     });
+  });
+
+  it("canonicalizes the MCP resource and rejects an unrelated path", () => {
+    expect(readConfig({ ...validEnv, MCP_PUBLIC_URL: "https://mcp.example.com" })).toMatchObject({
+      mcpPublicUrl: "https://mcp.example.com/mcp",
+    });
+    expect(
+      readConfig({ ...validEnv, MCP_PUBLIC_URL: "https://mcp.example.com/mcp/" }),
+    ).toMatchObject({ mcpPublicUrl: "https://mcp.example.com/mcp" });
+    expect(() =>
+      readConfig({ ...validEnv, MCP_PUBLIC_URL: "https://mcp.example.com/other" }),
+    ).toThrow("MCP_PUBLIC_URL path must be /mcp");
+    expect(() => readConfig({ ...validEnv, MCP_PUBLIC_URL: "http://mcp.facility.test" })).toThrow(
+      "MCP_PUBLIC_URL must use HTTPS unless it is a loopback URL",
+    );
+  });
+
+  it("preserves an exact same-origin HTTP OAuth flow outside production", () => {
+    expect(
+      readConfig({
+        ...validEnv,
+        PUBLIC_URL: "http://localhost:4400",
+        WEB_URL: "http://localhost:3400",
+        FACILITY_OAUTH_ISSUER: "http://localhost:3400",
+        AUTH_CALLBACK_URL: "http://localhost:3400/api/auth/callback",
+        MCP_PUBLIC_URL: "http://localhost:4420",
+        FACILITY_OAUTH_JWKS: validOauthJwks,
+      }),
+    ).toMatchObject({
+      webUrl: "http://localhost:3400",
+      oauthIssuer: "http://localhost:3400",
+      authCallbackUrl: "http://localhost:3400/api/auth/callback",
+      mcpPublicUrl: "http://localhost:4420/mcp",
+    });
+  });
+
+  it("allows all-loopback HTTP OAuth URLs when the Compose image sets production", () => {
+    expect(
+      readConfig({
+        ...validEnv,
+        NODE_ENV: "production",
+        PUBLIC_URL: "http://localhost:4400",
+        WEB_URL: "http://localhost:3400",
+        FACILITY_PREVIEW_URL: "https://facility-previews.example.net",
+        FACILITY_OAUTH_ISSUER: "http://localhost:3400",
+        AUTH_CALLBACK_URL: "http://localhost:3400/api/auth/callback",
+        MCP_PUBLIC_URL: "http://127.0.0.1:4420",
+        FACILITY_OAUTH_JWKS: validOauthJwks,
+      }),
+    ).toMatchObject({
+      oauthIssuer: "http://localhost:3400",
+      mcpPublicUrl: "http://127.0.0.1:4420/mcp",
+    });
+  });
+
+  it("does not apply Facility OAuth transport policy to an incomplete configuration", () => {
+    expect(
+      readConfig({
+        ...validEnv,
+        NODE_ENV: "production",
+        PUBLIC_URL: "http://api.example.com",
+        WEB_URL: "http://app.example.com",
+        FACILITY_PREVIEW_URL: "https://facility-previews.example.net",
+        FACILITY_OAUTH_ISSUER: "http://app.example.com",
+        AUTH_CALLBACK_URL: "http://app.example.com/api/auth/callback",
+        MCP_PUBLIC_URL: "https://mcp.example.org",
+        FACILITY_OAUTH_JWKS: "",
+      }),
+    ).toMatchObject({ oauthJwks: undefined, mcpPublicUrl: "https://mcp.example.org/mcp" });
+  });
+
+  it.each([
+    [
+      "WEB_URL",
+      {
+        WEB_URL: "http://app.example.com",
+        FACILITY_OAUTH_ISSUER: "http://app.example.com",
+        AUTH_CALLBACK_URL: "http://app.example.com/api/auth/callback",
+      },
+    ],
+    ["AUTH_CALLBACK_URL", { AUTH_CALLBACK_URL: "http://app.example.com/api/auth/callback" }],
+    ["FACILITY_OAUTH_ISSUER", { FACILITY_OAUTH_ISSUER: "http://app.example.com" }],
+  ])("requires HTTPS for %s in production", (name, overrides) => {
+    expect(() => readConfig({ ...validProductionOauthEnv, ...overrides })).toThrow(
+      `${name} must use HTTPS in production`,
+    );
+  });
+
+  it.each([
+    "https://user:secret@app.example.com",
+    "https://app.example.com/oauth",
+    "https://app.example.com?tenant=one",
+    "https://app.example.com#fragment",
+  ])("requires the OAuth WEB_URL to be a canonical origin: %s", (webUrl) => {
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        ...enabledOauthEnv,
+        PUBLIC_URL: "https://api.example.com",
+        WEB_URL: webUrl,
+        FACILITY_OAUTH_ISSUER: "https://app.example.com",
+      }),
+    ).toThrow(
+      "WEB_URL must be an HTTP(S) origin without credentials, path, query, or fragment when Facility OAuth is enabled",
+    );
+  });
+
+  it("requires the MCP authorization server issuer to be the canonical web origin", () => {
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        ...enabledOauthEnv,
+        PUBLIC_URL: "https://api.example.com",
+        WEB_URL: "https://app.example.com",
+        FACILITY_OAUTH_ISSUER: "https://api.example.com",
+      }),
+    ).toThrow(
+      "FACILITY_OAUTH_ISSUER must be the WEB_URL origin so OAuth browser cookies remain host-only and same-origin",
+    );
+    for (const oauthIssuer of [
+      "https://user:secret@app.example.com",
+      "https://app.example.com/oauth",
+      "https://app.example.com?tenant=one",
+      "https://app.example.com#fragment",
+    ]) {
+      expect(() =>
+        readConfig({
+          ...validEnv,
+          ...enabledOauthEnv,
+          WEB_URL: "https://app.example.com",
+          FACILITY_OAUTH_ISSUER: oauthIssuer,
+        }),
+      ).toThrow(
+        "FACILITY_OAUTH_ISSUER must be the WEB_URL origin so OAuth browser cookies remain host-only and same-origin",
+      );
+    }
+  });
+
+  it.each([
+    "https://user:secret@app.example.com/api/auth/callback",
+    "https://app.example.com/auth/callback",
+    "https://app.example.com/api/auth/callback/",
+    "https://app.example.com/api/auth/callback?tenant=one",
+    "https://app.example.com/api/auth/callback#fragment",
+    "https://other.example.com/api/auth/callback",
+  ])("requires the exact host-only OAuth callback URL: %s", (callbackUrl) => {
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        ...enabledOauthEnv,
+        PUBLIC_URL: "https://api.example.com",
+        WEB_URL: "https://app.example.com",
+        FACILITY_OAUTH_ISSUER: "https://app.example.com",
+        AUTH_CALLBACK_URL: callbackUrl,
+      }),
+    ).toThrow("AUTH_CALLBACK_URL must be exactly the WEB_URL /api/auth/callback URL");
   });
 });

--- a/services/api/test/oauth.test.ts
+++ b/services/api/test/oauth.test.ts
@@ -13,6 +13,7 @@ import { createLocalJWKSet, decodeJwt, exportJWK, generateKeyPair, SignJWT } fro
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp, mintSessionCookie } from "../src/app.js";
+import { oauthBrowserOrigin } from "../src/auth/authorization-server.js";
 import { pkceChallenge } from "../src/auth/identity-provider.js";
 import {
   AccessTokenError,
@@ -25,8 +26,8 @@ import type { AppConfig } from "../src/types.js";
 const databaseUrl =
   process.env.DATABASE_URL ?? "postgres://facility:facility@localhost:5461/facility_test";
 const masterKey = Buffer.alloc(32, 7).toString("base64");
-const issuer = "https://api.facility.test";
-const audience = "https://mcp.facility.test";
+const issuer = "https://facility.test";
+const audience = "https://mcp.facility.test/mcp";
 const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
 const privateJwk = { ...(await exportJWK(privateKey)), kid: "test-key", alg: "ES256", use: "sig" };
 const publicJwk = { ...(await exportJWK(publicKey)), kid: "test-key", alg: "ES256", use: "sig" };
@@ -36,12 +37,14 @@ const base: AppConfig = {
   databaseUrl,
   secretMasterKey: masterKey,
   port: 4400,
-  publicUrl: "http://localhost:4400",
+  publicUrl: "https://api.facility.test",
+  webUrl: issuer,
   sandboxApiUrl: "http://localhost:4400",
   sandboxGatewayUrl: "http://localhost:4410",
   gatewayUrl: "http://localhost:4410",
   sandboxRunnerImage: "facility-runner:dev",
   sandboxDriver: "docker",
+  authCallbackUrl: `${issuer}/api/auth/callback`,
   facilityInsecureDev: true,
   logLevel: "silent",
 };
@@ -107,6 +110,48 @@ describe("Facility OAuth access-token verification", () => {
   it("recognizes only three-segment JWT values", () => {
     expect(looksLikeJwt("a.b.c")).toBe(true);
     expect(looksLikeJwt("fak_test")).toBe(false);
+  });
+});
+
+describe("Facility OAuth browser-origin runtime guard", () => {
+  it("accepts an exact same-origin callback, including HTTP local development", () => {
+    expect(
+      oauthBrowserOrigin({
+        ...base,
+        publicUrl: "http://localhost:4400",
+        webUrl: "http://localhost:3400",
+        oauthIssuer: "http://localhost:3400",
+        authCallbackUrl: "http://localhost:3400/api/auth/callback",
+      }),
+    ).toBe("http://localhost:3400");
+  });
+
+  it.each([
+    ["web path", { webUrl: `${issuer}/app`, oauthIssuer: issuer }],
+    ["issuer path", { webUrl: issuer, oauthIssuer: `${issuer}/oauth` }],
+    ["issuer credentials", { webUrl: issuer, oauthIssuer: "https://user:secret@facility.test" }],
+    ["different issuer", { webUrl: issuer, oauthIssuer: "https://other.facility.test" }],
+  ])("rejects a non-canonical or mismatched %s at runtime", (_label, overrides) => {
+    expect(() => oauthBrowserOrigin({ ...base, ...overrides })).toThrow(
+      "Facility OAuth WEB_URL and issuer must be the same canonical HTTP(S) origin",
+    );
+  });
+
+  it.each([
+    `${issuer}/auth/callback`,
+    `${issuer}/api/auth/callback/`,
+    `${issuer}/api/auth/callback?tenant=one`,
+    `${issuer}/api/auth/callback#fragment`,
+    "https://other.facility.test/api/auth/callback",
+    "https://user:secret@facility.test/api/auth/callback",
+  ])("rejects a non-exact authentication callback at runtime: %s", (authCallbackUrl) => {
+    expect(() =>
+      oauthBrowserOrigin({
+        ...base,
+        oauthIssuer: issuer,
+        authCallbackUrl,
+      }),
+    ).toThrow("Facility OAuth authentication callback must be exactly WEB_URL /api/auth/callback");
   });
 });
 
@@ -285,6 +330,16 @@ describe("Facility OAuth resource-server integration", async () => {
       code_challenge: await pkceChallenge(verifier),
       code_challenge_method: "S256",
     });
+    const wrongResource = new URLSearchParams(query);
+    wrongResource.set("resource", "https://mcp.facility.test");
+    const rejectedResource = await app.inject({
+      method: "GET",
+      url: `/oauth/authorize?${wrongResource}`,
+      headers: proxyHeaders,
+    });
+    expect(rejectedResource.statusCode).toBe(400);
+    expect(rejectedResource.body).toContain("Unknown OAuth resource");
+
     const authorization = await app.inject({
       method: "GET",
       url: `/oauth/authorize?${query}`,
@@ -292,10 +347,21 @@ describe("Facility OAuth resource-server integration", async () => {
     });
     expect(authorization.statusCode).toBe(303);
     const providerCookies = authorization.cookies.map((cookie) => `${cookie.name}=${cookie.value}`);
-    const interactionPath = new URL(
+    const interactionUrl = new URL(
       required(authorization.headers.location, "interaction redirect"),
       config.publicUrl,
-    ).pathname;
+    );
+    expect(interactionUrl.origin).toBe(issuer);
+    const interactionPath = interactionUrl.pathname;
+    const signedOutInteraction = await app.inject({
+      method: "GET",
+      url: interactionPath,
+      headers: { cookie: providerCookies.join("; ") },
+    });
+    expect(signedOutInteraction.statusCode).toBe(302);
+    expect(signedOutInteraction.headers.location).toBe(
+      `${issuer}/api/auth/login?returnTo=${encodeURIComponent(interactionPath)}`,
+    );
     const facilityCookie = `facility_session=${await mintSessionCookie(config, userId, orgId)}`;
     const interaction = await app.inject({
       method: "GET",


### PR DESCRIPTION
Fixes #201

## Problem

Remote interactive MCP OAuth currently crosses the API and web origins during the browser interaction, so host-only login/interaction cookies do not survive the complete flow. The protected-resource metadata also advertises an origin-only resource even though the protected MCP endpoint is `/mcp`.

## Changes

- make `WEB_URL` the canonical OAuth issuer and proxy `/oauth/*` plus `/.well-known/*` through the web app;
- canonicalize `MCP_PUBLIC_URL` to the path-aware `/mcp` resource and serve RFC 9728 metadata at `/.well-known/oauth-protected-resource/mcp`;
- retain a 308 discovery alias for the old root metadata path and the authenticated legacy `POST /` transport without advertising the wrong resource;
- validate exact issuer, callback, resource, HTTPS, and loopback-only HTTP invariants;
- keep local Compose fully functional over loopback HTTP;
- enable interactive OAuth in AWS only when ACM is configured; certificate-less validation keeps scoped `fak_` access without advertising OAuth;
- document the coordinated upgrade and client reconnection procedure.

## Breaking change

BREAKING CHANGE: the Facility OAuth issuer moves from the API origin to `WEB_URL`, and the MCP resource audience moves from the MCP origin to the canonical `/mcp` URL. Apply configuration/Terraform first, deploy API, web, and MCP together, then reconnect interactive clients and start new browser sessions. Existing `fak_` API keys are unchanged.

## Verification

- `pnpm lint`: clean (408 files)
- `pnpm typecheck`: 16 tasks passed
- clean monorepo build: passed
- critical suites: DB 18, CLI 98, API 499, Gateway 57 passed with no skips
- `@facility/mcp`: 27/27 passed
- `@facility/web`: 66/66 passed
- focused API OAuth/config: 51 passed, 1 DB-dependent test skipped in the focused environment
- Terraform preview-origin tests: 5/5 passed
- repository guards: 2/2 passed
- `git diff --check`: clean
- the full parallel `pnpm verify` reached the unrelated runner suite and failed only two existing 100 ms PID-creation timing tests in `runner/test/workspace.test.ts`; the untouched `bounded Git delivery commands` group passes 3/3 in isolation (485 ms)

## Hosted CI

GitHub Actions completed successfully on head `c75dfc780ea6cd962b2d37ac00360887fbbe3c41`:

- `ci` run 32873810937: `verify`, `self-host-build`, and `sandbox-e2e` all passed;
- `conventional commit subjects` run 32873810854: PR title and commit subjects passed;
- release and publishing jobs were correctly skipped for this pull request.

A live end-to-end hosted Codex OAuth connection still requires deploying this coordinated API/web/MCP change. The deterministic API, web-proxy, MCP-discovery, Compose-config, and Terraform layers are covered here. Dependency audit was not rerun because it requires exporting lockfile dependency metadata to the public npm registry.