### PR TITLE
fix(release): avoid flaky Go HTTP/2 downloads

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -25,6 +25,12 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl libseccomp-dev pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
+# GitHub-hosted runners have repeatedly received HTTP/2 INTERNAL_ERROR resets
+# from proxy.golang.org during these clean, cacheless source builds. Go still
+# verifies every downloaded module against go.sum; use HTTP/1.1 so a transport
+# stream reset cannot abort publication after the release checks have passed.
+ENV GODEBUG=http2client=0
+
 # Keep these stages in a dependency chain so BuildKit cannot materialize eight
 # complete Go source trees and compiler caches at once. Each successful stage
 # retains only /out before the next source build begins.

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -363,6 +363,11 @@ test("Bake keeps thin target boundaries and publishes every target through one g
     runnerDockerfile,
     /^FROM golang:1\.26\.6-trixie@sha256:[0-9a-f]{64} AS go-tools-base$/m,
   );
+  assert.match(
+    runnerDockerfile,
+    /^ENV GODEBUG=http2client=0$/m,
+    "clean Go tool builds must avoid the flaky HTTP/2 module transport",
+  );
   for (const [parent, stage] of [
     ["go-tools-base", "moby-build"],
     ["moby-build", "docker-cli-build"],


### PR DESCRIPTION
## What changes

Forces Go module downloads in the chained runner tool-build stages to use HTTP/1.1 instead of HTTP/2. Module checksum and sumdb verification remain unchanged, and the setting is not inherited by the Node-based runtime stages.

Adds a repository regression assertion that keeps the transport safeguard in the runner Dockerfile.

## Why

The production release runs for `0f92f45` and `64b549d` both failed while compiling checksum-pinned Moby sources because `proxy.golang.org` reset HTTP/2 streams with `INTERNAL_ERROR`. The failures occurred on different modules and after the application packages had already built, so the flaky transport prevented npm and image publication.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (`docker build --target moby-build -f runner/Dockerfile .` completed from a clean Go module download in 65.6s, including the two modules that failed remotely)
- [x] Documentation updated, or no user-facing change

The focused image-build contract passed 6/6. Independent review confirmed that module integrity is unchanged and the environment setting is confined to build-only stages.