### PR TITLE
docs: add email fallback when private advisories are disabled

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,11 @@ itself.
 
 ## Reporting
 
-Report privately via [GitHub Security Advisories](https://github.com/theam/facility/security/advisories/new).
-Please don't open public issues for suspected vulnerabilities. We'll respond
-within five working days.
+Report privately via [GitHub Security Advisories](https://github.com/theam/facility/security/advisories/new)
+when private reporting is enabled on the repository. If that form is unavailable,
+email **security@theagilemonkeys.com** with a short description and reproduction
+steps instead. Please don't open public issues for suspected vulnerabilities.
+We'll respond within five working days.
 
 In scope, with examples:
 


### PR DESCRIPTION
GitHub private vulnerability reporting can be off for this repo. Point reporters at security@theagilemonkeys.com when the advisory form is unavailable so SECURITY.md matches how people can actually reach us.

The rest of the policy is the current 0.12 text (persistent workspaces, not generated CI workflows).

## Test plan
- [ ] Confirm the advisories form still 404s or is otherwise unavailable for this repo
- [ ] Confirm security@theagilemonkeys.com is the address the team wants in SECURITY.md