### PR TITLE
fix(cli): normalize Windows backslash paths in protect-files hook

### DIFF
--- a/packages/cli/templates/claude/hooks/protect-files.mjs
+++ b/packages/cli/templates/claude/hooks/protect-files.mjs
@@ -18,7 +18,10 @@ function readPayload() {
 }
 
 const payload = readPayload();
-const filePath = payload?.tool_input?.file_path ?? "";
+// Claude Code on Windows sends tool_input.file_path with backslashes; the
+// guards below are POSIX-style regexes, so normalise once, up front, for
+// this file and every module fragment spliced in below.
+const filePath = String(payload?.tool_input?.file_path ?? "").replace(/\\/g, "/");
 if (!filePath) process.exit(0);
 
 function block(reason) {

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -540,6 +540,48 @@ test("add database module wires the triple", async (t) => {
     encoding: "utf8",
   });
   assert.equal(parse.status, 0, parse.stderr);
+
+  // Windows sends tool_input.file_path with backslashes; the module's
+  // migration guard must still fire (issue #227).
+  const windowsMigration = spawnSync(process.execPath, [".claude/hooks/protect-files.mjs"], {
+    cwd: dir,
+    encoding: "utf8",
+    input: JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: "C:\\repo\\supabase\\migrations\\0001_init.sql" },
+    }),
+  });
+  assert.equal(windowsMigration.status, 2, windowsMigration.stdout + windowsMigration.stderr);
+});
+
+test("protect-files.mjs blocks a real .env on a Windows-style path (issue #227)", async (t) => {
+  const dir = makeTargetRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  runCli(["init", "--yes", `--dir=${dir}`, "--provision=npm run setup", "--checks=npm test"], dir);
+  const hookPath = ".claude/hooks/protect-files.mjs";
+
+  const posix = spawnSync(process.execPath, [hookPath], {
+    cwd: dir,
+    encoding: "utf8",
+    input: JSON.stringify({ tool_name: "Write", tool_input: { file_path: "/repo/.env" } }),
+  });
+  assert.equal(posix.status, 2, posix.stdout + posix.stderr);
+
+  const windows = spawnSync(process.execPath, [hookPath], {
+    cwd: dir,
+    encoding: "utf8",
+    input: JSON.stringify({ tool_name: "Write", tool_input: { file_path: "C:\\repo\\.env" } }),
+  });
+  assert.equal(windows.status, 2, windows.stdout + windows.stderr);
+
+  // .env.example stays writable on both path styles.
+  const windowsExample = spawnSync(process.execPath, [hookPath], {
+    cwd: dir,
+    encoding: "utf8",
+    input: JSON.stringify({ tool_name: "Write", tool_input: { file_path: "C:\\repo\\.env.example" } }),
+  });
+  assert.equal(windowsExample.status, 0, windowsExample.stdout + windowsExample.stderr);
 });
 
 test("doctor reports missing install", async (t) => {


### PR DESCRIPTION
## What changes

`protect-files.mjs` (and the database module's migration guard, which gets
spliced into the same file) now normalizes `tool_input.file_path` before
matching it against the regex guards. Backslashes become forward slashes, so
a Windows path matches the same way a POSIX one already did.

## Why

Claude Code on Windows sends `file_path` with backslashes. The guards are
POSIX-only regexes, so on Windows the `.env` protection and the migration
protection never fire. The hook exits 0 and the write goes through, and
`doctor` still reports the hook as installed and correct.

Fixes #227.

Left `.github/facility/doctor/resolve.mjs` alone. Its `SENSITIVE_PATHS` check
only ever sees paths from the GitHub API or `git diff`, both always
forward-slash regardless of OS, and its workflow is pinned to
`ubuntu-latest`, so there's no Windows-backslash path that ever reaches it.

## Verification

- [ ] `pnpm verify` passes locally — couldn't run it, this checkout has no
      `node_modules` installed and I didn't want to pull a full monorepo
      install just to touch one file. Said so instead of guessing.
- [x] Behaviour verified beyond the test suite: ran `protect-files.mjs`
      directly with `node` on Windows 11, before and after the fix, feeding
      it the same JSON Claude Code sends on stdin. POSIX `.env` path blocked
      both times, Windows `.env` path went from exit 0 to exit 2, and
      `.env.example` stays allowed on both path styles.
- [x] Added a test in `packages/cli/test/init.test.mjs` that spawns the
      installed hook with a Windows-style path, for both the base `.env`
      guard and the database module's migration guard.
- [ ] Documentation updated, or no user-facing change — no doc describes
      this hook's internals, nothing to update.
