### PR TITLE
fix(release): rebuild runner with patched Go crypto

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -85,6 +85,7 @@ RUN archive=/tmp/containerd.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.55.0 \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
   && make VERSION="v${CONTAINERD_VERSION}" REVISION="$CONTAINERD_COMMIT" STATIC=1 \
@@ -105,6 +106,7 @@ RUN archive=/tmp/rootlesskit.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.55.0 \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
   && CGO_ENABLED=0 go build -mod=mod -trimpath -ldflags='-s -w' -o /out/rootlesskit ./cmd/rootlesskit \
   && test "$(/out/rootlesskit --version | awk '{print $3}')" = "3.0.2" \
@@ -142,6 +144,7 @@ RUN archive=/tmp/compose.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.55.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
   && CGO_ENABLED=0 GOMAXPROCS=1 go build -p=1 -mod=mod -trimpath -tags=e2e \
     -ldflags="-s -w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
@@ -184,19 +187,23 @@ RUN archive=/tmp/gh.tar.gz \
   && rm -rf /src "$archive" /root/.cache/go-build /go/pkg/mod
 
 # Keep the toolchain claim executable: fail the image build if any copied Go
-# binary was not produced by the patched compiler, or if the two projects that
-# pinned vulnerable x/net code did not resolve the reviewed replacement.
+# binary was not produced by the patched compiler, or if projects that pinned
+# vulnerable Go modules did not resolve the reviewed replacements.
 FROM gh-build AS go-tools-audit
 RUN for binary in /out/*; do \
-    test "$(go version -m "$binary" | awk 'NR == 1 {print $2}')" = "go1.26.6"; \
+    test "$(go version -m "$binary" | awk 'NR == 1 {print $2}')" = "go1.26.6" || exit 1; \
   done \
   && for binary in /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/rootlesskit; do \
     go version -m "$binary" | awk \
-      '$1 == "=>" && $2 == "golang.org/x/net" && $3 == "v0.56.0" { found = 1 } END { exit !found }'; \
+      '$1 == "=>" && $2 == "golang.org/x/net" && $3 == "v0.56.0" { found = 1 } END { exit !found }' || exit 1; \
+  done \
+  && for binary in /out/containerd /out/rootlesskit /out/docker-compose; do \
+    go version -m "$binary" | awk \
+      '$1 == "=>" && $2 == "golang.org/x/crypto" && $3 == "v0.55.0" { found = 1 } END { exit !found }' || exit 1; \
   done \
   && for binary in /out/dockerd /out/containerd /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \
-      '$1 == "=>" && $2 == "golang.org/x/mod" && $3 == "v0.40.0" { found = 1 } END { exit !found }'; \
+      '$1 == "=>" && $2 == "golang.org/x/mod" && $3 == "v0.40.0" { found = 1 } END { exit !found }' || exit 1; \
   done \
   && go version -m /out/docker-buildx | awk \
     '$1 == "=>" && $2 == "github.com/moby/go-archive" && $3 == "v0.3.0" { found = 1 } END { exit !found }'

--- a/scripts/images-build.test.mjs
+++ b/scripts/images-build.test.mjs
@@ -385,6 +385,20 @@ test("Bake keeps thin target boundaries and publishes every target through one g
   assert.match(runnerDockerfile, /go version -m "\$binary"[\s\S]*go1\.26\.6/);
   assert.match(runnerDockerfile, /golang\.org\/x\/net[\s\S]*v0\.56\.0/);
   assert.equal(
+    runnerDockerfile.match(/golang\.org\/x\/crypto=golang\.org\/x\/crypto@v0\.55\.0/g)?.length,
+    3,
+    "every copied Go tool with the vulnerable x/crypto dependency must use the fixed release",
+  );
+  assert.match(
+    runnerDockerfile,
+    /for binary in \/out\/containerd \/out\/rootlesskit \/out\/docker-compose; do[\s\S]*golang\.org\/x\/crypto[\s\S]*v0\.55\.0/,
+  );
+  assert.equal(
+    (runnerDockerfile.match(/\|\| exit 1; \\\n\s+done/g) ?? []).length,
+    4,
+    "every multi-binary Go audit must stop on the first failed binary",
+  );
+  assert.equal(
     runnerDockerfile.match(/golang\.org\/x\/mod=golang\.org\/x\/mod@v0\.40\.0/g)?.length,
     5,
     "every copied Go tool with the vulnerable x/mod dependency must use the reviewed replacement",


### PR DESCRIPTION
## Summary

- rebuild containerd, RootlessKit, and Docker Compose against `golang.org/x/crypto@v0.55.0` to remove `GO-2026-6303` from the runner image
- make every multi-binary Go audit fail on the first mismatched binary
- add a regression assertion for the fixed module and fail-closed audit loops

This repairs the GHCR scan failure in release run 33400581089 without weakening `runner/grype.yaml` or the publication gate.

## Validation

- `node --test scripts/images-build.test.mjs` (6/6)
- `pnpm verify`
- `docker build --target go-tools-audit -f runner/Dockerfile .`
- built final `facility-runner:xcrypto-test` image
- pinned `anchore/grype:v0.110.0 --config runner/grype.yaml --fail-on high --only-fixed` against the final image: exit 0, `GO-2026-6303` absent
- independent final review: no blockers