### PR TITLE
fix(cli): make --canary-bot reachable on init

### DIFF
--- a/packages/cli/src/cli.mjs
+++ b/packages/cli/src/cli.mjs
@@ -93,6 +93,7 @@ function help() {
   item(dim('            --build-model=<id> --review-model=<id> --plan-model=<id>'));
   item(dim('            --codex-build-model=<id> --codex-plan-model=<id> --org=<org> --project=<n>'));
   item(dim('            --preview-image=<image> --preview-command=<cmd> --preview-port=<n> --preview-readiness-path=</health> --preview-ttl-hours=<n>'));
+  item(dim("            --canary-bot=<your-app>[bot]"));
   item(dim("Run facility <command> --help for precise usage."));
   item(dim("Global platform flags: --profile <name> --json --timeout <seconds>"));
   console.log("");
@@ -215,6 +216,7 @@ function validateLocalFlags(command, flags) {
       "preview-port",
       "preview-readiness-path",
       "preview-ttl-hours",
+      "canary-bot",
       "help",
     ]),
     add: new Set(["dir", "help"]),
@@ -277,6 +279,7 @@ function validateLocalFlags(command, flags) {
             "preview-port",
             "preview-readiness-path",
             "preview-ttl-hours",
+            "canary-bot",
           ]
         : ["dir"];
   for (const name of valueNames) {

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -463,6 +463,40 @@ test("init installs the method end to end", async (t) => {
   assert.ok(again.stdout.includes("left untouched"), "second init should skip existing files");
 });
 
+// Regression coverage for #229: the closing checklist tells the user to
+// "re-run init with --canary-bot=<your-app>[bot]", but the flag was missing
+// from validateLocalFlags's allowlist, so that documented command failed
+// before init() ever ran. https://github.com/theam/facility/issues/229
+test("init accepts --canary-bot and renders it into the crew workflow", async (t) => {
+  const dir = makeTargetRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const result = runCli(
+    ["init", "--yes", `--dir=${dir}`, "--provision=npm run setup", "--canary-bot=my-app[bot]"],
+    dir,
+  );
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+
+  const crew = readFileSync(join(dir, ".github/workflows/facility-crew.yml"), "utf8");
+  assert.ok(crew.includes("my-app[bot]"), "custom canary bot login must be rendered");
+  assert.ok(
+    !crew.includes("facility-canary[bot]"),
+    "default canary bot login must not leak in once overridden",
+  );
+});
+
+test("init rejects a valueless --canary-bot and documents the flag in help", () => {
+  const dir = makeTargetRepo();
+  const rejected = runCli(["init", "--yes", `--dir=${dir}`, "--canary-bot"], dir);
+  assert.equal(rejected.status, 1);
+  assert.match(rejected.stderr, /--canary-bot requires a value/);
+  rmSync(dir, { recursive: true, force: true });
+
+  const help = runCli(["help"]);
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /--canary-bot=<your-app>\[bot\]/, "global help must document --canary-bot");
+});
+
 test("init renders every supported Anthropic authentication mode consistently", async (t) => {
   const expectations = {
     "api-key": "anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}",


### PR DESCRIPTION
Fixes #229.

## What was broken
`init`'s closing checklist tells the user to re-run it with `--canary-bot=<your-app>[bot]` to enable the weekly canary, but the flag was missing from `validateLocalFlags`'s allowlist in `cli.mjs` — the CLI rejected it with `Unknown option: --canary-bot` before `init()` ever ran. The documented path to enable the canary was unreachable, and the watchtower reports the resulting default-skip as healthy rather than as a misconfiguration.

## Fix
Added `canary-bot` to the `init` allowlist, to the value-taking flags list (it takes a value), and to the global help text.

## Verification
- New tests in `packages/cli/test/init.test.mjs`: one runs `init` with `--canary-bot=my-app[bot]` and asserts it's rendered into `facility-crew.yml` (and that the default doesn't leak in when overridden); the other asserts a valueless `--canary-bot` still errors correctly and that `--canary-bot` is documented in global help.
- Reverted the fix locally and reran: both new tests fail with exactly `Unknown option: --canary-bot`, nothing else. Reapplied — both pass.
- Ran the full `packages/cli` suite (108 tests): no new failures. 12 tests already fail on a clean checkout of `main` on this machine (chmod-permission assertions, fixtures needing infra unavailable here) — confirmed against an unmodified checkout with the same command, unrelated to this change.
- Manually reproduced the issue's exact repro command end to end against a temp repo, before and after the fix.