### PR TITLE
fix(mcp): complete Codex OAuth authorization

### DIFF
--- a/apps/docs/docs/reference/mcp.md
+++ b/apps/docs/docs/reference/mcp.md
@@ -50,6 +50,27 @@ same issuer. `MCP_AUTHORIZATION_SERVER` must be an HTTPS origin; HTTP is accepte
 loopback development origin. The web origin proxies `/.well-known/*` and `/oauth/*` to the API so authorization,
 interaction, GitHub login/callback, and resume retain host-only cookies on one browser origin.
 
+### Codex remote OAuth smoke test
+
+Register the canonical MCP transport URL, complete browser authorization, and inspect the
+configured server:
+
+```console
+codex mcp add facility --url https://mcp.facility.yourorg.com/mcp
+codex mcp login facility
+codex mcp list
+```
+
+Restart any Codex session that was already open when the server was added, then read
+`facility://me` to verify authenticated access. Codex requests all authorization-server scopes
+advertised by `scopes_supported`. Facility advertises `facility:mcp` there so DCR can register it,
+also identifies it in protected-resource metadata, and grants it only for `MCP_PUBLIC_URL`; the
+requested `openid`, `offline_access`, `email`, and `profile` scopes remain in the OIDC grant.
+Authorization-code callbacks include the exact configured issuer in `iss`, as advertised by
+`authorization_response_iss_parameter_supported`. A repeated consent screen usually indicates an
+advertised scope was not persisted in the grant. A client error about a missing issuer means the
+authorization response did not satisfy that metadata contract.
+
 ### Breaking upgrade: same-origin, path-aware OAuth
 
 This OAuth layout changes both token identity boundaries: the issuer moves from the API origin to

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -23,6 +23,7 @@ export type HttpServerOptions = {
 
 const PROTECTED_RESOURCE_PATH = "/.well-known/oauth-protected-resource";
 const MCP_ENDPOINT_PATH = "/mcp";
+const MCP_OAUTH_SCOPE = "facility:mcp";
 
 export function serveHttp(options: HttpServerOptions) {
   const host = options.host ?? "127.0.0.1";
@@ -109,6 +110,7 @@ export function serveHttp(options: HttpServerOptions) {
           resource: resourceUrl ?? "",
           authorization_servers: [options.authorizationServer],
           bearer_methods_supported: ["header"],
+          scopes_supported: [MCP_OAUTH_SCOPE],
         }),
       );
       return;

--- a/packages/mcp/test/mcp.test.ts
+++ b/packages/mcp/test/mcp.test.ts
@@ -782,9 +782,11 @@ describe("@facility/mcp", () => {
     const body = (await response.json()) as {
       resource: string;
       authorization_servers: string[];
+      scopes_supported: string[];
     };
     assert.equal(body.resource, "https://mcp.facility.test/mcp");
     assert.deepEqual(body.authorization_servers, ["https://auth.facility.test"]);
+    assert.deepEqual(body.scopes_supported, ["facility:mcp"]);
     const legacyAlias = await fetch(
       `http://127.0.0.1:${port}/.well-known/oauth-protected-resource`,
       { redirect: "manual" },

--- a/services/api/src/auth/authorization-server.ts
+++ b/services/api/src/auth/authorization-server.ts
@@ -9,6 +9,9 @@ import { ApiError } from "../errors.js";
 import type { AppConfig } from "../types.js";
 import { oauthAdapterFactory } from "./oauth-adapter.js";
 
+export const FACILITY_OIDC_SCOPES = ["openid", "offline_access", "email", "profile"] as const;
+export const FACILITY_MCP_SCOPE = "facility:mcp";
+
 export async function registerAuthorizationServer(app: FastifyInstance, config: AppConfig) {
   if (!config.oauthIssuer || !config.oauthJwks || !config.mcpPublicUrl) return;
   const browserOrigin = oauthBrowserOrigin(config);
@@ -37,7 +40,7 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
           if (resource !== config.mcpPublicUrl)
             throw new ApiError(400, "invalid_target", "Unknown OAuth resource");
           return {
-            scope: "facility:mcp",
+            scope: FACILITY_MCP_SCOPE,
             audience: config.mcpPublicUrl,
             accessTokenTTL: 900,
             accessTokenFormat: "jwt",
@@ -55,7 +58,7 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
       end_session: "/oauth/session/end",
       userinfo: "/oauth/userinfo",
     },
-    scopes: ["openid", "offline_access"],
+    scopes: [...FACILITY_OIDC_SCOPES, FACILITY_MCP_SCOPE],
     claims: { openid: ["sub"], email: ["email", "email_verified"], profile: ["name"] },
     formats: { AccessToken: "jwt" },
     pkce: { required: () => true, methods: ["S256"] },
@@ -91,7 +94,9 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
     extraTokenClaims: async (_ctx: unknown, token: { accountId?: string; scope?: string }) => {
       if (!token.accountId) return {};
       const account = await activeAccount(app, token.accountId);
-      return account ? { org_id: account.member.orgId, scope: token.scope ?? "facility:mcp" } : {};
+      return account
+        ? { org_id: account.member.orgId, scope: token.scope ?? FACILITY_MCP_SCOPE }
+        : {};
     },
   });
   provider.proxy = true;
@@ -177,8 +182,16 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
         throw new ApiError(400, "invalid_target", "Unknown OAuth resource");
       let grant = details.grantId ? await provider.Grant.find(details.grantId) : undefined;
       if (!grant) grant = new provider.Grant({ accountId: request.principal.userId, clientId });
-      grant.addOIDCScope("openid offline_access");
-      grant.addResourceScope(resource, "facility:mcp");
+      const requestedScopes = oauthScopes(details.params?.scope);
+      const oidcScopes = oidcScopesForConsent(requestedScopes);
+      if (oidcScopes) grant.addOIDCScope(oidcScopes);
+      if (requestedScopes.has(FACILITY_MCP_SCOPE)) {
+        // The AS advertises this scope so clients may register and request it, but it must remain
+        // resource-bound. Mark it encountered-but-rejected in the unbound OIDC grant and grant it
+        // only for the canonical MCP resource below.
+        grant.rejectOIDCScope(FACILITY_MCP_SCOPE);
+        grant.addResourceScope(resource, FACILITY_MCP_SCOPE);
+      }
       const grantId = await grant.save();
       await provider.interactionFinished(
         request.raw,
@@ -192,6 +205,15 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
       return reply.hijack();
     },
   );
+}
+
+export function oidcScopesForConsent(requestedScope: unknown) {
+  const requested = requestedScope instanceof Set ? requestedScope : oauthScopes(requestedScope);
+  return FACILITY_OIDC_SCOPES.filter((scope) => requested.has(scope)).join(" ");
+}
+
+function oauthScopes(value: unknown) {
+  return new Set(typeof value === "string" ? value.split(/\s+/).filter(Boolean) : []);
 }
 
 async function activeAccount(app: FastifyInstance, userId: string) {

--- a/services/api/src/oidc-provider.d.ts
+++ b/services/api/src/oidc-provider.d.ts
@@ -6,6 +6,7 @@ declare module "oidc-provider" {
 
   interface GrantInstance {
     addOIDCScope(scope: string): void;
+    rejectOIDCScope(scope: string): void;
     addResourceScope(resource: string, scope: string): void;
     save(): Promise<string>;
   }

--- a/services/api/test/oauth.test.ts
+++ b/services/api/test/oauth.test.ts
@@ -13,7 +13,7 @@ import { createLocalJWKSet, decodeJwt, exportJWK, generateKeyPair, SignJWT } fro
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp, mintSessionCookie } from "../src/app.js";
-import { oauthBrowserOrigin } from "../src/auth/authorization-server.js";
+import { oauthBrowserOrigin, oidcScopesForConsent } from "../src/auth/authorization-server.js";
 import { pkceChallenge } from "../src/auth/identity-provider.js";
 import {
   AccessTokenError,
@@ -155,6 +155,22 @@ describe("Facility OAuth browser-origin runtime guard", () => {
   });
 });
 
+describe("Facility OAuth consent scopes", () => {
+  it("grants every requested advertised OIDC scope in canonical order", () => {
+    expect(oidcScopesForConsent("profile openid email offline_access")).toBe(
+      "openid offline_access email profile",
+    );
+  });
+
+  it("does not promote resource or unknown scopes into the OIDC grant", () => {
+    expect(oidcScopesForConsent("openid facility:mcp projects:write unknown")).toBe("openid");
+  });
+
+  it.each([undefined, null, 42, ["openid"]])("handles a non-string scope value: %j", (scope) => {
+    expect(oidcScopesForConsent(scope)).toBe("");
+  });
+});
+
 describe("Facility OAuth resource-server integration", async () => {
   const sql = postgres(databaseUrl, { max: 1, connect_timeout: 2 });
   let reachable = true;
@@ -239,6 +255,8 @@ describe("Facility OAuth resource-server integration", async () => {
       token_endpoint: `${issuer}/oauth/token`,
       registration_endpoint: `${issuer}/oauth/register`,
       code_challenge_methods_supported: ["S256"],
+      scopes_supported: ["openid", "offline_access", "email", "profile", "facility:mcp"],
+      authorization_response_iss_parameter_supported: true,
     });
     const poisonedMetadata = await app.inject({
       method: "GET",
@@ -269,14 +287,31 @@ describe("Facility OAuth resource-server integration", async () => {
         token_endpoint_auth_method: "none",
         grant_types: ["authorization_code", "refresh_token"],
         response_types: ["code"],
+        scope: "openid offline_access email profile facility:mcp",
       },
     });
     expect(registration.statusCode, registration.body).toBe(201);
     expect(registration.json()).toMatchObject({
       client_name: "Facility MCP test",
       token_endpoint_auth_method: "none",
+      scope: "openid offline_access email profile facility:mcp",
     });
     expect(registration.json().client_secret).toBeUndefined();
+    const rejectedRegistration = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      headers: proxyHeaders,
+      payload: {
+        client_name: "Invalid scope client",
+        redirect_uris: ["http://127.0.0.1:32123/callback"],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        scope: "openid facility:unknown",
+      },
+    });
+    expect(rejectedRegistration.statusCode).toBe(400);
+    expect(rejectedRegistration.json()).toMatchObject({ error: "invalid_client_metadata" });
   });
 
   it("resolves a current member and rejects cross-tenant claims", async () => {
@@ -324,7 +359,7 @@ describe("Facility OAuth resource-server integration", async () => {
       client_id: clientId,
       redirect_uri: redirectUri,
       response_type: "code",
-      scope: "openid offline_access facility:mcp",
+      scope: "openid offline_access email profile facility:mcp",
       resource: audience,
       state: "oauth-state",
       code_challenge: await pkceChallenge(verifier),
@@ -394,6 +429,7 @@ describe("Facility OAuth resource-server integration", async () => {
     });
     expect(resumed.statusCode).toBe(303);
     const callback = new URL(required(resumed.headers.location, "OAuth callback redirect"));
+    expect(callback.searchParams.get("iss")).toBe(issuer);
     expect(callback.searchParams.get("state")).toBe("oauth-state");
     const code = required(callback.searchParams.get("code"), "authorization code");
     const exchange = await tokenRequest(app, proxyHeaders, {
@@ -408,6 +444,7 @@ describe("Facility OAuth resource-server integration", async () => {
     const first = exchange.json();
     expect(first.access_token.split(".")).toHaveLength(3);
     expect(first.refresh_token).toBeTypeOf("string");
+    expect(decodeJwt(first.access_token).scope).toBe("facility:mcp");
     const persisted = JSON.stringify(await db.select().from(oauthArtifacts));
     expect(persisted).not.toContain(first.refresh_token);
     expect(persisted).not.toContain(first.access_token);


### PR DESCRIPTION
Closes #235.

## Problem

Codex defaults to every scope in the authorization server's `scopes_supported` metadata. Facility advertised `email` and `profile`, but its consent handler persisted only `openid offline_access`, so authorization returned to consent instead of completing.

The MCP scope had a second boundary mismatch: `facility:mcp` was available only inside the resource-server configuration. It was absent from discovery/DCR scopes, while the access-token implementation filters resource scopes against the scopes actually requested. A Codex-default request could therefore either fail registration or receive a token without `facility:mcp`.

The existing PKCE regression used a hand-crafted scope set and never asserted the RFC 9207 `iss` callback parameter, despite metadata advertising `authorization_response_iss_parameter_supported: true`.

## Solution

- Define the supported OIDC scopes and MCP resource scope explicitly.
- Advertise `facility:mcp` in authorization-server and protected-resource metadata so Codex DCR can register and request it.
- Grant only requested OIDC scopes.
- Mark `facility:mcp` encountered-but-rejected in the unbound OIDC grant, then grant it only for the canonical MCP resource when requested.
- Exercise the Codex scope set through DCR, consent, PKCE exchange, issuer binding, MCP access-token validation, refresh rotation, and replay rejection.
- Reject unknown DCR scopes and retain the existing wrong-resource denial.
- Document a Codex remote OAuth smoke test plus the scope and issuer contracts.

`oidc-provider` already emits `iss` on a completed authorization-code response. The new DB-backed assertion makes that advertised contract release-blocking instead of leaving it untested.

## Verification

- `pnpm lint` — passed (422 files)
- API OAuth regression — 28/28 passed against isolated Postgres
- MCP suite — 27/27 passed
- API and MCP typechecks — passed
- Docs tests — 12/12 passed
- Docusaurus production build — passed
- Repository guards — 2/2 passed
- Dependency audit — exited successfully; two repository-policy ignored high findings remain unchanged
- `pnpm verify` completed lint, all-package typecheck, clean build, DB recreation, DB tests (18), CLI tests (98), API tests (591), gateway tests (57), and the non-runner package suites. Two pre-existing 100 ms runner timing tests raced while the full suite was under load; the affected `workspace.test.ts` then passed 63/63 in isolation.

## Security notes

- Unknown scopes are not promoted into a grant.
- `facility:mcp` is not granted as an unbound OIDC scope.
- Resource audience validation, PKCE, refresh rotation/replay protection, token-at-rest checks, and poisoned forwarding-header tests remain green.
