### PR TITLE
fix(api): route legacy agents by name

### DIFF
--- a/services/api/src/github/agent-routing.ts
+++ b/services/api/src/github/agent-routing.ts
@@ -7,6 +7,28 @@ export function laneFor(repo: typeof repos.$inferSelect, command: string): "repo
   return lane === "platform" ? "platform" : "repo";
 }
 
+export function agentHandlesCommand(
+  agent: Pick<typeof agentDefs.$inferSelect, "name" | "triggers">,
+  command: string,
+) {
+  const triggers = agent.triggers as unknown;
+  if (!Array.isArray(triggers)) return agent.name === command;
+
+  const boundCommands = triggers.flatMap((trigger): string[] => {
+    if (!trigger || typeof trigger !== "object") return [];
+    const value =
+      (trigger as { command?: unknown; handle?: unknown }).command ??
+      (trigger as { handle?: unknown }).handle;
+    return typeof value === "string" ? [value] : [];
+  });
+
+  // Older seeded agents can contain only their manual trigger. The web UI
+  // still promises that every enabled agent is available on demand by name,
+  // so retain that compatibility unless an explicit command binding remaps it.
+  if (boundCommands.length === 0) return agent.name === command;
+  return boundCommands.some((value) => value === command || value === `/${command}`);
+}
+
 export async function findAgentDef(
   db: FacilityDb,
   orgId: string,
@@ -23,15 +45,5 @@ export async function findAgentDef(
         eq(agentDefs.enabled, true),
       ),
     );
-  return rows.find((row) => {
-    const triggers = row.triggers as unknown;
-    if (!Array.isArray(triggers)) return row.name === command;
-    return triggers.some((trigger) => {
-      if (!trigger || typeof trigger !== "object") return false;
-      const value =
-        (trigger as { command?: unknown; handle?: unknown }).command ??
-        (trigger as { handle?: unknown }).handle;
-      return value === command || value === `/${command}`;
-    });
-  });
+  return rows.find((row) => agentHandlesCommand(row, command));
 }

--- a/services/api/test/agent-routing.test.ts
+++ b/services/api/test/agent-routing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { agentHandlesCommand } from "../src/github/agent-routing.js";
+
+describe("agent command routing", () => {
+  it("routes a legacy manual-only agent by its name", () => {
+    expect(
+      agentHandlesCommand(
+        { name: "builder", triggers: [{ type: "manual", config: {} }] },
+        "builder",
+      ),
+    ).toBe(true);
+  });
+
+  it("routes a renamed agent through its explicit command binding", () => {
+    expect(
+      agentHandlesCommand(
+        {
+          name: "delivery-specialist",
+          triggers: [{ type: "github", command: "/builder" }],
+        },
+        "builder",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not override an explicit command remapping with the agent name", () => {
+    expect(
+      agentHandlesCommand(
+        { name: "builder", triggers: [{ type: "command", handle: "/ship" }] },
+        "builder",
+      ),
+    ).toBe(false);
+  });
+});

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -1941,6 +1941,27 @@ describe("api", async () => {
     expect(requiredPolicy.statusCode).toBe(200);
     expect(requiredPolicy.json().builderPlanPolicy).toBe("required");
 
+    const codexBuilder = (
+      await db
+        .select()
+        .from(agentDefs)
+        .where(
+          and(
+            eq(agentDefs.orgId, orgId),
+            eq(agentDefs.projectId, planProjectId),
+            eq(agentDefs.name, "codex-builder"),
+          ),
+        )
+        .limit(1)
+    )[0];
+    if (!codexBuilder) throw new Error("codex builder fixture missing");
+    // Projects seeded before command triggers were introduced retained only
+    // the manual trigger even though the UI advertised /codex-builder.
+    await db
+      .update(agentDefs)
+      .set({ triggers: [{ type: "manual", config: {} }] })
+      .where(eq(agentDefs.id, codexBuilder.id));
+
     await db
       .update(repos)
       .set({ fingerprintStatus: "pending", fingerprintVerifiedAt: null })
@@ -2099,20 +2120,6 @@ describe("api", async () => {
       );
     expect(builderRuns).toHaveLength(1);
     expect(builderRuns[0]?.mode).toBe("codex-builder");
-    const codexBuilder = (
-      await db
-        .select()
-        .from(agentDefs)
-        .where(
-          and(
-            eq(agentDefs.orgId, orgId),
-            eq(agentDefs.projectId, planProjectId),
-            eq(agentDefs.name, "codex-builder"),
-          ),
-        )
-        .limit(1)
-    )[0];
-    if (!codexBuilder) throw new Error("codex builder fixture missing");
     expect(builderRuns[0]).toMatchObject({
       agentDefId: codexBuilder.id,
       engine: codexBuilder.engine,


### PR DESCRIPTION
## Summary

- fall back to an enabled agent's name when its valid trigger array has no
  explicit command or handle binding
- preserve explicit aliases and explicit remappings
- cover the routing helper and the approved-plan executor with regressions for
  legacy manual-only Builders

This aligns the executor with the web UI's existing contract that an enabled
agent is always addressable on demand by its name. It unblocks projects seeded
before GitHub command triggers were added without mutating their stored agent
definitions.

Fixes #253

## Verification

- `pnpm turbo run build --filter='@facility/api^...'`
- `pnpm --filter @facility/api exec vitest run --fileParallelism=false test/agent-routing.test.ts` (3 passed)
- `pnpm --filter @facility/api typecheck`
- `pnpm exec biome check services/api/src/github/agent-routing.ts services/api/test/agent-routing.test.ts services/api/test/api.test.ts`
- `pnpm --filter @facility/api exec vitest run --fileParallelism=false test/api.test.ts -t 'dispatches an approved platform plan to the linked builder'` against local `facility_test` (1 passed)

No deployment or production data mutation is included in this PR.
