### PR TITLE
fix(release): restore package publication after partial failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 # A release decision is a read of shared tag state. Serialize main pushes at
 # the workflow boundary so a later merge cannot decide from that state until
-# the prior merge has either recorded its release or failed visibly.
+# the prior merge has allocated its immutable version or failed visibly.
 concurrency:
   group: ci-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -82,7 +82,8 @@ jobs:
   # Stamp the decided version and build the archive once, in a job with no
   # credentials. The npm environment later receives this exact, already-tested
   # archive rather than running package lifecycle code with publication rights.
-  # The stamp is never committed: the tag written at the end is the record.
+  # The stamp is never committed: the tag allocated after acceptance is the
+  # immutable version record.
   package-release:
     needs: [decide-release, verify]
     if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
@@ -266,12 +267,50 @@ jobs:
         if: steps.policy.outputs.required != 'true'
         run: echo "Sandbox E2E skipped by policy — ${{ steps.policy.outputs.reason }}."
 
+  # Allocate the immutable version only after every acceptance path and the
+  # exact npm artifact have passed, but before either registry can consume it.
+  # This closes the unavoidable uncertainty windows around a lost npm response
+  # and GHCR's per-image (non-atomic) promotion loop.
+  allocate-release:
+    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e]
+    if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Allocate the immutable release version
+        env:
+          TAG: ${{ needs.decide-release.outputs.tag }}
+          VERSION: ${{ needs.decide-release.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          head_sha="$(git rev-parse HEAD)"
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            tag_sha="$(git rev-parse "refs/tags/$TAG^{commit}")"
+            if [ "$tag_sha" != "$head_sha" ]; then
+              echo "$TAG points to $tag_sha, not accepted commit $head_sha" >&2
+              exit 1
+            fi
+            echo "$TAG already allocates the accepted commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "$VERSION"
+            git push origin "$TAG"
+          fi
+
   # Keep publication in the original accepted main-push run so npm provenance
   # identifies the commit that passed every acceptance job. A downstream
   # workflow_run would instead attest the default branch SHA.
   publish-npm:
     if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
-    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e]
+    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e, allocate-release]
     permissions:
       contents: read
       id-token: write
@@ -291,7 +330,7 @@ jobs:
   # revalidates the release before granting its jobs packages: write.
   publish-images:
     if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
-    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e]
+    needs: [decide-release, verify, package-release, self-host-build, sandbox-e2e, allocate-release]
     permissions:
       contents: read
       packages: write
@@ -299,13 +338,21 @@ jobs:
     with:
       version: ${{ needs.decide-release.outputs.version }}
 
-  # The tag is written last, and only after both registries accepted the
-  # release. It records what shipped; it is not the request to ship it. Retry a
-  # failed publisher in this same run so an already-successful peer is not
-  # asked to republish an immutable version.
+  # The tag was allocated before registry mutation. Add a GitHub Release only
+  # when at least one publisher confirms success, preserving the factual status
+  # of the other artifact set while failed publishers keep the workflow red.
   record-release:
-    needs: [decide-release, publish-npm, publish-images]
-    if: needs.decide-release.outputs.release == 'true' && github.event.repository.visibility == 'public'
+    needs: [decide-release, allocate-release, publish-npm, publish-images]
+    if: >-
+      !cancelled()
+      && needs.decide-release.result == 'success'
+      && needs.allocate-release.result == 'success'
+      && needs.decide-release.outputs.release == 'true'
+      && github.event.repository.visibility == 'public'
+      && (
+        needs.publish-npm.outputs.published == 'true'
+        || needs.publish-images.outputs.promoted == 'true'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -321,9 +368,17 @@ jobs:
           TAG: ${{ needs.decide-release.outputs.tag }}
           VERSION: ${{ needs.decide-release.outputs.version }}
           NOTES: ${{ needs.decide-release.outputs.notes }}
+          NPM_PUBLISHED: ${{ needs.publish-npm.outputs.published }}
+          IMAGES_PROMOTED: ${{ needs.publish-images.outputs.promoted }}
         shell: bash
         run: |
           set -euo pipefail
+          npm_published="${NPM_PUBLISHED:-false}"
+          images_promoted="${IMAGES_PROMOTED:-false}"
+          if [ "$npm_published" != "true" ] && [ "$images_promoted" != "true" ]; then
+            echo "refusing to record $TAG because no publisher confirmed an artifact" >&2
+            exit 1
+          fi
           head_sha="$(git rev-parse HEAD)"
           if git show-ref --verify --quiet "refs/tags/$TAG"; then
             tag_sha="$(git rev-parse "refs/tags/$TAG^{commit}")"
@@ -338,7 +393,20 @@ jobs:
             git tag -a "$TAG" -m "$VERSION"
             git push origin "$TAG"
           fi
-          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/notes.md"
+          {
+            printf '%s\n\n' "$NOTES"
+            printf '%s\n\n' '## Artifact status'
+            if [ "$npm_published" = "true" ]; then
+              printf '%s\n' '- npm package: published'
+            else
+              printf '%s\n' '- npm package: publication was not confirmed'
+            fi
+            if [ "$images_promoted" = "true" ]; then
+              printf '%s\n' '- container image set: promoted'
+            else
+              printf '%s\n' '- container image set: promotion was not confirmed complete'
+            fi
+          } > "$RUNNER_TEMP/notes.md"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub Release $TAG already exists."
           else

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -25,6 +25,10 @@ on:
         description: The version decided from the commits
         type: string
         required: true
+    outputs:
+      promoted:
+        description: Whether every immutable GHCR version tag was promoted
+        value: ${{ jobs.promote.outputs.promoted }}
   workflow_dispatch:
 
 permissions:
@@ -217,6 +221,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      promoted: ${{ steps.promotion.outputs.promoted }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -240,3 +246,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_TAGS_JSON: ${{ needs.plan.outputs.tags }}
         run: node scripts/images.mjs promote "$RUNNER_TEMP/image-digests"
+
+      - name: Record the promoted image version
+        id: promotion
+        run: echo 'promoted=true' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
         description: The version decided from the commits, stamped into the archive
         type: string
         required: true
+    outputs:
+      published:
+        description: Whether npm's immutable version namespace was consumed
+        value: ${{ jobs.publish.outputs.published }}
   workflow_dispatch:
 
 permissions:
@@ -76,6 +80,8 @@ jobs:
       contents: read
       id-token: write
     environment: npm
+    outputs:
+      published: ${{ steps.publication.outputs.published }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -130,6 +136,7 @@ jobs:
         run: node scripts/release.mjs registry-state "$CANDIDATE"
 
       - name: Publish with npm trusted publishing
+        id: oidc
         if: steps.registry.outputs.state == 'existing'
         env:
           CANDIDATE: ${{ steps.candidate.outputs.path }}
@@ -140,8 +147,25 @@ jobs:
       # spawning npm, preventing token fallback for existing packages or
       # uncertain registry state.
       - name: Bootstrap the package once with a granular token
+        id: bootstrap
         if: steps.registry.outputs.state == 'missing'
         env:
           CANDIDATE: ${{ steps.candidate.outputs.path }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
         run: node scripts/release.mjs publish "$CANDIDATE" --auth=bootstrap
+
+      # A version is consumed when an identical artifact already exists or
+      # when the matching authentication branch published it successfully.
+      # Export that fact instead of asking the caller to infer it from a job
+      # result, because skipped reusable jobs can still report success.
+      - name: Record the consumed npm version
+        id: publication
+        if: >-
+          !cancelled()
+          && steps.registry.outcome == 'success'
+          && (
+            steps.registry.outputs.state == 'published'
+            || (steps.registry.outputs.state == 'existing' && steps.oidc.outcome == 'success')
+            || (steps.registry.outputs.state == 'missing' && steps.bootstrap.outcome == 'success')
+          )
+        run: echo 'published=true' >> "$GITHUB_OUTPUT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,15 @@
 #
 #   docker build --target api     -t facility/api .
 #   docker build --target gateway -t facility/gateway .
-FROM node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d AS base
+FROM node:24-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf232863b07d3b02fe55ae0 AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH=/pnpm:$PATH
-RUN apt-get update \
+# Keep a digest-pinned base while still making a reviewed Debian security
+# refresh invalidate BuildKit's cached package layer.
+ARG DEBIAN_SECURITY_REFRESH=20260828
+RUN test -n "$DEBIAN_SECURITY_REFRESH" \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
   && apt-get install -y --no-install-recommends ca-certificates curl \
   && curl --fail --silent --show-error --location --retry 3 \
     https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,8 +1,13 @@
 # Facility web (Next.js standalone). Built once; FACILITY_API_URL is supplied
 # when the container starts so the same artifact works in every installation.
 #   docker build -f apps/web/Dockerfile -t facility/web .
-FROM node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d AS base
+FROM node:24-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf232863b07d3b02fe55ae0 AS base
 ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH
+ARG DEBIAN_SECURITY_REFRESH=20260828
+RUN test -n "$DEBIAN_SECURITY_REFRESH" \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
 WORKDIR /app
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,7 +3,7 @@
 **Merging to `main` is the release.** There is no version-bump commit, no
 release branch, and no tag to push by hand: `.github/workflows/ci.yml` decides
 from the commit subjects since the last release whether this merge publishes
-and as what version, then verifies, publishes, and writes the tag.
+and as what version, then verifies, allocates the tag, and publishes.
 
 What that asks of a contributor — an honest commit subject — is in
 [CONTRIBUTING.md](../CONTRIBUTING.md#releasing). Everything below is the
@@ -24,20 +24,27 @@ The order matters, and it is the whole safety argument:
    *inside the run*, the archive is built, installed the way `npx` would, and
    its binary is executed. Nothing is committed; the checkout's version number
    is not the source of truth.
-4. **Publish** — npm and, once the repository is public, the images, from that
+4. **Allocate** — after every acceptance path and the exact npm archive pass,
+   the annotated tag reserves that version for the accepted commit. This
+   happens before either registry changes, so a partial image promotion, a lost
+   registry response, or cancellation cannot let a later commit reuse it.
+5. **Publish** — npm and, once the repository is public, the images, from that
    exact archive and digest set.
-5. **Record** — only now is the annotated tag written and the GitHub release
-   published with the generated notes.
+6. **Record status** — when at least one publisher confirms success, a GitHub
+   Release records the generated notes and the factual status of both artifact
+   sets. The tag is the version allocation record, not a claim that every
+   artifact published successfully.
 
 ## Recovering a failed run
 
-A run that fails before both publishers finish leaves no tag. Retry the failed
-jobs in that same workflow run so they reuse the accepted artifacts and retain
-the successful publisher's result. Exact npm artifacts and image digests are
+A publication run has already allocated its tag. Retry the failed jobs in that
+same workflow run so they reuse the accepted artifacts and retain the
+successful publisher's result. Exact npm artifacts and image digests are
 idempotent on that retry; the publishers refuse the same version with different
-contents. Do not use another merge as the retry. If recording fails after the
-tag was pushed, rerunning that failed job verifies the tag still targets the
-released commit and creates the missing GitHub Release.
+contents. Do not use another merge as the retry: the tag ensures a later merge
+advances to a new version. If status recording fails, rerunning that failed job
+verifies the tag still targets the accepted commit and creates the missing
+GitHub Release.
 
 Do not run `npm publish` locally or invoke the release workflow as a substitute
 for those gates; its manual entry point is a dry run.
@@ -56,17 +63,17 @@ npm cannot attach a trusted publisher until the package exists. Bootstrap
    `NPM_BOOTSTRAP_TOKEN` environment secret.
 
    Do **not** add a ruleset restricting `v*` tag creation while
-   `record-release` pushes that tag with `GITHUB_TOKEN` after a successful
-   publish. A ruleset's bypass list accepts roles, teams, GitHub Apps and
-   Dependabot; Actions' own token is none of those, so the push is rejected and
-   the release stays on npm and GHCR with no tag recording it. The next merge
-   then recomputes the same version and npm rejects it as a duplicate. The
-   environment approval is the gate; the tag is a record written afterwards.
+   `allocate-release` pushes that tag with `GITHUB_TOKEN` before publication.
+   A ruleset's bypass list accepts roles, teams, GitHub Apps and Dependabot;
+   Actions' own token is none of those, so the allocation is rejected and
+   publication never starts. The environment approval and completed acceptance
+   jobs are the gates; the tag reserves the version before a registry can
+   consume it.
 
    The trade-off this accepts: anyone with write access can create a `v*` tag,
    and `scripts/version.mjs` reads the highest one as the release baseline, so
    a stray tag can skip a version or wedge a release after it has published.
-   Closing that means `record-release` authenticating as a GitHub App the
+   Closing that means `allocate-release` authenticating as a GitHub App the
    ruleset lists as a bypass actor — a change to the workflow, not a
    setting to switch on.
 3. Before merging the release-on-merge workflow, establish the inert history
@@ -81,7 +88,8 @@ npm cannot attach a trusted publisher until the package exists. Bootstrap
    the first automated decision.
 4. Merge the first release-impacting pull request to `main`. The main-push
    workflow accepts this credential only while the package is absent from npm;
-   it writes the release tag after npm and the images have both published.
+   it allocates the release tag after acceptance and before npm or the images
+   can publish.
 
 As soon as the first version exists, configure the package's
 [npm trusted publisher](https://docs.npmjs.com/trusted-publishers/) with these
@@ -98,7 +106,7 @@ workflow contains the publish command. Then delete the `NPM_BOOTSTRAP_TOKEN`
 GitHub secret, revoke the granular token on npm, and set the package's
 **Publishing access** to **Require two-factor authentication and disallow
 tokens**. Later release-impacting merges publish through short-lived OIDC
-credentials; their tags are written afterwards as records.
+credentials; their tags are allocated after acceptance and before publication.
 
 ## One-time GitHub Pages setup
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258 AS bind-broker-build
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132 AS bind-broker-build
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends gcc libc6-dev \
@@ -39,9 +39,10 @@ RUN archive=/tmp/moby.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
   && VERSION="$MOBY_VERSION" DOCKER_GITCOMMIT="$MOBY_COMMIT" \
     EXCLUDE_AUTO_BUILDTAG_JOURNALD=1 SOURCE_DATE_EPOCH=1785456000 \
-    ./hack/make.sh binary-daemon binary-proxy \
+    GOFLAGS=-mod=mod ./hack/make.sh binary-daemon binary-proxy \
   && install -m 0755 bundles/binary-daemon/dockerd /out/dockerd \
   && install -m 0755 bundles/binary-proxy/docker-proxy /out/docker-proxy \
   && test "$(/out/dockerd --version | awk '{print $3}' | tr -d ',')" = "$MOBY_VERSION" \
@@ -79,6 +80,7 @@ RUN archive=/tmp/containerd.tar.gz \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
+  && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
   && make VERSION="v${CONTAINERD_VERSION}" REVISION="$CONTAINERD_COMMIT" STATIC=1 \
     GO_BUILD_FLAGS='-mod=mod -trimpath' \
     bin/containerd bin/containerd-shim-runc-v2 bin/ctr \
@@ -113,7 +115,9 @@ RUN archive=/tmp/buildx.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
-  && CGO_ENABLED=0 go build -mod=vendor -trimpath \
+  && go mod edit -replace=github.com/moby/go-archive=github.com/moby/go-archive@v0.3.0 \
+  && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
+  && CGO_ENABLED=0 go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/docker/buildx/version.Version=${BUILDX_VERSION} \
       -X github.com/docker/buildx/version.Revision=${BUILDX_COMMIT} \
       -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
@@ -132,6 +136,7 @@ RUN archive=/tmp/compose.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
   && CGO_ENABLED=0 GOMAXPROCS=1 go build -p=1 -mod=mod -trimpath -tags=e2e \
     -ldflags="-s -w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
     -o /out/docker-compose ./cmd \
@@ -164,6 +169,7 @@ RUN archive=/tmp/gh.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
   && CGO_ENABLED=0 GOTOOLCHAIN=local go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/cli/cli/v2/internal/build.Version=${GH_VERSION} \
       -X github.com/cli/cli/v2/internal/build.Date=2026-07-31" \
@@ -181,20 +187,26 @@ RUN for binary in /out/*; do \
   && for binary in /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/rootlesskit; do \
     go version -m "$binary" | awk \
       '$1 == "=>" && $2 == "golang.org/x/net" && $3 == "v0.56.0" { found = 1 } END { exit !found }'; \
-  done
+  done \
+  && for binary in /out/dockerd /out/containerd /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
+    go version -m "$binary" | awk \
+      '$1 == "=>" && $2 == "golang.org/x/mod" && $3 == "v0.40.0" { found = 1 } END { exit !found }'; \
+  done \
+  && go version -m /out/docker-buildx | awk \
+    '$1 == "=>" && $2 == "github.com/moby/go-archive" && $3 == "v0.3.0" { found = 1 } END { exit !found }'
 
 # The full Node image inherits buildpack-deps and silently carries unrelated
 # database, image-processing, DNS, and web-server development stacks. Agents
 # need a native compiler toolchain, not that entire transitive surface, so start
 # from the official slim variant and install the small explicit toolchain below.
-FROM node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d AS runner-base
+FROM node:24-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf232863b07d3b02fe55ae0 AS runner-base
 
 # The digest-pinned Node base can lag Debian security uploads, while BuildKit
 # correctly caches an earlier apt upgrade against the unchanged base digest.
 # Bump this audited epoch only when a scanner identifies a distro fix that the
 # official image has not incorporated yet; using it in the command makes that
 # refresh explicit and reproducible instead of disabling the whole build cache.
-ARG DEBIAN_SECURITY_REFRESH=20260808
+ARG DEBIAN_SECURITY_REFRESH=20260828
 RUN test -n "$DEBIAN_SECURITY_REFRESH" \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -239,6 +239,17 @@ test("Bake keeps thin target boundaries and publishes every target through one g
       "services/gateway/package.json",
     ].map(async (path) => JSON.parse(await readFile(join(root, path), "utf8"))),
   );
+  for (const [name, dockerfile] of [
+    ["service", controlDockerfile],
+    ["web", webDockerfile],
+    ["runner", runnerDockerfile],
+  ]) {
+    assert.match(
+      dockerfile,
+      /ARG DEBIAN_SECURITY_REFRESH=20260828\s+RUN test -n "\$DEBIAN_SECURITY_REFRESH" \\\s+&& apt-get update \\\s+&& DEBIAN_FRONTEND=noninteractive apt-get upgrade -y/,
+      `${name} image must invalidate its cached Debian upgrade at the reviewed security epoch`,
+    );
+  }
   assert.doesNotMatch(webDockerfile, /^COPY \. \.$/m);
   assert.match(pnpmWorkspace, /^allowUnusedPatches: \$\{FACILITY_ALLOW_UNUSED_PATCHES-false\}$/m);
   for (const dockerfile of [controlDockerfile, webDockerfile]) {
@@ -368,6 +379,19 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   assert.equal((runnerDockerfile.match(/rm -rf \/src "\$archive"/g) ?? []).length, 8);
   assert.match(runnerDockerfile, /go version -m "\$binary"[\s\S]*go1\.26\.6/);
   assert.match(runnerDockerfile, /golang\.org\/x\/net[\s\S]*v0\.56\.0/);
+  assert.equal(
+    runnerDockerfile.match(/golang\.org\/x\/mod=golang\.org\/x\/mod@v0\.40\.0/g)?.length,
+    5,
+    "every copied Go tool with the vulnerable x/mod dependency must use the reviewed replacement",
+  );
+  assert.match(
+    runnerDockerfile,
+    /github\.com\/moby\/go-archive=github\.com\/moby\/go-archive@v0\.3\.0/,
+  );
+  assert.match(
+    runnerDockerfile,
+    /go version -m \/out\/docker-buildx[\s\S]*github\.com\/moby\/go-archive[\s\S]*v0\.3\.0/,
+  );
   assert.match(runnerDockerfile, /COPY --from=go-tools-audit[\s\S]*\/usr\/local\/bin\//);
   assert.match(runnerDockerfile, /COPY --from=docker-tools \/usr\/local\/bin\//);
   assert.doesNotMatch(runnerDockerfile, /^\s+docker\.io\s+\\$/m);

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -153,6 +153,10 @@ test("one Bake result records an exact, internally consistent digest set", (t) =
 
 test("CI gates release images and the reusable publisher stages digests before promotion", () => {
   assert.match(imagesWorkflow, /on:\n {2}workflow_call:\n {4}inputs:\n {6}version:/);
+  assert.match(
+    imagesWorkflow,
+    /workflow_call:[\s\S]*outputs:\n {6}promoted:[\s\S]*value: \$\{\{ jobs\.promote\.outputs\.promoted \}\}/,
+  );
   assert.match(imagesWorkflow, /\n {2}workflow_dispatch:\n/);
   assert.doesNotMatch(imagesWorkflow, /tags: \["v\*"\]/);
   assert.match(
@@ -209,8 +213,13 @@ test("CI gates release images and the reusable publisher stages digests before p
   assert.match(imagesWorkflow, /promote:\n {4}needs: \[plan, build, scan\]/);
   assert.match(imagesWorkflow, /node scripts\/images\.mjs promote/);
   assert.match(
+    imagesWorkflow,
+    /promote:[\s\S]*outputs:\n {6}promoted: \$\{\{ steps\.promotion\.outputs\.promoted \}\}/,
+  );
+  assert.match(imagesWorkflow, /id: promotion\n {8}run: echo 'promoted=true' >> "\$GITHUB_OUTPUT"/);
+  assert.match(
     ciWorkflow,
-    /publish-images:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
+    /publish-images:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e, allocate-release\]/,
   );
   assert.match(ciWorkflow, /publish-images:[\s\S]*uses: \.\/\.github\/workflows\/images\.yml/);
 });

--- a/scripts/release.integration.test.mjs
+++ b/scripts/release.integration.test.mjs
@@ -188,6 +188,32 @@ async function assertMissing(path) {
   await assert.rejects(access(path), { code: "ENOENT" });
 }
 
+async function releaseAllocationScript() {
+  const workflow = await readFile(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const allocationStep = workflow.split("      - name: Allocate the immutable release version\n")[1];
+  assert(allocationStep, "CI workflow must contain the release-allocation step");
+  const indentedScript = allocationStep.split("        run: |\n")[1];
+  assert(indentedScript, "release-allocation step must contain a shell script");
+  const lines = [];
+  for (const line of indentedScript.split("\n")) {
+    if (line && !line.startsWith("          ")) break;
+    lines.push(line.startsWith("          ") ? line.slice(10) : line);
+  }
+  return lines.join("\n");
+}
+
+async function releaseRecordingScript() {
+  const workflow = await readFile(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const recordStep = workflow.split("      - name: Tag the released commit and publish its notes\n")[1];
+  assert(recordStep, "CI workflow must contain the release-recording step");
+  const indentedScript = recordStep.split("        run: |\n")[1];
+  assert(indentedScript, "release-recording step must contain a shell script");
+  return indentedScript
+    .split("\n")
+    .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
+    .join("\n");
+}
+
 async function releaseCheckout(t) {
   const repoDir = await mkdtemp(join(tmpdir(), "facility-release-checkout-"));
   await mkdir(join(repoDir, "packages/cli"), { recursive: true });
@@ -270,6 +296,76 @@ test("a fresh checkout must be stamped before the decided release validates", as
   assert.equal(validated.code, 0, validated.stderr);
 });
 
+test("release allocation reserves the accepted commit before publication", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "facility-release-allocation-"));
+  const repoDir = join(root, "checkout");
+  const remoteDir = join(root, "origin.git");
+  await mkdir(repoDir);
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const git = (args, cwd = repoDir) =>
+    spawnSync(
+      "git",
+      [
+        "-c",
+        "commit.gpgSign=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "user.name=Facility Tests",
+        "-c",
+        "user.email=facility-tests@example.invalid",
+        ...args,
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+      },
+    );
+
+  assert.equal(git(["init", "--bare", "--initial-branch=main", remoteDir], root).status, 0);
+  assert.equal(git(["init", "--initial-branch=main"]).status, 0);
+  await writeFile(join(repoDir, "change.txt"), "accepted release\n");
+  assert.equal(git(["add", "change.txt"]).status, 0);
+  assert.equal(git(["commit", "-m", "fix: publish the accepted release"]).status, 0);
+  assert.equal(git(["remote", "add", "origin", remoteDir]).status, 0);
+  assert.equal(git(["push", "-u", "origin", "main"]).status, 0);
+  const acceptedSha = git(["rev-parse", "HEAD"]).stdout.trim();
+
+  const script = await releaseAllocationScript();
+  const environment = { ...process.env, TAG: "v0.4.0", VERSION: "0.4.0" };
+  const allocated = spawnSync("bash", ["-c", script], {
+    cwd: repoDir,
+    encoding: "utf8",
+    env: environment,
+  });
+  assert.equal(allocated.status, 0, allocated.stderr);
+  assert.equal(
+    git(["--git-dir", remoteDir, "rev-parse", "refs/tags/v0.4.0^{commit}"], root).stdout.trim(),
+    acceptedSha,
+  );
+
+  const replay = spawnSync("bash", ["-c", script], {
+    cwd: repoDir,
+    encoding: "utf8",
+    env: environment,
+  });
+  assert.equal(replay.status, 0, replay.stderr);
+  assert.match(replay.stdout, /already allocates the accepted commit/);
+
+  await writeFile(join(repoDir, "change.txt"), "later commit\n");
+  assert.equal(git(["add", "change.txt"]).status, 0);
+  assert.equal(git(["commit", "-m", "fix: advance after allocation"]).status, 0);
+  const conflict = spawnSync("bash", ["-c", script], {
+    cwd: repoDir,
+    encoding: "utf8",
+    env: environment,
+  });
+  assert.equal(conflict.status, 1);
+  assert.match(conflict.stderr, /not accepted commit/);
+});
+
 test("release recording retries after tag push and rejects a tag on another commit", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "facility-release-record-"));
   const repoDir = join(root, "checkout");
@@ -316,27 +412,22 @@ test("release recording retries after tag push and rejects a tag on another comm
   await writeFile(
     ghCommand,
     `#!/usr/bin/env node
-const { appendFileSync, existsSync, writeFileSync } = require("node:fs");
+const { appendFileSync, existsSync, readFileSync, writeFileSync } = require("node:fs");
 appendFileSync(process.env.FAKE_GH_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
-const [resource, action] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const [resource, action] = args;
 if (resource !== "release") process.exit(64);
 if (action === "view") process.exit(existsSync(process.env.FAKE_RELEASE_MARKER) ? 0 : 1);
 if (action !== "create") process.exit(64);
 if (process.env.FAKE_GH_FAIL_CREATE === "1") process.exit(23);
-writeFileSync(process.env.FAKE_RELEASE_MARKER, "created\\n");
+const notesIndex = args.indexOf("--notes-file");
+if (notesIndex === -1) process.exit(64);
+writeFileSync(process.env.FAKE_RELEASE_MARKER, readFileSync(args[notesIndex + 1], "utf8"));
 `,
   );
   await chmod(ghCommand, 0o755);
 
-  const workflow = await readFile(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
-  const recordStep = workflow.split("      - name: Tag the released commit and publish its notes\n")[1];
-  assert(recordStep, "CI workflow must contain the release-recording step");
-  const indentedScript = recordStep.split("        run: |\n")[1];
-  assert(indentedScript, "release-recording step must contain a shell script");
-  const script = indentedScript
-    .split("\n")
-    .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
-    .join("\n");
+  const script = await releaseRecordingScript();
   const baseEnv = {
     ...process.env,
     FAKE_GH_LOG: ghLog,
@@ -347,6 +438,8 @@ writeFileSync(process.env.FAKE_RELEASE_MARKER, "created\\n");
     RUNNER_TEMP: runnerTemp,
     TAG: "v0.4.0",
     VERSION: "0.4.0",
+    NPM_PUBLISHED: "true",
+    IMAGES_PROMOTED: "false",
   };
 
   const interrupted = spawnSync("bash", ["-c", script], {
@@ -368,7 +461,10 @@ writeFileSync(process.env.FAKE_RELEASE_MARKER, "created\\n");
     env: baseEnv,
   });
   assert.equal(retried.status, 0, retried.stderr);
-  assert.equal((await readFile(releaseMarker, "utf8")).trim(), "created");
+  const releaseNotes = await readFile(releaseMarker, "utf8");
+  assert.match(releaseNotes, /^fixture release notes/);
+  assert.match(releaseNotes, /- npm package: published/);
+  assert.match(releaseNotes, /- container image set: promotion was not confirmed complete/);
 
   await writeFile(join(repoDir, "change.txt"), "later commit\n");
   git(["add", "change.txt"]);
@@ -394,6 +490,136 @@ writeFileSync(process.env.FAKE_RELEASE_MARKER, "created\\n");
       ["release", "create", "v0.4.0"],
     ],
   );
+});
+
+test("release recording publishes status exactly when a publisher confirms an artifact", async (t) => {
+  const script = await releaseRecordingScript();
+  const cases = [
+    {
+      name: "npm only",
+      npmPublished: "true",
+      imagesPromoted: "false",
+      npmStatus: "published",
+      imageStatus: "promotion was not confirmed complete",
+      recorded: true,
+    },
+    {
+      name: "images only",
+      npmPublished: "false",
+      imagesPromoted: "true",
+      npmStatus: "publication was not confirmed",
+      imageStatus: "promoted",
+      recorded: true,
+    },
+    {
+      name: "both registries",
+      npmPublished: "true",
+      imagesPromoted: "true",
+      npmStatus: "published",
+      imageStatus: "promoted",
+      recorded: true,
+    },
+    {
+      name: "neither registry",
+      npmPublished: "false",
+      imagesPromoted: "false",
+      recorded: false,
+    },
+  ];
+
+  for (const releaseCase of cases) {
+    await t.test(releaseCase.name, async (t) => {
+      const root = await mkdtemp(join(tmpdir(), "facility-release-consumption-"));
+      const repoDir = join(root, "checkout");
+      const remoteDir = join(root, "origin.git");
+      const binDir = join(root, "bin");
+      const runnerTemp = join(root, "runner-temp");
+      const releaseMarker = join(root, "release-notes");
+      await mkdir(repoDir);
+      await mkdir(binDir);
+      await mkdir(runnerTemp);
+      t.after(() => rm(root, { recursive: true, force: true }));
+
+      const git = (args, cwd = repoDir) =>
+        spawnSync(
+          "git",
+          [
+            "-c",
+            "commit.gpgSign=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "user.name=Facility Tests",
+            "-c",
+            "user.email=facility-tests@example.invalid",
+            ...args,
+          ],
+          {
+            cwd,
+            encoding: "utf8",
+            env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+          },
+        );
+      assert.equal(git(["init", "--bare", "--initial-branch=main", remoteDir], root).status, 0);
+      assert.equal(git(["init", "--initial-branch=main"]).status, 0);
+      await writeFile(join(repoDir, "change.txt"), "release\n");
+      assert.equal(git(["add", "change.txt"]).status, 0);
+      assert.equal(git(["commit", "-m", "fix: publish the fixture"]).status, 0);
+      assert.equal(git(["remote", "add", "origin", remoteDir]).status, 0);
+      assert.equal(git(["push", "-u", "origin", "main"]).status, 0);
+
+      const ghCommand = join(binDir, "gh");
+      await writeFile(
+        ghCommand,
+        `#!/usr/bin/env node
+const { readFileSync, writeFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] !== "release") process.exit(64);
+if (args[1] === "view") process.exit(1);
+if (args[1] !== "create") process.exit(64);
+const notesIndex = args.indexOf("--notes-file");
+if (notesIndex === -1) process.exit(64);
+writeFileSync(process.env.FAKE_RELEASE_MARKER, readFileSync(args[notesIndex + 1], "utf8"));
+`,
+      );
+      await chmod(ghCommand, 0o755);
+
+      const result = spawnSync("bash", ["-c", script], {
+        cwd: repoDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_RELEASE_MARKER: releaseMarker,
+          GH_TOKEN: "local-test-token",
+          IMAGES_PROMOTED: releaseCase.imagesPromoted,
+          NOTES: "fixture release notes",
+          NPM_PUBLISHED: releaseCase.npmPublished,
+          PATH: `${binDir}:${process.env.PATH}`,
+          RUNNER_TEMP: runnerTemp,
+          TAG: "v0.4.0",
+          VERSION: "0.4.0",
+        },
+      });
+
+      if (!releaseCase.recorded) {
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /no publisher confirmed an artifact/);
+        assert.notEqual(git(["show-ref", "--verify", "--quiet", "refs/tags/v0.4.0"]).status, 0);
+        await assertMissing(releaseMarker);
+        return;
+      }
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(git(["show-ref", "--verify", "--quiet", "refs/tags/v0.4.0"]).status, 0);
+      assert.equal(
+        git(["--git-dir", remoteDir, "show-ref", "--verify", "--quiet", "refs/tags/v0.4.0"], root).status,
+        0,
+      );
+      const notes = await readFile(releaseMarker, "utf8");
+      assert.match(notes, new RegExp(`- npm package: ${releaseCase.npmStatus}`));
+      assert.match(notes, new RegExp(`- container image set: ${releaseCase.imageStatus}`));
+    });
+  }
 });
 
 test("an exact 404 permits bootstrap publication without running package lifecycle scripts", async (t) => {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -26,11 +26,11 @@ export function releaseMode({ eventName, ref, visibility, acceptancePassed, rele
 /**
  * What proves a release is no longer a tag someone pushed: it is the version
  * decided from the commit subjects (scripts/version.mjs), stamped into the two
- * package.json files inside this run. The tag is written afterwards, as the
- * record of what was published. So the checks here are that the run is a push
- * of main, that the stamp matches the decision, and that the commit really is
- * the head of main — plus the guard that outlives all of them, in
- * `registryState`, which refuses a version npm already has.
+ * package.json files inside this run. CI allocates the tag after acceptance
+ * and before either registry can consume the version. The checks here are that
+ * the run is a push of main, that the stamp matches the decision, and that the
+ * commit really is the head of main — plus the guard that outlives all of them,
+ * in `registryState`, which refuses a conflicting version npm already has.
  */
 export function validateReleasePolicy({
   eventName,
@@ -105,8 +105,8 @@ export function validateReleaseCandidate({
 
 /**
  * Writes the decided version into the two package.json files the release reads.
- * This happens inside the run and is never committed: the tags are the record of
- * what shipped, so main carries no version-bump commits and the two files cannot
+ * This happens inside the run and is never committed: tags allocate immutable
+ * versions, so main carries no version-bump commits and the two files cannot
  * drift apart between releases.
  */
 export function stampVersion(version, { repoDir = process.cwd() } = {}) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -131,6 +131,10 @@ test("GitHub publication requires the exact official npm registry", () => {
 
 test("the workflow keeps manual runs credential-free and real publication main-only", () => {
   assert.match(releaseWorkflow, /workflow_call:\n    inputs:\n      version:/);
+  assert.match(
+    releaseWorkflow,
+    /workflow_call:[\s\S]*outputs:\n      published:[\s\S]*value: \$\{\{ jobs\.publish\.outputs\.published \}\}/,
+  );
   assert.doesNotMatch(releaseWorkflow, /workflow_dispatch:\n\s+inputs:/);
   assert.match(releaseWorkflow, /dry-run:\n    if: github\.event_name == 'workflow_dispatch'/);
   assert.match(
@@ -159,6 +163,14 @@ test("the workflow keeps manual runs credential-free and real publication main-o
   assert.match(
     releaseWorkflow,
     /publish:[\s\S]*concurrency:\n      group: npm-theagilemonkeys-facility\n      cancel-in-progress: false/,
+  );
+  assert.match(
+    publishJob,
+    /outputs:\n      published: \$\{\{ steps\.publication\.outputs\.published \}\}/,
+  );
+  assert.match(
+    publishJob,
+    /steps\.registry\.outputs\.state == 'published'[\s\S]*steps\.oidc\.outcome == 'success'[\s\S]*steps\.bootstrap\.outcome == 'success'/,
   );
 });
 
@@ -219,14 +231,47 @@ test("CI publishes only the exact artifact produced after all acceptance jobs", 
   assert.match(ciWorkflow, /name: facility-release-package/);
   assert.match(
     ciWorkflow,
-    /publish-npm:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
+    /publish-npm:[\s\S]*needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e, allocate-release\]/,
   );
   assert.match(ciWorkflow, /publish-npm:[\s\S]*uses: \.\/\.github\/workflows\/release\.yml/);
 });
 
-test("release recording retries missing notes and rejects a tag on another commit", () => {
+test("CI allocates the version after acceptance and before registry mutation", () => {
+  const allocationJob = ciWorkflow
+    .split("\n  publish-npm:")[0]
+    .split("\n  allocate-release:")[1];
+  assert.ok(allocationJob, "CI workflow must contain an allocate-release job");
+  assert.match(
+    allocationJob,
+    /needs: \[decide-release, verify, package-release, self-host-build, sandbox-e2e\]/,
+  );
+  assert.match(allocationJob, /permissions:\n {6}contents: write/);
+  assert.match(allocationJob, /git tag -a "\$TAG" -m "\$VERSION"/);
+  assert.match(allocationJob, /git push origin "\$TAG"/);
+  assert.match(allocationJob, /if \[ "\$tag_sha" != "\$head_sha" \]; then/);
+  assert.ok(
+    ciWorkflow.indexOf("\n  allocate-release:") < ciWorkflow.indexOf("\n  publish-npm:"),
+    "the immutable version must be allocated before npm can consume it",
+  );
+  assert.ok(
+    ciWorkflow.indexOf("\n  allocate-release:") < ciWorkflow.indexOf("\n  publish-images:"),
+    "the immutable version must be allocated before GHCR can consume it",
+  );
+});
+
+test("release recording reports confirmed artifacts without bypassing cancellation", () => {
   const recordJob = ciWorkflow.split("\n  record-release:")[1];
   assert.ok(recordJob, "CI workflow must contain a record-release job");
+  assert.match(recordJob, /if: >-\n      !cancelled\(\)/);
+  assert.doesNotMatch(recordJob, /always\(\)/);
+  assert.match(recordJob, /needs\.decide-release\.result == 'success'/);
+  assert.match(recordJob, /needs\.allocate-release\.result == 'success'/);
+  assert.match(recordJob, /needs\.publish-npm\.outputs\.published == 'true'/);
+  assert.match(recordJob, /needs\.publish-images\.outputs\.promoted == 'true'/);
+  assert.doesNotMatch(recordJob, /needs\.publish-(?:npm|images)\.result == 'success'/);
+  assert.match(recordJob, /NPM_PUBLISHED: \$\{\{ needs\.publish-npm\.outputs\.published \}\}/);
+  assert.match(recordJob, /IMAGES_PROMOTED: \$\{\{ needs\.publish-images\.outputs\.promoted \}\}/);
+  assert.match(recordJob, /if \[ "\$npm_published" != "true" \] && \[ "\$images_promoted" != "true" \]; then/);
   assert.match(recordJob, /tag_sha="\$\(git rev-parse "refs\/tags\/\$TAG\^\{commit\}"\)"/);
   assert.match(recordJob, /if \[ "\$tag_sha" != "\$head_sha" \]; then/);
   assert.match(recordJob, /if gh release view "\$TAG" >\/dev\/null 2>&1; then/);
@@ -235,4 +280,9 @@ test("release recording retries missing notes and rejects a tag on another commi
     recordJob,
     /already exists; the release was recorded by an earlier run\."\n {12}exit 0/,
   );
+  assert.match(recordJob, /## Artifact status/);
+  assert.match(recordJob, /npm package: published/);
+  assert.match(recordJob, /npm package: publication was not confirmed/);
+  assert.match(recordJob, /container image set: promoted/);
+  assert.match(recordJob, /container image set: promotion was not confirmed complete/);
 });

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -3,8 +3,9 @@
 //
 // The full commit messages since the last release are the input; the repository has
 // no version-bump commit and no release pull request. `package.json` is stamped
-// from this decision inside the release run, so the git tag written afterwards
-// is the record of what was published rather than a request to publish it.
+// from this decision inside the release run. After every acceptance gate passes,
+// CI allocates the git tag before either immutable registry can consume the
+// version, preventing a partial or uncertain publish from reusing the number.
 import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
 import {

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -254,3 +254,16 @@ test("decide validates and classifies only messages after the latest stable tag"
   assert.equal(decision.considered, 1);
   assert.equal(decision.releasing, 1);
 });
+
+test("a backfilled consumed-version tag advances the next main change", (t) => {
+  const repoDir = localRepository(t, "consumed-version");
+  commit(repoDir, "fix(mcp)!: publish npm before the image gate failed");
+  tagRelease(repoDir, "v0.9.0");
+  commit(repoDir, "feat(governance): require approved plans for Builder");
+
+  const decision = decide({ repoDir });
+  assert.equal(decision.previous, "0.9.0");
+  assert.equal(decision.version, "0.9.1");
+  assert.equal(decision.considered, 1);
+  assert.equal(decision.releasing, 1);
+});


### PR DESCRIPTION
## What changes

- Patch the fixable OpenSSL and Go module findings that blocked all GHCR image scans.
- Allocate the immutable release tag after acceptance but before npm or GHCR can consume a version.
- Export factual npm publication and complete image-promotion outcomes for GitHub Release status notes.
- Add unit and integration regressions for tag allocation, idempotent retries, conflicting replays, partial publisher outcomes, and the reviewed image dependency replacements.
- Backfill v0.9.0 on f0a6d3c, the commit whose npm artifact already consumed that version, so this merge advances to v0.9.1.

## Why

The v0.9.0 npm package published successfully, but all GHCR image scans failed on fixable runtime vulnerabilities. Because the workflow wrote its release tag only after both publishers completed, no v0.9.0 tag was recorded. A later main run recomputed 0.9.0 and npm correctly rejected its different tarball as a conflicting immutable replay.

Reserving the version before either registry mutation prevents a partial promotion, lost registry response, cancellation, or retry from letting a later commit reuse an already-consumed version.

Failed runs:
- https://github.com/theam/facility/actions/runs/33078301172
- https://github.com/theam/facility/actions/runs/33080213060

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite: built the full linux/amd64 runner image, passed its embedded Go dependency audit, and scanned the API, web, and runner images with the production Grype policy using `--fail-on high --only-fixed`; all exited successfully. The release-allocation integration also exercised a real local Git remote, an idempotent replay, and a conflicting tag target.
- [x] Documentation updated, or no user-facing change