### PR TITLE
fix(governance): stop an empty issue body stranding an approved plan

### DIFF
--- a/services/api/src/github/issue-revision.ts
+++ b/services/api/src/github/issue-revision.ts
@@ -110,8 +110,18 @@ function issueLabels(value: unknown) {
   ].sort();
 }
 
+/**
+ * Fold every representation of "no text" onto `null` before it reaches the
+ * digest. The producers disagree about which one they emit for the same issue:
+ * `githubRequestContext` stores empty or whitespace-only text as `null`, while
+ * a live `GET /issues/:number` read returns `""` for a body that was cleared
+ * after creation. A revision digest has to describe the issue, not the producer
+ * that observed it, so both spellings have to canonicalize the same way.
+ */
 function normalizedText(value: unknown): string | null {
-  return typeof value === "string" ? value.replace(/\r\n?/g, "\n") : null;
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(/\r\n?/g, "\n");
+  return normalized.trim() ? normalized : null;
 }
 
 function stringValue(value: unknown) {

--- a/services/api/test/builder-plan-policy.integration.test.ts
+++ b/services/api/test/builder-plan-policy.integration.test.ts
@@ -25,9 +25,12 @@ import {
   withBuilderPlanPreflight,
 } from "../src/builder-plan-policy.js";
 import { ApiError } from "../src/errors.js";
-import { githubIssueRevisionSha256 } from "../src/github/issue-revision.js";
+import {
+  githubIssueRevisionContext,
+  githubIssueRevisionSha256,
+} from "../src/github/issue-revision.js";
 import { syncRepoFacilityConfig } from "../src/github/kickstart.js";
-import { routeTrigger, type TriggerPayload } from "../src/github/router.js";
+import { githubRequestContext, routeTrigger, type TriggerPayload } from "../src/github/router.js";
 import { dispatchRun } from "../src/sandbox/orchestrator.js";
 import type { AppConfig } from "../src/types.js";
 
@@ -132,6 +135,35 @@ describe("builder plan policy integration", async () => {
         trigger: { ...fixture.dispatch.trigger, proposalId: duplicateProposalId },
       }),
     ).rejects.toMatchObject({ code: "builder_plan_already_consumed" });
+  });
+
+  it("admits a fresh plan whose issue body GitHub reports as empty rather than absent", async () => {
+    // An issue body cleared after creation reads back as `""` from
+    // `GET /issues/:number`, while `githubRequestContext` stored the same issue
+    // with `body: null`. Nothing about the issue changed between the Architect
+    // run and this dispatch, so the required gate has to admit it rather than
+    // report `builder_plan_stale` against a revision that never moved.
+    const fixture = await canonicalFixture({ issueBody: "" });
+    await expect(assertBuilderPlanDispatch(db, fixture.dispatch)).resolves.toEqual({
+      mode: "builder",
+      isBuilder: true,
+    });
+  });
+
+  it("still denies an empty-bodied issue whose live revision moved", async () => {
+    const fixture = await canonicalFixture({ issueBody: "" });
+    const before = await projectRuns(fixture.orgId, fixture.projectId);
+    await expect(
+      assertBuilderPlanDispatch(db, {
+        ...fixture.dispatch,
+        freshnessEvidence: {
+          ...fixture.dispatch.freshnessEvidence,
+          issueRevisionSha256: createHash("sha256").update("moved").digest("hex"),
+        },
+      }),
+    ).rejects.toMatchObject({ code: "builder_plan_stale" });
+    expect(await projectRuns(fixture.orgId, fixture.projectId)).toHaveLength(before.length);
+    await expect(lastDenialCode(fixture.orgId)).resolves.toBe("builder_plan_stale");
   });
 
   it("recognizes a Builder by agentDefId when the run mode is a surface alias", async () => {
@@ -922,7 +954,9 @@ describe("builder plan policy integration", async () => {
     await expect(lastDenialCode(fixture.orgId)).resolves.toBe(expected);
   });
 
-  async function canonicalFixture(options: { state?: string; expiresAt?: Date } = {}): Promise<{
+  async function canonicalFixture(
+    options: { state?: string; expiresAt?: Date; issueBody?: string | null } = {},
+  ): Promise<{
     orgId: string;
     projectId: string;
     proposalId: string;
@@ -941,17 +975,28 @@ describe("builder plan policy integration", async () => {
     const actionTypeId = `act_plan_${suffix}`;
     const baseSha = "a".repeat(40);
     const issueUrl = `https://github.test/facility-test/plan-${suffix}/issues/204`;
-    const issueRequest = {
+    // Derive each side of the freshness comparison the way production does
+    // rather than sharing one literal digest between them: `trigger.request` is
+    // whatever `githubRequestContext` stored at Architect dispatch, while the
+    // Builder gate re-derives its digest from a live `GET /issues/:number` read.
+    // Reusing a single value here would hide any disagreement between the two.
+    const liveIssue = {
+      number: 204,
       title: "Require a plan",
-      body: "Implement it",
+      body: options.issueBody === undefined ? "Implement it" : options.issueBody,
       state: "open",
-      author: "requester",
-      url: issueUrl,
+      user: { login: "requester" },
       labels: [],
-      comments: [],
+      html_url: issueUrl,
     };
+    const issueRequest = githubRequestContext({ issue: liveIssue }, []);
     const issueRevisionSha256 = githubIssueRevisionSha256(issueRequest);
-    if (!issueRevisionSha256) throw new Error("issue revision fixture missing");
+    const liveIssueRevisionSha256 = githubIssueRevisionSha256(
+      githubIssueRevisionContext(liveIssue, []),
+    );
+    if (!issueRevisionSha256 || !liveIssueRevisionSha256) {
+      throw new Error("issue revision fixture missing");
+    }
     const plan = "Implement the reviewed change and run the named checks.";
     const planSha256 = createHash("sha256").update(plan).digest("hex");
     const decidedAt = new Date();
@@ -1109,7 +1154,7 @@ describe("builder plan policy integration", async () => {
         source: "integration_test",
         freshnessEvidence: {
           baseSha,
-          issueRevisionSha256,
+          issueRevisionSha256: liveIssueRevisionSha256,
           checkedAt: new Date().toISOString(),
         },
       },

--- a/services/api/test/github-issue-revision.test.ts
+++ b/services/api/test/github-issue-revision.test.ts
@@ -3,6 +3,7 @@ import {
   githubIssueRevisionContext,
   githubIssueRevisionSha256,
 } from "../src/github/issue-revision.js";
+import { githubRequestContext } from "../src/github/router.js";
 
 describe("GitHub issue revision", () => {
   const issue = {
@@ -91,5 +92,52 @@ describe("GitHub issue revision", () => {
         githubIssueRevisionContext({ ...issue, body: "A changed scope." }, comments),
       ),
     ).not.toBe(baseline);
+  });
+});
+
+describe("GitHub issue revision producers agree", () => {
+  // Two different producers feed the same digest. At Architect dispatch the
+  // router stores `githubRequestContext(...)` in `run.trigger.request`, and
+  // `ensureArchitectPlanAcceptance` seals its digest into the proposal payload.
+  // At Builder dispatch `resolveBuilderPlanFreshnessForProposal` re-derives the
+  // digest from a live `GET /issues/:number` read. A project on
+  // `builderPlanPolicy: "required"` compares the two, so they have to agree
+  // whenever the issue itself did not change.
+  const issueWithBody = (body: string | null) => ({
+    number: 204,
+    title: "Keep sources consistent",
+    body,
+    state: "open",
+    user: { login: "requester" },
+    labels: [{ name: "frontend" }, "delivery"],
+    html_url: "https://github.test/theam/aifindr-ui/issues/116",
+  });
+  type LiveIssue = ReturnType<typeof issueWithBody>;
+
+  /** What Facility sealed into the proposal at Architect time. */
+  const storedDigest = (issue: LiveIssue) =>
+    githubIssueRevisionSha256(githubRequestContext({ issue }, []));
+
+  /** What the Builder gate observes from GitHub at dispatch time. */
+  const liveDigest = (issue: LiveIssue) =>
+    githubIssueRevisionSha256(githubIssueRevisionContext(issue, []));
+
+  it.each([
+    ["absent since creation", null],
+    ["cleared after creation", ""],
+    ["spaces only", "   "],
+    ["a newline only", "\n"],
+    ["CRLF only", "\r\n"],
+    ["ordinary prose", "Apply the same rule on every surface."],
+  ])("digests an unchanged issue whose body is %s identically on both sides", (_case, body) => {
+    const issue = issueWithBody(body);
+    expect(liveDigest(issue)).toBe(storedDigest(issue));
+  });
+
+  it("still detects an issue that gained or lost material body text", () => {
+    const empty = issueWithBody("");
+    const filled = issueWithBody("A changed scope.");
+    expect(liveDigest(filled)).not.toBe(storedDigest(empty));
+    expect(liveDigest(empty)).not.toBe(storedDigest(filled));
   });
 });


### PR DESCRIPTION
## What changes

`githubIssueRevisionContext` now folds empty and whitespace-only text onto
`null` before the issue-revision digest is taken, matching what
`githubRequestContext` already stores. Both producers of that digest now agree,
so a project on `builderPlanPolicy: "required"` stops reporting
`builder_plan_stale` for an issue that never changed.

## Why

The Builder gate compares two digests that are produced by two different pieces
of code, and they canonicalize "this issue has no body" differently.

**Write side** — at Architect dispatch the router stores the issue snapshot in
`run.trigger.request` via `githubRequestContext`
([router.ts:733-734](services/api/src/github/router.ts#L733-L734)), which uses
`nullableText` ([router.ts:781-783](services/api/src/github/router.ts#L781-L783)):

```ts
return typeof value === "string" && value.trim() ? value : null;
```

`ensureArchitectPlanAcceptance` seals the digest of that snapshot into the
proposal payload
([orchestrator.ts:948](services/api/src/sandbox/orchestrator.ts#L948)).

**Read side** — at Builder dispatch `resolveBuilderPlanFreshnessForProposal`
re-derives the digest from a live `GET /issues/:number`
([builder-plan-freshness.ts:110-112](services/api/src/builder-plan-freshness.ts#L110-L112)),
which goes through `normalizedText`
([issue-revision.ts:113-115](services/api/src/github/issue-revision.ts#L113-L115)):

```ts
return typeof value === "string" ? value.replace(/\r\n?/g, "\n") : null;
```

`nullableText("")` is `null`. `normalizedText("")` is `""`. `JSON.stringify`
sees two different objects, so the two digests differ for an issue nobody
touched, and the gate refuses the dispatch at
[builder-plan-policy.ts:629-630](services/api/src/builder-plan-policy.ts#L629-L630):

```ts
if (currentBaseSha !== expectedBaseSha || currentIssueRevision !== expectedIssueRevision) {
  return invalid("builder_plan_stale", "base_or_issue_revision_changed");
}
```

The write side collapses `null`, `undefined`, `""`, `" "`, `"\n"`, `"\t"` and
`"  \n  "` onto one digest. The read side gives each of them a different one.
`null` is the only representation that lands in the same place on both sides,
so an issue with no body at all is fine and an issue whose body is empty or
whitespace-only can never dispatch.

### Reproduction

1. Set a project to `builderPlanPolicy: "required"`.
2. Give the issue a body that is present but blank — a single space is enough
   (`PATCH /issues/:n` with `body: " "`). GitHub stores and returns it verbatim.
3. Comment `/architect`. The run succeeds and publishes a plan.
4. Approve it and comment `/builder`.

Expected: the Builder run starts. Actual: `409 builder_plan_stale`, reason
`base_or_issue_revision_changed`, and a `run.builder_plan_denied` audit event —
against a revision that never moved. Re-running does not help; the stored
digest can never be reproduced from a live read, so the plan is stranded for the
life of the proposal. The audit trail attributes the refusal to a change in the
issue, which sends whoever investigates to look for an edit that did not happen.

The added integration test reproduces exactly this through
`assertBuilderPlanDispatch`; without the source change it fails with
`{ statusCode: 409, code: 'builder_plan_stale', details: { reason: 'base_or_issue_revision_changed' } }`.

### Why the suite did not catch it

Both existing tests exercise one side each, and never compare them:

- [github-issue-revision.test.ts](services/api/test/github-issue-revision.test.ts)
  only calls `githubIssueRevisionContext`, so it never sees what the router stored.
- [github.test.ts:985](services/api/test/github.test.ts#L985) asserts the shape
  `githubRequestContext` returns, but never digests it.
- [builder-plan-policy.integration.test.ts:953](services/api/test/builder-plan-policy.integration.test.ts#L953)
  computed one digest from a hand-written request literal and then used that same
  value as the *observed* freshness evidence, so the comparison was true by
  construction.

That last one is the reason this could not surface: the integration test proved
the gate compares two values, not that the two producers agree. This PR rewires
the fixture to derive each side the way production does — `githubRequestContext`
for the stored digest, `githubIssueRevisionContext` for the live one. The change
is digest-neutral for the existing cases, so every other assertion in that file
is unaffected.

## The fix

Canonicalizing in `githubIssueRevisionContext` rather than changing
`nullableText` is deliberate:

- Both paths already funnel through `githubIssueRevisionContext`
  (`githubIssueRevisionSha256` re-applies it to whatever it is handed), so one
  change fixes both without touching the stored shape of `run.trigger.request`,
  which the runner also reads as the end-user request.
- It keeps the digest producer-independent, which is the property the gate
  depends on. Any future producer gets the same canonical form for free.
- It stays idempotent, which `githubIssueRevisionSha256` relies on when it
  re-canonicalizes an already-canonical context.

The security property is unchanged: whitespace-only and empty bodies are
equivalent *to each other*, and any body that gains or loses material text still
moves the digest. There are explicit tests for both directions.

### Effect on stored digests

Digests are recomputed on both sides at dispatch, so nothing persisted needs a
migration. The only proposals whose digest changes meaning are ones whose issue
body is empty or whitespace-only — exactly the ones that could never dispatch
before. A proposal sealed before this change against a whitespace-only body
keeps its stored digest and will now match, because the live read canonicalizes
to the same `null`.

## Two related divergences I did not change

Both are unreachable through the GitHub API, so fixing them would be speculative:

- A label name with surrounding whitespace canonicalizes as `"bug"` on the write
  side ([router.ts:743](services/api/src/github/router.ts#L743) trims) and
  `"bug "` on the read side (`issueLabels` does not). GitHub trims label names on
  create and rename, so it cannot occur.
- `materialIssueComment`
  ([issue-revision.ts:95](services/api/src/github/issue-revision.ts#L95)) reads
  `comment.authorType.toLowerCase()` and would throw on a comment without that
  field. `FacilityGithubClient.listIssueComments`
  ([client.ts:875](services/api/src/github/client.ts#L875)) defaults it to
  `"User"`, so no live path can produce one.

Happy to fold either in if you would rather have the canonicalizer total.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (see below)
- [x] Documentation updated, or no user-facing change — no user-facing surface changed

What I ran, and what it proved:

- `vitest run test/github-issue-revision.test.ts` — 9 passed with the fix.
  Reverting only `issue-revision.ts` fails 4 of them, so the new cases are a real
  regression test and not a restatement of current behaviour.
- `vitest run test/builder-plan-policy.integration.test.ts` against Postgres 16 —
  32 passed. Reverting only `issue-revision.ts` fails
  `admits a fresh plan whose issue body GitHub reports as empty rather than absent`
  with the exact production error.
- Full `@facility/api` suite against Postgres — 591 passed. Three failures
  (`api.test.ts` audit-chain and readiness-doctor, `github.test.ts` review agent)
  reproduce identically on a clean checkout of `main` in this environment and
  are unrelated to this change; they need seeded registry and installation
  fixtures my local database does not have.
- `tsc --noEmit` for `@facility/api`, `biome check .` over 422 files, and
  `node guards/run.mjs` all clean.
- Differential harness over both producers across 30 issue shapes: 6 divergences
  before the change, 2 after — the two documented above as unreachable.
