### PR TITLE
fix(api): keep queued run comments from expiring plans

### DIFF
--- a/services/api/src/executors.ts
+++ b/services/api/src/executors.ts
@@ -1317,7 +1317,7 @@ async function executeKnownMcpTool(
         const github = await createGithubClientForRepo(db, factory, repo);
         await github.createIssueComment(
           number,
-          `Facility queued ${agentName} run ${run.id} (triggered through an approved MCP proposal).`,
+          `<!-- facility-run-queued run=${run.id} -->\nFacility queued ${agentName} run ${run.id} (triggered through an approved MCP proposal).`,
         );
       } catch {
         // Queueing is authoritative; the acknowledgement is best-effort parity

--- a/services/api/src/github/issue-revision.ts
+++ b/services/api/src/github/issue-revision.ts
@@ -19,6 +19,13 @@ type GithubIssueLike = {
 };
 
 const FACILITY_COMMENT_MARKERS = ["<!-- facility-run-progress", "<!-- facility:architect-plan:"];
+const FACILITY_QUEUED_RUN =
+  /^<!-- facility-run-queued run=(run_[a-z0-9]+) -->\r?\nFacility queued (.+?) run \1 \(triggered (?:from the control plane|through an approved MCP proposal)\)\.\s*$/is;
+// Keep old issues usable after upgrading, but match only the exact historical
+// acknowledgement. The Bot-author check below prevents user lookalikes from
+// disappearing from the issue revision.
+const LEGACY_FACILITY_QUEUED_RUN =
+  /^Facility queued (.+?) run run_[a-z0-9]+ \(triggered (?:from the control plane|through an approved MCP proposal)\)\.\s*$/is;
 const BUILDER_APPROVAL_ONLY = /^\s*\/(?:codex-)?builder\s*[.!?]?\s*$/i;
 
 /**
@@ -93,7 +100,9 @@ function materialIssueComment(comment: GithubIssueRevisionComment) {
   if (BUILDER_APPROVAL_ONLY.test(comment.body)) return false;
   return !(
     comment.authorType.toLowerCase() === "bot" &&
-    FACILITY_COMMENT_MARKERS.some((marker) => comment.body.includes(marker))
+    (FACILITY_COMMENT_MARKERS.some((marker) => comment.body.includes(marker)) ||
+      FACILITY_QUEUED_RUN.test(comment.body) ||
+      LEGACY_FACILITY_QUEUED_RUN.test(comment.body))
   );
 }
 

--- a/services/api/src/routes/v1/github.ts
+++ b/services/api/src/routes/v1/github.ts
@@ -1681,7 +1681,7 @@ async function ackIssueQueued(
     // guard, so this acknowledgement cannot become a trigger input.
     await client.createIssueComment(
       issueNumber,
-      `Facility queued ${agent} run ${runId} (triggered from the control plane).`,
+      `<!-- facility-run-queued run=${runId} -->\nFacility queued ${agent} run ${runId} (triggered from the control plane).`,
     );
   } catch {
     // Best effort only.

--- a/services/api/test/builder-plan-policy.integration.test.ts
+++ b/services/api/test/builder-plan-policy.integration.test.ts
@@ -26,8 +26,8 @@ import {
 import { and, desc, eq } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { resolveBuilderPlanFreshnessForProposal } from "../src/builder-plan-freshness.js";
 import { buildApp } from "../src/app.js";
+import { resolveBuilderPlanFreshnessForProposal } from "../src/builder-plan-freshness.js";
 import {
   assertBuilderPlanDispatch,
   lockBuilderPlanPolicy,

--- a/services/api/test/builder-plan-policy.integration.test.ts
+++ b/services/api/test/builder-plan-policy.integration.test.ts
@@ -19,6 +19,7 @@ import {
 import { and, desc, eq } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { resolveBuilderPlanFreshnessForProposal } from "../src/builder-plan-freshness.js";
 import {
   assertBuilderPlanDispatch,
   lockBuilderPlanPolicy,
@@ -132,6 +133,63 @@ describe("builder plan policy integration", async () => {
         trigger: { ...fixture.dispatch.trigger, proposalId: duplicateProposalId },
       }),
     ).rejects.toMatchObject({ code: "builder_plan_already_consumed" });
+  });
+
+  it("keeps an approved plan fresh across Facility queued-run acknowledgements", async () => {
+    const fixture = await canonicalFixture();
+    const proposal = (
+      await db.select().from(proposals).where(eq(proposals.id, fixture.proposalId)).limit(1)
+    )[0];
+    if (!proposal) throw new Error("proposal fixture missing");
+    const repoName = `plan-${fixture.orgId.replace("org_plan_", "")}`;
+    const freshnessEvidence = await resolveBuilderPlanFreshnessForProposal(db, proposal, {
+      githubClient: {
+        owner: "facility-test",
+        repo: repoName,
+        client: {
+          getDefaultBranchSha: async () => fixture.dispatch.freshnessEvidence.baseSha,
+          getIssue: async () => ({
+            number: 204,
+            title: "Require a plan",
+            body: "Implement it",
+            state: "open",
+            user: { login: "requester" },
+            labels: [],
+            html_url: `https://github.test/facility-test/${repoName}/issues/204`,
+          }),
+          listIssueComments: async () => [
+            {
+              id: 9001,
+              author: "facility-agent[bot]",
+              authorType: "Bot",
+              body: "<!-- facility-run-queued run=run_01slash -->\nFacility queued /architect run run_01slash (triggered from the control plane).",
+              createdAt: "2026-08-29T17:46:47Z",
+              url: "https://github.test/comments/9001",
+            },
+            {
+              id: 9002,
+              author: "facility-agent[bot]",
+              authorType: "Bot",
+              body: "<!-- facility-run-queued run=run_01custom -->\nFacility queued release planner run run_01custom (triggered through an approved MCP proposal).",
+              createdAt: "2026-08-29T17:46:48Z",
+              url: "https://github.test/comments/9002",
+            },
+            {
+              id: 9003,
+              author: "facility-agent[bot]",
+              authorType: "Bot",
+              body: "Facility queued architect.v2 run run_01legacy (triggered from the control plane).",
+              createdAt: "2026-08-29T17:46:49Z",
+              url: "https://github.test/comments/9003",
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(
+      assertBuilderPlanDispatch(db, { ...fixture.dispatch, freshnessEvidence }),
+    ).resolves.toEqual({ mode: "builder", isBuilder: true });
   });
 
   it("recognizes a Builder by agentDefId when the run mode is a surface alias", async () => {

--- a/services/api/test/github-issue-revision.test.ts
+++ b/services/api/test/github-issue-revision.test.ts
@@ -64,6 +64,89 @@ describe("GitHub issue revision", () => {
     expect(updated).toBe(baseline);
   });
 
+  it("ignores current and legacy Facility queued-run acknowledgements from bots", () => {
+    const baseline = githubIssueRevisionSha256(githubIssueRevisionContext(issue, comments));
+    const queueComments = ["/architect", "release planner", "architect.v2"].flatMap(
+      (agentName, index) => {
+        const legacyRunId = `run_legacy${String(index)}`;
+        const markedRunId = `run_marked${String(index)}`;
+        return [
+          {
+            id: 5 + index * 2,
+            author: "facility-agent[bot]",
+            authorType: "Bot",
+            body: `Facility queued ${agentName} run ${legacyRunId} (triggered from the control plane).`,
+            createdAt: `2026-08-26T10:0${String(4 + index * 2)}:00Z`,
+            url: `https://github.test/comments/${String(5 + index * 2)}`,
+          },
+          {
+            id: 6 + index * 2,
+            author: "facility-agent[bot]",
+            authorType: "Bot",
+            body: `<!-- facility-run-queued run=${markedRunId} -->\nFacility queued ${agentName} run ${markedRunId} (triggered through an approved MCP proposal).`,
+            createdAt: `2026-08-26T10:0${String(5 + index * 2)}:00Z`,
+            url: `https://github.test/comments/${String(6 + index * 2)}`,
+          },
+        ];
+      },
+    );
+    const legacyQueueComment = queueComments[0];
+    const markedQueueComment = queueComments[1];
+    if (!legacyQueueComment || !markedQueueComment) {
+      throw new Error("queue comment fixtures are incomplete");
+    }
+    expect(
+      githubIssueRevisionSha256(githubIssueRevisionContext(issue, [...comments, ...queueComments])),
+    ).toBe(baseline);
+
+    expect(
+      githubIssueRevisionSha256(
+        githubIssueRevisionContext(issue, [
+          ...comments,
+          { ...legacyQueueComment, authorType: "User" },
+        ]),
+      ),
+    ).not.toBe(baseline);
+    expect(
+      githubIssueRevisionSha256(
+        githubIssueRevisionContext(issue, [
+          ...comments,
+          { ...legacyQueueComment, body: `${legacyQueueComment.body} Also change the API.` },
+        ]),
+      ),
+    ).not.toBe(baseline);
+    expect(
+      githubIssueRevisionSha256(
+        githubIssueRevisionContext(issue, [
+          ...comments,
+          { ...markedQueueComment, body: `${markedQueueComment.body} Also change the API.` },
+        ]),
+      ),
+    ).not.toBe(baseline);
+    expect(
+      githubIssueRevisionSha256(
+        githubIssueRevisionContext(issue, [
+          ...comments,
+          {
+            ...markedQueueComment,
+            body: "<!-- facility-run-queued run=run_expected -->\nFacility queued /architect run run_other (triggered from the control plane).",
+          },
+        ]),
+      ),
+    ).not.toBe(baseline);
+    expect(
+      githubIssueRevisionSha256(
+        githubIssueRevisionContext(issue, [
+          ...comments,
+          {
+            ...markedQueueComment,
+            body: "<!-- facility-run-queued run=run_empty -->\nFacility queued  run run_empty (triggered from the control plane).",
+          },
+        ]),
+      ),
+    ).not.toBe(baseline);
+  });
+
   it("changes for material issue, state, or comment edits", () => {
     const baseline = githubIssueRevisionSha256(githubIssueRevisionContext(issue, comments));
     expect(


### PR DESCRIPTION
## Summary

- Prefix new control-plane and MCP queue acknowledgements with a hidden Facility run marker.
- Ignore queue acknowledgements during issue-revision calculation only when a GitHub Bot posts an exact recognized message.
- Keep legacy markerless Facility acknowledgements compatible while treating user lookalikes, appended content, and mismatched run IDs as material changes.

## Why

Closes #222 

Facility could count its own queued-run acknowledgement as a new issue revision. An already approved architect plan would then appear stale before the builder started.

## Testing

- pnpm --filter @facility/api exec vitest run --fileParallelism=false test/github-issue-revision.test.ts test/builder-plan-policy.integration.test.ts (34 passed, 0 skipped)
- pnpm --filter @facility/api typecheck
- pnpm exec biome check on all five changed files
- git diff --check

The full release-shaped pnpm verify runs in GitHub Actions on Ubuntu with Node.js 22. It is not reported as a Windows-local result because the upstream checkout currently has unrelated Windows-only baseline failures; no repository check or test was disabled.