### PR TITLE
feat(web): polish project interface

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -29,9 +29,12 @@ export const viewport: Viewport = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // Extensions such as Grammarly inject body attributes before React hydrates.
   return (
     <html lang="en" className={`${plexMono.variable} ${plexSans.variable}`}>
-      <body className="grain min-h-dvh">{children}</body>
+      <body suppressHydrationWarning className="grain min-h-dvh">
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/web/components/ask/ask-bar.tsx
+++ b/apps/web/components/ask/ask-bar.tsx
@@ -78,7 +78,7 @@ export function AskBar({ projectId }: { projectId: string }) {
           <AskComposer
             projectId={projectId}
             conversationId={conversationId}
-            placeholder="chat with the digital product owner ( / to focus )"
+            placeholder="talk with the product owner ( / to focus )"
             inputRef={inputRef}
             onTurnStarted={({ conversationId: nextId, runId, question }) => {
               setConversationId(nextId);

--- a/apps/web/components/ask/ask-composer.tsx
+++ b/apps/web/components/ask/ask-composer.tsx
@@ -15,7 +15,7 @@ export type TurnStart = { conversationId: string; runId: string; question: strin
 export function AskComposer({
   projectId,
   conversationId,
-  placeholder = "chat with the digital product owner",
+  placeholder = "talk with the product owner",
   inputRef: externalRef,
   onTurnStarted,
 }: {
@@ -107,7 +107,7 @@ export function AskComposer({
           data-lpignore="true"
           data-bwignore="true"
           data-form-type="other"
-          aria-label="Chat with the digital product owner"
+          aria-label="Talk with the product owner"
           value={value}
           onChange={(event) => {
             setValue(event.target.value);

--- a/apps/web/components/shell/nav-icons.tsx
+++ b/apps/web/components/shell/nav-icons.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+
+export type NavIconName =
+  | "activity"
+  | "agents"
+  | "approvals"
+  | "audit"
+  | "overview"
+  | "product"
+  | "projects"
+  | "runs"
+  | "settings"
+  | "skills"
+  | "stories";
+
+const shapes: Record<NavIconName, ReactNode> = {
+  activity: <path d="M1.5 8h3l1.5-3.5L8.5 11l1.5-3h4.5" />,
+  agents: (
+    <>
+      <rect x="4" y="4" width="8" height="8" />
+      <path d="M6 1.5V4m4-2.5V4M6 12v2.5m4-2.5v2.5M1.5 6H4m-2.5 4H4m8-4h2.5M12 10h2.5" />
+    </>
+  ),
+  approvals: (
+    <>
+      <rect x="2" y="2" width="12" height="12" />
+      <path d="m4.5 8 2.25 2.25L11.5 5.5" />
+    </>
+  ),
+  audit: (
+    <>
+      <circle cx="8" cy="8" r="6" />
+      <path d="M8 4.5V8l2.5 1.5" />
+    </>
+  ),
+  overview: (
+    <>
+      <rect x="2" y="2" width="5" height="12" />
+      <rect x="9" y="2" width="5" height="5" />
+      <rect x="9" y="9" width="5" height="5" />
+    </>
+  ),
+  product: (
+    <>
+      <path d="M3 1.75h7l3 3v9.5H3z" />
+      <path d="M10 1.75v3h3M5.5 7.5h5m-5 3h5" />
+    </>
+  ),
+  projects: (
+    <>
+      <rect x="2" y="4" width="9" height="9" />
+      <path d="M5 4V2h9v9h-3" />
+    </>
+  ),
+  runs: (
+    <>
+      <rect x="1.75" y="2.25" width="12.5" height="11.5" />
+      <path d="m4 5.25 2.25 2.25L4 9.75M8.25 10h3.5" />
+    </>
+  ),
+  settings: (
+    <>
+      <path d="M2 4h3m3 0h6M2 11h7m3 0h2" />
+      <rect x="5" y="2.5" width="3" height="3" />
+      <rect x="9" y="9.5" width="3" height="3" />
+    </>
+  ),
+  skills: (
+    <>
+      <path d="M1.5 3.25h4.75C7.22 3.25 8 4.03 8 5v7.75c0-.83-.67-1.5-1.5-1.5h-5z" />
+      <path d="M14.5 3.25H9.75C8.78 3.25 8 4.03 8 5v7.75c0-.83.67-1.5 1.5-1.5h5z" />
+    </>
+  ),
+  stories: (
+    <>
+      <rect x="1.75" y="2" width="3" height="3" />
+      <rect x="11.25" y="2" width="3" height="3" />
+      <rect x="11.25" y="11" width="3" height="3" />
+      <path d="M4.75 3.5h2A2.25 2.25 0 0 1 9 5.75v4.5a2.25 2.25 0 0 0 2.25 2.25M9 7.5h2.25" />
+    </>
+  ),
+};
+
+export function NavIcon({ name, className }: { name: NavIconName; className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="miter"
+      strokeWidth="1.25"
+      viewBox="0 0 16 16"
+    >
+      {shapes[name]}
+    </svg>
+  );
+}

--- a/apps/web/components/shell/nav.tsx
+++ b/apps/web/components/shell/nav.tsx
@@ -4,23 +4,24 @@ import { cx } from "@facility/ui";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { NavIcon, type NavIconName } from "./nav-icons";
 
 export type NavProject = { id: string; slug: string; name?: string };
 
-type NavItem = { href: string; label: string; badge?: number; sub?: string };
+type NavItem = { href: string; icon: NavIconName; label: string; badge?: number };
 
 /** Org mode is the projects dashboard; everything else is the platform beneath it. */
 export function orgNav(): NavItem[] {
-  return [{ href: "/projects", label: "Projects" }];
+  return [{ href: "/projects", icon: "projects", label: "Projects" }];
 }
 
-/** Cross-project operator surfaces — secondary by design; explained, not assumed. */
+/** Cross-project operator surfaces — secondary by design. */
 export function orgPlatformNav(): NavItem[] {
   return [
-    { href: "/sessions", label: "Activity", sub: "live agent work, all projects" },
-    { href: "/harness", label: "Skills & Rules", sub: "what your agents know" },
-    { href: "/audit", label: "Audit log", sub: "every action, recorded" },
-    { href: "/settings", label: "Settings" },
+    { href: "/sessions", icon: "activity", label: "Activity" },
+    { href: "/harness", icon: "skills", label: "Skills & Rules" },
+    { href: "/audit", icon: "audit", label: "Audit log" },
+    { href: "/settings", icon: "settings", label: "Settings" },
   ];
 }
 
@@ -28,22 +29,18 @@ export function orgPlatformNav(): NavItem[] {
 export function projectNav(projectId: string, inboxCount?: number): NavItem[] {
   const base = `/projects/${projectId}`;
   return [
-    { href: base, label: "Overview" },
-    {
-      href: `${base}/product`,
-      label: "Product",
-      sub: "decisions & docs — the project's knowledge base",
-    },
-    { href: `${base}/stories`, label: "Stories", sub: "the story of every unit of work" },
-    { href: `${base}/sessions`, label: "Runs", sub: "agent work on this project" },
+    { href: base, icon: "overview", label: "Overview" },
+    { href: `${base}/product`, icon: "product", label: "Product Owner" },
+    { href: `${base}/stories`, icon: "stories", label: "Stories" },
+    { href: `${base}/sessions`, icon: "runs", label: "Runs" },
     {
       href: `${base}/approvals`,
+      icon: "approvals",
       label: "Approvals",
       badge: inboxCount,
-      sub: "decisions waiting on you",
     },
-    { href: `${base}/agents`, label: "Agents" },
-    { href: `${base}/settings`, label: "Settings" },
+    { href: `${base}/agents`, icon: "agents", label: "Agents" },
+    { href: `${base}/settings`, icon: "settings", label: "Settings" },
   ];
 }
 
@@ -73,21 +70,20 @@ function NavLinks({
             onClick={onNavigate}
             aria-current={active ? "page" : undefined}
             className={cx(
-              "group flex items-baseline gap-3 border-l-2 px-5 py-2 text-[13px] transition-colors",
+              "group flex items-center gap-3 border-l-2 px-5 py-3.5 text-[13px] transition-colors lg:py-2",
               active
                 ? "border-(--line-strong) font-medium text-(--ink)"
                 : "border-transparent text-(--mut) hover:text-(--ink)",
             )}
           >
-            <span className={cx("font-mono text-[10px]", active ? "text-(--ink)" : "text-(--dim)")}>
-              {String(i + 1).padStart(2, "0")}
-            </span>
-            <span className="flex min-w-0 flex-col">
-              {item.label}
-              {item.sub ? (
-                <span className="text-[10px] leading-snug text-(--dim)">{item.sub}</span>
-              ) : null}
-            </span>
+            <NavIcon
+              name={item.icon}
+              className={cx(
+                "size-4 shrink-0 transition-colors",
+                active ? "text-(--ink)" : "text-(--dim) group-hover:text-(--ink)",
+              )}
+            />
+            <span className="min-w-0">{item.label}</span>
             {item.badge ? (
               <span className="ml-auto font-mono text-[11px] text-(--human)">{item.badge}</span>
             ) : null}
@@ -129,7 +125,7 @@ function NavSections({
   // Project mode: the sidebar belongs to the project. The way out is explicit
   // (back link on top) and the section is titled by the project itself.
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-6">
       <Link
         href="/projects"
         onClick={onNavigate}
@@ -148,34 +144,17 @@ function NavSections({
   );
 }
 
-function FacilityMark() {
+function FooterSignature() {
   return (
-    <span
-      aria-hidden
-      className="relative h-8 w-8 shrink-0 overflow-hidden rounded-[1.5px] bg-(--card)"
-    >
-      <span className="absolute left-1 right-1 top-1/2 h-px -translate-y-1/2 bg-(--machine)" />
-      <span className="absolute left-[9px] top-2 h-4 w-px bg-(--ink)" />
-      <span className="absolute right-[9px] top-2 h-4 w-px bg-(--ink)" />
-      <span className="absolute left-1/2 top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 bg-(--accent)" />
-    </span>
-  );
-}
-
-function FooterSignature({ compact = false }: { compact?: boolean }) {
-  return (
-    <div className={cx("flex items-center gap-3 px-5", compact && "items-start")}>
-      <FacilityMark />
-      <p className="font-mono text-[10px] leading-relaxed text-(--dim)">
-        An initiative by{" "}
-        <a
-          href="https://theagilemonkeys.com"
-          className="underline-offset-4 hover:text-(--mut) hover:underline"
-        >
-          The Agile Monkeys
-        </a>
-      </p>
-    </div>
+    <p className="px-5 font-mono text-[10px] leading-relaxed text-(--dim)">
+      An initiative by{" "}
+      <a
+        href="https://theagilemonkeys.com"
+        className="underline-offset-4 hover:text-(--mut) hover:underline"
+      >
+        The Agile Monkeys
+      </a>
+    </p>
   );
 }
 
@@ -250,7 +229,7 @@ export function MobileNav({ project, inboxCount }: { project?: NavProject; inbox
             inboxCount={inboxCount}
             onNavigate={() => setOpen(false)}
           />
-          <FooterSignature compact />
+          <FooterSignature />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## What changes

- Simplify the project sidebar by removing descriptive subtitles and numeric prefixes, adding semantic navigation icons, and removing the Facility mark from the initiative footer.
- Rename the Product section to Product Owner and add clearer spacing below the project back link.
- Update the composer copy to “talk with the product owner”.
- Suppress body-level hydration warnings caused by browser extensions that inject attributes before React hydrates.

## Why

The project shell should be faster to scan and use language that matches the Product Owner workflow. Browser-extension attributes should also not trigger a blocking development overlay for an otherwise valid render.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (checked the seeded project in Chrome across Overview and Product Owner; confirmed icons, labels, spacing, composer copy, focus hint, and absence of the hydration overlay)
- [ ] Documentation updated, or no user-facing change
