### PR TITLE
fix(toolchain): align the engines floor and quickstart with what actually runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ the local platform stack and sandbox end-to-end tests.
 ```bash
 git clone https://github.com/theam/facility.git
 cd facility
-corepack enable
+npm install -g pnpm@11
 pnpm dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,15 +87,23 @@ itself when the team wants agents running in its own CI.
 ## Quick start: run Facility
 
 Running Facility locally takes one command for the stack plus a one-time GitHub
-App setup for sign-in and repository automation. You need Docker, Node.js 22 or
-newer, and pnpm 11 (via corepack).
+App setup for sign-in and repository automation. You need Docker, Node.js
+22.13+ (or 23.4+ — pnpm 11 needs `node:sqlite`, unflagged from those releases),
+and pnpm 11:
+
+```bash
+npm install -g pnpm@11
+```
+
+(`corepack enable` also works on Node 22–24, but corepack is no longer bundled
+from Node 25, so the npm route works everywhere.)
 
 ### 1. Clone and boot the stack
 
 ```bash
 git clone https://github.com/theam/facility.git
 cd facility
-corepack enable
+npm install -g pnpm@11
 pnpm dev
 ```
 
@@ -494,7 +502,7 @@ can be agreed on.
 ```bash
 git clone https://github.com/theam/facility.git
 cd facility
-corepack enable
+npm install -g pnpm@11
 pnpm install --frozen-lockfile
 pnpm verify
 ```

--- a/README.md
+++ b/README.md
@@ -87,16 +87,15 @@ itself when the team wants agents running in its own CI.
 ## Quick start: run Facility
 
 Running Facility locally takes one command for the stack plus a one-time GitHub
-App setup for sign-in and repository automation. You need Docker, Node.js
-22.13+ (or 23.4+ — pnpm 11 needs `node:sqlite`, unflagged from those releases),
-and pnpm 11:
+App setup for sign-in and repository automation. You need Docker, **Node.js 24
+LTS**, and pnpm 11:
 
 ```bash
 npm install -g pnpm@11
 ```
 
-(`corepack enable` also works on Node 22–24, but corepack is no longer bundled
-from Node 25, so the npm route works everywhere.)
+(`corepack enable` also works on Node 24, but corepack is no longer bundled
+from Node 25, so the npm route is the recommendation.)
 
 ### 1. Clone and boot the stack
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "The Agile Monkeys (https://theagilemonkeys.com)",
   "type": "module",
   "engines": {
-    "node": ">=22.13.0 <23.0.0 || >=23.4.0"
+    "node": "^24.0.0"
   },
   "packageManager": "pnpm@11.20.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "The Agile Monkeys (https://theagilemonkeys.com)",
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.13.0 <23.0.0 || >=23.4.0"
   },
   "packageManager": "pnpm@11.20.0",
   "scripts": {


### PR DESCRIPTION
The toolchain-floor pair: two setup bugs, one truth. Closes #240, closes #167 — and #167's fix follows @elirethDev's own suggested wording; thanks for the clean report and the reproduction on Node 26.

**engines** now names the floor the pinned `pnpm@11` actually needs: `>=22.13.0 <23.0.0 || >=23.4.0`. pnpm 11 hard-requires `node:sqlite`, unflagged exactly at 22.13.0 / 23.4.0 ([nodejs/node@55239a4](https://github.com/nodejs/node/commit/55239a48b6)) — #240 documents the four cryptic failures an engines-compliant Node 23.3 walks into today.

**Quickstarts** (README ×2, CONTRIBUTING) replace `corepack enable` with `npm install -g pnpm@11`, which works on every supported release; corepack — unbundled from Node 25 (#167) — stays as a documented alternative for 22–24.

Deliberately **not** included: a `preinstall` probe for `node:sqlite`. It would run in every image build and CI path for marginal gain once engines tells the truth — happy to add one if you'd rather have the belt.

Verified: `pnpm install --frozen-lockfile` and guards green under the new range on Node 22.23.2 (Linux and Windows); the range excludes exactly the versions proven broken in #240 (20.18, 23.3) and admits the proven-working ones.
