### PR TITLE
fix(cli): authorize the sender before judging the command shape

### DIFF
--- a/packages/cli/templates/workflows/facility-codex.yml
+++ b/packages/cli/templates/workflows/facility-codex.yml
@@ -72,15 +72,9 @@ jobs:
             [ "$mode" = builder ] && has_builder=true
             [ "$mode" = architect ] && has_architect=true
           done
-          if [ "$has_builder" = true ] && [ "$has_architect" = true ]; then
-            echo "::error::Use exactly one command: /codex-builder or /codex-architect."
-            exit 1
-          fi
-          if [ "$has_builder" = false ] && [ "$has_architect" = false ]; then
-            echo "::notice::No Codex command starts a line; treating the mention as prose."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Authorization decides before command shape does: the job prefilter matches
+          # the command anywhere in the body, so on a public repository any sender
+          # reaches this step and must leave a skip, never a red run.
           sender="$(jq -r '.sender.login // ""' "$GITHUB_EVENT_PATH")"
           permission="$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$sender/permission" --jq '.permission' 2>/dev/null || echo none)"
           case "$permission" in
@@ -91,6 +85,15 @@ jobs:
               exit 0
               ;;
           esac
+          if [ "$has_builder" = true ] && [ "$has_architect" = true ]; then
+            echo "::error::Use exactly one command: /codex-builder or /codex-architect."
+            exit 1
+          fi
+          if [ "$has_builder" = false ] && [ "$has_architect" = false ]; then
+            echo "::notice::No Codex command starts a line; treating the mention as prose."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           mode=architect
           [ "$has_builder" = true ] && mode=builder
           number="$(jq -r '.issue.number // .pull_request.number // ""' "$GITHUB_EVENT_PATH")"

--- a/packages/cli/templates/workflows/facility-crew.yml
+++ b/packages/cli/templates/workflows/facility-crew.yml
@@ -102,23 +102,10 @@ jobs:
             fi
           done
 
-          if [ "$has_builder" = true ] && [ "$has_architect" = true ]; then
-            echo "::error::Use exactly one agent command: /builder or /architect."
-            exit 1
-          fi
-          if [ "$has_builder" = false ] && [ "$has_architect" = false ]; then
-            echo "::error::No supported agent command found. Use /builder or /architect at the start of a line."
-            exit 1
-          fi
-
-          if [ "$has_builder" = true ]; then
-            echo "mode=builder" >> "$GITHUB_OUTPUT"
-            echo "trigger_phrase=/builder" >> "$GITHUB_OUTPUT"
-          else
-            echo "mode=architect" >> "$GITHUB_OUTPUT"
-            echo "trigger_phrase=/architect" >> "$GITHUB_OUTPUT"
-          fi
-
+          # Authorization decides before command shape does. The job prefilter
+          # matches '/builder' or '/architect' ANYWHERE in the body, so on a
+          # public repository any sender reaches this step: one without write
+          # access must leave a quiet skip, never a red run.
           sender="$(jq -r '.sender.login // ""' "$GITHUB_EVENT_PATH")"
 
           # Authorize the canary: '{{CANARY_BOT}}' is the ONLY Bot sender
@@ -152,7 +139,6 @@ jobs:
               echo "::warning::Skipping crew: canary bot comment does not match the pinned canary probe text."
               echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
             fi
-            echo "run=true" >> "$GITHUB_OUTPUT"
           else
             # Explicit write-access gate — defense in depth beyond the
             # action's own check, and it skips gracefully instead of failing
@@ -160,14 +146,35 @@ jobs:
             permission="$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$sender/permission" --jq '.permission' 2>/dev/null || echo none)"
             case "$permission" in
               admin|maintain|write)
-                echo "run=true" >> "$GITHUB_OUTPUT"
+                # Authorized: fall through to command-shape validation.
                 ;;
               *)
                 echo "::warning::Skipping crew: @$sender has repository permission '$permission', but /builder and /architect require write access."
-                echo "run=false" >> "$GITHUB_OUTPUT"
+                echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
                 ;;
             esac
           fi
+
+          if [ "$has_builder" = true ] && [ "$has_architect" = true ]; then
+            echo "::error::Use exactly one agent command: /builder or /architect."
+            exit 1
+          fi
+          # Only a command at the start of a line dispatches, but the prefilter also
+          # matches prose that merely names one ("ask /architect about it"). That is
+          # not a request, so skip it instead of failing the run red on the issue.
+          if [ "$has_builder" = false ] && [ "$has_architect" = false ]; then
+            echo "::warning::Skipping crew: no /builder or /architect command at the start of a line."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          if [ "$has_builder" = true ]; then
+            echo "mode=builder" >> "$GITHUB_OUTPUT"
+            echo "trigger_phrase=/builder" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=architect" >> "$GITHUB_OUTPUT"
+            echo "trigger_phrase=/architect" >> "$GITHUB_OUTPUT"
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/packages/cli/test/crew-resolve.test.mjs
+++ b/packages/cli/test/crew-resolve.test.mjs
@@ -1,0 +1,173 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(pkgRoot, "bin", "facility.mjs");
+
+// Both agent triggers decide authorization and command shape as ordered
+// statements in one shell script, and a text assertion cannot see their order.
+// These tests render the real workflows through the installer, lift those steps
+// out, and execute them the way Actions does — bash, the event payload on disk,
+// GITHUB_OUTPUT on disk — so a sender without write access reaching a hard
+// failure is caught here.
+
+const TRIGGERS = [
+  { name: "crew", file: "facility-crew.yml", step: "requested-agent", architect: "/architect", builder: "/builder" },
+  { name: "codex", file: "facility-codex.yml", step: "resolve", architect: "/codex-architect", builder: "/codex-builder" },
+];
+
+// The shipped resolve script uses `mapfile`, a bash 4 builtin. Runners provide
+// bash 5; macOS still ships 3.2 as /bin/bash, where the script cannot run at
+// all. Skip rather than report a false failure about the workflow.
+const bashMajor = Number(
+  spawnSync("bash", ["-c", "echo ${BASH_VERSINFO[0]}"], { encoding: "utf8" }).stdout?.trim(),
+);
+const needsBash4 = { skip: bashMajor >= 4 ? false : `requires bash >= 4 (found ${bashMajor || "none"})` };
+
+let rendered;
+function renderWorkflows() {
+  if (rendered) return rendered;
+  const dir = mkdtempSync(join(tmpdir(), "facility-trigger-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir });
+  writeFileSync(
+    join(dir, "package.json"),
+    `${JSON.stringify(
+      { name: "demo-app", private: true, scripts: { test: "vitest run", setup: "npm ci" } },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(join(dir, "package-lock.json"), "{}\n");
+  const result = spawnSync(
+    process.execPath,
+    [cli, "init", "--yes", `--dir=${dir}`, "--provision=npm run setup", "--checks=npm test"],
+    { cwd: dir, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  rendered = dir;
+  return dir;
+}
+
+// Read the step's `run:` block out of the rendered YAML instead of
+// re-implementing it, so the test tracks whatever the installer actually ships.
+function resolveScript({ file, step }) {
+  const yaml = readFileSync(join(renderWorkflows(), ".github/workflows", file), "utf8");
+  const lines = yaml.split("\n");
+  const stepIndex = lines.findIndex((line) => line.trim() === `id: ${step}`);
+  assert.ok(stepIndex > 0, `${file} must define the ${step} step`);
+  const runIndex = lines.findIndex((line, i) => i > stepIndex && line.trim() === "run: |");
+  assert.ok(runIndex > 0, `${file} ${step} must carry an inline run block`);
+  const indent = lines[runIndex + 1].match(/^ */)[0].length;
+  const body = [];
+  for (const line of lines.slice(runIndex + 1)) {
+    if (line.trim() !== "" && line.match(/^ */)[0].length < indent) break;
+    body.push(line.slice(indent));
+  }
+  const script = body.join("\n");
+  assert.match(script, /GITHUB_EVENT_PATH/, `${file} ${step} must read the event payload`);
+  return script;
+}
+
+function runResolve(script, { body, sender, permission }) {
+  const dir = mkdtempSync(join(tmpdir(), "facility-resolve-"));
+  const binDir = join(dir, "bin");
+  const eventPath = join(dir, "event.json");
+  const outputPath = join(dir, "output.txt");
+  mkdirSync(binDir);
+  // The gate shells out to `gh api …/collaborators/<sender>/permission`.
+  // Stub it so the test fixes the sender's access without a network call.
+  writeFileSync(join(binDir, "gh"), `#!/bin/sh\necho ${permission}\n`);
+  chmodSync(join(binDir, "gh"), 0o755);
+  writeFileSync(join(dir, "resolve.sh"), script);
+  writeFileSync(
+    eventPath,
+    JSON.stringify({
+      action: "created",
+      sender: { login: sender, type: "User" },
+      issue: { number: 7, title: "Something", body: "" },
+      comment: { body },
+    }),
+  );
+  writeFileSync(outputPath, "");
+
+  const result = spawnSync("bash", [join(dir, "resolve.sh")], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      GITHUB_EVENT_NAME: "issue_comment",
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_REPOSITORY: "acme/demo-app",
+      GITHUB_SHA: "0".repeat(40),
+      GH_TOKEN: "test-token",
+    },
+  });
+  const outputs = Object.fromEntries(
+    readFileSync(outputPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const at = line.indexOf("=");
+        return [line.slice(0, at), line.slice(at + 1)];
+      }),
+  );
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr, outputs };
+}
+
+for (const trigger of TRIGGERS) {
+  test(`${trigger.name}: a write-access sender dispatches a line-anchored command`, needsBash4, () => {
+    const run = runResolve(resolveScript(trigger), {
+      body: trigger.architect,
+      sender: "maintainer",
+      permission: "write",
+    });
+    assert.equal(run.status, 0, `${run.stdout}${run.stderr}`);
+    assert.equal(run.outputs.run, "true");
+    assert.equal(run.outputs.mode, "architect");
+  });
+
+  test(`${trigger.name}: prose naming a command is skipped, not failed`, needsBash4, () => {
+    // The job prefilter matches the command anywhere in the body, so a comment
+    // that merely discusses it still reaches this step. Documenting the agents
+    // in an issue must not turn the repository's checks red.
+    const run = runResolve(resolveScript(trigger), {
+      body: `ask ${trigger.architect} about it before you start`,
+      sender: "maintainer",
+      permission: "write",
+    });
+    assert.equal(run.status, 0, `prose must not fail the run: ${run.stdout}${run.stderr}`);
+    assert.equal(run.outputs.run, "false");
+    assert.equal(run.outputs.mode, undefined);
+  });
+
+  test(`${trigger.name}: a sender without write access never fails the run`, needsBash4, () => {
+    // Anyone can comment on a public repository. No comment body from a sender
+    // without write access may dispatch an agent or produce a red run.
+    const bodies = [
+      trigger.architect,
+      `ask ${trigger.architect} about it`,
+      `${trigger.builder}\n${trigger.architect}`,
+    ];
+    for (const body of bodies) {
+      const run = runResolve(resolveScript(trigger), { body, sender: "outsider", permission: "none" });
+      assert.equal(run.status, 0, `unauthorized ${JSON.stringify(body)} must not fail the run`);
+      assert.equal(run.outputs.run, "false", `unauthorized ${JSON.stringify(body)} dispatched`);
+    }
+  });
+
+  test(`${trigger.name}: an authorized sender asking for both agents is a hard error`, needsBash4, () => {
+    const run = runResolve(resolveScript(trigger), {
+      body: `${trigger.builder}\n${trigger.architect}`,
+      sender: "maintainer",
+      permission: "write",
+    });
+    assert.equal(run.status, 1, "an ambiguous request from a collaborator must fail loudly");
+    assert.equal(run.outputs.run, undefined);
+  });
+}


### PR DESCRIPTION
Relates to #218.

**If this does not match how you want the triggers to behave, please just close it — no explanation needed.** It changes behavior rather than fixing something plainly broken, so the call is yours. I wrote it because I had the reproduction in front of me and it seemed more useful to show the change than describe it. The evidence stands in #218 either way.

## Problem

Both agent triggers validate command shape and exit non-zero **before** checking whether the sender has write access. In `facility-crew.yml` the error is at line 110 and the permission gate at line 160.

The job-level prefilter matches the command anywhere in a comment body, so any account on a public repository reaches that step. An account with `read` permission commenting prose produced:

```
##[error]No supported agent command found. Use /builder or /architect at the start of a line.
##[error]Process completed with exit code 1.
```

It also affects maintainers: writing about the commands in an issue turns the repository's checks red. The step's own comment says the line-anchored pattern "ignores prose examples (`ask /architect about it`)" — it does ignore them for dispatch, but the run still fails loudly rather than skipping.

`facility-codex.yml` already handles the same input the way I would expect (`::notice::No Codex command starts a line; treating the mention as prose`), so the two sibling workflows currently disagree.

## Change

The authorization gate runs first, and a body with no line-anchored command becomes a `run=false` skip rather than a hard error — matching what codex already does. A genuinely ambiguous request from an authorized sender (both commands, line-anchored) stays a hard error.

## Test

`packages/cli/test/crew-resolve.test.mjs` renders both workflows through the real installer, lifts the resolve step's `run:` block out of the rendered YAML, and executes it under bash against real event payloads with a stubbed `gh` permission lookup.

Statement order is not observable from a text assertion, which is why CONTRIBUTING's rule about exercising the rendered workflow rather than checking text matters here. 8 tests; 3 fail on `main`.

The tests require bash 4 for `mapfile`, as the shipped script does, and skip on older shells — macOS still ships bash 3.2, so a contributor there would otherwise see a false failure.

## Deliberately not included

The unguarded toolchain steps. A refused request still checks out the repository and runs `pnpm install --frozen-lockfile`, because `{{TOOLCHAIN_STEPS}}` carries no `if:` while the steps either side of it do — the job then reports success. Guarding those steps is the right fix, but `toolchainSteps()`'s existing `conditional` option guards on `steps.workflow-change.outputs.changed`, so it is not a drop-in, and the shape of that fix is yours to choose. Evidence and run logs in #218.