### PR TITLE
fix(runs): fence governed retry side effects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ FACILITY_RUNNER_IMAGE=facility-runner:dev
 # Two-phase rollout only: enable after every API replica supports durable
 # repository-write leases and the old replicas have been drained.
 FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION=0
+# Two-phase rollout only: enable after every worker understands immutable
+# governed Builder successors and every old worker has been drained.
+FACILITY_GOVERNED_BUILDER_RETRY_PROMOTION=0
 # URLs as resolved from inside a sandbox, not necessarily browser-facing URLs.
 SANDBOX_API_URL=http://host.docker.internal:4400
 SANDBOX_GATEWAY_URL=http://host.docker.internal:4410

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ FACILITY_SANDBOX_DRIVER=docker
 # runner — build it with `docker build -f runner/Dockerfile -t facility-runner:dev .`. In the
 # Vercel this is a project-scoped VCR repository/tag; AWS fixes it on CodeBuild.
 FACILITY_RUNNER_IMAGE=facility-runner:dev
+# Two-phase rollout only: enable after every API replica supports durable
+# repository-write leases and the old replicas have been drained.
+FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION=0
 # URLs as resolved from inside a sandbox, not necessarily browser-facing URLs.
 SANDBOX_API_URL=http://host.docker.internal:4400
 SANDBOX_GATEWAY_URL=http://host.docker.internal:4410

--- a/apps/docs/docs/self-host/production.md
+++ b/apps/docs/docs/self-host/production.md
@@ -68,6 +68,23 @@ with compose.
 
 5. Start or roll the services in this order: `api`, `worker`, `gateway`, `mcp`,
    then optional `web`.
+
+   Repository-write tracking uses an explicit two-phase promotion during the
+   upgrade that introduces durable write leases:
+
+   1. Deploy the new API and runner everywhere with
+      `FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION=0` (the default). New
+      runners negotiate version `0` and use the legacy token wire format; those
+      runs remain permanently ineligible for governed retry.
+   2. After every old API replica is drained, set
+      `FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION=1` on every API replica.
+      New handshakes then negotiate version `1`, and every write token is
+      backed by a durable repository-write lease.
+
+   Once phase 2 has created any version-1 run, do not roll back to an old API
+   binary until all version-1 runs are terminal and drained. The promotion flag
+   controls only new `/hello` negotiation: a new API always enforces an existing
+   version-1 marker even when the flag is off.
 6. Bootstrap the first owner and issue an API key. On an empty installation,
    run `facility instance bootstrap`, then open `https://<web-host>/api/auth/login`; the configured GitHub user
    signs into the organization already created by bootstrap. With the optional web

--- a/apps/docs/docs/self-host/production.md
+++ b/apps/docs/docs/self-host/production.md
@@ -85,6 +85,19 @@ with compose.
    binary until all version-1 runs are terminal and drained. The promotion flag
    controls only new `/hello` negotiation: a new API always enforces an existing
    version-1 marker even when the flag is off.
+
+   Governed Builder successor retries use a second, independent two-phase gate:
+
+   1. Deploy the migration, API, and worker everywhere with
+      `FACILITY_GOVERNED_BUILDER_RETRY_PROMOTION=0` (the default). Drain every
+      worker that predates immutable retry-lineage validation.
+   2. Set `FACILITY_GOVERNED_BUILDER_RETRY_PROMOTION=1` on every API replica.
+      Only then can `POST /v1/runs/:runId/retry` create successor rows.
+
+   Once any successor row exists, do not reintroduce an old API or worker binary
+   until every successor is terminal and drained. Turning the promotion flag
+   off stops creation only; upgraded workers continue to enforce and dispatch
+   already-created successors.
 6. Bootstrap the first owner and issue an API key. On an empty installation,
    run `facility instance bootstrap`, then open `https://<web-host>/api/auth/login`; the configured GitHub user
    signs into the organization already created by bootstrap. With the optional web

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -30,6 +30,7 @@ export const ID_PREFIXES = {
   evt: "evt",
   int: "int",
   fp: "fp",
+  rwl: "rwl",
 } as const;
 
 export type IdPrefix = keyof typeof ID_PREFIXES;

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -113,6 +113,7 @@ describe("ids", () => {
   it("creates prefixed uuidv7 ids", () => {
     expect(newId("proj")).toMatch(/^proj_[0-9a-f]{32}$/);
     expect(newId("pvh")).toMatch(/^pvh_[0-9a-f]{32}$/);
+    expect(newId("rwl")).toMatch(/^rwl_[0-9a-f]{32}$/);
   });
 });
 

--- a/packages/db/migrations/0044_run_repository_write_leases.sql
+++ b/packages/db/migrations/0044_run_repository_write_leases.sql
@@ -1,0 +1,216 @@
+-- A run is retry-eligible with zero lease rows only after a runner that speaks
+-- the tracked write protocol has completed its authenticated hello handshake.
+ALTER TABLE runs
+  ADD COLUMN IF NOT EXISTS repository_write_tracking_version integer NOT NULL DEFAULT 0;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runs_repository_write_tracking_version_check'
+      AND conrelid = 'runs'::regclass
+  ) THEN
+    ALTER TABLE runs
+      ADD CONSTRAINT runs_repository_write_tracking_version_check
+      CHECK (repository_write_tracking_version IN (0, 1));
+  END IF;
+END
+$$;
+
+-- Version 1 is evidence, not ordinary mutable configuration. Historical rows
+-- always insert at 0; the only promotion is the authenticated one-shot hello
+-- claim that moves the same run from provisioning to running.
+CREATE OR REPLACE FUNCTION enforce_repository_write_tracking_handshake()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.repository_write_tracking_version <> 0 THEN
+      RAISE EXCEPTION 'repository write tracking must be negotiated by hello'
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF NEW.repository_write_tracking_version IS DISTINCT FROM OLD.repository_write_tracking_version
+    AND NOT (
+      OLD.repository_write_tracking_version = 0
+      AND NEW.repository_write_tracking_version = 1
+      AND OLD.status = 'provisioning'
+      AND NEW.status = 'running'
+    )
+  THEN
+    RAISE EXCEPTION 'invalid repository write tracking transition'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS runs_repository_write_tracking_guard ON runs;
+
+CREATE TRIGGER runs_repository_write_tracking_guard
+BEFORE INSERT OR UPDATE OF repository_write_tracking_version
+ON runs
+FOR EACH ROW
+EXECUTE FUNCTION enforce_repository_write_tracking_handshake();
+
+-- A repository write credential can outlive the runner request that obtained
+-- it. Persist the exact repository/base/branch intent before issuance so a
+-- later governed retry can prove that no ambiguous remote output exists.
+CREATE TABLE IF NOT EXISTS run_repository_write_leases (
+  id text PRIMARY KEY,
+  org_id text NOT NULL REFERENCES orgs(id),
+  project_id text NOT NULL REFERENCES projects(id),
+  run_id text NOT NULL REFERENCES runs(id),
+  repo_id text NOT NULL REFERENCES repos(id),
+  provider text NOT NULL,
+  status text NOT NULL DEFAULT 'reserved',
+  requested_branch text NOT NULL,
+  authorized_branch text NOT NULL,
+  base_sha text NOT NULL,
+  permissions jsonb NOT NULL,
+  issued_at timestamptz,
+  expires_at timestamptz,
+  failure_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT run_repository_write_leases_provider_check
+    CHECK (provider IN ('github_installation', 'configured_fallback')),
+  CONSTRAINT run_repository_write_leases_status_check
+    CHECK (status IN ('reserved', 'issued', 'failed')),
+  CONSTRAINT run_repository_write_leases_base_sha_check
+    CHECK (base_sha ~ '^[0-9a-f]{40}$'),
+  CONSTRAINT run_repository_write_leases_branch_check
+    CHECK (
+      char_length(requested_branch) BETWEEN 1 AND 255
+      AND requested_branch = btrim(requested_branch)
+      AND requested_branch !~ '[[:cntrl:]]'
+      AND char_length(authorized_branch) BETWEEN 1 AND 255
+      AND authorized_branch = btrim(authorized_branch)
+      AND authorized_branch !~ '[[:cntrl:]]'
+    ),
+  CONSTRAINT run_repository_write_leases_permissions_check
+    CHECK (permissions IN ('["contents"]'::jsonb, '["contents", "workflows"]'::jsonb)),
+  CONSTRAINT run_repository_write_leases_state_check
+    CHECK (
+      (
+        status = 'reserved'
+        AND issued_at IS NULL
+        AND expires_at IS NULL
+        AND failure_reason IS NULL
+      )
+      OR (
+        status = 'failed'
+        AND issued_at IS NULL
+        AND expires_at IS NULL
+        AND failure_reason IS NOT NULL
+      )
+      OR (
+        status = 'issued'
+        AND issued_at IS NOT NULL
+        AND failure_reason IS NULL
+        AND (
+          (
+            provider = 'github_installation'
+            AND expires_at IS NOT NULL
+            AND expires_at > issued_at
+          )
+          OR (provider = 'configured_fallback' AND expires_at IS NULL)
+        )
+      )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS run_repository_write_leases_run_created_idx
+  ON run_repository_write_leases (run_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS run_repository_write_leases_repo_branch_idx
+  ON run_repository_write_leases (org_id, project_id, repo_id, authorized_branch, created_at DESC);
+
+-- IDs are globally unique, but the duplicated tenant columns are deliberate:
+-- they make every later eligibility query tenant-scoped. A trigger prevents a
+-- malformed/manual insert from binding a run or repository from another scope.
+CREATE OR REPLACE FUNCTION enforce_run_repository_write_lease_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM runs AS r
+    JOIN repos AS repo
+      ON repo.id = NEW.repo_id
+    WHERE r.id = NEW.run_id
+      AND r.org_id = NEW.org_id
+      AND r.project_id = NEW.project_id
+      AND repo.org_id = NEW.org_id
+      AND repo.project_id = NEW.project_id
+  ) THEN
+    RAISE EXCEPTION 'run repository write lease scope mismatch'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS run_repository_write_leases_scope_guard
+  ON run_repository_write_leases;
+
+CREATE TRIGGER run_repository_write_leases_scope_guard
+BEFORE INSERT OR UPDATE OF org_id, project_id, run_id, repo_id
+ON run_repository_write_leases
+FOR EACH ROW
+EXECUTE FUNCTION enforce_run_repository_write_lease_scope();
+
+CREATE OR REPLACE FUNCTION enforce_run_repository_write_lease_evidence()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'run repository write lease evidence is append-only'
+      USING ERRCODE = '23514';
+  END IF;
+  IF ROW(
+    NEW.org_id,
+    NEW.project_id,
+    NEW.run_id,
+    NEW.repo_id,
+    NEW.provider,
+    NEW.requested_branch,
+    NEW.authorized_branch,
+    NEW.base_sha,
+    NEW.permissions,
+    NEW.created_at
+  ) IS DISTINCT FROM ROW(
+    OLD.org_id,
+    OLD.project_id,
+    OLD.run_id,
+    OLD.repo_id,
+    OLD.provider,
+    OLD.requested_branch,
+    OLD.authorized_branch,
+    OLD.base_sha,
+    OLD.permissions,
+    OLD.created_at
+  ) THEN
+    RAISE EXCEPTION 'run repository write lease identity is immutable'
+      USING ERRCODE = '23514';
+  END IF;
+  IF OLD.status <> 'reserved' OR NEW.status NOT IN ('issued', 'failed') THEN
+    RAISE EXCEPTION 'invalid run repository write lease transition'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS run_repository_write_leases_evidence_guard
+  ON run_repository_write_leases;
+
+CREATE TRIGGER run_repository_write_leases_evidence_guard
+BEFORE UPDATE OR DELETE
+ON run_repository_write_leases
+FOR EACH ROW
+EXECUTE FUNCTION enforce_run_repository_write_lease_evidence();

--- a/packages/db/migrations/0045_governed_builder_retry_lineage.sql
+++ b/packages/db/migrations/0045_governed_builder_retry_lineage.sql
@@ -1,0 +1,161 @@
+-- Immutable, tenant-scoped lineage for governed Builder successor attempts.
+ALTER TABLE runs
+  ADD COLUMN IF NOT EXISTS retry_of_run_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS runs_org_project_id_uidx
+  ON runs (org_id, project_id, id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'runs_retry_parent_fk'
+      AND conrelid = 'runs'::regclass
+  ) THEN
+    ALTER TABLE runs
+      ADD CONSTRAINT runs_retry_parent_fk
+      FOREIGN KEY (org_id, project_id, retry_of_run_id)
+      REFERENCES runs (org_id, project_id, id);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'runs_retry_not_self_check'
+      AND conrelid = 'runs'::regclass
+  ) THEN
+    ALTER TABLE runs
+      ADD CONSTRAINT runs_retry_not_self_check
+      CHECK (retry_of_run_id IS NULL OR retry_of_run_id <> id);
+  END IF;
+END $$;
+
+-- A parent has at most one direct successor. Repeated attempts form a linear
+-- root -> child -> child chain rather than a tree of competing executions.
+CREATE UNIQUE INDEX IF NOT EXISTS runs_retry_of_run_uidx
+  ON runs (org_id, project_id, retry_of_run_id)
+  WHERE retry_of_run_id IS NOT NULL;
+
+-- Proposal and Architect-run uniqueness identify only the canonical root.
+-- Governed successors deliberately carry the byte-identical accepted trigger.
+DROP INDEX IF EXISTS runs_plan_acceptance_proposal_uidx;
+CREATE UNIQUE INDEX runs_plan_acceptance_proposal_uidx
+  ON runs (org_id, ((trigger->>'proposalId')))
+  WHERE trigger->>'source' = 'plan_acceptance'
+    AND retry_of_run_id IS NULL;
+
+DROP INDEX IF EXISTS runs_plan_acceptance_architect_run_uidx;
+CREATE UNIQUE INDEX runs_plan_acceptance_architect_run_uidx
+  ON runs (org_id, ((trigger->>'architectRunId')))
+  WHERE trigger->>'source' = 'plan_acceptance'
+    AND retry_of_run_id IS NULL;
+
+CREATE OR REPLACE FUNCTION enforce_governed_run_retry_lineage()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  parent runs%ROWTYPE;
+  has_child boolean;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.retry_of_run_id IS NULL THEN
+      RETURN NEW;
+    END IF;
+
+    IF NEW.retry_of_run_id = NEW.id THEN
+      RAISE EXCEPTION 'run retry cannot reference itself'
+        USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_not_self_check';
+    END IF;
+
+    SELECT * INTO parent
+    FROM runs
+    WHERE id = NEW.retry_of_run_id
+      AND org_id = NEW.org_id
+      AND project_id = NEW.project_id
+    FOR SHARE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'run retry parent is not in the same organization and project'
+        USING ERRCODE = '23503', CONSTRAINT = 'runs_retry_parent_fk';
+    END IF;
+    IF parent.status <> 'failed'
+      OR parent.mode NOT IN ('builder', 'codex-builder')
+      OR parent.trigger->>'source' IS DISTINCT FROM 'plan_acceptance'
+    THEN
+      RAISE EXCEPTION 'run retry parent is not a failed plan-linked Builder'
+        USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_parent_state_check';
+    END IF;
+    IF NEW.status <> 'queued'
+      OR NEW.trigger IS DISTINCT FROM parent.trigger
+      OR NEW.agent_def_id IS DISTINCT FROM parent.agent_def_id
+      OR NEW.mode IS DISTINCT FROM parent.mode
+      OR NEW.engine IS DISTINCT FROM parent.engine
+    THEN
+      RAISE EXCEPTION 'run retry identity must exactly match its parent'
+        USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_identity_check';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.retry_of_run_id IS DISTINCT FROM OLD.retry_of_run_id THEN
+    RAISE EXCEPTION 'run retry lineage is immutable'
+      USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_lineage_immutable';
+  END IF;
+
+  -- A failed plan-linked Builder is a sealed execution record, whether or not
+  -- its successor has committed yet. Freezing the parent unconditionally
+  -- closes the concurrent INSERT-child / UPDATE-parent snapshot race: whichever
+  -- statement obtains the parent row lock first, the other statement either
+  -- observes a non-failed parent and rejects or this UPDATE rejects here.
+  IF OLD.status = 'failed'
+    AND OLD.mode IN ('builder', 'codex-builder')
+    AND OLD.trigger->>'source' = 'plan_acceptance'
+  THEN
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+      RAISE EXCEPTION 'failed plan-linked Builder status is immutable'
+        USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_parent_status_immutable';
+    END IF;
+    IF NEW.org_id IS DISTINCT FROM OLD.org_id
+      OR NEW.project_id IS DISTINCT FROM OLD.project_id
+      OR NEW.trigger IS DISTINCT FROM OLD.trigger
+      OR NEW.agent_def_id IS DISTINCT FROM OLD.agent_def_id
+      OR NEW.mode IS DISTINCT FROM OLD.mode
+      OR NEW.engine IS DISTINCT FROM OLD.engine
+    THEN
+      RAISE EXCEPTION 'failed plan-linked Builder execution identity is immutable'
+        USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_parent_identity_immutable';
+    END IF;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM runs child
+    WHERE child.org_id = OLD.org_id
+      AND child.project_id = OLD.project_id
+      AND child.retry_of_run_id = OLD.id
+  ) INTO has_child;
+  IF (OLD.retry_of_run_id IS NOT NULL OR has_child)
+    AND (
+      NEW.org_id IS DISTINCT FROM OLD.org_id
+      OR NEW.project_id IS DISTINCT FROM OLD.project_id
+      OR NEW.trigger IS DISTINCT FROM OLD.trigger
+      OR NEW.agent_def_id IS DISTINCT FROM OLD.agent_def_id
+      OR NEW.mode IS DISTINCT FROM OLD.mode
+      OR NEW.engine IS DISTINCT FROM OLD.engine
+    )
+  THEN
+    RAISE EXCEPTION 'run retry execution identity is immutable'
+      USING ERRCODE = '23514', CONSTRAINT = 'runs_retry_identity_immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS runs_governed_retry_lineage_guard ON runs;
+CREATE TRIGGER runs_governed_retry_lineage_guard
+BEFORE INSERT OR UPDATE OF retry_of_run_id, org_id, project_id, trigger, agent_def_id, mode, engine, status
+ON runs
+FOR EACH ROW
+EXECUTE FUNCTION enforce_governed_run_retry_lineage();

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -485,6 +485,11 @@ export const runs = pgTable(
     mode: text("mode").notNull(),
     engine: text("engine").notNull(),
     status: text("status").notNull().default("queued"),
+    // Zero write-lease rows are meaningful only after the upgraded runner has
+    // explicitly negotiated this protocol during /hello.
+    repositoryWriteTrackingVersion: integer("repository_write_tracking_version")
+      .notNull()
+      .default(0),
     trigger: jsonb("trigger").notNull().default(sql`'{}'::jsonb`),
     sandbox: jsonb("sandbox").notNull().default(sql`'{}'::jsonb`),
     receipt: jsonb("receipt"),
@@ -513,6 +518,10 @@ export const runs = pgTable(
     uniqueIndex("runs_org_ci_repair_key_uidx")
       .on(table.orgId, table.ciRepairKey)
       .where(sql`${table.ciRepairKey} is not null`),
+    check(
+      "runs_repository_write_tracking_version_check",
+      sql`${table.repositoryWriteTrackingVersion} in (0, 1)`,
+    ),
   ],
 );
 
@@ -585,6 +594,95 @@ export const runDeliveries = pgTable(
       sql`${table.status} in ('pending', 'delivering', 'delivered', 'blocked')`,
     ),
     check("run_deliveries_attempts_check", sql`${table.attempts} >= 0`),
+  ],
+);
+
+export const runRepositoryWriteLeases = pgTable(
+  "run_repository_write_leases",
+  {
+    id: text("id").primaryKey(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => orgs.id),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id),
+    runId: text("run_id")
+      .notNull()
+      .references(() => runs.id),
+    repoId: text("repo_id")
+      .notNull()
+      .references(() => repos.id),
+    provider: text("provider").notNull(),
+    status: text("status").notNull().default("reserved"),
+    requestedBranch: text("requested_branch").notNull(),
+    authorizedBranch: text("authorized_branch").notNull(),
+    baseSha: text("base_sha").notNull(),
+    permissions: jsonb("permissions").notNull(),
+    issuedAt: timestamp("issued_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    failureReason: text("failure_reason"),
+    ...timestamps,
+  },
+  (table) => [
+    index("run_repository_write_leases_run_created_idx").on(table.runId, table.createdAt.desc()),
+    index("run_repository_write_leases_repo_branch_idx").on(
+      table.orgId,
+      table.projectId,
+      table.repoId,
+      table.authorizedBranch,
+      table.createdAt.desc(),
+    ),
+    check(
+      "run_repository_write_leases_provider_check",
+      sql`${table.provider} in ('github_installation', 'configured_fallback')`,
+    ),
+    check(
+      "run_repository_write_leases_status_check",
+      sql`${table.status} in ('reserved', 'issued', 'failed')`,
+    ),
+    check("run_repository_write_leases_base_sha_check", sql`${table.baseSha} ~ '^[0-9a-f]{40}$'`),
+    check(
+      "run_repository_write_leases_branch_check",
+      sql`char_length(${table.requestedBranch}) between 1 and 255
+        and ${table.requestedBranch} = btrim(${table.requestedBranch})
+        and ${table.requestedBranch} !~ '[[:cntrl:]]'
+        and char_length(${table.authorizedBranch}) between 1 and 255
+        and ${table.authorizedBranch} = btrim(${table.authorizedBranch})
+        and ${table.authorizedBranch} !~ '[[:cntrl:]]'`,
+    ),
+    check(
+      "run_repository_write_leases_permissions_check",
+      sql`${table.permissions} in ('["contents"]'::jsonb, '["contents", "workflows"]'::jsonb)`,
+    ),
+    check(
+      "run_repository_write_leases_state_check",
+      sql`(
+          ${table.status} = 'reserved'
+          and ${table.issuedAt} is null
+          and ${table.expiresAt} is null
+          and ${table.failureReason} is null
+        ) or (
+          ${table.status} = 'failed'
+          and ${table.issuedAt} is null
+          and ${table.expiresAt} is null
+          and ${table.failureReason} is not null
+        ) or (
+          ${table.status} = 'issued'
+          and ${table.issuedAt} is not null
+          and ${table.failureReason} is null
+          and (
+            (
+              ${table.provider} = 'github_installation'
+              and ${table.expiresAt} is not null
+              and ${table.expiresAt} > ${table.issuedAt}
+            ) or (
+              ${table.provider} = 'configured_fallback'
+              and ${table.expiresAt} is null
+            )
+          )
+        )`,
+    ),
   ],
 );
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -485,6 +485,10 @@ export const runs = pgTable(
     mode: text("mode").notNull(),
     engine: text("engine").notNull(),
     status: text("status").notNull().default("queued"),
+    // Governed Builder retries are immutable successor rows. Composite scope
+    // and identity enforcement lives in migration 0045 because the parent is
+    // another row in this table.
+    retryOfRunId: text("retry_of_run_id"),
     // Zero write-lease rows are meaningful only after the upgraded runner has
     // explicitly negotiated this protocol during /hello.
     repositoryWriteTrackingVersion: integer("repository_write_tracking_version")
@@ -518,6 +522,14 @@ export const runs = pgTable(
     uniqueIndex("runs_org_ci_repair_key_uidx")
       .on(table.orgId, table.ciRepairKey)
       .where(sql`${table.ciRepairKey} is not null`),
+    uniqueIndex("runs_org_project_id_uidx").on(table.orgId, table.projectId, table.id),
+    uniqueIndex("runs_retry_of_run_uidx")
+      .on(table.orgId, table.projectId, table.retryOfRunId)
+      .where(sql`${table.retryOfRunId} is not null`),
+    check(
+      "runs_retry_not_self_check",
+      sql`${table.retryOfRunId} is null or ${table.retryOfRunId} <> ${table.id}`,
+    ),
     check(
       "runs_repository_write_tracking_version_check",
       sql`${table.repositoryWriteTrackingVersion} in (0, 1)`,

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -1242,6 +1242,177 @@ describe("db", async () => {
     ).toHaveLength(1);
   });
 
+  it("enforces tenant-scoped immutable linear Builder retry lineage", async () => {
+    const orgId = newId("org");
+    const projectId = newId("proj");
+    const otherProjectId = newId("proj");
+    await db.insert(schema.orgs).values({
+      id: orgId,
+      name: "Retry Lineage",
+      slug: `retry-lineage-${orgId}`,
+      settings: {},
+    });
+    await db.insert(schema.projects).values([
+      { id: projectId, orgId, name: "Retry Lineage", slug: `retry-${projectId}`, settings: {} },
+      {
+        id: otherProjectId,
+        orgId,
+        name: "Other Retry Lineage",
+        slug: `retry-${otherProjectId}`,
+        settings: {},
+      },
+    ]);
+    for (const source of [undefined, null] as const) {
+      const invalidTrigger = source === undefined ? {} : { source };
+      const invalidParent = (
+        await db
+          .insert(schema.runs)
+          .values({
+            id: newId("run"),
+            orgId,
+            projectId,
+            mode: "builder",
+            engine: "codex",
+            status: "failed",
+            trigger: invalidTrigger,
+            createdBy: { type: "system", id: "invalid-parent" },
+          })
+          .returning()
+      )[0];
+      if (!invalidParent) throw new Error("invalid retry parent fixture missing");
+      await expectCheckViolation(
+        db.insert(schema.runs).values({
+          id: newId("run"),
+          orgId,
+          projectId,
+          retryOfRunId: invalidParent.id,
+          mode: invalidParent.mode,
+          engine: invalidParent.engine,
+          trigger: invalidTrigger,
+          createdBy: { type: "system", id: "invalid-child" },
+        }),
+        { constraintName: "runs_retry_parent_state_check" },
+      );
+    }
+    const trigger = {
+      source: "plan_acceptance",
+      proposalId: newId("prop"),
+      architectRunId: newId("run"),
+      approvedPlan: "Immutable plan",
+    };
+    const root = (
+      await db
+        .insert(schema.runs)
+        .values({
+          id: newId("run"),
+          orgId,
+          projectId,
+          mode: "builder",
+          engine: "codex",
+          status: "failed",
+          trigger,
+          createdBy: { type: "system", id: "test" },
+        })
+        .returning()
+    )[0];
+    if (!root) throw new Error("retry root fixture missing");
+    for (const status of ["queued", "running"] as const) {
+      await expectCheckViolation(
+        db.update(schema.runs).set({ status }).where(eq(schema.runs.id, root.id)),
+        { constraintName: "runs_retry_parent_status_immutable" },
+      );
+    }
+    const child = (
+      await db
+        .insert(schema.runs)
+        .values({
+          id: newId("run"),
+          orgId,
+          projectId,
+          retryOfRunId: root.id,
+          mode: root.mode,
+          engine: root.engine,
+          trigger,
+          createdBy: { type: "system", id: "test" },
+        })
+        .returning()
+    )[0];
+    expect(child?.retryOfRunId).toBe(root.id);
+
+    await expect(
+      db.insert(schema.runs).values({
+        id: newId("run"),
+        orgId,
+        projectId,
+        retryOfRunId: root.id,
+        mode: root.mode,
+        engine: root.engine,
+        trigger,
+        createdBy: { type: "system", id: "duplicate" },
+      }),
+    ).rejects.toMatchObject({
+      cause: { code: "23505", constraint_name: "runs_retry_of_run_uidx" },
+    });
+    await expectCheckViolation(
+      db.insert(schema.runs).values({
+        id: newId("run"),
+        orgId,
+        projectId,
+        retryOfRunId: root.id,
+        mode: root.mode,
+        engine: root.engine,
+        trigger: { ...trigger, approvedPlan: "forged" },
+        createdBy: { type: "system", id: "forged" },
+      }),
+      { constraintName: "runs_retry_identity_check" },
+    );
+    await expect(
+      db.insert(schema.runs).values({
+        id: newId("run"),
+        orgId,
+        projectId: otherProjectId,
+        retryOfRunId: root.id,
+        mode: root.mode,
+        engine: root.engine,
+        trigger,
+        createdBy: { type: "system", id: "cross-project" },
+      }),
+    ).rejects.toMatchObject({ cause: { code: "23503", constraint_name: "runs_retry_parent_fk" } });
+    if (!child) throw new Error("retry child fixture missing");
+    await expectCheckViolation(
+      db.update(schema.runs).set({ mode: "codex-builder" }).where(eq(schema.runs.id, child.id)),
+      { constraintName: "runs_retry_identity_immutable" },
+    );
+    await expectCheckViolation(
+      db
+        .update(schema.runs)
+        .set({ trigger: { ...trigger, approvedPlan: "mutated root" } })
+        .where(eq(schema.runs.id, root.id)),
+      { constraintName: "runs_retry_parent_identity_immutable" },
+    );
+
+    await db
+      .update(schema.runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(schema.runs.id, child.id));
+    const grandchild = (
+      await db
+        .insert(schema.runs)
+        .values({
+          id: newId("run"),
+          orgId,
+          projectId,
+          retryOfRunId: child.id,
+          mode: child.mode,
+          engine: child.engine,
+          trigger,
+          createdBy: { type: "system", id: "test" },
+        })
+        .returning()
+    )[0];
+    expect(grandchild?.retryOfRunId).toBe(child.id);
+  });
+
   it("applies metering precision and index migrations in order", async () => {
     const columns = (await db.execute(
       sql`
@@ -1253,6 +1424,7 @@ describe("db", async () => {
            OR (table_name = 'provider_credentials' AND column_name = 'auth_mode')
            OR (table_name = 'projects' AND column_name = 'builder_plan_policy')
            OR (table_name = 'runs' AND column_name = 'workspace_base_sha')
+           OR (table_name = 'runs' AND column_name = 'retry_of_run_id')
            OR (table_name = 'run_deliveries' AND column_name = 'base_sha')
       `,
     )) as Iterable<{ table_name: string; column_name: string; data_type: string }>;
@@ -1270,6 +1442,7 @@ describe("db", async () => {
     expect(columnTypes.get("provider_credentials.auth_mode")).toBe("text");
     expect(columnTypes.get("projects.builder_plan_policy")).toBe("text");
     expect(columnTypes.get("runs.workspace_base_sha")).toBe("text");
+    expect(columnTypes.get("runs.retry_of_run_id")).toBe("text");
     expect(columnTypes.get("run_deliveries.base_sha")).toBe("text");
     const indexes = (await db.execute(
       sql`
@@ -1294,6 +1467,7 @@ describe("db", async () => {
           'registry_versions_one_active_uidx',
           'runs_plan_acceptance_proposal_uidx',
           'runs_plan_acceptance_architect_run_uidx',
+          'runs_retry_of_run_uidx',
           'webhook_deliveries_pending_idx',
           'webhook_deliveries_org_created_idx',
           'idempotency_records_expiry_idx',
@@ -1333,6 +1507,7 @@ describe("db", async () => {
         "runs_plan_acceptance_proposal_uidx",
         // Duplicate proposals for one architect plan cannot double-dispatch (migration 0020).
         "runs_plan_acceptance_architect_run_uidx",
+        "runs_retry_of_run_uidx",
         // Durable integration outbox and API replay records (migrations 0021-0022).
         "webhook_deliveries_pending_idx",
         "webhook_deliveries_org_created_idx",
@@ -1401,6 +1576,9 @@ describe("db", async () => {
     // is the newest row in that shared database.
     expect(Array.from(applied).map((row) => row.name)).toContain(
       "0044_run_repository_write_leases.sql",
+    );
+    expect(Array.from(applied).map((row) => row.name)).toContain(
+      "0045_governed_builder_retry_lineage.sql",
     );
     expect(Array.from(applied).map((row) => row.name)).toContain("0043_builder_plan_policy.sql");
     expect(Array.from(applied).map((row) => row.name)).toContain(

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -43,6 +43,35 @@ async function canConnect() {
   }
 }
 
+async function expectCheckViolation(
+  operation: PromiseLike<unknown>,
+  expected: { constraintName?: string; message?: RegExp } = {},
+) {
+  try {
+    await operation;
+    throw new Error("expected Postgres to reject the operation");
+  } catch (error) {
+    let databaseError: unknown = error;
+    while (
+      databaseError &&
+      typeof databaseError === "object" &&
+      "cause" in databaseError &&
+      databaseError.cause
+    ) {
+      databaseError = databaseError.cause;
+    }
+    expect(databaseError).toEqual(
+      expect.objectContaining({
+        code: "23514",
+        ...(expected.constraintName ? { constraint_name: expected.constraintName } : {}),
+      }),
+    );
+    if (expected.message) {
+      expect(String((databaseError as { message?: unknown }).message)).toMatch(expected.message);
+    }
+  }
+}
+
 describe("db", async () => {
   const reachable = await canConnect();
   if (!reachable) {
@@ -234,6 +263,469 @@ describe("db", async () => {
     ).rejects.toMatchObject({
       cause: { code: "23505", constraint_name: "preview_sandboxes_run_uidx" },
     });
+  });
+
+  it("installs the repository-write tracking schema and indexes", async () => {
+    const columns = (await db.execute(
+      sql`
+        SELECT column_name, data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'runs'
+          AND column_name = 'repository_write_tracking_version'
+      `,
+    )) as Iterable<{
+      column_default: string | null;
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+    }>;
+    expect(Array.from(columns)).toEqual([
+      {
+        column_default: "0",
+        column_name: "repository_write_tracking_version",
+        data_type: "integer",
+        is_nullable: "NO",
+      },
+    ]);
+
+    const tableColumns = (await db.execute(
+      sql`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'run_repository_write_leases'
+        ORDER BY ordinal_position
+      `,
+    )) as Iterable<{ column_name: string }>;
+    expect(Array.from(tableColumns).map((row) => row.column_name)).toEqual([
+      "id",
+      "org_id",
+      "project_id",
+      "run_id",
+      "repo_id",
+      "provider",
+      "status",
+      "requested_branch",
+      "authorized_branch",
+      "base_sha",
+      "permissions",
+      "issued_at",
+      "expires_at",
+      "failure_reason",
+      "created_at",
+      "updated_at",
+    ]);
+
+    const indexes = (await db.execute(
+      sql`
+        SELECT indexname, indexdef
+        FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND tablename = 'run_repository_write_leases'
+          AND indexname IN (
+            'run_repository_write_leases_run_created_idx',
+            'run_repository_write_leases_repo_branch_idx'
+          )
+      `,
+    )) as Iterable<{ indexdef: string; indexname: string }>;
+    const indexDefinitions = new Map(
+      Array.from(indexes).map((row) => [row.indexname, row.indexdef.toLowerCase()]),
+    );
+    expect(indexDefinitions.get("run_repository_write_leases_run_created_idx")).toContain(
+      "(run_id, created_at desc)",
+    );
+    expect(indexDefinitions.get("run_repository_write_leases_repo_branch_idx")).toContain(
+      "(org_id, project_id, repo_id, authorized_branch, created_at desc)",
+    );
+
+    const checks = (await db.execute(
+      sql`
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid IN ('runs'::regclass, 'run_repository_write_leases'::regclass)
+          AND conname IN (
+            'runs_repository_write_tracking_version_check',
+            'run_repository_write_leases_provider_check',
+            'run_repository_write_leases_status_check',
+            'run_repository_write_leases_base_sha_check',
+            'run_repository_write_leases_branch_check',
+            'run_repository_write_leases_permissions_check',
+            'run_repository_write_leases_state_check'
+          )
+      `,
+    )) as Iterable<{ conname: string }>;
+    expect(new Set(Array.from(checks).map((row) => row.conname))).toEqual(
+      new Set([
+        "runs_repository_write_tracking_version_check",
+        "run_repository_write_leases_provider_check",
+        "run_repository_write_leases_status_check",
+        "run_repository_write_leases_base_sha_check",
+        "run_repository_write_leases_branch_check",
+        "run_repository_write_leases_permissions_check",
+        "run_repository_write_leases_state_check",
+      ]),
+    );
+  });
+
+  it("keeps repository-write evidence tenant-scoped, canonical, and append-only", async () => {
+    const orgA = newId("org");
+    const orgB = newId("org");
+    const projectA = newId("proj");
+    const projectB = newId("proj");
+    const runA = newId("run");
+    const runB = newId("run");
+    const repoA = newId("repo");
+    const repoB = newId("repo");
+
+    await db.insert(schema.orgs).values([
+      {
+        id: orgA,
+        name: "Repository write evidence A",
+        slug: `repository-write-evidence-${orgA}`,
+        settings: {},
+      },
+      {
+        id: orgB,
+        name: "Repository write evidence B",
+        slug: `repository-write-evidence-${orgB}`,
+        settings: {},
+      },
+    ]);
+    await db.insert(schema.projects).values([
+      {
+        id: projectA,
+        orgId: orgA,
+        name: "Repository write evidence A",
+        slug: "repository-write-evidence",
+        settings: {},
+      },
+      {
+        id: projectB,
+        orgId: orgB,
+        name: "Repository write evidence B",
+        slug: "repository-write-evidence",
+        settings: {},
+      },
+    ]);
+    await db.insert(schema.repos).values([
+      {
+        id: repoA,
+        orgId: orgA,
+        projectId: projectA,
+        owner: "facility-test",
+        name: `repository-write-evidence-${repoA}`,
+        defaultBranch: "main",
+      },
+      {
+        id: repoB,
+        orgId: orgB,
+        projectId: projectB,
+        owner: "facility-test",
+        name: `repository-write-evidence-${repoB}`,
+        defaultBranch: "main",
+      },
+    ]);
+    const insertedRuns = await db
+      .insert(schema.runs)
+      .values([
+        {
+          id: runA,
+          orgId: orgA,
+          projectId: projectA,
+          mode: "builder",
+          engine: "codex",
+          status: "provisioning",
+          createdBy: { type: "test", id: "repository-write-evidence" },
+        },
+        {
+          id: runB,
+          orgId: orgB,
+          projectId: projectB,
+          mode: "builder",
+          engine: "codex",
+          createdBy: { type: "test", id: "repository-write-evidence" },
+        },
+      ])
+      .returning({
+        id: schema.runs.id,
+        trackingVersion: schema.runs.repositoryWriteTrackingVersion,
+      });
+    expect(new Map(insertedRuns.map((run) => [run.id, run.trackingVersion]))).toEqual(
+      new Map([
+        [runA, 0],
+        [runB, 0],
+      ]),
+    );
+    await db
+      .update(schema.runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(schema.runs.id, runA));
+    await expectCheckViolation(
+      db.insert(schema.runs).values({
+        id: newId("run"),
+        orgId: orgA,
+        projectId: projectA,
+        mode: "builder",
+        engine: "codex",
+        repositoryWriteTrackingVersion: 1,
+        createdBy: { type: "test", id: "forged-repository-write-tracking" },
+      }),
+      { message: /must be negotiated by hello/ },
+    );
+    await expectCheckViolation(
+      db
+        .update(schema.runs)
+        .set({ repositoryWriteTrackingVersion: 1 })
+        .where(eq(schema.runs.id, runB)),
+      { message: /invalid repository write tracking transition/ },
+    );
+    await expectCheckViolation(
+      db
+        .update(schema.runs)
+        .set({ repositoryWriteTrackingVersion: 0 })
+        .where(eq(schema.runs.id, runA)),
+      { message: /invalid repository write tracking transition/ },
+    );
+    await expectCheckViolation(
+      db
+        .update(schema.runs)
+        .set({ repositoryWriteTrackingVersion: 2 })
+        .where(eq(schema.runs.id, runA)),
+      { message: /invalid repository write tracking transition/ },
+    );
+
+    const baseSha = "1".repeat(40);
+    const alternateBaseSha = "2".repeat(40);
+    const lease = (
+      overrides: Partial<typeof schema.runRepositoryWriteLeases.$inferInsert> = {},
+    ): typeof schema.runRepositoryWriteLeases.$inferInsert => ({
+      id: `rwl_${randomUUID().replaceAll("-", "")}`,
+      orgId: orgA,
+      projectId: projectA,
+      runId: runA,
+      repoId: repoA,
+      provider: "github_installation",
+      status: "reserved",
+      requestedBranch: "facility/run-a",
+      authorizedBranch: "facility/run-a",
+      baseSha,
+      permissions: ["contents"],
+      ...overrides,
+    });
+
+    await expectCheckViolation(
+      db.insert(schema.runRepositoryWriteLeases).values(
+        lease({
+          orgId: orgB,
+          projectId: projectB,
+        }),
+      ),
+      { message: /scope mismatch/ },
+    );
+    await expectCheckViolation(
+      db.insert(schema.runRepositoryWriteLeases).values(
+        lease({
+          repoId: repoB,
+        }),
+      ),
+      { message: /scope mismatch/ },
+    );
+
+    const invalidLeases: Array<{
+      constraintName: string;
+      label: string;
+      values: Partial<typeof schema.runRepositoryWriteLeases.$inferInsert>;
+    }> = [
+      {
+        label: "unknown provider",
+        constraintName: "run_repository_write_leases_provider_check",
+        values: { provider: "github_pat" },
+      },
+      {
+        label: "uppercase base SHA",
+        constraintName: "run_repository_write_leases_base_sha_check",
+        values: { baseSha: "A".repeat(40) },
+      },
+      {
+        label: "non-canonical requested branch",
+        constraintName: "run_repository_write_leases_branch_check",
+        values: { requestedBranch: " facility/run-a" },
+      },
+      {
+        label: "control character in authorized branch",
+        constraintName: "run_repository_write_leases_branch_check",
+        values: { authorizedBranch: "facility/\u0007run-a" },
+      },
+      {
+        label: "permissions in non-canonical order",
+        constraintName: "run_repository_write_leases_permissions_check",
+        values: { permissions: ["workflows", "contents"] },
+      },
+      {
+        label: "duplicate permissions",
+        constraintName: "run_repository_write_leases_permissions_check",
+        values: { permissions: ["contents", "contents"] },
+      },
+      {
+        label: "reserved row carrying issuance evidence",
+        constraintName: "run_repository_write_leases_state_check",
+        values: { issuedAt: new Date() },
+      },
+      {
+        label: "installation issuance without an expiry",
+        constraintName: "run_repository_write_leases_state_check",
+        values: { status: "issued", issuedAt: new Date() },
+      },
+      {
+        label: "installation expiry before issuance",
+        constraintName: "run_repository_write_leases_state_check",
+        values: {
+          status: "issued",
+          issuedAt: new Date("2026-01-01T00:00:01.000Z"),
+          expiresAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      },
+      {
+        label: "fallback issuance carrying a fabricated expiry",
+        constraintName: "run_repository_write_leases_state_check",
+        values: {
+          provider: "configured_fallback",
+          status: "issued",
+          issuedAt: new Date("2026-01-01T00:00:00.000Z"),
+          expiresAt: new Date("2026-01-01T01:00:00.000Z"),
+        },
+      },
+      {
+        label: "failed row without a reason",
+        constraintName: "run_repository_write_leases_state_check",
+        values: { status: "failed" },
+      },
+    ];
+    for (const invalid of invalidLeases) {
+      await expectCheckViolation(
+        db.insert(schema.runRepositoryWriteLeases).values(lease(invalid.values)),
+        { constraintName: invalid.constraintName },
+      );
+    }
+
+    const issuedLease = lease({
+      permissions: ["contents", "workflows"],
+      requestedBranch: "facility/run-a-issued",
+      authorizedBranch: "facility/run-a-issued",
+    });
+    const failedLease = lease({
+      requestedBranch: "facility/run-a-failed",
+      authorizedBranch: "facility/run-a-failed",
+    });
+    const fallbackLease = lease({
+      provider: "configured_fallback",
+      requestedBranch: "facility/run-a-fallback",
+      authorizedBranch: "facility/run-a-fallback",
+    });
+    const immutableLease = lease({
+      requestedBranch: "facility/run-a-immutable",
+      authorizedBranch: "facility/run-a-immutable",
+    });
+    await db
+      .insert(schema.runRepositoryWriteLeases)
+      .values([issuedLease, failedLease, fallbackLease, immutableLease]);
+    expect(
+      await db
+        .select({ id: schema.runRepositoryWriteLeases.id })
+        .from(schema.runRepositoryWriteLeases)
+        .where(eq(schema.runRepositoryWriteLeases.runId, runA)),
+    ).toHaveLength(4);
+
+    const issuedAt = new Date("2026-01-01T00:00:00.000Z");
+    const expiresAt = new Date("2026-01-01T01:00:00.000Z");
+    await db
+      .update(schema.runRepositoryWriteLeases)
+      .set({ status: "issued", issuedAt, expiresAt })
+      .where(eq(schema.runRepositoryWriteLeases.id, issuedLease.id));
+    await db
+      .update(schema.runRepositoryWriteLeases)
+      .set({ status: "failed", failureReason: "provider denied issuance" })
+      .where(eq(schema.runRepositoryWriteLeases.id, failedLease.id));
+    await db
+      .update(schema.runRepositoryWriteLeases)
+      .set({ status: "issued", issuedAt })
+      .where(eq(schema.runRepositoryWriteLeases.id, fallbackLease.id));
+
+    await expectCheckViolation(
+      db
+        .update(schema.runRepositoryWriteLeases)
+        .set({ status: "failed", issuedAt: null, expiresAt: null, failureReason: "rewritten" })
+        .where(eq(schema.runRepositoryWriteLeases.id, issuedLease.id)),
+      { message: /invalid run repository write lease transition/ },
+    );
+    await expectCheckViolation(
+      db
+        .update(schema.runRepositoryWriteLeases)
+        .set({ status: "issued", issuedAt, expiresAt, failureReason: null })
+        .where(eq(schema.runRepositoryWriteLeases.id, failedLease.id)),
+      { message: /invalid run repository write lease transition/ },
+    );
+    await expectCheckViolation(
+      db
+        .update(schema.runRepositoryWriteLeases)
+        .set({ status: "reserved" })
+        .where(eq(schema.runRepositoryWriteLeases.id, immutableLease.id)),
+      { message: /invalid run repository write lease transition/ },
+    );
+
+    const identityMutations: Array<{
+      label: string;
+      values: Partial<typeof schema.runRepositoryWriteLeases.$inferInsert>;
+    }> = [
+      { label: "provider", values: { provider: "configured_fallback" } },
+      { label: "requested branch", values: { requestedBranch: "facility/changed-request" } },
+      { label: "authorized branch", values: { authorizedBranch: "facility/changed-authority" } },
+      { label: "base SHA", values: { baseSha: alternateBaseSha } },
+      { label: "permissions", values: { permissions: ["contents", "workflows"] } },
+      { label: "creation time", values: { createdAt: new Date("2025-01-01T00:00:00.000Z") } },
+      {
+        label: "tenant and repository identity",
+        values: {
+          orgId: orgB,
+          projectId: projectB,
+          runId: runB,
+          repoId: repoB,
+        },
+      },
+    ];
+    for (const mutation of identityMutations) {
+      await expectCheckViolation(
+        db
+          .update(schema.runRepositoryWriteLeases)
+          .set(mutation.values)
+          .where(eq(schema.runRepositoryWriteLeases.id, immutableLease.id)),
+        { message: /identity is immutable/ },
+      );
+    }
+    await expectCheckViolation(
+      db
+        .delete(schema.runRepositoryWriteLeases)
+        .where(eq(schema.runRepositoryWriteLeases.id, issuedLease.id)),
+      { message: /evidence is append-only/ },
+    );
+
+    const finalRows = await db
+      .select({
+        failureReason: schema.runRepositoryWriteLeases.failureReason,
+        id: schema.runRepositoryWriteLeases.id,
+        status: schema.runRepositoryWriteLeases.status,
+      })
+      .from(schema.runRepositoryWriteLeases)
+      .where(eq(schema.runRepositoryWriteLeases.runId, runA));
+    expect(finalRows).toEqual(
+      expect.arrayContaining([
+        { id: issuedLease.id, status: "issued", failureReason: null },
+        { id: failedLease.id, status: "failed", failureReason: "provider denied issuance" },
+        { id: fallbackLease.id, status: "issued", failureReason: null },
+        { id: immutableLease.id, status: "reserved", failureReason: null },
+      ]),
+    );
   });
 
   it("runs schema and system-data reconciliation behind one deploy entry point", async () => {
@@ -907,6 +1399,9 @@ describe("db", async () => {
     // A developer database can include later migrations from another worktree;
     // assert this checkout's latest migration was applied without assuming it
     // is the newest row in that shared database.
+    expect(Array.from(applied).map((row) => row.name)).toContain(
+      "0044_run_repository_write_leases.sql",
+    );
     expect(Array.from(applied).map((row) => row.name)).toContain("0043_builder_plan_policy.sql");
     expect(Array.from(applied).map((row) => row.name)).toContain(
       "0042_run_base_sha_provenance.sql",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -6594,6 +6594,10 @@
                       "status": {
                         "type": "string"
                       },
+                      "retryOfRunId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
                       "trigger": {
                         "type": "object",
                         "additionalProperties": {}
@@ -6728,6 +6732,7 @@
                       "mode",
                       "engine",
                       "status",
+                      "retryOfRunId",
                       "trigger",
                       "sandbox",
                       "receipt",
@@ -6928,6 +6933,10 @@
                     "status": {
                       "type": "string"
                     },
+                    "retryOfRunId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "trigger": {
                       "type": "object",
                       "additionalProperties": {}
@@ -7062,6 +7071,7 @@
                     "mode",
                     "engine",
                     "status",
+                    "retryOfRunId",
                     "trigger",
                     "sandbox",
                     "receipt",
@@ -7428,6 +7438,10 @@
                     "status": {
                       "type": "string"
                     },
+                    "retryOfRunId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "trigger": {
                       "type": "object",
                       "additionalProperties": {}
@@ -7562,6 +7576,7 @@
                     "mode",
                     "engine",
                     "status",
+                    "retryOfRunId",
                     "trigger",
                     "sandbox",
                     "receipt",
@@ -7893,6 +7908,10 @@
                       "status": {
                         "type": "string"
                       },
+                      "retryOfRunId": {
+                        "nullable": true,
+                        "type": "string"
+                      },
                       "trigger": {
                         "type": "object",
                         "additionalProperties": {}
@@ -8047,6 +8066,7 @@
                       "mode",
                       "engine",
                       "status",
+                      "retryOfRunId",
                       "trigger",
                       "sandbox",
                       "receipt",
@@ -8209,6 +8229,10 @@
                     "status": {
                       "type": "string"
                     },
+                    "retryOfRunId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "trigger": {
                       "type": "object",
                       "additionalProperties": {}
@@ -8343,6 +8367,7 @@
                     "mode",
                     "engine",
                     "status",
+                    "retryOfRunId",
                     "trigger",
                     "sandbox",
                     "receipt",
@@ -8461,8 +8486,27 @@
         "x-facility-permission": "runs:read"
       }
     },
-    "/v1/runs/{runId}/cancel": {
+    "/v1/runs/{runId}/retry": {
       "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "default": {},
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
         "parameters": [
           {
             "schema": {
@@ -8512,6 +8556,10 @@
                       "type": "string"
                     },
                     "status": {
+                      "type": "string"
+                    },
+                    "retryOfRunId": {
+                      "nullable": true,
                       "type": "string"
                     },
                     "trigger": {
@@ -8648,6 +8696,317 @@
                     "mode",
                     "engine",
                     "status",
+                    "retryOfRunId",
+                    "trigger",
+                    "sandbox",
+                    "receipt",
+                    "gh",
+                    "engineSessionId",
+                    "transcriptUri",
+                    "sessionStateUri",
+                    "workspaceBaseSha",
+                    "error",
+                    "queuedAt",
+                    "startedAt",
+                    "endedAt",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The authenticated principal lacks the required permission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource was not found or is outside the principal scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The request conflicts with current resource state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The request rate limit was exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server error occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "A required service is unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postRunsByRunIdRetry",
+        "summary": "Retry run",
+        "tags": [
+          "Runs"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "x-facility-permission": "runs:trigger"
+      }
+    },
+    "/v1/runs/{runId}/cancel": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "runId",
+            "required": true
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Replays the original response for the same principal, path, key, and request body for 24 hours.",
+            "schema": {
+              "type": "string",
+              "minLength": 8,
+              "maxLength": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "orgId": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "agentDefId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "type": "string"
+                    },
+                    "engine": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "retryOfRunId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "trigger": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "sandbox": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "receipt": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "usage": {
+                          "type": "object",
+                          "properties": {
+                            "input_tokens": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "output_tokens": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "cache_read": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "cache_write": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "cost_cents": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "cost_source": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "input_tokens",
+                            "output_tokens",
+                            "cost_cents",
+                            "cost_source"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "events": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "checks": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "checks"
+                          ],
+                          "additionalProperties": {}
+                        }
+                      },
+                      "additionalProperties": {}
+                    },
+                    "gh": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "engineSessionId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "transcriptUri": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "sessionStateUri": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "workspaceBaseSha": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "error": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "queuedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "startedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "endedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "createdBy": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "orgId",
+                    "projectId",
+                    "agentDefId",
+                    "mode",
+                    "engine",
+                    "status",
+                    "retryOfRunId",
                     "trigger",
                     "sandbox",
                     "receipt",
@@ -9794,6 +10153,10 @@
                     "status": {
                       "type": "string"
                     },
+                    "retryOfRunId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "trigger": {
                       "type": "object",
                       "additionalProperties": {}
@@ -9928,6 +10291,7 @@
                     "mode",
                     "engine",
                     "status",
+                    "retryOfRunId",
                     "trigger",
                     "sandbox",
                     "receipt",
@@ -13470,6 +13834,10 @@
                     "status": {
                       "type": "string"
                     },
+                    "retryOfRunId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "trigger": {
                       "type": "object",
                       "additionalProperties": {}
@@ -13604,6 +13972,7 @@
                     "mode",
                     "engine",
                     "status",
+                    "retryOfRunId",
                     "trigger",
                     "sandbox",
                     "receipt",

--- a/packages/sdk/src/routes.ts
+++ b/packages/sdk/src/routes.ts
@@ -140,6 +140,7 @@ export const FACILITY_V1_ROUTES = [
   "POST /v1/runs/:runId/interrupt",
   "POST /v1/runs/:runId/kb-checkpoint",
   "POST /v1/runs/:runId/resume",
+  "POST /v1/runs/:runId/retry",
   "POST /v1/runs/:runId/steer",
   "POST /v1/sandbox-profiles",
   "POST /v1/tasks/:taskId/propose",

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -543,6 +543,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/runs/{runId}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Retry run */
+        post: operations["postRunsByRunIdRetry"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/runs/{runId}/cancel": {
         parameters: {
             query?: never;
@@ -6110,6 +6127,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -6276,6 +6294,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -6541,6 +6560,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -6792,6 +6812,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -6946,6 +6967,166 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
+                        trigger: {
+                            [key: string]: unknown;
+                        };
+                        sandbox: {
+                            [key: string]: unknown;
+                        };
+                        receipt: ({
+                            usage?: {
+                                input_tokens: number;
+                                output_tokens: number;
+                                cache_read?: number;
+                                cache_write?: number;
+                                cost_cents: number;
+                                cost_source: string;
+                            } & {
+                                [key: string]: unknown;
+                            };
+                            events?: {
+                                count: number;
+                                checks: number;
+                            } & {
+                                [key: string]: unknown;
+                            };
+                        } & {
+                            [key: string]: unknown;
+                        }) | null;
+                        gh: {
+                            [key: string]: unknown;
+                        };
+                        engineSessionId: string | null;
+                        transcriptUri: string | null;
+                        sessionStateUri: string | null;
+                        workspaceBaseSha: string | null;
+                        error: string | null;
+                        /** Format: date-time */
+                        queuedAt: string;
+                        /** Format: date-time */
+                        startedAt: string | null;
+                        /** Format: date-time */
+                        endedAt: string | null;
+                        createdBy: {
+                            [key: string]: unknown;
+                        };
+                        /** Format: date-time */
+                        createdAt: string;
+                        /** Format: date-time */
+                        updatedAt: string;
+                    };
+                };
+            };
+            /** @description The request is invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Authentication is required or invalid. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The authenticated principal lacks the required permission. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The requested resource was not found or is outside the principal scope. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The request conflicts with current resource state. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description The request rate limit was exceeded. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description An unexpected server error occurred. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description A required service is unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    postRunsByRunIdRetry: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Replays the original response for the same principal, path, key, and request body for 24 hours. */
+                "Idempotency-Key"?: string;
+            };
+            path: {
+                runId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    reason?: string;
+                } | null;
+            };
+        };
+        responses: {
+            /** @description Default Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        orgId: string;
+                        projectId: string;
+                        agentDefId: string | null;
+                        mode: string;
+                        engine: string;
+                        status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -7098,6 +7279,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -7877,6 +8059,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };
@@ -9664,6 +9847,7 @@ export interface operations {
                         mode: string;
                         engine: string;
                         status: string;
+                        retryOfRunId: string | null;
                         trigger: {
                             [key: string]: unknown;
                         };

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -74,6 +74,20 @@ let activeEngineChild: ReturnType<typeof spawn> | null = null;
 let clearInterruptEscalation: (() => void) | null = null;
 let interruptRequested = false;
 let engineEventTransportDegraded = false;
+let negotiatedRepositoryWriteTrackingVersion: 0 | 1 = 0;
+
+export function repositoryWriteTrackingVersionFromHello(value: unknown): 0 | 1 {
+  return value === 1 ? 1 : 0;
+}
+
+export function repositoryWriteTokenRequest(
+  version: 0 | 1,
+  workflowWrite: boolean,
+  requestedBranch: string,
+  baseSha: string,
+) {
+  return version === 1 ? { workflowWrite, requestedBranch, baseSha } : { workflowWrite };
+}
 
 // Secret values injected into the run (virtual key, platform key, runner token,
 // repo clone token) that must never surface in captured check output persisted to
@@ -116,7 +130,11 @@ async function main() {
     phases.start("bootstrap");
     const hello = await api<Record<string, unknown>>(`/internal/runs/${currentRunId()}/hello`, {
       method: "POST",
+      body: JSON.stringify({ repositoryWriteTrackingVersion: 1 }),
     });
+    negotiatedRepositoryWriteTrackingVersion = repositoryWriteTrackingVersionFromHello(
+      hello.repositoryWriteTrackingVersion,
+    );
     bundle = (await fetchJson(String(hello.bundleUrl), {
       headers: { authorization: `Bearer ${runnerToken()}` },
     })) as RunBundle;
@@ -1909,16 +1927,33 @@ export async function shipGitChanges(
       );
     }
     const workflowWrite = githubWorkflowWriteRequired(changes);
-    const { token } = await api<{ token: string }>(`/internal/runs/${runId}/push-token`, {
+    const { token, authorizedBranch } = await api<{
+      token: string;
+      authorizedBranch: string | null;
+    }>(`/internal/runs/${runId}/push-token`, {
       method: "POST",
-      body: JSON.stringify({ workflowWrite }),
+      body: JSON.stringify(
+        repositoryWriteTokenRequest(
+          negotiatedRepositoryWriteTrackingVersion,
+          workflowWrite,
+          requestedBranch,
+          baseSha,
+        ),
+      ),
     });
     secretsToRedact.add(token);
+    if (
+      negotiatedRepositoryWriteTrackingVersion === 1 &&
+      (!authorizedBranch || (repairRepositoryMode(mode) && authorizedBranch !== requestedBranch))
+    ) {
+      throw new Error("repository_write_authorized_branch_mismatch");
+    }
+    const deliveryBranch = authorizedBranch ?? requestedBranch;
     const published = repairRepositoryMode(mode)
       ? await publishVerifiedGithubBranchUpdate({
           repo,
           token,
-          branch: requestedBranch,
+          branch: deliveryBranch,
           expectedHeadSha: baseSha,
           commitMessage: delivery.commitMessage,
           changes,
@@ -1928,7 +1963,8 @@ export async function shipGitChanges(
       : await publishVerifiedGithubChanges({
           repo,
           token,
-          requestedBranch,
+          authorizedBranch: deliveryBranch,
+          branchReserved: negotiatedRepositoryWriteTrackingVersion === 1,
           baseSha,
           commitMessage: delivery.commitMessage,
           changes,
@@ -2441,7 +2477,9 @@ function objectValue(value: unknown): Record<string, unknown> {
 export async function publishVerifiedGithubChanges(input: {
   repo: string;
   token: string;
-  requestedBranch: string;
+  authorizedBranch: string;
+  /** False only during phase-one rolling compatibility (retry stays denied). */
+  branchReserved?: boolean;
   baseSha: string;
   commitMessage: string;
   changes: GithubFileChange[];
@@ -2450,13 +2488,10 @@ export async function publishVerifiedGithubChanges(input: {
 }) {
   assertGithubCommitMessages(input.commitMessage, input.changes.length, input.runId);
   const request = input.fetchImpl ?? fetch;
-  const branch = await availableGithubBranch(
-    request,
-    input.repo,
-    input.requestedBranch,
-    input.runId,
-    input.token,
-  );
+  const requestedBranch = semanticDeliveryBranch(input.authorizedBranch, "");
+  const branch = input.branchReserved
+    ? requestedBranch
+    : await availableGithubBranch(request, input.repo, requestedBranch, input.runId, input.token);
   await githubRequest(request, `https://api.github.com/repos/${input.repo}/git/refs`, input.token, {
     method: "POST",
     body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: input.baseSha }),

--- a/runner/test/workspace.test.ts
+++ b/runner/test/workspace.test.ts
@@ -45,6 +45,8 @@ import {
   readAgentUpdateMetadata,
   readOnlyEngineProgress,
   readSecurityReport,
+  repositoryWriteTokenRequest,
+  repositoryWriteTrackingVersionFromHello,
   requiresAgentProgress,
   restoreWorkspaceCheckpoint,
   resumeContinuationPrompt,
@@ -794,7 +796,8 @@ describe("workspace preparation", () => {
       publishVerifiedGithubChanges({
         repo: "acme/widget",
         token: "installation-token",
-        requestedBranch: "feature/task",
+        authorizedBranch: "feature/task",
+        branchReserved: true,
         baseSha: "base_sha",
         commitMessage:
           "feat!: deliver task\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
@@ -803,7 +806,7 @@ describe("workspace preparation", () => {
         fetchImpl,
       }),
     ).resolves.toEqual({ branch: "feature/task", headSha: "signed_sha" });
-    const mutation = JSON.parse(String(requests[2]?.init?.body));
+    const mutation = JSON.parse(String(requests[1]?.init?.body));
     expect(mutation.variables.input.message).toEqual({
       headline: "feat!: deliver task",
       body: "Delivered by Facility run run_12345678.\n\nExplain the migration.\n\nBREAKING CHANGE: use the new task API",
@@ -812,9 +815,67 @@ describe("workspace preparation", () => {
       path: "src/task.js",
       contents: "Y29udGVudA==",
     });
-    expect(requests[1]?.init?.headers).toMatchObject({
+    expect(requests[0]?.init?.headers).toMatchObject({
       authorization: "Bearer installation-token",
     });
+    expect(requests).toHaveLength(2);
+  });
+
+  it("negotiates tracked push evidence and keeps the legacy availability probe", async () => {
+    expect(repositoryWriteTrackingVersionFromHello(undefined)).toBe(0);
+    expect(repositoryWriteTrackingVersionFromHello(0)).toBe(0);
+    expect(repositoryWriteTrackingVersionFromHello(1)).toBe(1);
+    expect(repositoryWriteTokenRequest(0, true, "feature/task", "a".repeat(40))).toEqual({
+      workflowWrite: true,
+    });
+    expect(repositoryWriteTokenRequest(1, false, "feature/task", "a".repeat(40))).toEqual({
+      workflowWrite: false,
+      requestedBranch: "feature/task",
+      baseSha: "a".repeat(40),
+    });
+
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      requests.push({ url, init });
+      if (!init?.method || init.method === "GET") {
+        const exists = url.endsWith("/feature/task");
+        return new Response(JSON.stringify({ message: exists ? "exists" : "Not Found" }), {
+          status: exists ? 200 : 404,
+        });
+      }
+      if (init?.method === "POST" && url.endsWith("/git/refs")) {
+        return new Response(JSON.stringify({ ref: "refs/heads/feature/task-12345678" }), {
+          status: 201,
+        });
+      }
+      if (url.endsWith("/graphql")) {
+        return new Response(
+          JSON.stringify({ data: { createCommitOnBranch: { commit: { oid: "legacy_sha" } } } }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ message: "unexpected" }), { status: 500 });
+    };
+    await expect(
+      publishVerifiedGithubChanges({
+        repo: "acme/widget",
+        token: "legacy-token",
+        authorizedBranch: "feature/task",
+        branchReserved: false,
+        baseSha: "base_sha",
+        commitMessage: "fix: deliver legacy task",
+        changes: [{ kind: "addition", path: "task.js", contents: "YQ==" }],
+        runId: "run_12345678",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({ branch: "feature/task-12345678", headSha: "legacy_sha" });
+    expect(
+      requests
+        .slice(0, 2)
+        .every((request) => !request.init?.method || request.init.method === "GET"),
+    ).toBe(true);
+    expect(requests[2]?.init?.method).toBe("POST");
   });
 
   it("fails before publishing when a Conventional Commit prefix cannot fit GitHub", async () => {
@@ -828,7 +889,7 @@ describe("workspace preparation", () => {
       publishVerifiedGithubChanges({
         repo: "acme/widget",
         token: "installation-token",
-        requestedBranch: "feature/task",
+        authorizedBranch: "feature/task",
         baseSha: "base_sha",
         commitMessage: `feat(${"a".repeat(112)}): x`,
         changes: [{ kind: "addition", path: "src/task.js", contents: "Y29udGVudA==" }],

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -30,7 +30,12 @@ import { z } from "zod";
 import { registerAuthorizationServer } from "./auth/authorization-server.js";
 import { readConfig } from "./config.js";
 import { ApiError, sendError } from "./errors.js";
-import { beginIdempotentRequest, completeIdempotentRequest } from "./idempotency.js";
+import {
+  abandonIdempotentRequest,
+  beginIdempotentRequest,
+  completeIdempotentRequest,
+  finalizeIndeterminateIdempotentRequest,
+} from "./idempotency.js";
 import { looksLikeJwt, oauthConfigFromApp, verifyAccessToken } from "./oauth.js";
 import {
   enrichOpenApi,
@@ -43,6 +48,11 @@ import { registerGithubRoutes } from "./routes/github.js";
 import { registerInternalRoutes } from "./routes/internal.js";
 import { registerV1Routes } from "./routes/v1.js";
 import { registerWebhookRoutes } from "./routes/webhooks.js";
+import {
+  acquireExclusiveRunTransitionRequestLease,
+  acquireRunApiKeyRequestLease,
+  acquireSharedRunRequestLease,
+} from "./run-api-key-lease.js";
 import type { AppConfig, Principal } from "./types.js";
 
 const publicRoutes = new Set([
@@ -64,10 +74,27 @@ export async function buildApp(
   });
   const routeRecords: OpenApiRouteRecord[] = [];
   const { db, client } = createDb(config.databaseUrl);
+  // Session advisory locks intentionally outlive individual SQL statements.
+  // Keep them on a small dedicated pool so slow run-key requests can never
+  // consume the application's query pool and deadlock their own handlers.
+  const { client: runRequestLeaseClient } = createDb(config.databaseUrl, { max: 4 });
+  // Writers need a distinct pool: if every shared slot is held by a long
+  // callback, an exclusive transition must still connect and wait on the
+  // advisory lock instead of starving behind the pool's FIFO queue.
+  const { db: runTransitionDb, client: runTransitionLeaseClient } = createDb(config.databaseUrl, {
+    max: 2,
+  });
   app.decorate("facilityDb", db);
   app.decorate("githubClientFactory", undefined);
   app.decorate("githubInstallationTokenFactory", undefined);
   app.decorate("githubAppMetadataReader", undefined);
+  app.decorate("runTransitionDb", runTransitionDb);
+  app.decorate("acquireRunTransitionLease", (runId: string) =>
+    acquireExclusiveRunTransitionRequestLease(runTransitionLeaseClient, runId),
+  );
+  app.decorate("acquireRunRequestLease", (runId: string) =>
+    acquireSharedRunRequestLease(runRequestLeaseClient, runId),
+  );
 
   // Producer-only pg-boss handle: routes enqueue, the worker consumes.
   const boss = new PgBoss({ connectionString: config.databaseUrl });
@@ -184,6 +211,15 @@ export async function buildApp(
   app.decorateRequest("principal", undefined);
   app.decorateRequest("idempotencyId", undefined);
   app.decorateRequest("idempotencyReplayed", false);
+  app.decorateRequest("releasePlatformRunRequestLease", undefined);
+  app.decorateRequest("releaseRunnerRunRequestLease", undefined);
+  app.decorateRequest("releaseRunTransitionLease", undefined);
+  app.decorateRequest("runRequestOperationCount", 0);
+  app.decorateRequest("runRequestAborted", false);
+  app.decorateRequest("runRequestAbortReleaseDeferred", false);
+  app.decorateRequest("runRequestAbortCleanupPromise", undefined);
+  app.decorateRequest("runRequestHandlerStarted", false);
+  app.decorateRequest("runRequestHandlerSettled", false);
   app.decorateRequest(
     "audit",
     async function audit(this: FastifyRequest, action: string, target, payload = {}) {
@@ -255,6 +291,17 @@ export async function buildApp(
       }
     }
     const allowedPermissions = Array.isArray(permission) ? permission : [permission];
+    // A sandbox platform key must never enter a terminal/retry route while it
+    // holds this run's shared request lease. Besides exceeding its purpose,
+    // self-cancel would wait on its own shared lock and cross-cancel could form
+    // an A->B / B->A deadlock. Runner lifecycle uses the separate frt_ channel.
+    if (request.principal.runId && request.routeOptions.config?.runLifecycle === true) {
+      throw new ApiError(
+        403,
+        "run_key_lifecycle_forbidden",
+        "Run-scoped platform keys cannot control run lifecycle",
+      );
+    }
     if (
       !allowedPermissions.some((candidate) => can(request.principal?.permissions ?? [], candidate))
     ) {
@@ -264,33 +311,222 @@ export async function buildApp(
     }
   });
 
+  const releasePlatformRunRequestLease = async (request: FastifyRequest) => {
+    const release = request.releasePlatformRunRequestLease;
+    request.releasePlatformRunRequestLease = undefined;
+    if (release) await release();
+  };
+
+  const releaseRunnerRunRequestLease = async (request: FastifyRequest) => {
+    const release = request.releaseRunnerRunRequestLease;
+    request.releaseRunnerRunRequestLease = undefined;
+    if (release) await release();
+  };
+
+  const releaseRunTransitionLease = async (request: FastifyRequest) => {
+    const release = request.releaseRunTransitionLease;
+    request.releaseRunTransitionLease = undefined;
+    if (release) await release();
+  };
+
+  const releaseAllRunRequestLeases = async (request: FastifyRequest) => {
+    await Promise.all([
+      releasePlatformRunRequestLease(request),
+      releaseRunnerRunRequestLease(request),
+      releaseRunTransitionLease(request),
+    ]);
+  };
+
+  const releaseAbortedIdleRunRequest = async (request: FastifyRequest) => {
+    if (!request.runRequestAborted || (request.runRequestOperationCount ?? 0) !== 0) return;
+    if (request.runRequestAbortCleanupPromise) {
+      await request.runRequestAbortCleanupPromise;
+      return;
+    }
+    // Raw socket close and handler settlement can observe the same idle
+    // request. Single-flight the durable idempotency transition so neither can
+    // release the advisory lease while the other is still sealing the row.
+    const cleanup = (async () => {
+      if (!request.runRequestAborted || (request.runRequestOperationCount ?? 0) !== 0) return;
+      if (request.runRequestHandlerStarted && !request.runRequestHandlerSettled) return;
+      if (request.runRequestAbortReleaseDeferred || request.idempotencyId) {
+        if (request.runRequestHandlerStarted) {
+          await finalizeIndeterminateIdempotentRequest(db, request);
+        } else {
+          await abandonIdempotentRequest(db, request);
+        }
+      }
+      request.runRequestAbortReleaseDeferred = false;
+      await releaseAllRunRequestLeases(request);
+    })();
+    request.runRequestAbortCleanupPromise = cleanup;
+    try {
+      await cleanup;
+    } finally {
+      if (request.runRequestAbortCleanupPromise === cleanup) {
+        request.runRequestAbortCleanupPromise = undefined;
+      }
+    }
+  };
+
+  // An aborted socket does not cancel JavaScript work. Count every pre-handler,
+  // handler, and response hook that can still mutate state; an abort releases
+  // leases only after the last such operation settles. Successful requests keep
+  // their lease until onResponse, including one-shot credential delivery.
+  app.decorate("beginRunRequestOperation", (request: FastifyRequest) => {
+    request.runRequestOperationCount = (request.runRequestOperationCount ?? 0) + 1;
+    let ended = false;
+    return async () => {
+      if (ended) return;
+      ended = true;
+      request.runRequestOperationCount = Math.max(0, (request.runRequestOperationCount ?? 1) - 1);
+      await releaseAbortedIdleRunRequest(request);
+    };
+  });
+
+  app.addHook("onRoute", (route) => {
+    const handler = route.handler;
+    route.handler = async function runRequestLeaseHandler(request, reply) {
+      const endOperation = app.beginRunRequestOperation(request);
+      try {
+        if (request.runRequestAborted || request.raw.aborted) {
+          request.runRequestAborted = true;
+          throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+        }
+        request.runRequestHandlerStarted = true;
+        return await handler.call(this, request, reply);
+      } finally {
+        request.runRequestHandlerSettled = true;
+        await endOperation();
+      }
+    };
+  });
+
+  app.addHook("onTimeout", async (request) => {
+    request.runRequestAborted = true;
+    await releaseAbortedIdleRunRequest(request);
+  });
+  app.addHook("onRequestAbort", async (request) => {
+    request.runRequestAborted = true;
+    await releaseAbortedIdleRunRequest(request);
+  });
+
+  // onRequestAbort covers an incomplete inbound body. A client may also send
+  // its full mutation and disconnect while a pre-handler or onSend barrier is
+  // waiting; Node does not mark IncomingMessage.aborted in that case. Observe
+  // the response socket as well so request-lifetime advisory locks cannot leak.
+  app.addHook("onRequest", async (request, reply) => {
+    reply.raw.once("close", () => {
+      if (reply.raw.writableFinished) return;
+      request.runRequestAborted = true;
+      void releaseAbortedIdleRunRequest(request).catch((error) => {
+        request.log.error({ err: error }, "failed to release aborted run request lease");
+      });
+    });
+  });
+
   app.addHook("preHandler", async (request, reply) => {
-    return beginIdempotentRequest(db, request, reply);
+    const endOperation = app.beginRunRequestOperation(request);
+    try {
+      if (request.runRequestAborted || request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+      }
+      const principal = request.principal;
+      if (
+        reply.sent ||
+        !principal?.runId ||
+        ["GET", "HEAD", "OPTIONS"].includes(request.method.toUpperCase())
+      ) {
+        return;
+      }
+      request.releasePlatformRunRequestLease = await acquireRunApiKeyRequestLease(
+        runRequestLeaseClient,
+        {
+          keyId: principal.id,
+          runId: principal.runId,
+          orgId: principal.orgId,
+          projectId: principal.projectId,
+        },
+      );
+      if (request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+      }
+    } finally {
+      await endOperation();
+    }
+  });
+
+  // Acquire and revalidate before idempotency replay. Otherwise a revoked
+  // run-scoped key could receive a cached success (and mutate the replay row)
+  // after a terminal transition had already won the exclusive lease.
+  app.addHook("preHandler", async (request, reply) => {
+    const endOperation = app.beginRunRequestOperation(request);
+    try {
+      if (request.runRequestAborted || request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+      }
+      const result = await beginIdempotentRequest(db, request, reply);
+      if (request.idempotencyId) request.runRequestAbortReleaseDeferred = true;
+      if (request.runRequestAborted || request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+      }
+      return result;
+    } finally {
+      await endOperation();
+    }
   });
 
   app.addHook("onSend", async (request, reply, payload) => {
-    await completeIdempotentRequest(db, request, reply, payload);
-    return payload;
+    const endOperation = app.beginRunRequestOperation(request);
+    try {
+      // If the transport disappeared before this hook started, the cleanup
+      // owns the idempotency outcome. Await it rather than racing a 409 seal
+      // with persistence of a response the client can no longer receive.
+      await request.runRequestAbortCleanupPromise;
+      if ((request.runRequestAborted || request.raw.aborted) && !request.runRequestHandlerStarted) {
+        request.runRequestAborted = true;
+        await abandonIdempotentRequest(db, request);
+      } else {
+        await completeIdempotentRequest(db, request, reply, payload, {
+          completeServerError: request.runRequestAborted === true,
+        });
+      }
+      return payload;
+    } finally {
+      request.runRequestAbortReleaseDeferred = Boolean(request.idempotencyId);
+      await endOperation();
+    }
   });
 
   app.addHook("onResponse", async (request, reply) => {
-    const permission = request.routeOptions.config?.permission;
-    const action = request.routeOptions.config?.auditAction as string | undefined;
-    if (
-      !permission ||
-      request.idempotencyReplayed ||
-      request.method === "GET" ||
-      reply.statusCode < 200 ||
-      reply.statusCode >= 300 ||
-      !action
-    ) {
-      return;
+    const endOperation = app.beginRunRequestOperation(request);
+    try {
+      if (request.runRequestAborted || request.raw.aborted) return;
+      const permission = request.routeOptions.config?.permission;
+      const action = request.routeOptions.config?.auditAction as string | undefined;
+      if (
+        !permission ||
+        request.idempotencyReplayed ||
+        request.method === "GET" ||
+        reply.statusCode < 200 ||
+        reply.statusCode >= 300 ||
+        !action
+      ) {
+        return;
+      }
+      const params = request.params as Record<string, string | undefined>;
+      await request.audit(action, {
+        type: params.projectId ? "project" : "route",
+        id: params.projectId ?? request.url,
+      });
+    } finally {
+      await endOperation();
+      await releaseAllRunRequestLeases(request);
     }
-    const params = request.params as Record<string, string | undefined>;
-    await request.audit(action, {
-      type: params.projectId ? "project" : "route",
-      id: params.projectId ?? request.url,
-    });
   });
 
   const healthOptions = {
@@ -360,6 +596,10 @@ export async function buildApp(
 
   app.addHook("onClose", async () => {
     if (bossStarted) await boss.stop({ close: true });
+    // Stop shared request holders before closing the pool used by exclusive
+    // transitions that may be waiting on them.
+    await runRequestLeaseClient.end({ timeout: 1 });
+    await runTransitionLeaseClient.end({ timeout: 1 });
     await client.end();
   });
 
@@ -404,6 +644,7 @@ async function resolvePrincipal(
           id: row.key.id,
           orgId: row.key.orgId,
           projectId: row.key.projectId,
+          runId: row.key.runId,
           permissions: row.role.permissions,
         };
       }

--- a/services/api/src/assistant/loop.ts
+++ b/services/api/src/assistant/loop.ts
@@ -10,8 +10,9 @@ import {
 } from "@facility/db";
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
+import { acquireExclusiveRunTransitionTransactionLease } from "../run-api-key-lease.js";
 import { failRun, finishConversationTurn, revokeRunKeys } from "../sandbox/orchestrator.js";
-import { appendRunEvents } from "../sandbox/state.js";
+import { appendRunEvents, readSandbox } from "../sandbox/state.js";
 import type { AppConfig } from "../types.js";
 import { assistantSystemPrompt } from "./prompt.js";
 import { ASSISTANT_TOOLS } from "./tools.js";
@@ -326,11 +327,17 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<void>
       type: "assistant",
       message: { content: [{ type: "text", text }] },
     });
-    const succeeded = await db
-      .update(runs)
-      .set({ status: "succeeded", endedAt: new Date(), updatedAt: new Date() })
-      .where(and(eq(runs.orgId, orgId), eq(runs.id, runId), eq(runs.status, "running")))
-      .returning({ id: runs.id, trigger: runs.trigger });
+    const succeeded = await input.app.runTransitionDb.transaction(async (transaction) => {
+      const tx = transaction as unknown as Db;
+      await acquireExclusiveRunTransitionTransactionLease(tx, runId);
+      const succeeded = await tx
+        .update(runs)
+        .set({ status: "succeeded", endedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(runs.orgId, orgId), eq(runs.id, runId), eq(runs.status, "running")))
+        .returning({ id: runs.id, trigger: runs.trigger, sandbox: runs.sandbox });
+      for (const row of succeeded) await revokeRunKeys(tx, readSandbox(row.sandbox));
+      return succeeded;
+    });
     if (succeeded.length === 0) return; // cancelled mid-flight — cancel path owns cleanup
     await emit("result", { status: "succeeded" });
     const runRow = (
@@ -346,7 +353,14 @@ export async function runAssistantTurn(input: AssistantTurnInput): Promise<void>
     await maybeTitleConversation(db, driver, input, conversationId, text).catch(() => undefined);
   } catch (error) {
     const message = error instanceof Error ? error.message : "assistant_turn_failed";
-    await failRun(db, orgId, runId, message, "assistant_turn_failed").catch(() => undefined);
+    await failRun(
+      db,
+      orgId,
+      runId,
+      message,
+      "assistant_turn_failed",
+      input.app.runTransitionDb,
+    ).catch(() => undefined);
   } finally {
     turns.delete(runId);
     releaseAssistantTurn(runId);

--- a/services/api/src/builder-plan-freshness.ts
+++ b/services/api/src/builder-plan-freshness.ts
@@ -122,9 +122,10 @@ export async function resolveBuilderPlanFreshnessForProposal(
     if (error instanceof ApiError && error.code === "builder_plan_freshness_unavailable") {
       throw error;
     }
-    throw freshnessUnavailable(
-      error instanceof Error ? `github_freshness_error:${error.message}` : "github_freshness_error",
-    );
+    // Provider errors can include URLs, installation identifiers, or request
+    // fragments. Keep the public/audited reason stable and sanitized; the
+    // original exception remains available to process-local observability.
+    throw freshnessUnavailable("github_freshness_error");
   }
 }
 

--- a/services/api/src/builder-plan-policy.ts
+++ b/services/api/src/builder-plan-policy.ts
@@ -13,7 +13,7 @@ import {
   runs,
 } from "@facility/db";
 import { agentDefTriggersBuilder, isBuilderMode } from "@facility/run-objective";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { ApiError } from "./errors.js";
 
 export type BuilderPlanPolicy = "optional" | "required";
@@ -45,6 +45,8 @@ export type BuilderPlanDispatchInput = {
   trigger: unknown;
   gh?: unknown;
   runId?: string | null;
+  /** Canonical root that consumed Gate 1 when dispatching an immutable retry child. */
+  acceptanceRunId?: string | null;
   actor?: AuditInsert["actor"];
   source?: string;
   /** Trusted, live evidence resolved by the canonical executor/worker, never request JSON. */
@@ -108,6 +110,44 @@ export function builderPlanDecision(input: BuilderPlanDecisionInput): BuilderPla
 
 export function builderIdentity(mode: string, agentName?: string | null) {
   return isBuilderMode(mode) || (agentName ? isBuilderMode(agentName) : false);
+}
+
+/**
+ * Generic session resume is intentionally unavailable to every Builder,
+ * regardless of the project's current Gate 1 policy. Builder recovery must
+ * create a governed immutable successor so the original attempt stays sealed.
+ */
+export async function assertGenericRunResumeAllowed(
+  db: FacilityDb,
+  run: Pick<typeof runs.$inferSelect, "orgId" | "projectId" | "agentDefId" | "mode" | "trigger">,
+): Promise<void> {
+  const trigger = objectValue(run.trigger);
+  let isBuilder = builderIdentity(run.mode) || trigger.source === "plan_acceptance";
+  if (!isBuilder && run.agentDefId) {
+    const agent = (
+      await db
+        .select({ name: agentDefs.name, triggers: agentDefs.triggers })
+        .from(agentDefs)
+        .where(
+          and(
+            eq(agentDefs.orgId, run.orgId),
+            eq(agentDefs.projectId, run.projectId),
+            eq(agentDefs.id, run.agentDefId),
+          ),
+        )
+        .limit(1)
+    )[0];
+    isBuilder = Boolean(
+      agent && (builderIdentity(run.mode, agent.name) || agentDefTriggersBuilder(agent.triggers)),
+    );
+  }
+  if (isBuilder) {
+    throw new ApiError(
+      409,
+      "builder_resume_forbidden",
+      "Builder runs must be recovered through a governed immutable retry",
+    );
+  }
 }
 
 export function isBuilderPlanDenialError(error: unknown): error is ApiError {
@@ -394,6 +434,7 @@ async function validatePlanAcceptance(
   ) {
     return invalid("builder_plan_expired", "proposal_expired");
   }
+  const acceptanceRunId = input.acceptanceRunId ?? input.runId;
   const linkedRuns = await db
     .select({ id: runs.id })
     .from(runs)
@@ -403,10 +444,11 @@ async function validatePlanAcceptance(
         eq(runs.projectId, input.projectId),
         sql`${runs.trigger}->>'source' = 'plan_acceptance'`,
         sql`${runs.trigger}->>'proposalId' = ${proposal.id}`,
+        isNull(runs.retryOfRunId),
       ),
     )
     .limit(2);
-  if (linkedRuns.some((run) => run.id !== input.runId)) {
+  if (linkedRuns.some((run) => run.id !== acceptanceRunId)) {
     return invalid("builder_plan_already_consumed", "proposal_linked_to_another_run");
   }
   const architectLinkedRuns = await db
@@ -418,16 +460,17 @@ async function validatePlanAcceptance(
         eq(runs.projectId, input.projectId),
         sql`${runs.trigger}->>'source' = 'plan_acceptance'`,
         sql`${runs.trigger}->>'architectRunId' = ${architectRunId}`,
+        isNull(runs.retryOfRunId),
       ),
     )
     .limit(2);
-  if (architectLinkedRuns.some((run) => run.id !== input.runId)) {
+  if (architectLinkedRuns.some((run) => run.id !== acceptanceRunId)) {
     return invalid("builder_plan_already_consumed", "architect_plan_linked_to_another_run");
   }
   const dispatchingLinkedRun = Boolean(
-    input.runId &&
-      linkedRuns.some((run) => run.id === input.runId) &&
-      architectLinkedRuns.some((run) => run.id === input.runId),
+    acceptanceRunId &&
+      linkedRuns.some((run) => run.id === acceptanceRunId) &&
+      architectLinkedRuns.some((run) => run.id === acceptanceRunId),
   );
   if (proposal.state === "executed" && !dispatchingLinkedRun) {
     return invalid("builder_plan_context_invalid", "executed_proposal_missing_linked_run");

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -50,6 +50,7 @@ const EnvSchema = z
     // seeded default sandbox profile and `facility doctor` both key off this.
     FACILITY_RUNNER_IMAGE: z.string().default("facility-runner:dev"),
     FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION: z.enum(["0", "1"]).default("0"),
+    FACILITY_GOVERNED_BUILDER_RETRY_PROMOTION: z.enum(["0", "1"]).default("0"),
     // Driver the seeded default sandbox profile uses. Must match the deployment:
     // "docker" for local/self-host, "vercel" for managed Sandboxes, or "aws"
     // for the CodeBuild development provider.
@@ -273,6 +274,7 @@ export function readConfig(env = process.env): AppConfig {
     sandboxRunnerImage: parsed.FACILITY_RUNNER_IMAGE,
     repositoryWriteTrackingPromotionEnabled:
       parsed.FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION === "1",
+    governedBuilderRetryPromotionEnabled: parsed.FACILITY_GOVERNED_BUILDER_RETRY_PROMOTION === "1",
     sandboxDriver: parsed.FACILITY_SANDBOX_DRIVER,
     authIdentityProvider: parsed.AUTH_IDENTITY_PROVIDER,
     authCallbackUrl: parsed.AUTH_CALLBACK_URL ?? `${webUrl.replace(/\/$/, "")}/api/auth/callback`,

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -49,6 +49,7 @@ const EnvSchema = z
     // Container image that runs the Facility runner for platform-lane runs. The
     // seeded default sandbox profile and `facility doctor` both key off this.
     FACILITY_RUNNER_IMAGE: z.string().default("facility-runner:dev"),
+    FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION: z.enum(["0", "1"]).default("0"),
     // Driver the seeded default sandbox profile uses. Must match the deployment:
     // "docker" for local/self-host, "vercel" for managed Sandboxes, or "aws"
     // for the CodeBuild development provider.
@@ -270,6 +271,8 @@ export function readConfig(env = process.env): AppConfig {
     sandboxGatewayUrl: parsed.SANDBOX_GATEWAY_URL ?? parsed.GATEWAY_URL,
     gatewayUrl: parsed.GATEWAY_URL,
     sandboxRunnerImage: parsed.FACILITY_RUNNER_IMAGE,
+    repositoryWriteTrackingPromotionEnabled:
+      parsed.FACILITY_REPOSITORY_WRITE_TRACKING_PROMOTION === "1",
     sandboxDriver: parsed.FACILITY_SANDBOX_DRIVER,
     authIdentityProvider: parsed.AUTH_IDENTITY_PROVIDER,
     authCallbackUrl: parsed.AUTH_CALLBACK_URL ?? `${webUrl.replace(/\/$/, "")}/api/auth/callback`,

--- a/services/api/src/executors.ts
+++ b/services/api/src/executors.ts
@@ -41,6 +41,7 @@ import {
 } from "./builder-plan-freshness.js";
 import {
   architectRunIdentityValid,
+  assertGenericRunResumeAllowed,
   builderPlanDenialCode,
   builderPlanRequired,
   lockBuilderPlanPolicy,
@@ -627,6 +628,7 @@ export async function loadPlanBuilderRun(db: Db, proposal: typeof proposals.$inf
           eq(runs.orgId, proposal.orgId),
           eq(runs.projectId, proposal.projectId ?? ""),
           inArray(runs.mode, ["builder", "codex-builder"]),
+          isNull(runs.retryOfRunId),
           sql`${runs.trigger} @> ${JSON.stringify({
             source: "plan_acceptance",
             proposalId: proposal.id,
@@ -648,6 +650,7 @@ async function loadArchitectBuilderRun(db: Db, proposal: typeof proposals.$infer
           eq(runs.orgId, proposal.orgId),
           eq(runs.projectId, proposal.projectId ?? ""),
           inArray(runs.mode, ["builder", "codex-builder"]),
+          isNull(runs.retryOfRunId),
           sql`${runs.trigger} @> ${JSON.stringify({
             source: "plan_acceptance",
             architectRunId: proposal.runId,
@@ -1032,6 +1035,7 @@ async function executeKnownMcpTool(
         .limit(1)
     )[0];
     if (!parent) throw new Error("run_not_found");
+    await assertGenericRunResumeAllowed(db, parent);
     if (!TERMINAL_RUN_STATUSES.includes(parent.status as (typeof TERMINAL_RUN_STATUSES)[number])) {
       throw new Error("run_not_terminal");
     }
@@ -1176,6 +1180,22 @@ async function executeKnownMcpTool(
             .returning()
         )[0];
         if (!conversation) throw new Error("conversation_turn_in_flight");
+        if (conversation.engineSessionId && conversation.lastRunId) {
+          const parent = (
+            await tx
+              .select()
+              .from(runs)
+              .where(
+                and(
+                  eq(runs.orgId, conversation.orgId),
+                  eq(runs.projectId, conversation.projectId),
+                  eq(runs.id, conversation.lastRunId),
+                ),
+              )
+              .limit(1)
+          )[0];
+          if (parent) await assertGenericRunResumeAllowed(tx, parent);
+        }
         const rows = await tx
           .select({ max: sql<number>`coalesce(max(${conversationMessages.seq}), 0)` })
           .from(conversationMessages)

--- a/services/api/src/executors.ts
+++ b/services/api/src/executors.ts
@@ -33,7 +33,7 @@ import {
   webhookDeliveries,
 } from "@facility/db";
 import { artifactIdFor, validate, wsjfValueSection } from "@facility/harness";
-import { and, desc, eq, gt, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, notInArray, sql } from "drizzle-orm";
 import { assertBudgetAgentInProject, resolveBudgetScope } from "./budget-scope.js";
 import {
   type BuilderPlanFreshnessOptions,
@@ -74,8 +74,9 @@ import {
 } from "./harness.js";
 import { MCP_TOOL_PERMISSIONS } from "./mcp-policy.js";
 import { createNextDraftVersion, publishRegistryVersion } from "./registry.js";
-import { cancelRun } from "./sandbox/orchestrator.js";
-import { appendRunEvents, TERMINAL_RUN_STATUSES } from "./sandbox/state.js";
+import { acquireExclusiveRunTransitionTransactionLease } from "./run-api-key-lease.js";
+import { cancelRun, revokeRunKeys } from "./sandbox/orchestrator.js";
+import { appendRunEvents, readSandbox, TERMINAL_RUN_STATUSES } from "./sandbox/state.js";
 import { validateScheduleTrigger } from "./schedules.js";
 import type { AppConfig } from "./types.js";
 
@@ -98,6 +99,7 @@ export type GitHubIssueClient = {
 
 type ExecuteApprovedProposalOptions = {
   config?: AppConfig;
+  transitionDb?: FacilityDb;
   github?: GitHubIssueClient;
   githubFactory?: GithubClientFactory;
   githubClient?: BuilderPlanFreshnessOptions["githubClient"];
@@ -760,22 +762,31 @@ async function assertMcpRequesterStillAuthorized(
   if (requesterType === "key") {
     const key = (
       await db
-        .select({ permissions: roles.permissions, projectId: apiKeys.projectId })
+        .select({
+          permissions: roles.permissions,
+          projectId: apiKeys.projectId,
+          runId: apiKeys.runId,
+          revokedAt: apiKeys.revokedAt,
+          expiresAt: apiKeys.expiresAt,
+        })
         .from(apiKeys)
         .innerJoin(roles, eq(apiKeys.roleId, roles.id))
-        .where(
-          and(
-            eq(apiKeys.orgId, orgId),
-            eq(apiKeys.id, requesterId),
-            isNull(apiKeys.revokedAt),
-            or(isNull(apiKeys.expiresAt), gt(apiKeys.expiresAt, new Date())),
-          ),
-        )
+        .where(and(eq(apiKeys.orgId, orgId), eq(apiKeys.id, requesterId)))
         .limit(1)
     )[0];
+    // Also fence proposals created before the admission guard above existed.
+    // Restoring this capability requires executor-lifetime run leasing; a
+    // revoked/active snapshot check alone cannot close the deferred TOCTOU.
+    if (key?.runId) {
+      throw new Error("run_key_deferred_mcp_forbidden");
+    }
+    const activeKey =
+      key && key.revokedAt === null && (key.expiresAt === null || key.expiresAt > new Date())
+        ? key
+        : undefined;
     assertCurrentMcpAuthority(
-      key?.permissions,
-      key?.projectId ?? null,
+      activeKey?.permissions,
+      activeKey?.projectId ?? null,
       expectedPermission,
       targetProjectId,
     );
@@ -906,19 +917,25 @@ async function executeKnownMcpTool(
   if (toolName === "facility_cancel_run") {
     const runId = requiredString(args.runId, "runId");
     // Guard the transition so a terminal run isn't reopened to "canceled".
-    const row = (
-      await db
-        .update(runs)
-        .set({ status: "canceled", endedAt: new Date(), updatedAt: new Date() })
-        .where(
-          and(
-            eq(runs.orgId, orgId),
-            eq(runs.id, runId),
-            notInArray(runs.status, [...TERMINAL_RUN_STATUSES]),
-          ),
-        )
-        .returning()
-    )[0];
+    const row = await (options.transitionDb ?? db).transaction(async (transaction) => {
+      const tx = transaction as unknown as FacilityDb;
+      await acquireExclusiveRunTransitionTransactionLease(tx, runId);
+      const row = (
+        await tx
+          .update(runs)
+          .set({ status: "canceled", endedAt: new Date(), updatedAt: new Date() })
+          .where(
+            and(
+              eq(runs.orgId, orgId),
+              eq(runs.id, runId),
+              notInArray(runs.status, [...TERMINAL_RUN_STATUSES]),
+            ),
+          )
+          .returning()
+      )[0];
+      if (row) await revokeRunKeys(tx, readSandbox(row.sandbox));
+      return row;
+    });
     if (!row) {
       const current = (
         await db

--- a/services/api/src/github/client.ts
+++ b/services/api/src/github/client.ts
@@ -63,6 +63,7 @@ export type Octokit = {
           head?: { ref?: string; sha?: string };
           base?: { ref?: string };
         }>;
+        headers?: { link?: string };
       }>;
       update: (args: Record<string, unknown>) => Promise<{ data: unknown }>;
       listReviews?: (args: Record<string, unknown>) => Promise<{ data: unknown[] }>;
@@ -167,7 +168,7 @@ export type GithubInstallationTokenFactory = (input: {
   owner: string;
   repo: string;
   permissions?: Record<string, string>;
-}) => Promise<string>;
+}) => Promise<{ token: string; expiresAt: string }>;
 
 export class GithubIssueContextTooLargeError extends Error {
   constructor() {
@@ -248,7 +249,17 @@ export function createGithubInstallationTokenFactory(
         ...(permissions ? { permissions } : {}),
       },
     );
-    return response.data.token;
+    const token = response.data.token;
+    const expiresAt = response.data.expires_at;
+    if (
+      typeof token !== "string" ||
+      token.length === 0 ||
+      typeof expiresAt !== "string" ||
+      !Number.isFinite(new Date(expiresAt).getTime())
+    ) {
+      throw new Error("GitHub installation token response omitted an exact expiry");
+    }
+    return { token, expiresAt };
   };
 }
 
@@ -317,6 +328,22 @@ export class FacilityGithubClient {
       branch: this.repo.defaultBranch,
     });
     return response.data.commit.sha;
+  }
+
+  async assertRepositoryAccessible(): Promise<void> {
+    if (!this.octokit.rest.repos.get) {
+      throw new Error("GitHub repository lookup is unavailable");
+    }
+    const response = await this.octokit.rest.repos.get({
+      owner: this.repo.owner,
+      repo: this.repo.repo,
+    });
+    if (
+      response.data.name.toLowerCase() !== this.repo.repo.toLowerCase() ||
+      response.data.owner?.login?.toLowerCase() !== this.repo.owner.toLowerCase()
+    ) {
+      throw new Error("GitHub repository identity is unavailable");
+    }
   }
 
   async getRef(branch: string): Promise<string> {
@@ -471,6 +498,25 @@ export class FacilityGithubClient {
     });
   }
 
+  async listPullRequestsForHead(
+    head: string,
+  ): Promise<{ pullRequests: unknown[]; hasNextPage: boolean }> {
+    if (!this.octokit.rest.pulls.list) {
+      throw new Error("GitHub pull-request lookup is unavailable");
+    }
+    const response = await this.octokit.rest.pulls.list({
+      owner: this.repo.owner,
+      repo: this.repo.repo,
+      state: "all",
+      head: `${this.repo.owner}:${head}`,
+      per_page: GITHUB_EVIDENCE_PAGE_SIZE,
+    });
+    return {
+      pullRequests: response.data,
+      hasNextPage: /rel="next"/.test(response.headers?.link ?? ""),
+    };
+  }
+
   async getPullRequestDeliveryRef(number: number): Promise<{
     number: number;
     url: string;
@@ -496,6 +542,40 @@ export class FacilityGithubClient {
       headRef: head.ref,
       headSha: head.sha,
       baseRef: base.ref,
+    };
+  }
+
+  async getPullRequestWriteTarget(number: number): Promise<{
+    number: number;
+    state: string;
+    mergedAt: string | null;
+    headRef: string;
+    headSha: string;
+    headRepo: string;
+    baseRef: string;
+    baseRepo: string;
+  }> {
+    if (!this.octokit.rest.pulls.get) {
+      throw new Error("GitHub pull-request lookup is unavailable");
+    }
+    const response = await this.octokit.rest.pulls.get({
+      owner: this.repo.owner,
+      repo: this.repo.repo,
+      pull_number: number,
+    });
+    const { head, base } = response.data;
+    if (!head?.ref || !head.sha || !head.repo?.full_name || !base?.ref || !base.repo?.full_name) {
+      throw new Error("GitHub pull-request write target is unavailable");
+    }
+    return {
+      number: response.data.number,
+      state: response.data.state,
+      mergedAt: response.data.merged_at ?? null,
+      headRef: head.ref,
+      headSha: head.sha,
+      headRepo: head.repo.full_name,
+      baseRef: base.ref,
+      baseRepo: base.repo.full_name,
     };
   }
 

--- a/services/api/src/governed-builder-retry.ts
+++ b/services/api/src/governed-builder-retry.ts
@@ -1,0 +1,940 @@
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { newId } from "@facility/core";
+import {
+  agentDefs,
+  apiKeys,
+  type FacilityDb,
+  insertAuditEvent,
+  outcomes,
+  proposals,
+  repos,
+  runDeliveries,
+  runEvents,
+  runRepositoryWriteLeases,
+  runs,
+  virtualKeys,
+} from "@facility/db";
+import { agentDefTriggersBuilder, isBuilderMode } from "@facility/run-objective";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import {
+  type BuilderPlanFreshnessEvidence,
+  type BuilderPlanFreshnessOptions,
+  resolveBuilderPlanFreshnessForRun,
+} from "./builder-plan-freshness.js";
+import {
+  assertBuilderPlanDispatch,
+  builderPlanDenialCode,
+  builderPlanRequired,
+  lockBuilderPlanPolicy,
+  recordBuilderPlanDenial,
+} from "./builder-plan-policy.js";
+import { ApiError } from "./errors.js";
+import { laneFor } from "./github/agent-routing.js";
+import {
+  createGithubClientFactory,
+  type FacilityGithubClient,
+  type GithubClientFactory,
+} from "./github/client.js";
+import { createGithubClientForRepo } from "./github/kickstart.js";
+import {
+  inspectRemoteRepositoryWriteOutput,
+  repositoryWriteLeaseEligibility,
+} from "./repository-write-lease.js";
+import { acquireExclusiveRunTransitionTransactionLease } from "./run-api-key-lease.js";
+import { readSandbox } from "./sandbox/state.js";
+import type { AppConfig } from "./types.js";
+
+type RunRow = typeof runs.$inferSelect;
+type RetryActor = { type: "user" | "key" | "system"; id: string };
+type EligibleRepositoryWriteEvidence = Extract<
+  ReturnType<typeof repositoryWriteLeaseEligibility>,
+  { eligible: true }
+>;
+
+export type GovernedRetryExternalOptions = BuilderPlanFreshnessOptions & {
+  config?: AppConfig;
+  githubFactory?: GithubClientFactory;
+  repositoryWriteClient?: {
+    repoId: string;
+    client: Pick<
+      FacilityGithubClient,
+      "assertRepositoryAccessible" | "getRef" | "listPullRequestsForHead"
+    >;
+  };
+};
+
+export type GovernedRetryLineage = {
+  attempt: RunRow;
+  parent: RunRow | null;
+  root: RunRow;
+  /** Current attempt followed by every immutable ancestor through the root. */
+  attempts: RunRow[];
+  /** Number of immutable retry edges between this attempt and the root. */
+  depth: number;
+};
+
+export type GovernedRetryEvidence = {
+  freshness: BuilderPlanFreshnessEvidence;
+  /** Digest of every completed attempt's repository-write evidence in lineage order. */
+  repositoryLeaseChainDigest: string;
+};
+
+export type GovernedRetryCreation = {
+  run: RunRow;
+  created: boolean;
+};
+
+const FINGERPRINT_MAX_AGE_MS = 5 * 60_000;
+const MAX_LINEAGE_DEPTH = 100;
+const GOVERNED_RETRY_DENIAL_CODES = new Set([
+  "governed_retry_agent_invalid",
+  "governed_retry_cleanup_incomplete",
+  "governed_retry_durable_output",
+  "governed_retry_lane_invalid",
+  "governed_retry_lineage_invalid",
+  "governed_retry_output_indeterminate",
+  "governed_retry_parent_not_found",
+  "governed_retry_parent_not_retryable",
+  "governed_retry_policy_required",
+  "governed_retry_repository_write_blocked",
+  "governed_retry_requires_fresh_gate1",
+]);
+const GOVERNED_RETRY_DENIAL_REASONS = new Set([
+  "ancestor_not_failed",
+  "base_or_issue_revision_changed",
+  "builder_agent_disabled_or_changed",
+  "delivery_or_outcome_exists",
+  "execution_identity_changed",
+  "github_client_repo_mismatch",
+  "github_client_unavailable",
+  "github_issue_identity_missing",
+  "legacy_resume_descendant_exists",
+  "legacy_repository_write_tracking_unavailable",
+  "lineage_changed",
+  "lineage_cycle_or_depth",
+  "lineage_depth_exceeded",
+  "parent_not_failed",
+  "parent_not_failed_plan_builder",
+  "parent_not_found",
+  "project_policy_not_required",
+  "proposal_not_found",
+  "proposal_repository_invalid",
+  "recorded_repository_output",
+  "remote_branch_or_pull_request_exists",
+  "remote_state_unavailable",
+  "repository_fingerprint_unverified",
+  "repository_issue_changed",
+  "repository_lane_changed",
+  "repository_not_found",
+  "repository_write_credential_persistent",
+  "repository_write_credential_unexpired",
+  "repository_write_lease_ambiguous",
+  "repository_write_lease_malformed",
+  "repository_write_lease_reserved",
+  "repository_write_tracking_unavailable",
+  "retry_parent_missing",
+  "root_not_plan_builder",
+  "run_credentials_live",
+  "sandbox_not_destroyed",
+  "successor_not_clean",
+  "write_base_changed",
+  "write_evidence_changed",
+]);
+
+/** Resolve and revalidate the immutable root -> ... -> attempt chain. */
+export async function resolveGovernedRetryLineage(
+  db: FacilityDb,
+  attempt: RunRow,
+): Promise<GovernedRetryLineage> {
+  const seen = new Set<string>([attempt.id]);
+  const attempts = [attempt];
+  let child = attempt;
+  let directParent: RunRow | null = null;
+  let depth = 0;
+  while (child.retryOfRunId) {
+    if (depth >= MAX_LINEAGE_DEPTH || seen.has(child.retryOfRunId)) {
+      throw retryError("governed_retry_lineage_invalid", "lineage_cycle_or_depth");
+    }
+    const parent = (
+      await db
+        .select()
+        .from(runs)
+        .where(
+          and(
+            eq(runs.orgId, attempt.orgId),
+            eq(runs.projectId, attempt.projectId),
+            eq(runs.id, child.retryOfRunId),
+          ),
+        )
+        .limit(1)
+    )[0];
+    if (!parent) throw retryError("governed_retry_lineage_invalid", "parent_not_found");
+    if (parent.status !== "failed") {
+      throw retryError("governed_retry_lineage_invalid", "ancestor_not_failed");
+    }
+    assertSameExecutionIdentity(child, parent);
+    if (!directParent) directParent = parent;
+    seen.add(parent.id);
+    attempts.push(parent);
+    child = parent;
+    depth += 1;
+  }
+  if (objectValue(child.trigger).source !== "plan_acceptance" || !isBuilderMode(child.mode)) {
+    throw retryError("governed_retry_lineage_invalid", "root_not_plan_builder");
+  }
+  return { attempt, parent: directParent, root: child, attempts, depth };
+}
+
+/**
+ * Resolve GitHub freshness and every repository-write lease for all completed
+ * attempts in a retry chain. Tracking version zero is rejected before any
+ * network lookup.
+ */
+export async function resolveGovernedRetryEvidence(
+  db: FacilityDb,
+  completedAttempts: readonly RunRow[],
+  root: RunRow,
+  options: GovernedRetryExternalOptions = {},
+): Promise<GovernedRetryEvidence> {
+  const parent = completedAttempts[0];
+  if (!parent) throw retryError("governed_retry_lineage_invalid", "parent_not_found");
+  assertRetryableParent(parent);
+  await assertNoLegacyResumeDescendants(db, completedAttempts);
+
+  const leaseEvidence: Array<{
+    attempt: RunRow;
+    rows: (typeof runRepositoryWriteLeases.$inferSelect)[];
+    eligibility: EligibleRepositoryWriteEvidence;
+  }> = [];
+  const now = new Date();
+  await assertNoDurableRetryOutput(db, completedAttempts);
+  const leasesByAttempt = await loadRepositoryWriteLeases(db, completedAttempts);
+  for (const attempt of completedAttempts) {
+    const rows = leasesByAttempt.get(attempt.id) ?? [];
+    const eligibility = repositoryWriteLeaseEligibility(rows, now, {
+      trackingVersion: attempt.repositoryWriteTrackingVersion,
+    });
+    if (!eligibility.eligible) {
+      if (eligibility.reason === "repository_write_tracking_unavailable") {
+        throw new ApiError(
+          409,
+          "governed_retry_requires_fresh_gate1",
+          "This historical Builder run cannot prove complete repository-write tracking",
+          {
+            reason: "legacy_repository_write_tracking_unavailable",
+            requiredAction: "run_architect_and_approve_new_plan",
+          },
+        );
+      }
+      throw retryError("governed_retry_repository_write_blocked", eligibility.reason);
+    }
+    leaseEvidence.push({ attempt, rows, eligibility });
+  }
+
+  const freshness = await resolveBuilderPlanFreshnessForRun(db, root, options);
+  for (const { attempt, eligibility } of leaseEvidence) {
+    for (const inspection of eligibility.remoteInspections) {
+      if (inspection.baseSha.toLowerCase() !== freshness.baseSha.toLowerCase()) {
+        throw retryError("governed_retry_repository_write_blocked", "write_base_changed");
+      }
+      const repo = (
+        await db
+          .select()
+          .from(repos)
+          .where(
+            and(
+              eq(repos.orgId, attempt.orgId),
+              eq(repos.projectId, attempt.projectId),
+              eq(repos.id, inspection.repoId),
+            ),
+          )
+          .limit(1)
+      )[0];
+      if (!repo) throw retryError("governed_retry_output_indeterminate", "repository_not_found");
+      const client = await repositoryWriteClient(db, repo, options);
+      const remote = await inspectRemoteRepositoryWriteOutput(
+        client,
+        inspection.authorizedBranch,
+        inspection.baseSha,
+      );
+      if (remote.state === "indeterminate") {
+        throw retryError("governed_retry_output_indeterminate", "remote_state_unavailable");
+      }
+      if (remote.state === "durable_output") {
+        throw retryError("governed_retry_durable_output", "remote_branch_or_pull_request_exists");
+      }
+    }
+  }
+  return {
+    freshness,
+    repositoryLeaseChainDigest: repositoryLeaseChainDigest(leaseEvidence),
+  };
+}
+
+/** Revalidate all durable state after the project and parent locks are held. */
+export async function assertGovernedRetryLockedAdmission(
+  db: FacilityDb,
+  completedAttempts: readonly RunRow[],
+  root: RunRow,
+  evidence: GovernedRetryEvidence,
+  actor: RetryActor,
+  source: string,
+): Promise<void> {
+  const parent = completedAttempts[0];
+  if (!parent) throw retryError("governed_retry_lineage_invalid", "parent_not_found");
+  assertRetryableParent(parent);
+  await assertNoLegacyResumeDescendants(db, completedAttempts);
+  const now = new Date();
+  const leaseEvidence: Array<{
+    attempt: RunRow;
+    rows: (typeof runRepositoryWriteLeases.$inferSelect)[];
+  }> = [];
+  await assertNoDurableRetryOutput(db, completedAttempts);
+  const leasesByAttempt = await loadRepositoryWriteLeases(db, completedAttempts);
+  for (const attempt of completedAttempts) {
+    const rows = leasesByAttempt.get(attempt.id) ?? [];
+    const eligibility = repositoryWriteLeaseEligibility(rows, now, {
+      trackingVersion: attempt.repositoryWriteTrackingVersion,
+    });
+    if (!eligibility.eligible) {
+      throw retryError("governed_retry_repository_write_blocked", "write_evidence_changed");
+    }
+    leaseEvidence.push({ attempt, rows });
+  }
+  if (repositoryLeaseChainDigest(leaseEvidence) !== evidence.repositoryLeaseChainDigest) {
+    throw retryError("governed_retry_repository_write_blocked", "write_evidence_changed");
+  }
+  if (!(await builderPlanRequired(db, parent.orgId, parent.projectId))) {
+    throw retryError("governed_retry_policy_required", "project_policy_not_required");
+  }
+  const trigger = objectValue(root.trigger);
+  const proposalId = stringValue(trigger.proposalId);
+  const proposal = proposalId
+    ? (
+        await db
+          .select()
+          .from(proposals)
+          .where(
+            and(
+              eq(proposals.orgId, parent.orgId),
+              eq(proposals.projectId, parent.projectId),
+              eq(proposals.id, proposalId),
+            ),
+          )
+          .limit(1)
+      )[0]
+    : undefined;
+  if (!proposal) throw retryError("governed_retry_lineage_invalid", "proposal_not_found");
+  const payload = objectValue(proposal.payload);
+  const repoId = stringValue(payload.repoId);
+  const repo = repoId
+    ? (
+        await db
+          .select()
+          .from(repos)
+          .where(
+            and(
+              eq(repos.orgId, parent.orgId),
+              eq(repos.projectId, parent.projectId),
+              eq(repos.id, repoId),
+            ),
+          )
+          .limit(1)
+      )[0]
+    : undefined;
+  if (!repo) throw retryError("governed_retry_lineage_invalid", "proposal_repository_invalid");
+  const gh = objectValue(root.gh);
+  if (
+    gh.owner !== repo.owner ||
+    gh.repo !== repo.name ||
+    positiveInteger(gh.issueNumber) !== positiveInteger(payload.issueNumber)
+  ) {
+    throw retryError("governed_retry_lineage_invalid", "repository_issue_changed");
+  }
+  const agent = root.agentDefId
+    ? (
+        await db
+          .select()
+          .from(agentDefs)
+          .where(
+            and(
+              eq(agentDefs.orgId, root.orgId),
+              eq(agentDefs.projectId, root.projectId),
+              eq(agentDefs.id, root.agentDefId),
+            ),
+          )
+          .limit(1)
+      )[0]
+    : undefined;
+  if (
+    !agent?.enabled ||
+    agent.engine !== root.engine ||
+    !(
+      isBuilderMode(root.mode) ||
+      isBuilderMode(agent.name) ||
+      agentDefTriggersBuilder(agent.triggers)
+    )
+  ) {
+    throw retryError("governed_retry_agent_invalid", "builder_agent_disabled_or_changed");
+  }
+  if (laneFor(repo, root.mode) !== "platform") {
+    throw retryError("governed_retry_lane_invalid", "repository_lane_changed");
+  }
+  const verifiedAt = repo.fingerprintVerifiedAt?.getTime() ?? Number.NaN;
+  if (
+    !repo.fingerprint ||
+    repo.fingerprintStatus !== "ok" ||
+    !Number.isFinite(verifiedAt) ||
+    verifiedAt < Date.now() - FINGERPRINT_MAX_AGE_MS ||
+    verifiedAt > Date.now() + 30_000
+  ) {
+    throw retryError("governed_retry_lane_invalid", "repository_fingerprint_unverified");
+  }
+  await assertBuilderPlanDispatch(db, {
+    orgId: root.orgId,
+    projectId: root.projectId,
+    mode: root.mode,
+    agentDefId: root.agentDefId,
+    trigger: root.trigger,
+    gh: root.gh,
+    runId: root.id,
+    actor,
+    source,
+    freshnessEvidence: evidence.freshness,
+  });
+}
+
+export async function createGovernedBuilderRetry(
+  db: FacilityDb,
+  transitionDb: FacilityDb,
+  input: {
+    orgId: string;
+    projectId?: string | null;
+    parentRunId: string;
+    actor: RetryActor;
+    reason?: string;
+  },
+  options: GovernedRetryExternalOptions = {},
+): Promise<GovernedRetryCreation> {
+  const parent = await loadScopedRun(db, input.orgId, input.projectId, input.parentRunId);
+  const existing = await loadRetryChild(db, parent);
+  if (existing) {
+    assertSameExecutionIdentity(existing, parent);
+    return { run: existing, created: false };
+  }
+  let lineage: GovernedRetryLineage | undefined;
+  let evidence: GovernedRetryEvidence | undefined;
+  try {
+    lineage = await resolveGovernedRetryLineage(db, parent);
+    if (lineage.depth >= MAX_LINEAGE_DEPTH) {
+      throw retryError("governed_retry_lineage_invalid", "lineage_depth_exceeded");
+    }
+    evidence = await resolveGovernedRetryEvidence(db, lineage.attempts, lineage.root, options);
+    const admissionEvidence = evidence;
+
+    return await transitionDb.transaction(async (tx) => {
+      const lockedDb = tx as unknown as FacilityDb;
+      await lockBuilderPlanPolicy(lockedDb, parent.orgId, parent.projectId);
+      await acquireExclusiveRunTransitionTransactionLease(lockedDb, parent.id);
+      const lockedParent = (
+        await lockedDb
+          .select()
+          .from(runs)
+          .where(
+            and(
+              eq(runs.orgId, parent.orgId),
+              eq(runs.projectId, parent.projectId),
+              eq(runs.id, parent.id),
+            ),
+          )
+          .for("update")
+          .limit(1)
+      )[0];
+      if (!lockedParent) throw retryError("governed_retry_parent_not_found", "parent_not_found");
+      const winningChild = await loadRetryChild(lockedDb, lockedParent);
+      if (winningChild) {
+        assertSameExecutionIdentity(winningChild, lockedParent);
+        return { run: winningChild, created: false };
+      }
+      const lockedLineage = await resolveGovernedRetryLineage(lockedDb, lockedParent);
+      if (lockedLineage.depth >= MAX_LINEAGE_DEPTH) {
+        throw retryError("governed_retry_lineage_invalid", "lineage_depth_exceeded");
+      }
+      await assertGovernedRetryLockedAdmission(
+        lockedDb,
+        lockedLineage.attempts,
+        lockedLineage.root,
+        admissionEvidence,
+        input.actor,
+        "governed_retry_admission",
+      );
+
+      // builder-plan-preflight: governed_builder_retry
+      const child = (
+        await lockedDb
+          .insert(runs)
+          .values({
+            id: newId("run"),
+            orgId: lockedParent.orgId,
+            projectId: lockedParent.projectId,
+            agentDefId: lockedParent.agentDefId,
+            mode: lockedParent.mode,
+            engine: lockedParent.engine,
+            retryOfRunId: lockedParent.id,
+            trigger: lockedParent.trigger,
+            gh: minimalGithubIdentity(lockedLineage.root.gh),
+            createdBy: input.actor,
+          })
+          .returning()
+      )[0];
+      if (!child) throw new ApiError(500, "run_create_failed", "Retry run could not be created");
+      const trigger = objectValue(lockedLineage.root.trigger);
+      await lockedDb.insert(runEvents).values({
+        orgId: child.orgId,
+        runId: child.id,
+        seq: 1,
+        type: "queued",
+        data: {
+          queue: "runs.dispatch",
+          source: "governed_retry",
+          rootRunId: lockedLineage.root.id,
+          parentRunId: lockedParent.id,
+          proposalId: stringValue(trigger.proposalId),
+          architectRunId: stringValue(trigger.architectRunId),
+        },
+      });
+      await insertAuditEvent(lockedDb, {
+        orgId: child.orgId,
+        projectId: child.projectId,
+        actor: input.actor,
+        action: "run.retried",
+        target: { type: "run", id: child.id },
+        payload: {
+          rootRunId: lockedLineage.root.id,
+          parentRunId: lockedParent.id,
+          childRunId: child.id,
+          proposalId: stringValue(trigger.proposalId),
+          architectRunId: stringValue(trigger.architectRunId),
+          planSha256: sha256Value(trigger.planSha256),
+          baseSha: admissionEvidence.freshness.baseSha,
+          issueRevisionSha256: admissionEvidence.freshness.issueRevisionSha256,
+          ...(sanitizedReason(input.reason) ? { reason: sanitizedReason(input.reason) } : {}),
+        },
+      });
+      return { run: child, created: true };
+    });
+  } catch (error) {
+    const planCode = error instanceof ApiError ? builderPlanDenialCode(error.code) : null;
+    if (planCode && lineage) {
+      await recordBuilderPlanDenial(
+        db,
+        {
+          orgId: lineage.root.orgId,
+          projectId: lineage.root.projectId,
+          mode: lineage.root.mode,
+          agentDefId: lineage.root.agentDefId,
+          trigger: lineage.root.trigger,
+          gh: lineage.root.gh,
+          runId: lineage.root.id,
+          actor: input.actor,
+          source: "governed_retry_admission",
+          freshnessEvidence: evidence?.freshness,
+        },
+        planCode,
+        governedReason(error, "transactional_retry_preflight_denied"),
+      ).catch(() => undefined);
+    }
+    await recordGovernedRetryDenial(
+      db,
+      parent,
+      input.actor,
+      "governed_retry_admission",
+      error,
+    ).catch(() => undefined);
+    throw error;
+  }
+}
+
+export function governedRetryDenial(error: unknown): { code: string; reason: string } | null {
+  if (!(error instanceof ApiError) || !GOVERNED_RETRY_DENIAL_CODES.has(error.code)) return null;
+  return { code: error.code, reason: governedReason(error, "denied") };
+}
+
+export async function recordGovernedRetryDenial(
+  db: FacilityDb,
+  run: Pick<RunRow, "id" | "orgId" | "projectId" | "retryOfRunId">,
+  actor: RetryActor,
+  source: string,
+  error: unknown,
+): Promise<void> {
+  const denial = governedRetryDenial(error);
+  if (!denial) return;
+  await insertAuditEvent(db, {
+    orgId: run.orgId,
+    projectId: run.projectId,
+    actor,
+    action: "run.governed_retry_denied",
+    target: { type: "run", id: run.id },
+    payload: {
+      code: denial.code,
+      reason: denial.reason,
+      source,
+      parentRunId: run.retryOfRunId,
+    },
+  });
+}
+
+export async function validateGovernedRetryForDispatch(
+  db: FacilityDb,
+  run: RunRow,
+  options: GovernedRetryExternalOptions = {},
+): Promise<{ lineage: GovernedRetryLineage; evidence: GovernedRetryEvidence }> {
+  if (!run.retryOfRunId) {
+    throw retryError("governed_retry_lineage_invalid", "retry_parent_missing");
+  }
+  const lineage = await resolveGovernedRetryLineage(db, run);
+  if (lineage.parent?.status !== "failed") {
+    throw retryError("governed_retry_lineage_invalid", "parent_not_failed");
+  }
+  assertSameExecutionIdentity(run, lineage.parent);
+  if (["queued", "provisioning"].includes(run.status))
+    assertUnprovisionedRetryChild(run, lineage.root);
+  const evidence = await resolveGovernedRetryEvidence(
+    db,
+    lineage.attempts.slice(1),
+    lineage.root,
+    options,
+  );
+  return { lineage, evidence };
+}
+
+export async function assertGovernedRetryDispatchState(
+  db: FacilityDb,
+  run: RunRow,
+  expected: { lineage: GovernedRetryLineage; evidence: GovernedRetryEvidence },
+): Promise<void> {
+  const currentLineage = await resolveGovernedRetryLineage(db, run);
+  if (
+    !isDeepStrictEqual(
+      currentLineage.attempts.map((attempt) => attempt.id),
+      expected.lineage.attempts.map((attempt) => attempt.id),
+    )
+  ) {
+    throw retryError("governed_retry_lineage_invalid", "lineage_changed");
+  }
+  assertUnprovisionedRetryChild(run, currentLineage.root);
+  if (!currentLineage.parent) {
+    throw retryError("governed_retry_lineage_invalid", "parent_not_found");
+  }
+  await assertGovernedRetryLockedAdmission(
+    db,
+    currentLineage.attempts.slice(1),
+    currentLineage.root,
+    expected.evidence,
+    { type: "system", id: "runs.dispatch" },
+    "governed_retry_worker",
+  );
+}
+
+async function loadScopedRun(
+  db: FacilityDb,
+  orgId: string,
+  projectId: string | null | undefined,
+  runId: string,
+) {
+  const row = (
+    await db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.orgId, orgId),
+          eq(runs.id, runId),
+          ...(projectId ? [eq(runs.projectId, projectId)] : []),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (!row) throw new ApiError(404, "run_not_found", "Run not found");
+  return row;
+}
+
+async function loadRetryChild(db: FacilityDb, parent: RunRow) {
+  return (
+    await db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.orgId, parent.orgId),
+          eq(runs.projectId, parent.projectId),
+          eq(runs.retryOfRunId, parent.id),
+        ),
+      )
+      .limit(1)
+  )[0];
+}
+
+async function loadRepositoryWriteLeases(db: FacilityDb, attempts: readonly RunRow[]) {
+  const first = assertSameLineageScope(attempts);
+  const rows = await db
+    .select()
+    .from(runRepositoryWriteLeases)
+    .where(
+      and(
+        eq(runRepositoryWriteLeases.orgId, first.orgId),
+        eq(runRepositoryWriteLeases.projectId, first.projectId),
+        inArray(
+          runRepositoryWriteLeases.runId,
+          attempts.map((attempt) => attempt.id),
+        ),
+      ),
+    );
+  const byAttempt = new Map<string, (typeof runRepositoryWriteLeases.$inferSelect)[]>();
+  for (const row of rows) {
+    const attemptRows = byAttempt.get(row.runId) ?? [];
+    attemptRows.push(row);
+    byAttempt.set(row.runId, attemptRows);
+  }
+  return byAttempt;
+}
+
+async function assertNoLegacyResumeDescendants(
+  db: FacilityDb,
+  completedAttempts: readonly RunRow[],
+) {
+  const first = assertSameLineageScope(completedAttempts);
+  const attemptIds = completedAttempts.map((attempt) => attempt.id);
+  const legacy = await db
+    .select({ id: runs.id })
+    .from(runs)
+    .where(
+      and(
+        eq(runs.orgId, first.orgId),
+        eq(runs.projectId, first.projectId),
+        isNull(runs.retryOfRunId),
+        inArray(sql<string>`${runs.trigger}->>'resumeOf'`, attemptIds),
+      ),
+    )
+    .limit(1);
+  if (legacy.length) {
+    throw retryError("governed_retry_durable_output", "legacy_resume_descendant_exists");
+  }
+}
+
+async function assertNoDurableRetryOutput(db: FacilityDb, attempts: readonly RunRow[]) {
+  const first = assertSameLineageScope(attempts);
+  const attemptIds = attempts.map((attempt) => attempt.id);
+  for (const attempt of attempts) {
+    const gh = objectValue(attempt.gh);
+    const receiptGithub = objectValue(objectValue(attempt.receipt).github);
+    if (
+      stringValue(gh.branch) ||
+      stringValue(gh.headSha) ||
+      Object.keys(objectValue(gh.pr)).length > 0 ||
+      positiveInteger(receiptGithub.pr)
+    ) {
+      throw retryError("governed_retry_durable_output", "recorded_repository_output");
+    }
+    const sandbox = readSandbox(attempt.sandbox);
+    if (sandbox.ref && (!sandbox.destroyedAt || sandbox.lastStatus !== "destroyed")) {
+      throw retryError("governed_retry_cleanup_incomplete", "sandbox_not_destroyed");
+    }
+  }
+  const [delivery, outcome, livePlatformKey, liveVirtualKey] = await Promise.all([
+    db
+      .select({ runId: runDeliveries.runId })
+      .from(runDeliveries)
+      .where(and(eq(runDeliveries.orgId, first.orgId), inArray(runDeliveries.runId, attemptIds)))
+      .limit(1),
+    db
+      .select({ id: outcomes.id })
+      .from(outcomes)
+      .where(and(eq(outcomes.orgId, first.orgId), inArray(outcomes.runId, attemptIds)))
+      .limit(1),
+    db
+      .select({ id: apiKeys.id })
+      .from(apiKeys)
+      .where(
+        and(
+          eq(apiKeys.orgId, first.orgId),
+          inArray(apiKeys.runId, attemptIds),
+          isNull(apiKeys.revokedAt),
+        ),
+      )
+      .limit(1),
+    db
+      .select({ id: virtualKeys.id })
+      .from(virtualKeys)
+      .where(
+        and(
+          eq(virtualKeys.orgId, first.orgId),
+          inArray(virtualKeys.runId, attemptIds),
+          isNull(virtualKeys.revokedAt),
+        ),
+      )
+      .limit(1),
+  ]);
+  if (delivery.length || outcome.length) {
+    throw retryError("governed_retry_durable_output", "delivery_or_outcome_exists");
+  }
+  if (livePlatformKey.length || liveVirtualKey.length) {
+    throw retryError("governed_retry_cleanup_incomplete", "run_credentials_live");
+  }
+}
+
+function assertSameLineageScope(attempts: readonly RunRow[]) {
+  const first = attempts[0];
+  if (
+    !first ||
+    attempts.some(
+      (attempt) => attempt.orgId !== first.orgId || attempt.projectId !== first.projectId,
+    )
+  ) {
+    throw retryError("governed_retry_lineage_invalid", "lineage_changed");
+  }
+  return first;
+}
+
+function assertRetryableParent(parent: RunRow) {
+  if (
+    parent.status !== "failed" ||
+    !isBuilderMode(parent.mode) ||
+    objectValue(parent.trigger).source !== "plan_acceptance"
+  ) {
+    throw retryError("governed_retry_parent_not_retryable", "parent_not_failed_plan_builder");
+  }
+}
+
+function assertSameExecutionIdentity(child: RunRow, parent: RunRow) {
+  if (
+    child.orgId !== parent.orgId ||
+    child.projectId !== parent.projectId ||
+    child.retryOfRunId !== parent.id ||
+    child.agentDefId !== parent.agentDefId ||
+    child.mode !== parent.mode ||
+    child.engine !== parent.engine ||
+    !isDeepStrictEqual(child.trigger, parent.trigger)
+  ) {
+    throw retryError("governed_retry_lineage_invalid", "execution_identity_changed");
+  }
+}
+
+function assertUnprovisionedRetryChild(child: RunRow, root: RunRow) {
+  if (
+    !["queued", "provisioning"].includes(child.status) ||
+    !isDeepStrictEqual(objectValue(child.gh), minimalGithubIdentity(root.gh)) ||
+    Object.keys(readSandbox(child.sandbox)).length > 0 ||
+    child.receipt !== null ||
+    child.engineSessionId !== null ||
+    child.transcriptUri !== null ||
+    child.sessionStateUri !== null ||
+    child.workspaceBaseSha !== null ||
+    child.error !== null
+  ) {
+    throw retryError("governed_retry_lineage_invalid", "successor_not_clean");
+  }
+}
+
+function minimalGithubIdentity(value: unknown) {
+  const gh = objectValue(value);
+  const owner = stringValue(gh.owner);
+  const repo = stringValue(gh.repo);
+  const issueNumber = positiveInteger(gh.issueNumber);
+  if (!owner || !repo || !issueNumber) {
+    throw retryError("governed_retry_lineage_invalid", "github_issue_identity_missing");
+  }
+  return { owner, repo, issueNumber };
+}
+
+async function repositoryWriteClient(
+  db: FacilityDb,
+  repo: typeof repos.$inferSelect,
+  options: GovernedRetryExternalOptions,
+) {
+  if (options.repositoryWriteClient) {
+    if (options.repositoryWriteClient.repoId !== repo.id) {
+      throw retryError("governed_retry_output_indeterminate", "github_client_repo_mismatch");
+    }
+    return options.repositoryWriteClient.client;
+  }
+  const factory =
+    options.githubFactory ??
+    (options.config?.githubAppId && options.config.githubAppPrivateKey
+      ? createGithubClientFactory(options.config)
+      : null);
+  if (!factory) {
+    throw retryError("governed_retry_output_indeterminate", "github_client_unavailable");
+  }
+  try {
+    return await createGithubClientForRepo(db, factory, repo);
+  } catch {
+    throw retryError("governed_retry_output_indeterminate", "github_client_unavailable");
+  }
+}
+
+function repositoryLeaseChainDigest(
+  evidence: readonly {
+    attempt: RunRow;
+    rows: readonly (typeof runRepositoryWriteLeases.$inferSelect)[];
+  }[],
+) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify(
+        evidence.map(({ attempt, rows }) => ({
+          runId: attempt.id,
+          trackingVersion: attempt.repositoryWriteTrackingVersion,
+          leases: [...rows]
+            .sort((left, right) => left.id.localeCompare(right.id))
+            .map((row) => ({
+              id: row.id,
+              repoId: row.repoId,
+              provider: row.provider,
+              status: row.status,
+              requestedBranch: row.requestedBranch,
+              authorizedBranch: row.authorizedBranch,
+              baseSha: row.baseSha,
+              permissions: row.permissions,
+              issuedAt: row.issuedAt?.toISOString() ?? null,
+              expiresAt: row.expiresAt?.toISOString() ?? null,
+              failureReason: row.failureReason,
+            })),
+        })),
+      ),
+    )
+    .digest("hex");
+}
+
+function sanitizedReason(value: string | undefined) {
+  const normalized = value?.trim().replaceAll(/\p{Cc}/gu, " ");
+  return normalized ? normalized.slice(0, 500) : null;
+}
+
+function retryError(code: string, reason: string) {
+  return new ApiError(409, code, "Governed Builder retry was denied", { reason });
+}
+
+function governedReason(error: unknown, fallback: string) {
+  const reason = stringValue(objectValue(error instanceof ApiError ? error.details : null).reason);
+  return reason && GOVERNED_RETRY_DENIAL_REASONS.has(reason) ? reason : fallback;
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function positiveInteger(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function sha256Value(value: unknown) {
+  return typeof value === "string" && /^[a-f0-9]{64}$/i.test(value) ? value.toLowerCase() : null;
+}

--- a/services/api/src/idempotency.ts
+++ b/services/api/src/idempotency.ts
@@ -77,6 +77,17 @@ export async function beginIdempotentRequest(
     );
   }
   if (existing.state !== "completed" || existing.statusCode === null) {
+    // A run-scoped credential can commit domain work while its transport is
+    // disappearing. Never time-reclaim that pending outcome: the matching run
+    // key must remain fail closed until the key/record itself expires.
+    if (principal.runId) {
+      reply.header("retry-after", "1");
+      throw new ApiError(
+        409,
+        "idempotency_in_progress",
+        "A request with this Idempotency-Key is still in progress",
+      );
+    }
     const staleBefore = new Date(Date.now() - IDEMPOTENCY_PENDING_TIMEOUT_MS);
     const reclaimed = await db
       .delete(idempotencyRecords)
@@ -111,27 +122,81 @@ export async function completeIdempotentRequest(
   request: FastifyRequest,
   reply: FastifyReply,
   payload: unknown,
+  options: { completeServerError?: boolean } = {},
 ) {
   const id = request.idempotencyId;
   if (!id) return;
-  try {
-    if (reply.statusCode >= 500) {
+  if (reply.statusCode >= 500) {
+    // A run-scoped handler may have committed before producing its error.
+    // Persist that known response so the sandbox cannot repeat the mutation;
+    // retain the ordinary-user retry behavior outside this trust boundary.
+    if (!options.completeServerError && !request.principal?.runId) {
       await db.delete(idempotencyRecords).where(eq(idempotencyRecords.id, id));
+      request.idempotencyId = undefined;
       return;
     }
-    const responseBody = parsePayload(payload);
-    await db
-      .update(idempotencyRecords)
-      .set({
-        state: "completed",
-        statusCode: reply.statusCode,
-        responseBody,
-        updatedAt: new Date(),
-      })
-      .where(eq(idempotencyRecords.id, id));
-  } catch (error) {
-    request.log.error({ err: error, idempotencyId: id }, "could not persist idempotent response");
   }
+  const responseBody = parsePayload(payload);
+  const completed = await db
+    .update(idempotencyRecords)
+    .set({
+      state: "completed",
+      statusCode: reply.statusCode,
+      responseBody,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(idempotencyRecords.id, id), eq(idempotencyRecords.state, "pending")))
+    .returning({ id: idempotencyRecords.id });
+  if (completed.length !== 1) {
+    throw new Error(`Idempotency record ${id} could not be completed`);
+  }
+  request.idempotencyId = undefined;
+}
+
+/**
+ * A handler committed but its transport disappeared before onSend could
+ * persist the actual response. Seal the key as non-replayable rather than
+ * deleting/reclaiming an outcome that may already have external side effects.
+ */
+export async function finalizeIndeterminateIdempotentRequest(
+  db: FacilityDb,
+  request: FastifyRequest,
+) {
+  const id = request.idempotencyId;
+  if (!id) return;
+  const completed = await db
+    .update(idempotencyRecords)
+    .set({
+      state: "completed",
+      statusCode: 409,
+      responseBody: {
+        error: {
+          code: "idempotency_outcome_indeterminate",
+          message: "The original request may have completed; automatic replay is refused",
+        },
+      },
+      updatedAt: new Date(),
+    })
+    .where(and(eq(idempotencyRecords.id, id), eq(idempotencyRecords.state, "pending")))
+    .returning({ id: idempotencyRecords.id });
+  if (completed.length !== 1) {
+    throw new Error(`Idempotency record ${id} could not be sealed as indeterminate`);
+  }
+  request.idempotencyId = undefined;
+}
+
+/** Remove a pending replay record when its client disconnected before a response. */
+export async function abandonIdempotentRequest(db: FacilityDb, request: FastifyRequest) {
+  const id = request.idempotencyId;
+  if (!id) return;
+  const deleted = await db
+    .delete(idempotencyRecords)
+    .where(and(eq(idempotencyRecords.id, id), eq(idempotencyRecords.state, "pending")))
+    .returning({ id: idempotencyRecords.id });
+  if (deleted.length !== 1) {
+    throw new Error(`Pending idempotency record ${id} could not be abandoned`);
+  }
+  request.idempotencyId = undefined;
 }
 
 export async function expireIdempotencyRecords(db: FacilityDb, now = new Date()) {

--- a/services/api/src/repository-write-lease.ts
+++ b/services/api/src/repository-write-lease.ts
@@ -1,0 +1,508 @@
+import { newId } from "@facility/core";
+import { type FacilityDb, insertAuditEvent, runRepositoryWriteLeases } from "@facility/db";
+import { and, eq } from "drizzle-orm";
+import { ApiError } from "./errors.js";
+
+const GIT_SHA = /^[a-f0-9]{40}$/i;
+export const REPOSITORY_WRITE_EXPIRY_SAFETY_MS = 5 * 60_000;
+
+export type RepositoryWriteLeaseRow = Pick<
+  typeof runRepositoryWriteLeases.$inferSelect,
+  | "id"
+  | "repoId"
+  | "provider"
+  | "status"
+  | "requestedBranch"
+  | "authorizedBranch"
+  | "baseSha"
+  | "permissions"
+  | "issuedAt"
+  | "expiresAt"
+  | "failureReason"
+>;
+
+export type RepositoryWriteLeaseEligibility =
+  | {
+      eligible: true;
+      remoteInspections: Array<{
+        leaseId: string;
+        repoId: string;
+        authorizedBranch: string;
+        baseSha: string;
+      }>;
+    }
+  | {
+      eligible: false;
+      reason:
+        | "repository_write_lease_malformed"
+        | "repository_write_tracking_unavailable"
+        | "repository_write_lease_reserved"
+        | "repository_write_lease_ambiguous"
+        | "repository_write_credential_persistent"
+        | "repository_write_credential_unexpired";
+      leaseId?: string;
+      expiresAt?: Date;
+    };
+
+/**
+ * Pure, fail-closed barrier consumed by the follow-up governed retry PR.
+ * Every lease is inspected; a later installation token can never hide an
+ * earlier persistent fallback or malformed reservation.
+ */
+export function repositoryWriteLeaseEligibility(
+  values: readonly unknown[],
+  now: Date,
+  options: { trackingVersion: number },
+): RepositoryWriteLeaseEligibility {
+  if (options.trackingVersion !== 1) {
+    return { eligible: false, reason: "repository_write_tracking_unavailable" };
+  }
+  const rows: RepositoryWriteLeaseRow[] = [];
+  for (const value of values) {
+    const parsed = repositoryWriteLeaseRow(value);
+    if (!parsed) {
+      return { eligible: false, reason: "repository_write_lease_malformed" };
+    }
+    rows.push(parsed);
+  }
+
+  const fallback = rows.find(
+    (row) => row.status === "issued" && row.provider === "configured_fallback",
+  );
+  if (fallback) {
+    return {
+      eligible: false,
+      reason: "repository_write_credential_persistent",
+      leaseId: fallback.id,
+    };
+  }
+  const reserved = rows.find((row) => row.status === "reserved");
+  if (reserved) {
+    return {
+      eligible: false,
+      reason: "repository_write_lease_reserved",
+      leaseId: reserved.id,
+    };
+  }
+  const failed = rows.find((row) => row.status === "failed");
+  if (failed) {
+    return {
+      eligible: false,
+      reason: "repository_write_lease_ambiguous",
+      leaseId: failed.id,
+    };
+  }
+
+  const active = rows
+    .filter((row) => row.status === "issued")
+    .filter(
+      (row) =>
+        (row.expiresAt?.getTime() ?? Number.POSITIVE_INFINITY) + REPOSITORY_WRITE_EXPIRY_SAFETY_MS >
+        now.getTime(),
+    )
+    .sort(
+      (left, right) =>
+        (right.expiresAt?.getTime() ?? Number.POSITIVE_INFINITY) -
+        (left.expiresAt?.getTime() ?? Number.POSITIVE_INFINITY),
+    )[0];
+  if (active) {
+    return {
+      eligible: false,
+      reason: "repository_write_credential_unexpired",
+      leaseId: active.id,
+      ...(active.expiresAt ? { expiresAt: active.expiresAt } : {}),
+    };
+  }
+
+  return {
+    eligible: true,
+    remoteInspections: rows
+      .filter((row) => row.status === "issued")
+      .map((row) => ({
+        leaseId: row.id,
+        repoId: row.repoId,
+        authorizedBranch: row.authorizedBranch,
+        baseSha: row.baseSha,
+      })),
+  };
+}
+
+export type RemoteRepositoryWriteState =
+  | { state: "safe_absent"; pullRequestCount: 0 }
+  | { state: "safe_unchanged"; headSha: string; pullRequestCount: 0 }
+  | {
+      state: "durable_output";
+      refState: "absent" | "unchanged" | "changed";
+      headSha?: string;
+      pullRequestCount: number;
+    }
+  | { state: "indeterminate" };
+
+export async function inspectRemoteRepositoryWriteOutput(
+  client: {
+    assertRepositoryAccessible: () => Promise<void>;
+    getRef: (branch: string) => Promise<string>;
+    listPullRequestsForHead: (
+      branch: string,
+    ) => Promise<{ pullRequests: readonly unknown[]; hasNextPage: boolean }>;
+  },
+  authorizedBranch: string,
+  baseSha: string,
+): Promise<RemoteRepositoryWriteState> {
+  const normalizedBaseSha = normalizeGitSha(baseSha);
+  if (!normalizedBaseSha || !validGithubBranch(authorizedBranch)) {
+    return { state: "indeterminate" };
+  }
+  try {
+    // A ref 404 alone is ambiguous: GitHub also uses it for an inaccessible
+    // repository. Prove repository access first, then inspect the exact ref and
+    // every PR state for the same head.
+    await client.assertRepositoryAccessible();
+    const [headResult, pullRequestPage] = await Promise.all([
+      client
+        .getRef(authorizedBranch)
+        .then((headSha) => ({ found: true as const, headSha }))
+        .catch((error) => {
+          if (githubStatus(error) === 404) return { found: false as const, headSha: null };
+          throw error;
+        }),
+      client.listPullRequestsForHead(authorizedBranch),
+    ]);
+    if (pullRequestPage.hasNextPage) return { state: "indeterminate" };
+    const pullRequestCount = pullRequestPage.pullRequests.length;
+    if (!headResult.found) {
+      return pullRequestCount > 0
+        ? { state: "durable_output", refState: "absent", pullRequestCount }
+        : { state: "safe_absent", pullRequestCount: 0 };
+    }
+    const headSha = normalizeGitSha(headResult.headSha);
+    if (!headSha) return { state: "indeterminate" };
+    const refState = headSha === normalizedBaseSha ? "unchanged" : "changed";
+    if (pullRequestCount > 0 || refState === "changed") {
+      return { state: "durable_output", refState, headSha, pullRequestCount };
+    }
+    return { state: "safe_unchanged", headSha, pullRequestCount: 0 };
+  } catch {
+    return { state: "indeterminate" };
+  }
+}
+
+export async function selectAvailableRepositoryWriteBranch(
+  client: {
+    assertRepositoryAccessible: () => Promise<void>;
+    getRef: (branch: string) => Promise<string>;
+    listPullRequestsForHead: (
+      branch: string,
+    ) => Promise<{ pullRequests: readonly unknown[]; hasNextPage: boolean }>;
+  },
+  requestedBranch: string,
+  runId: string,
+) {
+  if (!validGithubBranch(requestedBranch)) {
+    throw new ApiError(
+      409,
+      "repository_write_branch_unavailable",
+      "Repository write branch is invalid",
+    );
+  }
+  try {
+    await client.assertRepositoryAccessible();
+  } catch {
+    throw new ApiError(
+      409,
+      "repository_write_branch_unavailable",
+      "Facility could not verify repository access",
+    );
+  }
+  // The run id is globally unique and part of the very first candidate. Two
+  // independent Builders therefore cannot reserve the same future head after
+  // both observe the human-requested semantic name as absent.
+  const runSuffix = runId.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (!runSuffix) {
+    throw new ApiError(
+      409,
+      "repository_write_branch_unavailable",
+      "Repository write run identity is invalid",
+    );
+  }
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const candidate = `${requestedBranch}-${runSuffix}${attempt === 0 ? "" : `-${attempt + 1}`}`;
+    if (!validGithubBranch(candidate)) break;
+    try {
+      await client.getRef(candidate);
+    } catch (error) {
+      if (githubStatus(error) === 404) {
+        try {
+          const pullRequests = await client.listPullRequestsForHead(candidate);
+          if (pullRequests.hasNextPage) {
+            throw new Error("github_pull_request_pagination_ambiguous");
+          }
+          // A deleted ref may retain open, closed or merged PR history. Never
+          // reuse that head name for a new run; move to a collision suffix.
+          if (pullRequests.pullRequests.length === 0) return candidate;
+          continue;
+        } catch {
+          throw new ApiError(
+            409,
+            "repository_write_branch_unavailable",
+            "Facility could not verify repository branch pull-request history",
+          );
+        }
+      }
+      throw new ApiError(
+        409,
+        "repository_write_branch_unavailable",
+        "Facility could not verify an available repository write branch",
+      );
+    }
+  }
+  throw new ApiError(
+    409,
+    "repository_write_branch_unavailable",
+    "No collision-free repository write branch is available",
+  );
+}
+
+export async function reserveRepositoryWriteLease(
+  db: FacilityDb,
+  input: {
+    orgId: string;
+    projectId: string;
+    runId: string;
+    repoId: string;
+    requestedBranch: string;
+    authorizedBranch: string;
+    baseSha: string;
+    permissions: string[];
+    provider?: "github_installation" | "configured_fallback";
+  },
+) {
+  const id = newId("rwl");
+  const provider = input.provider ?? "github_installation";
+  const permissions = canonicalPermissions(input.permissions);
+  const baseSha = normalizeGitSha(input.baseSha);
+  if (
+    !baseSha ||
+    !validGithubBranch(input.requestedBranch) ||
+    !validGithubBranch(input.authorizedBranch) ||
+    !permissions
+  ) {
+    throw new ApiError(
+      409,
+      "repository_write_lease_invalid",
+      "Repository write lease evidence is invalid",
+    );
+  }
+  const row = (
+    await db
+      .insert(runRepositoryWriteLeases)
+      .values({
+        id,
+        orgId: input.orgId,
+        projectId: input.projectId,
+        runId: input.runId,
+        repoId: input.repoId,
+        provider,
+        requestedBranch: input.requestedBranch,
+        authorizedBranch: input.authorizedBranch,
+        baseSha,
+        permissions,
+      })
+      .returning()
+  )[0];
+  if (!row) throw new ApiError(500, "repository_write_lease_failed", "Lease was not reserved");
+  await insertAuditEvent(db, {
+    orgId: input.orgId,
+    projectId: input.projectId,
+    actor: { type: "agent", id: input.runId },
+    action: "run.repository_write_reserved",
+    target: { type: "run_repository_write_lease", id },
+    payload: {
+      runId: input.runId,
+      repoId: input.repoId,
+      provider,
+      requestedBranch: input.requestedBranch,
+      authorizedBranch: input.authorizedBranch,
+      baseSha,
+      permissions,
+    },
+  });
+  return row;
+}
+
+export async function markRepositoryWriteLeaseIssued(
+  db: FacilityDb,
+  lease: typeof runRepositoryWriteLeases.$inferSelect,
+  issuedAt: Date,
+  expiresAt: Date | null,
+) {
+  const row = (
+    await db
+      .update(runRepositoryWriteLeases)
+      .set({ status: "issued", issuedAt, expiresAt, updatedAt: issuedAt })
+      .where(
+        and(
+          eq(runRepositoryWriteLeases.id, lease.id),
+          eq(runRepositoryWriteLeases.runId, lease.runId),
+          eq(runRepositoryWriteLeases.status, "reserved"),
+        ),
+      )
+      .returning()
+  )[0];
+  if (!row) {
+    throw new ApiError(409, "repository_write_lease_changed", "Lease changed before issuance");
+  }
+  await insertAuditEvent(db, {
+    orgId: lease.orgId,
+    projectId: lease.projectId,
+    actor: { type: "agent", id: lease.runId },
+    action: "run.repository_write_issued",
+    target: { type: "run_repository_write_lease", id: lease.id },
+    payload: {
+      runId: lease.runId,
+      repoId: lease.repoId,
+      provider: lease.provider,
+      requestedBranch: lease.requestedBranch,
+      authorizedBranch: lease.authorizedBranch,
+      baseSha: lease.baseSha,
+      permissions: lease.permissions,
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt?.toISOString() ?? null,
+    },
+  });
+  return row;
+}
+
+export async function markRepositoryWriteLeaseFailed(
+  db: FacilityDb,
+  lease: typeof runRepositoryWriteLeases.$inferSelect,
+  reason: string,
+) {
+  const failureReason = reason.replace(/[^a-z0-9_.:-]/gi, "_").slice(0, 120) || "issuance_failed";
+  const row = (
+    await db
+      .update(runRepositoryWriteLeases)
+      .set({ status: "failed", failureReason, updatedAt: new Date() })
+      .where(
+        and(
+          eq(runRepositoryWriteLeases.id, lease.id),
+          eq(runRepositoryWriteLeases.runId, lease.runId),
+          eq(runRepositoryWriteLeases.status, "reserved"),
+        ),
+      )
+      .returning({ id: runRepositoryWriteLeases.id })
+  )[0];
+  if (!row) {
+    throw new ApiError(409, "repository_write_lease_changed", "Lease changed before failure");
+  }
+  await insertAuditEvent(db, {
+    orgId: lease.orgId,
+    projectId: lease.projectId,
+    actor: { type: "agent", id: lease.runId },
+    action: "run.repository_write_failed",
+    target: { type: "run_repository_write_lease", id: lease.id },
+    payload: { runId: lease.runId, repoId: lease.repoId, reason: failureReason },
+  });
+}
+
+function repositoryWriteLeaseRow(value: unknown): RepositoryWriteLeaseRow | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  const status = stringValue(row.status);
+  const provider = stringValue(row.provider);
+  const id = stringValue(row.id);
+  const repoId = stringValue(row.repoId);
+  const requestedBranch = stringValue(row.requestedBranch);
+  const authorizedBranch = stringValue(row.authorizedBranch);
+  const baseSha = normalizeGitSha(row.baseSha);
+  const issuedAt = dateValue(row.issuedAt);
+  const expiresAt = dateValue(row.expiresAt);
+  const failureReason = nullableString(row.failureReason);
+  const permissions = canonicalPermissions(row.permissions);
+  if (
+    !id ||
+    !repoId ||
+    !requestedBranch ||
+    !validGithubBranch(requestedBranch) ||
+    !authorizedBranch ||
+    !validGithubBranch(authorizedBranch) ||
+    !baseSha ||
+    !permissions
+  ) {
+    return null;
+  }
+  if (status !== "reserved" && status !== "issued" && status !== "failed") return null;
+  if (provider !== "github_installation" && provider !== "configured_fallback") return null;
+  if ((row.issuedAt != null && !issuedAt) || (row.expiresAt != null && !expiresAt)) return null;
+  if (row.failureReason != null && !failureReason) return null;
+  if (status === "reserved" && (issuedAt || expiresAt || failureReason)) return null;
+  if (status === "failed" && (issuedAt || expiresAt || !failureReason)) return null;
+  if (status === "issued") {
+    if (!issuedAt || failureReason) return null;
+    if (provider === "github_installation" && (!expiresAt || expiresAt <= issuedAt)) return null;
+    if (provider === "configured_fallback" && expiresAt) return null;
+  }
+  return {
+    id,
+    repoId,
+    provider,
+    status,
+    requestedBranch,
+    authorizedBranch,
+    baseSha,
+    permissions,
+    issuedAt,
+    expiresAt,
+    failureReason,
+  };
+}
+
+function canonicalPermissions(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  if (value.length === 1 && value[0] === "contents") return ["contents"];
+  if (value.length === 2 && value[0] === "contents" && value[1] === "workflows") {
+    return ["contents", "workflows"];
+  }
+  return null;
+}
+
+function dateValue(value: unknown) {
+  if (value === null || value === undefined) return null;
+  const date = value instanceof Date ? value : typeof value === "string" ? new Date(value) : null;
+  return date && Number.isFinite(date.getTime()) ? date : null;
+}
+
+function normalizeGitSha(value: unknown) {
+  return typeof value === "string" && GIT_SHA.test(value) ? value.toLowerCase() : null;
+}
+
+function validGithubBranch(value: string) {
+  if (value.length < 1 || value.length > 255 || value !== value.trim()) return false;
+  if (value === "@" || value.startsWith("/") || value.endsWith("/") || value.endsWith(".")) {
+    return false;
+  }
+  if (value.includes("..") || value.includes("@{") || value.includes("//")) return false;
+  if (
+    [...value].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x20 || codePoint === 0x7f || "~^:?*[\\".includes(character);
+    })
+  ) {
+    return false;
+  }
+  return value.split("/").every((component) => component && !component.endsWith(".lock"));
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function nullableString(value: unknown) {
+  return value === null || value === undefined ? null : stringValue(value);
+}
+
+function githubStatus(error: unknown) {
+  return error && typeof error === "object" && "status" in error
+    ? Number((error as { status?: unknown }).status)
+    : undefined;
+}

--- a/services/api/src/routes/internal.ts
+++ b/services/api/src/routes/internal.ts
@@ -1,5 +1,13 @@
 import { open, verifyKey } from "@facility/core";
-import { githubInstallations, insertAuditEvent, repos, runs, steerMessages } from "@facility/db";
+import {
+  type FacilityDb,
+  githubInstallations,
+  insertAuditEvent,
+  repos,
+  runs,
+  steerMessages,
+} from "@facility/db";
+import { isBuilderMode } from "@facility/run-objective";
 import { and, asc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
@@ -12,8 +20,15 @@ import { ApiError, notFound } from "../errors.js";
 import {
   createGithubClientFactory,
   createGithubInstallationTokenFactory,
+  FacilityGithubClient,
+  type GithubInstallationTokenFactory,
 } from "../github/client.js";
 import { collectGithubSecuritySweepEvidence } from "../github/security-sweep.js";
+import {
+  markRepositoryWriteLeaseIssued,
+  reserveRepositoryWriteLease,
+  selectAvailableRepositoryWriteBranch,
+} from "../repository-write-lease.js";
 import { finishRun, updateGithubRunProgress } from "../sandbox/orchestrator.js";
 import {
   appendRunEvents,
@@ -25,10 +40,16 @@ import type { AppConfig } from "../types.js";
 
 const Params = z.object({ runId: z.string() });
 const GitCommitSha = z.string().regex(/^[0-9a-f]{40}$/i);
-// Fastify represents a POST with no payload as null. Accept that wire shape so
-// runners deployed before the capability body continue to receive the
-// contents-only token; populated bodies remain strict and closed.
-const PushTokenRequest = z.object({ workflowWrite: z.boolean().optional() }).strict().nullish();
+const TrackedPushTokenRequest = z
+  .object({
+    workflowWrite: z.boolean().optional(),
+    requestedBranch: z.string().min(1).max(255),
+    baseSha: GitCommitSha,
+  })
+  .strict();
+const PushTokenRequest = z
+  .union([TrackedPushTokenRequest, z.object({ workflowWrite: z.boolean().optional() }).strict()])
+  .nullish();
 const TRANSCRIPT_MAX_BYTES = 50 * 1024 * 1024;
 const SESSION_STATE_MAX_BYTES = 200 * 1024 * 1024;
 const EventBatch = z.array(
@@ -75,12 +96,72 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     (request as RunnerRequest).runnerRun = run;
   }
 
+  async function leaseRunnerMutation(request: FastifyRequest) {
+    const endOperation = app.beginRunRequestOperation(request);
+    const snapshot = (request as RunnerRequest).runnerRun;
+    try {
+      if (!snapshot) throw notFound("Run not found");
+      const snapshotSandbox = readSandbox(snapshot.sandbox);
+      if (!snapshotSandbox.runnerTokenHash) {
+        throw new ApiError(401, "unauthorized", "Runner token required");
+      }
+      const release = await app.acquireRunRequestLease(snapshot.id);
+      request.releaseRunnerRunRequestLease = release;
+      if (request.runRequestAborted || request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+      }
+      const current = (
+        await db
+          .select()
+          .from(runs)
+          .where(
+            and(
+              eq(runs.id, snapshot.id),
+              eq(runs.orgId, snapshot.orgId),
+              eq(runs.projectId, snapshot.projectId),
+              eq(runs.status, "running"),
+            ),
+          )
+          .limit(1)
+      )[0];
+      const sandbox = current ? readSandbox(current.sandbox) : null;
+      if (
+        !current ||
+        !sandbox?.runnerTokenHash ||
+        sandbox.runnerTokenHash !== snapshotSandbox.runnerTokenHash
+      ) {
+        throw new ApiError(
+          409,
+          "runner_callback_inactive",
+          "Runner callback is no longer attached to an active run",
+        );
+      }
+      if (request.runRequestAborted || request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
+      }
+      (request as RunnerRequest).runnerRun = current;
+    } finally {
+      await endOperation();
+    }
+  }
+
   app.post(
     "/internal/runs/:runId/hello",
     {
       config: { public: true },
       preHandler: authenticate,
-      schema: { params: Params, response: { 200: z.record(z.string(), z.unknown()) } },
+      schema: {
+        params: Params,
+        // Optional for a rolling upgrade: old runners remain usable, but their
+        // runs retain tracking version 0 and therefore fail closed for retry.
+        body: z
+          .object({ repositoryWriteTrackingVersion: z.literal(1) })
+          .strict()
+          .nullish(),
+        response: { 200: z.record(z.string(), z.unknown()) },
+      },
     },
     async (request) => {
       const run = (request as RunnerRequest).runnerRun;
@@ -95,6 +176,13 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
       const securitySweepEvidence = isSecuritySweepMode(run.mode)
         ? await securitySweepEvidenceForRun(run, sandbox)
         : null;
+      const repositoryWriteTrackingVersion = (
+        request.body as { repositoryWriteTrackingVersion?: number } | null | undefined
+      )?.repositoryWriteTrackingVersion;
+      const acceptedRepositoryWriteTrackingVersion =
+        config.repositoryWriteTrackingPromotionEnabled && repositoryWriteTrackingVersion === 1
+          ? 1
+          : 0;
       const virtualKeyRevealedAt = new Date().toISOString();
       // Claim the transition to running only if the run is still active. A cancel
       // that lands between the auth snapshot and here must win — we must not
@@ -105,6 +193,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         .set({
           status: "running",
           startedAt: run.startedAt ?? new Date(),
+          repositoryWriteTrackingVersion: acceptedRepositoryWriteTrackingVersion,
           // launch() and /hello race on fast providers. Merge only the field
           // owned by this endpoint so a provider ref attached after the auth
           // snapshot cannot be erased by this one-shot credential claim.
@@ -120,6 +209,11 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
           "Run credentials are no longer available",
         );
       }
+      // /hello is the sole provisioning -> running handshake. Take the shared
+      // callback lease only after that CAS, then revalidate under it before any
+      // one-shot credential is revealed. A concurrent cancel either waits for
+      // the response or wins first and makes this fail closed.
+      await leaseRunnerMutation(request);
       await appendRunEvents(db, run.orgId, run.id, [{ type: "hello", data: {} }]);
       await updateGithubRunProgress(db, run.id, "running", {
         config,
@@ -140,7 +234,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         // Short-lived clone credential for private repos. In production this is
         // a per-run GitHub App installation token; here it falls back to a
         // configured token for self-host / validation.
-        repoToken: await repoTokenForRun(sandbox),
+        repoToken: await repoTokenForRun(run, sandbox),
         // Released through the same one-shot authenticated handshake as the
         // virtual and clone keys, and only when this run has a dedicated
         // dependency-install phase. The sandbox task itself has no IAM access
@@ -150,6 +244,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
           : null,
         securitySweepEvidence,
         gatewayUrls: sandbox.bundle.gatewayUrls,
+        repositoryWriteTrackingVersion: acceptedRepositoryWriteTrackingVersion,
       };
     },
   );
@@ -177,7 +272,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     "/internal/runs/:runId/workspace",
     {
       config: { public: true },
-      preHandler: authenticate,
+      preHandler: [authenticate, leaseRunnerMutation],
       schema: {
         params: Params,
         body: z.object({ baseSha: GitCommitSha }),
@@ -216,7 +311,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     "/internal/runs/:runId/events",
     {
       config: { public: true },
-      preHandler: authenticate,
+      preHandler: [authenticate, leaseRunnerMutation],
       schema: {
         params: Params,
         body: EventBatch,
@@ -266,6 +361,9 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     "/internal/runs/:runId/steer",
     {
       config: { public: true },
+      // Polling is read-only and may wait for 25 seconds. Acquire the shared
+      // run lease only once there is a message to claim, so long polls cannot
+      // exhaust the callback lease pool.
       preHandler: authenticate,
       schema: {
         params: Params,
@@ -288,19 +386,25 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
           .orderBy(asc(steerMessages.createdAt))
           .limit(10);
         if (messages.length > 0) {
-          await db
+          await leaseRunnerMutation(request);
+          const activeRun = (request as RunnerRequest).runnerRun;
+          if (!activeRun) throw notFound("Run not found");
+          const claimed = await db
             .update(steerMessages)
             .set({ deliveredAt: new Date() })
             .where(
               and(
-                eq(steerMessages.runId, run.id),
+                eq(steerMessages.runId, activeRun.id),
+                isNull(steerMessages.deliveredAt),
                 inArray(
                   steerMessages.id,
                   messages.map((message) => message.id),
                 ),
               ),
-            );
-          return messages;
+            )
+            .returning();
+          const claimedIds = new Set(claimed.map((message) => message.id));
+          return messages.filter((message) => claimedIds.has(message.id));
         }
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
@@ -316,56 +420,222 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
       schema: {
         params: Params,
         body: PushTokenRequest,
-        response: { 200: z.object({ token: z.string() }) },
+        response: {
+          200: z.object({
+            token: z.string(),
+            authorizedBranch: z.string().min(1).max(255).nullable(),
+          }),
+        },
       },
     },
     async (request) => {
-      const run = (request as RunnerRequest).runnerRun;
-      if (!run) throw notFound("Run not found");
-      const sandbox = readSandbox(run.sandbox);
-      const repoRef = await repoForRun(run, sandbox);
-      if (!repoRef?.installationId) {
-        throw new ApiError(409, "no_installation", "Run repository has no GitHub installation");
+      const authenticatedRun = (request as RunnerRequest).runnerRun;
+      if (!authenticatedRun) throw notFound("Run not found");
+      const authenticatedSandbox = readSandbox(authenticatedRun.sandbox);
+      if (!authenticatedSandbox.runnerTokenHash) {
+        throw new ApiError(401, "unauthorized", "Runner token required");
       }
-      const installation = (
-        await db
-          .select()
-          .from(githubInstallations)
-          .where(
-            and(
-              eq(githubInstallations.id, repoRef.installationId),
-              eq(githubInstallations.orgId, run.orgId),
-              sql`lower(${githubInstallations.accountLogin}) = lower(${repoRef.owner})`,
-              isNull(githubInstallations.suspendedAt),
-            ),
-          )
-          .limit(1)
-      )[0];
-      if (!installation) {
-        throw new ApiError(409, "no_installation", "Run repository has no GitHub installation");
+      const body = (request.body ?? {}) as NonNullable<z.infer<typeof PushTokenRequest>>;
+      const releaseTransitionLease = await app.acquireRunTransitionLease(authenticatedRun.id);
+      request.releaseRunTransitionLease = releaseTransitionLease;
+      if (request.runRequestAborted || request.raw.aborted) {
+        request.runRequestAborted = true;
+        throw new ApiError(409, "request_aborted", "Request was aborted before execution");
       }
-      const tokenFactory =
-        app.githubInstallationTokenFactory ?? createGithubInstallationTokenFactory(config);
-      const workflowWrite =
-        (request.body as { workflowWrite?: boolean } | null | undefined)?.workflowWrite ?? false;
+      const loadIssuanceContext = async (database: FacilityDb) => {
+        const run = (
+          await database
+            .select()
+            .from(runs)
+            .where(
+              and(
+                eq(runs.id, authenticatedRun.id),
+                eq(runs.orgId, authenticatedRun.orgId),
+                eq(runs.projectId, authenticatedRun.projectId),
+              ),
+            )
+            .limit(1)
+        )[0];
+        if (run?.status !== "running") {
+          throw new ApiError(409, "run_terminal", "Run is not active for repository writes");
+        }
+        const sandbox = readSandbox(run.sandbox);
+        if (sandbox.runnerTokenHash !== authenticatedSandbox.runnerTokenHash) {
+          throw new ApiError(409, "runner_callback_inactive", "Runner credential changed");
+        }
+        if (!isBuilderMode(run.mode) && !repairRepositoryMode(run.mode)) {
+          throw new ApiError(
+            409,
+            "repository_write_mode_forbidden",
+            "Run mode is not allowed to request repository write credentials",
+          );
+        }
+        const repoRef = await repoForRun(run, sandbox, database);
+        if (!repoRef?.installationId) {
+          throw new ApiError(409, "no_installation", "Run repository has no GitHub installation");
+        }
+        if (run.repositoryWriteTrackingVersion === 1) {
+          if (!isTrackedPushTokenRequest(body)) {
+            throw new ApiError(
+              409,
+              "repository_write_tracking_required",
+              "Tracked runner omitted its durable repository write intent",
+            );
+          }
+          assertRepositoryWriteIntent(run, sandbox, body.requestedBranch, body.baseSha);
+        }
+        const installation = (
+          await database
+            .select()
+            .from(githubInstallations)
+            .where(
+              and(
+                eq(githubInstallations.id, repoRef.installationId),
+                eq(githubInstallations.orgId, run.orgId),
+                sql`lower(${githubInstallations.accountLogin}) = lower(${repoRef.owner})`,
+                isNull(githubInstallations.suspendedAt),
+              ),
+            )
+            .limit(1)
+        )[0];
+        if (!installation) {
+          throw new ApiError(409, "no_installation", "Run repository has no GitHub installation");
+        }
+        return { run, sandbox, repoRef, installation };
+      };
+
+      const initial = await loadIssuanceContext(db);
+      const workflowWrite = body.workflowWrite ?? false;
       const permissions: Record<string, string> = workflowWrite
         ? { contents: "write", workflows: "write" }
         : { contents: "write" };
-      const token = await tokenFactory({
-        installationId: installation.installationId,
-        owner: repoRef.owner,
-        repo: repoRef.name,
-        permissions,
+      const permissionNames = Object.keys(permissions);
+      const tokenFactory =
+        app.githubInstallationTokenFactory ?? createGithubInstallationTokenFactory(config);
+      if (initial.run.repositoryWriteTrackingVersion !== 1) {
+        if (isTrackedPushTokenRequest(body)) {
+          throw new ApiError(
+            409,
+            "repository_write_tracking_required",
+            "Run did not negotiate durable repository write tracking",
+          );
+        }
+        const credential = await mintRepositoryWriteCredential(tokenFactory, initial, permissions);
+        const { issuedAt, expiresAt } = exactCredentialTimes(credential);
+        await insertAuditEvent(db, {
+          orgId: initial.run.orgId,
+          projectId: initial.run.projectId,
+          actor: { type: "agent", id: initial.run.id },
+          action: "run.push_token_issued",
+          target: { type: "run", id: initial.run.id },
+          payload: {
+            repoId: initial.repoRef.id,
+            provider: "github_installation",
+            permissions: permissionNames,
+            issuedAt: issuedAt.toISOString(),
+            expiresAt: expiresAt.toISOString(),
+            repositoryWriteTrackingVersion: 0,
+          },
+        });
+        // Rolling-deploy compatibility only. There is deliberately no
+        // invented branch evidence, and tracking version 0 makes this run
+        // permanently fail closed for governed retry.
+        return { token: credential.token, authorizedBranch: null };
+      }
+      if (!isTrackedPushTokenRequest(body)) {
+        throw new ApiError(
+          409,
+          "repository_write_tracking_required",
+          "Tracked runner omitted its durable repository write intent",
+        );
+      }
+      const githubFactory = app.githubClientFactory ?? createGithubClientFactory(config);
+      const github = new FacilityGithubClient(
+        await githubFactory(initial.installation.installationId),
+        {
+          owner: initial.repoRef.owner,
+          repo: initial.repoRef.name,
+          defaultBranch: initial.repoRef.defaultBranch,
+        },
+      );
+      const authorizedBranch = repairRepositoryMode(initial.run.mode)
+        ? await verifyExistingRepositoryWriteBranch(
+            github,
+            initial.run,
+            initial.repoRef,
+            body.requestedBranch,
+            body.baseSha,
+          )
+        : await selectAvailableRepositoryWriteBranch(github, body.requestedBranch, initial.run.id);
+
+      // Transaction 1 commits durable evidence before any provider call. If
+      // token minting becomes ambiguous, this reservation remains and later
+      // retry admission fails closed until explicit reconciliation.
+      const lease = await db.transaction(async (transaction) => {
+        const tx = transaction as unknown as FacilityDb;
+        const current = await loadIssuanceContext(tx);
+        if (
+          current.repoRef.id !== initial.repoRef.id ||
+          current.installation.id !== initial.installation.id
+        ) {
+          throw new ApiError(
+            409,
+            "repository_write_context_changed",
+            "Repository write context changed before reservation",
+          );
+        }
+        return reserveRepositoryWriteLease(tx, {
+          orgId: current.run.orgId,
+          projectId: current.run.projectId,
+          runId: current.run.id,
+          repoId: current.repoRef.id,
+          requestedBranch: body.requestedBranch,
+          authorizedBranch,
+          baseSha: body.baseSha,
+          permissions: permissionNames,
+        });
       });
-      await insertAuditEvent(db, {
-        orgId: run.orgId,
-        projectId: run.projectId,
-        actor: { type: "agent", id: run.id },
-        action: "run.push_token_issued",
-        target: { type: "run", id: run.id },
-        payload: { repoId: repoRef.id, permissions: Object.keys(permissions) },
+
+      let credential: Awaited<ReturnType<typeof tokenFactory>>;
+      try {
+        credential = await mintRepositoryWriteCredential(tokenFactory, initial, permissions);
+      } catch {
+        throw new ApiError(
+          503,
+          "repository_write_credential_indeterminate",
+          "Repository write credential issuance is indeterminate",
+          undefined,
+          true,
+        );
+      }
+      const { issuedAt, expiresAt } = exactCredentialTimes(credential);
+
+      // Transaction 2 makes the exact provider expiry and audit durable. A
+      // commit failure leaves transaction 1's reservation visible and the
+      // credential is never returned to the runner.
+      await db.transaction(async (transaction) => {
+        const tx = transaction as unknown as FacilityDb;
+        await markRepositoryWriteLeaseIssued(tx, lease, issuedAt, expiresAt);
+        await insertAuditEvent(tx, {
+          orgId: initial.run.orgId,
+          projectId: initial.run.projectId,
+          actor: { type: "agent", id: initial.run.id },
+          action: "run.push_token_issued",
+          target: { type: "run", id: initial.run.id },
+          payload: {
+            leaseId: lease.id,
+            repoId: initial.repoRef.id,
+            requestedBranch: body.requestedBranch,
+            authorizedBranch,
+            baseSha: body.baseSha.toLowerCase(),
+            provider: "github_installation",
+            permissions: permissionNames,
+            issuedAt: issuedAt.toISOString(),
+            expiresAt: expiresAt.toISOString(),
+          },
+        });
       });
-      return { token };
+      return { token: credential.token, authorizedBranch };
     },
   );
 
@@ -373,7 +643,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     "/internal/runs/:runId/transcript",
     {
       config: { public: true },
-      preHandler: authenticate,
+      preHandler: [authenticate, leaseRunnerMutation],
       schema: {
         params: Params,
         response: { 200: z.object({ uri: z.string() }) },
@@ -406,7 +676,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
     "/internal/runs/:runId/session-state",
     {
       config: { public: true },
-      preHandler: authenticate,
+      preHandler: [authenticate, leaseRunnerMutation],
       schema: {
         params: Params,
         response: { 200: z.object({ uri: z.string() }) },
@@ -518,6 +788,7 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
       return (await finishRun(db, run, body, {
         config,
         githubClientFactory: app.githubClientFactory,
+        transitionDb: app.runTransitionDb,
         enqueue: app.enqueue,
       })) as unknown as Record<string, unknown>;
     },
@@ -531,40 +802,59 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
   const cloneTokenFallback = (): string | null =>
     config.facilityInsecureDev ? (config.githubCloneToken ?? null) : null;
 
-  async function repoTokenForRun(sandbox: RunSandboxState): Promise<string | null> {
-    const repo = sandbox.bundle?.repo;
-    if (!repo?.installationTokenRef || !repo.cloneUrl) return cloneTokenFallback();
+  async function repoTokenForRun(
+    run: typeof runs.$inferSelect,
+    sandbox: RunSandboxState,
+  ): Promise<string | null> {
+    const bundleRepo = sandbox.bundle?.repo;
+    if (!bundleRepo?.installationTokenRef || !bundleRepo.cloneUrl) return cloneTokenFallback();
+    const parsed = parseGithubCloneUrl(bundleRepo.cloneUrl);
+    if (!parsed) return cloneTokenFallback();
+    const boundRepo = await repoForRun(run, sandbox);
+    if (!boundRepo || boundRepo.installationId !== bundleRepo.installationTokenRef) {
+      return cloneTokenFallback();
+    }
     const installation = (
       await db
         .select()
         .from(githubInstallations)
-        .where(eq(githubInstallations.id, repo.installationTokenRef))
+        .where(
+          and(
+            eq(githubInstallations.id, bundleRepo.installationTokenRef),
+            eq(githubInstallations.orgId, run.orgId),
+            sql`lower(${githubInstallations.accountLogin}) = lower(${parsed.owner})`,
+            isNull(githubInstallations.suspendedAt),
+          ),
+        )
         .limit(1)
     )[0];
     if (!installation) return cloneTokenFallback();
-    const parsed = parseGithubCloneUrl(repo.cloneUrl);
-    if (!parsed) return cloneTokenFallback();
     const tokenFactory =
       app.githubInstallationTokenFactory ??
       (config.githubAppId && config.githubAppPrivateKey
         ? createGithubInstallationTokenFactory(config)
         : null);
     if (!tokenFactory) return cloneTokenFallback();
-    return tokenFactory({
+    const credential = await tokenFactory({
       installationId: installation.installationId,
       owner: parsed.owner,
       repo: parsed.repo,
       permissions: { contents: "read" },
     });
+    return credential.token;
   }
 
-  async function repoForRun(run: typeof runs.$inferSelect, sandbox: RunSandboxState) {
+  async function repoForRun(
+    run: typeof runs.$inferSelect,
+    sandbox: RunSandboxState,
+    database: FacilityDb = db,
+  ) {
     const parsed = sandbox.bundle?.repo?.cloneUrl
       ? parseGithubCloneUrl(sandbox.bundle.repo.cloneUrl)
       : null;
     if (!parsed) return null;
     return (
-      await db
+      await database
         .select()
         .from(repos)
         .where(
@@ -577,6 +867,60 @@ export async function registerInternalRoutes(app: FastifyInstance, config: AppCo
         )
         .limit(1)
     )[0];
+  }
+
+  function assertRepositoryWriteIntent(
+    run: typeof runs.$inferSelect,
+    sandbox: RunSandboxState,
+    requestedBranch: string,
+    baseSha: string,
+  ) {
+    const normalizedBaseSha = baseSha.toLowerCase();
+    const workspaceBaseSha = gitCommitSha(run.workspaceBaseSha);
+    const bundleBaseSha = gitCommitSha(sandbox.bundle?.repo.expectedHeadSha);
+    const checkoutBranch = sandbox.bundle?.repo.branch;
+    if (
+      !workspaceBaseSha ||
+      normalizedBaseSha !== workspaceBaseSha ||
+      (bundleBaseSha && bundleBaseSha !== normalizedBaseSha) ||
+      !checkoutBranch
+    ) {
+      throw new ApiError(
+        409,
+        "repository_write_base_mismatch",
+        "Repository write intent does not match the verified workspace base",
+      );
+    }
+    if (repairRepositoryMode(run.mode)) {
+      const expectedBranch = stringValue(objectValue(run.gh).branch);
+      if (
+        !expectedBranch ||
+        requestedBranch !== expectedBranch ||
+        requestedBranch !== checkoutBranch
+      ) {
+        throw new ApiError(
+          409,
+          "repository_write_branch_mismatch",
+          "Repository repair must target the exact admitted pull-request branch",
+        );
+      }
+      assertGithubRefName(requestedBranch);
+      return;
+    }
+    if (
+      !isBuilderMode(run.mode) ||
+      requestedBranch === checkoutBranch ||
+      !/^(feature|fix|chore|ci|docs|refactor|perf|test|build|revert)\/[a-z0-9][a-z0-9._/-]*$/.test(
+        requestedBranch,
+      )
+    ) {
+      throw new ApiError(
+        409,
+        "repository_write_branch_mismatch",
+        "Builder repository writes require a new semantic branch",
+      );
+    }
+    assertGithubRefName(requestedBranch);
   }
 
   async function securitySweepEvidenceForRun(
@@ -644,6 +988,57 @@ function bearer(value: string | undefined) {
   return value.slice("Bearer ".length);
 }
 
+function isTrackedPushTokenRequest(
+  value: NonNullable<z.infer<typeof PushTokenRequest>>,
+): value is z.infer<typeof TrackedPushTokenRequest> {
+  return "requestedBranch" in value && "baseSha" in value;
+}
+
+async function mintRepositoryWriteCredential(
+  tokenFactory: GithubInstallationTokenFactory,
+  context: {
+    installation: { installationId: number };
+    repoRef: { owner: string; name: string };
+  },
+  permissions: Record<string, string>,
+) {
+  try {
+    return await tokenFactory({
+      installationId: context.installation.installationId,
+      owner: context.repoRef.owner,
+      repo: context.repoRef.name,
+      permissions,
+    });
+  } catch {
+    throw new ApiError(
+      503,
+      "repository_write_credential_indeterminate",
+      "Repository write credential issuance is indeterminate",
+      undefined,
+      true,
+    );
+  }
+}
+
+function exactCredentialTimes(credential: { token: string; expiresAt: string }) {
+  const issuedAt = new Date();
+  const expiresAt = new Date(credential.expiresAt);
+  if (
+    !credential.token ||
+    !Number.isFinite(expiresAt.getTime()) ||
+    expiresAt.getTime() <= issuedAt.getTime()
+  ) {
+    throw new ApiError(
+      503,
+      "repository_write_credential_indeterminate",
+      "Repository write credential expiry is indeterminate",
+      undefined,
+      true,
+    );
+  }
+  return { issuedAt, expiresAt };
+}
+
 function parseGithubCloneUrl(value: string): { owner: string; repo: string } | null {
   const match = value.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
   if (!match?.[1] || !match[2]) return null;
@@ -652,4 +1047,104 @@ function parseGithubCloneUrl(value: string): { owner: string; repo: string } | n
 
 function isSecuritySweepMode(mode: string) {
   return ["security", "security_sweep"].includes(mode.replace(/^codex-/, "").replace(/-/g, "_"));
+}
+
+function repairRepositoryMode(mode: string) {
+  return ["address_review", "ci_doctor"].includes(mode.replace(/^codex-/, "").replace(/-/g, "_"));
+}
+
+async function verifyExistingRepositoryWriteBranch(
+  github: FacilityGithubClient,
+  run: typeof runs.$inferSelect,
+  repo: typeof repos.$inferSelect,
+  branch: string,
+  baseSha: string,
+) {
+  await github.assertRepositoryAccessible();
+  const triggerPullRequest = objectValue(objectValue(run.trigger).pullRequest);
+  const pullNumber = numberValue(triggerPullRequest.number);
+  const admittedHead = stringValue(triggerPullRequest.head);
+  const admittedHeadSha = gitCommitSha(triggerPullRequest.headSha);
+  const admittedBase = stringValue(triggerPullRequest.base);
+  if (
+    !pullNumber ||
+    admittedHead !== branch ||
+    admittedHeadSha !== gitCommitSha(baseSha) ||
+    admittedBase !== repo.defaultBranch ||
+    numberValue(objectValue(run.gh).issueNumber) !== pullNumber
+  ) {
+    throw new ApiError(
+      409,
+      "repository_write_pull_request_mismatch",
+      "Repository repair is not bound to its admitted pull request",
+    );
+  }
+  try {
+    const [headSha, pullRequest] = await Promise.all([
+      github.getRef(branch),
+      github.getPullRequestWriteTarget(pullNumber),
+    ]);
+    const repository = `${repo.owner}/${repo.name}`.toLowerCase();
+    if (
+      gitCommitSha(headSha) !== gitCommitSha(baseSha) ||
+      pullRequest.number !== pullNumber ||
+      pullRequest.state !== "open" ||
+      pullRequest.mergedAt !== null ||
+      pullRequest.headRepo.toLowerCase() !== repository ||
+      pullRequest.baseRepo.toLowerCase() !== repository ||
+      pullRequest.headRef !== branch ||
+      gitCommitSha(pullRequest.headSha) !== gitCommitSha(baseSha) ||
+      pullRequest.baseRef !== admittedBase
+    ) {
+      throw new Error("pull_request_write_target_changed");
+    }
+  } catch {
+    throw new ApiError(
+      409,
+      "repository_write_pull_request_mismatch",
+      "Repository repair pull request could not be verified",
+    );
+  }
+  return branch;
+}
+
+function assertGithubRefName(branch: string) {
+  if (
+    !branch ||
+    branch.length > 255 ||
+    branch.startsWith("/") ||
+    branch.endsWith("/") ||
+    branch.endsWith(".") ||
+    branch.includes("..") ||
+    branch.includes("@{") ||
+    [...branch].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code <= 32 || code === 127;
+    }) ||
+    ["~", "^", ":", "?", "*", "[", "\\"].some((character) => branch.includes(character))
+  ) {
+    throw new ApiError(
+      409,
+      "repository_write_branch_mismatch",
+      "Repository write branch is not a valid GitHub ref name",
+    );
+  }
+}
+
+function gitCommitSha(value: unknown) {
+  return typeof value === "string" && /^[a-f0-9]{40}$/i.test(value) ? value.toLowerCase() : null;
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(value: unknown) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
 }

--- a/services/api/src/routes/v1/conversations.ts
+++ b/services/api/src/routes/v1/conversations.ts
@@ -10,7 +10,10 @@ import {
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { withBuilderPlanPreflight } from "../../builder-plan-policy.js";
+import {
+  assertGenericRunResumeAllowed,
+  withBuilderPlanPreflight,
+} from "../../builder-plan-policy.js";
 import { ApiError, notFound } from "../../errors.js";
 import {
   assertBareRowProjectScope,
@@ -221,6 +224,22 @@ export async function registerConversationsRoutes(app: FastifyInstance, context:
               .returning()
           )[0];
           if (!claimed) return null;
+          if (claimed.engineSessionId && claimed.lastRunId) {
+            const parent = (
+              await tx
+                .select()
+                .from(runs)
+                .where(
+                  and(
+                    eq(runs.orgId, claimed.orgId),
+                    eq(runs.projectId, claimed.projectId),
+                    eq(runs.id, claimed.lastRunId),
+                  ),
+                )
+                .limit(1)
+            )[0];
+            if (parent) await assertGenericRunResumeAllowed(tx, parent);
+          }
           const rows = await tx
             .select({ max: sql<number>`coalesce(max(seq), 0)` })
             .from(conversationMessages)

--- a/services/api/src/routes/v1/hitl.ts
+++ b/services/api/src/routes/v1/hitl.ts
@@ -247,6 +247,16 @@ export async function registerHitlRoutes(app: FastifyInstance, context: V1RouteC
       if (!can(p.permissions, body.permission)) {
         throw new ApiError(403, "forbidden", "Permission denied", { needed: body.permission });
       }
+      // Deferred execution outlives this request lease. Keep run credentials
+      // fail-closed until the executor can hold and revalidate the same run
+      // lease for the full deferred side effect.
+      if (p.runId) {
+        throw new ApiError(
+          403,
+          "run_key_deferred_mcp_forbidden",
+          "Run-scoped platform keys cannot create deferred MCP proposals",
+        );
+      }
       if (can(p.permissions, "hitl:decide")) {
         throw new ApiError(
           403,
@@ -561,7 +571,12 @@ export async function registerHitlRoutes(app: FastifyInstance, context: V1RouteC
           db,
           row,
           { type: p.type, id: p.id },
-          { config, enqueue: app.enqueue, githubFactory: app.githubClientFactory },
+          {
+            config,
+            transitionDb: app.runTransitionDb,
+            enqueue: app.enqueue,
+            githubFactory: app.githubClientFactory,
+          },
         );
         const executed = (
           await db
@@ -608,6 +623,7 @@ export async function registerHitlRoutes(app: FastifyInstance, context: V1RouteC
         { type: p.type, id: p.id },
         {
           config,
+          transitionDb: app.runTransitionDb,
           enqueue: app.enqueue,
           githubFactory: app.githubClientFactory,
         },

--- a/services/api/src/routes/v1/runs.ts
+++ b/services/api/src/routes/v1/runs.ts
@@ -17,10 +17,12 @@ import { z } from "zod";
 import { withBuilderPlanPreflight } from "../../builder-plan-policy.js";
 import { readTranscriptObject } from "../../envelopes.js";
 import { ApiError, notFound } from "../../errors.js";
-import { cancelRun } from "../../sandbox/orchestrator.js";
+import { acquireExclusiveRunTransitionTransactionLease } from "../../run-api-key-lease.js";
+import { cancelRun, revokeRunKeys } from "../../sandbox/orchestrator.js";
 import {
   appendRunEvents,
   notifyRunEvent,
+  readSandbox,
   TERMINAL_RUN_STATUSES,
   terminalStatus,
 } from "../../sandbox/state.js";
@@ -500,7 +502,11 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
   app.post(
     "/v1/runs/:runId/cancel",
     {
-      config: { permission: "runs:write", auditAction: "run.canceled" },
+      config: {
+        permission: "runs:write",
+        auditAction: "run.canceled",
+        runLifecycle: true,
+      },
       schema: { params: IdParams, response: { 200: RunSchema } },
     },
     async (request) => {
@@ -510,7 +516,8 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
       // Only cancel a non-terminal run — never overwrite a run that already
       // succeeded/failed/canceled. If the guard matches nothing the run is
       // already terminal, so return it unchanged (idempotent).
-      const { row, event } = await db.transaction(async (tx) => {
+      const { row, event } = await app.runTransitionDb.transaction(async (tx) => {
+        await acquireExclusiveRunTransitionTransactionLease(tx, runId);
         // Serialize the terminal transition with event-sequence allocation so
         // every successful cancellation has exactly one durable result event.
         await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${runId}))`);
@@ -544,6 +551,7 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
             })
             .returning()
         )[0];
+        await revokeRunKeys(tx as unknown as typeof db, readSandbox(row.sandbox));
         return { row, event };
       });
       if (!row) return redactRunSecrets(existing);
@@ -786,7 +794,7 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
   app.post(
     "/v1/runs/:runId/resume",
     {
-      config: { permission: "runs:trigger" },
+      config: { permission: "runs:trigger", runLifecycle: true },
       schema: {
         params: IdParams,
         body: z.object({ message: z.string().optional() }).nullable().default({}),

--- a/services/api/src/routes/v1/runs.ts
+++ b/services/api/src/routes/v1/runs.ts
@@ -14,9 +14,13 @@ import { and, desc, eq, notInArray, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply } from "fastify";
 import postgres from "postgres";
 import { z } from "zod";
-import { withBuilderPlanPreflight } from "../../builder-plan-policy.js";
+import {
+  assertGenericRunResumeAllowed,
+  withBuilderPlanPreflight,
+} from "../../builder-plan-policy.js";
 import { readTranscriptObject } from "../../envelopes.js";
 import { ApiError, notFound } from "../../errors.js";
+import { createGovernedBuilderRetry } from "../../governed-builder-retry.js";
 import { acquireExclusiveRunTransitionTransactionLease } from "../../run-api-key-lease.js";
 import { cancelRun, revokeRunKeys } from "../../sandbox/orchestrator.js";
 import {
@@ -500,6 +504,54 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
   );
 
   app.post(
+    "/v1/runs/:runId/retry",
+    {
+      config: { permission: "runs:trigger", idempotent: true, runLifecycle: true },
+      schema: {
+        params: IdParams,
+        body: z
+          .object({ reason: z.string().max(500).optional() })
+          .strict()
+          .nullable()
+          .default({}),
+        response: { 200: RunSchema },
+      },
+    },
+    async (request) => {
+      if (!config.governedBuilderRetryPromotionEnabled) {
+        throw new ApiError(
+          409,
+          "governed_retry_promotion_disabled",
+          "Governed Builder retry is not enabled on this Facility deployment",
+          { requiredAction: "complete_retry_worker_rollout_and_enable_promotion" },
+        );
+      }
+      const p = principal(request);
+      const { runId } = request.params as { runId: string };
+      const body = (request.body ?? {}) as { reason?: string };
+      const result = await createGovernedBuilderRetry(
+        db,
+        app.runTransitionDb,
+        {
+          orgId: p.orgId,
+          projectId: p.projectId,
+          parentRunId: runId,
+          actor: auditActor(p),
+          reason: body.reason,
+        },
+        {
+          config,
+          githubFactory: app.githubClientFactory,
+        },
+      );
+      if (result.run.status === "queued") {
+        await app.enqueue("runs.dispatch", { runId: result.run.id, orgId: result.run.orgId });
+      }
+      return redactRunSecrets(result.run);
+    },
+  );
+
+  app.post(
     "/v1/runs/:runId/cancel",
     {
       config: {
@@ -805,6 +857,7 @@ export async function registerRunsRoutes(app: FastifyInstance, context: V1RouteC
       const p = principal(request);
       const { runId } = request.params as { runId: string };
       const parent = await loadRun(p, runId);
+      await assertGenericRunResumeAllowed(db, parent);
       if (!terminalStatus(parent.status)) {
         throw new ApiError(409, "run_not_terminal", "Only terminal runs can be resumed");
       }

--- a/services/api/src/routes/v1/shared.ts
+++ b/services/api/src/routes/v1/shared.ts
@@ -170,6 +170,7 @@ export const RunSchema = z.object({
   mode: z.string(),
   engine: z.string(),
   status: z.string(),
+  retryOfRunId: z.string().nullable(),
   trigger: AnyObject,
   sandbox: AnyObject,
   receipt: z

--- a/services/api/src/run-api-key-lease.ts
+++ b/services/api/src/run-api-key-lease.ts
@@ -1,0 +1,207 @@
+import type { FacilityDb } from "@facility/db";
+import { sql } from "drizzle-orm";
+import type postgres from "postgres";
+import { ApiError } from "./errors.js";
+
+const DEFAULT_LOCK_TIMEOUT_MS = 30_000;
+
+export function runApiKeyLeaseName(runId: string) {
+  return `facility:run-api-key:${runId}`;
+}
+
+export type RunApiKeyLeaseIdentity = {
+  keyId: string;
+  runId: string;
+  orgId: string;
+  projectId: string | null | undefined;
+};
+
+export async function acquireExclusiveRunTransitionRequestLease(
+  client: postgres.Sql,
+  runId: string,
+  options: { timeoutMs?: number } = {},
+) {
+  const { release } = await acquireSessionRunLease(client, runId, "exclusive", options.timeoutMs);
+  return release;
+}
+
+/** Shared session lease for any authenticated mutation attached to an active run. */
+export async function acquireSharedRunRequestLease(
+  client: postgres.Sql,
+  runId: string,
+  options: { timeoutMs?: number } = {},
+) {
+  const { release } = await acquireSessionRunLease(client, runId, "shared", options.timeoutMs);
+  return release;
+}
+
+/**
+ * Hold a shared session advisory lock for the complete run-scoped API-key request.
+ * Future terminal/retry transitions take the matching exclusive lock, so a
+ * key that authenticated before revocation cannot finish a mutation after a
+ * successor run becomes active.
+ */
+export async function acquireRunApiKeyRequestLease(
+  client: postgres.Sql,
+  identity: RunApiKeyLeaseIdentity,
+  options: { timeoutMs?: number } = {},
+): Promise<() => Promise<void>> {
+  const { reserved, release } = await acquireSessionRunLease(
+    client,
+    identity.runId,
+    "shared",
+    options.timeoutMs,
+  );
+  try {
+    const rows = await reserved<
+      Array<{
+        key_id: string;
+        key_org_id: string;
+        key_project_id: string | null;
+        run_id: string;
+        run_org_id: string;
+        run_project_id: string;
+        run_status: string;
+      }>
+    >`
+      select
+        k.id as key_id,
+        k.org_id as key_org_id,
+        k.project_id as key_project_id,
+        r.id as run_id,
+        r.org_id as run_org_id,
+        r.project_id as run_project_id,
+        r.status as run_status
+      from api_keys as k
+      join runs as r on r.id = k.run_id
+      where k.id = ${identity.keyId}
+        and k.run_id = ${identity.runId}
+        and k.scope_type = 'project'
+        and k.revoked_at is null
+        and (k.expires_at is null or k.expires_at > now())
+      limit 1
+    `;
+    const row = rows[0];
+    if (
+      !row ||
+      !identity.projectId ||
+      row.key_org_id !== identity.orgId ||
+      row.key_project_id !== identity.projectId ||
+      row.run_org_id !== identity.orgId ||
+      row.run_project_id !== identity.projectId ||
+      row.run_status !== "running"
+    ) {
+      throw new ApiError(
+        409,
+        "run_key_inactive",
+        "The run-scoped API key is no longer attached to an active run",
+      );
+    }
+
+    return release;
+  } catch (error) {
+    await release().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function acquireSessionRunLease(
+  client: postgres.Sql,
+  runId: string,
+  mode: "shared" | "exclusive",
+  configuredTimeoutMs?: number,
+): Promise<{ reserved: postgres.ReservedSql; release: () => Promise<void> }> {
+  const reserved = await client.reserve();
+  let locked = false;
+  let releasePromise: Promise<void> | null = null;
+  const release = () => {
+    releasePromise ??= (async () => {
+      let reusable = false;
+      try {
+        if (locked) {
+          // This connection is dedicated to exactly one run lease, so clearing
+          // all session advisory locks is both safer and easier to verify than
+          // returning a pooled session after a mismatched unlock.
+          await reserved`select pg_advisory_unlock_all()`;
+          locked = false;
+        }
+        await reserved`select set_config('lock_timeout', '0', false)`;
+        reusable = true;
+      } finally {
+        // postgres.js ReservedSql has no reliable per-session end() API. A
+        // failed unlock therefore quarantines this dedicated pool slot instead
+        // of returning a possibly locked connection to the pool. Process/app
+        // shutdown closes every quarantined session and its advisory locks.
+        if (reusable) reserved.release();
+      }
+    })();
+    return releasePromise;
+  };
+
+  try {
+    const timeoutMs = Math.max(1, configuredTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS);
+    await reserved`select set_config('lock_timeout', ${`${timeoutMs}ms`}, false)`;
+    if (mode === "shared") {
+      await reserved`select pg_advisory_lock_shared(hashtextextended(${runApiKeyLeaseName(
+        runId,
+      )}, 0))`;
+    } else {
+      await reserved`select pg_advisory_lock(hashtextextended(${runApiKeyLeaseName(runId)}, 0))`;
+    }
+    locked = true;
+    return { reserved, release };
+  } catch (error) {
+    await release().catch(() => undefined);
+    if (postgresErrorCode(error) === "55P03") {
+      throw new ApiError(
+        503,
+        "run_key_lease_timeout",
+        "The active run request could not acquire its execution lease",
+      );
+    }
+    throw error;
+  }
+}
+
+/** Matching exclusive transition primitive for terminal/retry code. */
+export async function acquireExclusiveRunTransitionTransactionLease(
+  db: Pick<FacilityDb, "execute">,
+  runId: string,
+  options: { timeoutMs?: number } = {},
+) {
+  const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS);
+  await db.execute(sql`select set_config('lock_timeout', ${`${timeoutMs}ms`}, true)`);
+  try {
+    await db.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${runApiKeyLeaseName(runId)}, 0))`,
+    );
+  } catch (error) {
+    if (postgresErrorCode(error) === "55P03") {
+      throw new ApiError(
+        503,
+        "run_transition_lease_timeout",
+        "Run transition is waiting for an active run request",
+      );
+    }
+    throw error;
+  }
+}
+
+/** Transaction wrapper used when the caller does not already own a transaction. */
+export async function withExclusiveRunTransitionLease<T>(
+  db: FacilityDb,
+  runId: string,
+  callback: (tx: FacilityDb) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    const database = tx as unknown as FacilityDb;
+    await acquireExclusiveRunTransitionTransactionLease(database, runId);
+    return callback(database);
+  });
+}
+
+function postgresErrorCode(error: unknown) {
+  return error && typeof error === "object" && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : null;
+}

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -47,6 +47,7 @@ import {
 } from "../builder-plan-freshness.js";
 import {
   assertBuilderPlanDispatch,
+  assertGenericRunResumeAllowed,
   builderPlanDenialCode,
   builderPlanRequired,
   recordBuilderPlanDenial,
@@ -80,6 +81,13 @@ import {
   sanitizeSecurityReport,
   syncSecurityFindings,
 } from "../github/security-findings.js";
+import {
+  assertGovernedRetryDispatchState,
+  type GovernedRetryExternalOptions,
+  governedRetryDenial,
+  recordGovernedRetryDenial,
+  validateGovernedRetryForDispatch,
+} from "../governed-builder-retry.js";
 import { harnessFragmentForBundle, validateProjectKb } from "../harness.js";
 import {
   assertPreviewProvisioningAvailable,
@@ -119,6 +127,7 @@ type DispatchRunDeps = {
   sandboxDriver?: (name: SandboxDriverName) => Promise<SandboxDriver>;
   githubFactory?: GithubClientFactory;
   githubClient?: BuilderPlanFreshnessOptions["githubClient"];
+  repositoryWriteClient?: GovernedRetryExternalOptions["repositoryWriteClient"];
 };
 
 type ArchitectPlanPublicationJob = {
@@ -178,21 +187,41 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
   let launchedSandbox: { driver: SandboxDriver; ref: string } | undefined;
   let run: RunRow | undefined;
   let freshnessFailureSource: "worker_initial_freshness" | "worker_claimed_freshness" | null = null;
+  let governedRetryFailureSource:
+    | "worker_initial_governed_retry"
+    | "worker_claimed_governed_retry"
+    | null = null;
   try {
     run = await loadRun(db, job.orgId, job.runId);
     if (run?.status !== "queued") return;
-    const requiredBuilderPlan =
-      isBuilderMode(run.mode) && (await builderPlanRequired(db, run.orgId, run.projectId));
-    const requiredPlanFreshness =
-      requiredBuilderPlan && objectOrEmpty(run.trigger).source === "plan_acceptance";
-    freshnessFailureSource = requiredPlanFreshness ? "worker_initial_freshness" : null;
-    const initialFreshness = requiredPlanFreshness
-      ? await resolveBuilderPlanFreshnessForRun(db, run, {
+    governedRetryFailureSource = run.retryOfRunId ? "worker_initial_governed_retry" : null;
+    freshnessFailureSource = run.retryOfRunId ? "worker_initial_freshness" : null;
+    const initialGovernedRetry = run.retryOfRunId
+      ? await validateGovernedRetryForDispatch(db, run, {
           config,
           githubFactory: deps.githubFactory,
           githubClient: deps.githubClient,
+          repositoryWriteClient: deps.repositoryWriteClient,
         })
       : undefined;
+    const planRoot = initialGovernedRetry?.lineage.root ?? run;
+    const requiredBuilderPlan =
+      isBuilderMode(run.mode) && (await builderPlanRequired(db, run.orgId, run.projectId));
+    const requiredPlanFreshness =
+      requiredBuilderPlan && objectOrEmpty(planRoot.trigger).source === "plan_acceptance";
+    freshnessFailureSource = requiredPlanFreshness ? "worker_initial_freshness" : null;
+    const initialFreshness = initialGovernedRetry
+      ? initialGovernedRetry.evidence.freshness
+      : requiredPlanFreshness
+        ? await resolveBuilderPlanFreshnessForRun(db, planRoot, {
+            config,
+            githubFactory: deps.githubFactory,
+            githubClient: deps.githubClient,
+          })
+        : undefined;
+    // assertBuilderPlanDispatch persists its own denial. Keep this source only
+    // around the external freshness lookup so the outer catch cannot duplicate
+    // that durable audit.
     freshnessFailureSource = null;
     await assertBuilderPlanDispatch(db, {
       orgId: run.orgId,
@@ -202,6 +231,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
       trigger: run.trigger,
       gh: run.gh,
       runId: run.id,
+      acceptanceRunId: initialGovernedRetry?.lineage.root.id,
       actor: { type: "system", id: "runs.dispatch" },
       source: "worker_dispatch",
       freshnessEvidence: initialFreshness,
@@ -220,14 +250,33 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
     // claiming first prevents another worker racing ahead while this final
     // check fails. The outer failure boundary marks the row failed before any
     // credential or sandbox side effect is created.
-    freshnessFailureSource = requiredPlanFreshness ? "worker_claimed_freshness" : null;
-    const claimedFreshness = requiredPlanFreshness
-      ? await resolveBuilderPlanFreshnessForRun(db, run, {
+    const claimedCurrentRun = await loadRun(db, run.orgId, run.id);
+    if (!claimedCurrentRun) return;
+    governedRetryFailureSource = claimedCurrentRun.retryOfRunId
+      ? "worker_claimed_governed_retry"
+      : governedRetryFailureSource;
+    freshnessFailureSource = claimedCurrentRun.retryOfRunId
+      ? "worker_claimed_freshness"
+      : requiredPlanFreshness
+        ? "worker_claimed_freshness"
+        : null;
+    const claimedGovernedRetry = claimedCurrentRun.retryOfRunId
+      ? await validateGovernedRetryForDispatch(db, claimedCurrentRun, {
           config,
           githubFactory: deps.githubFactory,
           githubClient: deps.githubClient,
+          repositoryWriteClient: deps.repositoryWriteClient,
         })
       : undefined;
+    const claimedFreshness = claimedGovernedRetry
+      ? claimedGovernedRetry.evidence.freshness
+      : requiredPlanFreshness
+        ? await resolveBuilderPlanFreshnessForRun(db, planRoot, {
+            config,
+            githubFactory: deps.githubFactory,
+            githubClient: deps.githubClient,
+          })
+        : undefined;
     freshnessFailureSource = null;
     const claimedRunScope = { orgId: run.orgId, runId: run.id };
     const dispatchSnapshot = await withBuilderPlanPreflight(
@@ -240,6 +289,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
         trigger: run.trigger,
         gh: run.gh,
         runId: run.id,
+        acceptanceRunId: claimedGovernedRetry?.lineage.root.id,
         actor: { type: "system", id: "runs.dispatch" },
         source: "worker_claimed_dispatch",
         freshnessEvidence: claimedFreshness,
@@ -247,6 +297,9 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
       async (tx, admission) => {
         let claimedRun = await loadRun(tx, claimedRunScope.orgId, claimedRunScope.runId);
         if (claimedRun?.status !== "provisioning") return null;
+        if (claimedGovernedRetry) {
+          await assertGovernedRetryDispatchState(tx, claimedRun, claimedGovernedRetry);
+        }
         if (claimedRun.mode !== admission.mode) {
           const sealed = (
             await tx
@@ -429,6 +482,7 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
     await updateGithubRunProgress(db, run.id, "provisioning", { config }).catch(() => undefined);
   } catch (error) {
     const builderPlanCode = error instanceof ApiError ? builderPlanDenialCode(error.code) : null;
+    const governedRetry = governedRetryDenial(error);
     if (builderPlanCode && freshnessFailureSource && run) {
       await recordBuilderPlanDenial(
         db,
@@ -448,12 +502,28 @@ export async function dispatchRun(config: AppConfig, job: DispatchJob, deps: Dis
           "freshness_resolution_failed",
       ).catch(() => undefined);
     }
+    if (governedRetry && run) {
+      await recordGovernedRetryDenial(
+        db,
+        run,
+        { type: "system", id: "runs.dispatch" },
+        governedRetryFailureSource ?? "worker_governed_retry",
+        error,
+      ).catch(() => undefined);
+    }
+    const stableFailure = governedRetry
+      ? `${governedRetry.code}:${governedRetry.reason}`
+      : (builderPlanCode ?? errorMessage(error));
     await failRun(
       db,
       job.orgId,
       job.runId,
-      builderPlanCode ?? errorMessage(error),
-      builderPlanCode ? "builder_plan_denied" : "provision_failed",
+      stableFailure,
+      governedRetry
+        ? "governed_retry_denied"
+        : builderPlanCode
+          ? "builder_plan_denied"
+          : "provision_failed",
     ).catch(() => undefined);
     await updateGithubRunProgress(db, job.runId, "failed", { config }).catch(() => undefined);
     // failRun revokes by the persisted sandbox, which on a pre-persist failure
@@ -2761,6 +2831,7 @@ async function resumeForRun(db: ReturnType<typeof createDb>["db"], run: RunRow) 
     if (!parentId) return null;
     const parent = await loadResumeParent(db, run, parentId);
     if (!parent?.engineSessionId) return null;
+    await assertGenericRunResumeAllowed(db, parent);
     return {
       sessionId: parent.engineSessionId,
       sessionStateFrom: parent.id,
@@ -2792,6 +2863,7 @@ async function resumeForRun(db: ReturnType<typeof createDb>["db"], run: RunRow) 
     if (!conversation?.engineSessionId || !parentId) return null;
     const parent = await loadResumeParent(db, run, parentId);
     if (!parent) return null;
+    await assertGenericRunResumeAllowed(db, parent);
     return {
       sessionId: conversation.engineSessionId,
       sessionStateFrom: parent.id,
@@ -3240,6 +3312,44 @@ async function canonicalRunReceipt(
 }
 
 async function previousReceiptDigest(db: ReturnType<typeof createDb>["db"], run: RunRow) {
+  if (run.retryOfRunId) {
+    const seen = new Set<string>([run.id]);
+    let ancestorId: string | null = run.retryOfRunId;
+    for (let depth = 0; ancestorId && depth < 100; depth += 1) {
+      if (seen.has(ancestorId)) return null;
+      seen.add(ancestorId);
+      const ancestor:
+        | {
+            id: string;
+            retryOfRunId: string | null;
+            receipt: unknown;
+          }
+        | undefined = (
+        await db
+          .select({
+            id: runs.id,
+            retryOfRunId: runs.retryOfRunId,
+            receipt: runs.receipt,
+          })
+          .from(runs)
+          .where(
+            and(
+              eq(runs.orgId, run.orgId),
+              eq(runs.projectId, run.projectId),
+              eq(runs.id, ancestorId),
+            ),
+          )
+          .limit(1)
+      )[0];
+      if (!ancestor) return null;
+      const parsed = FacilityReceiptSchema.safeParse(ancestor.receipt);
+      if (parsed.success && verifyFacilityReceipt(parsed.data)) {
+        return parsed.data.integrity?.payload_sha256 ?? null;
+      }
+      ancestorId = ancestor.retryOfRunId;
+    }
+    return null;
+  }
   const candidates = await db
     .select({ receipt: runs.receipt })
     .from(runs)

--- a/services/api/src/sandbox/orchestrator.ts
+++ b/services/api/src/sandbox/orchestrator.ts
@@ -86,6 +86,7 @@ import {
   createPreviewRecord,
   previewAccessUrl,
 } from "../previews.js";
+import { acquireExclusiveRunTransitionTransactionLease } from "../run-api-key-lease.js";
 import type { AppConfig } from "../types.js";
 import { raisePlatformIssue, resolvePlatformIssue } from "../watchtower/issues.js";
 import { sandboxCachePartition, sandboxNamespace } from "./cache.js";
@@ -108,6 +109,8 @@ type RunRow = typeof runs.$inferSelect;
 type FinishRunDeps = {
   config?: AppConfig;
   githubClientFactory?: GithubClientFactory;
+  /** API-originated terminal claims use the dedicated transition pool. */
+  transitionDb?: ReturnType<typeof createDb>["db"];
   enqueue?: (queue: string, data: Record<string, unknown>) => Promise<unknown>;
   /** Test seam for proving terminal run + proposal commit atomicity. */
   afterArchitectPlanOutboxWrite?: () => Promise<void> | void;
@@ -514,63 +517,95 @@ export async function finishRun(
       error = "security_report_invalid";
     }
   }
-  const deliveryError = status === "succeeded" ? platformDeliveryFailure(run, input.git) : null;
-  if (deliveryError) {
-    status = "failed";
-    error = deliveryError;
-  }
-  if (status === "succeeded" && (await runUsesHarness(db, run))) {
-    const checkpoint = await validateProjectKb(db, run.orgId, run.projectId);
-    if (!checkpoint.ok) {
-      status = "failed";
-      error = `kb_checkpoint_failed:${checkpoint.errors.map((e) => e.code).join(",")}`;
-    }
-  }
-  const persistedGh =
-    input.git?.branch && isBuilderMode(run.mode)
-      ? {
-          ...objectOrEmpty(run.gh),
-          branch: input.git.branch,
-          ...(input.git.headSha ? { headSha: input.git.headSha } : {}),
-        }
-      : run.gh;
-  let deliveryPlan: Awaited<ReturnType<typeof prepareRunDelivery>> | null = null;
-  let deliveryPreparationError: string | null = null;
-  if (status === "succeeded" && input.git?.branch && isBuilderMode(run.mode)) {
-    try {
-      deliveryPlan = await prepareRunDelivery(db, { ...run, gh: persistedGh }, input.git);
-    } catch (prepareError) {
-      deliveryPreparationError = errorMessage(prepareError);
-      status = "failed";
-      error = `delivery_repo_unresolvable:${deliveryPreparationError}`;
-    }
-  }
-  const sandbox = readSandbox(run.sandbox);
-  const aggregate = await gatewayAggregate(db, run.id);
-  // A delivery receipt names the published range. Runs without a delivery
-  // still expose the prepared workspace base they actually inspected.
-  const receiptBaseSha = input.git?.baseSha ?? run.workspaceBaseSha;
-  let receipt = await canonicalRunReceipt(
-    db,
-    run,
-    input.receipt,
-    aggregate,
-    status,
-    receiptBaseSha,
-  );
-  const claim = await db.transaction(async (transaction) => {
+  const claim = await (deps?.transitionDb ?? db).transaction(async (transaction) => {
     const tx = transaction as unknown as ReturnType<typeof createDb>["db"];
+    await acquireExclusiveRunTransitionTransactionLease(tx, run.id);
+    // The shared request lease excludes every runner/platform mutation while
+    // we re-read and aggregate terminal evidence. Receipt/KB decisions must
+    // describe this exact immutable parent, not a pre-lock snapshot.
+    const current = (
+      await tx
+        .select()
+        .from(runs)
+        .where(
+          and(eq(runs.id, run.id), eq(runs.orgId, run.orgId), eq(runs.projectId, run.projectId)),
+        )
+        .limit(1)
+    )[0];
+    if (!current || terminalStatus(current.status)) return null;
+    const authenticatedRunnerHash = readSandbox(run.sandbox).runnerTokenHash;
+    if (
+      authenticatedRunnerHash &&
+      readSandbox(current.sandbox).runnerTokenHash !== authenticatedRunnerHash
+    ) {
+      throw new ApiError(
+        409,
+        "runner_callback_inactive",
+        "Runner credential changed before terminal transition",
+      );
+    }
+
+    let claimedStatus = status;
+    let claimedError = error;
+    const deliveryError =
+      claimedStatus === "succeeded" ? platformDeliveryFailure(current, input.git) : null;
+    if (deliveryError) {
+      claimedStatus = "failed";
+      claimedError = deliveryError;
+    }
+    if (claimedStatus === "succeeded" && (await runUsesHarness(tx, current))) {
+      const checkpoint = await validateProjectKb(tx, current.orgId, current.projectId);
+      if (!checkpoint.ok) {
+        claimedStatus = "failed";
+        claimedError = `kb_checkpoint_failed:${checkpoint.errors.map((e) => e.code).join(",")}`;
+      }
+    }
+    const persistedGh =
+      input.git?.branch && isBuilderMode(current.mode)
+        ? {
+            ...objectOrEmpty(current.gh),
+            branch: input.git.branch,
+            ...(input.git.headSha ? { headSha: input.git.headSha } : {}),
+          }
+        : current.gh;
+    let deliveryPlan: Awaited<ReturnType<typeof prepareRunDelivery>> | null = null;
+    let deliveryPreparationError: string | null = null;
+    if (claimedStatus === "succeeded" && input.git?.branch && isBuilderMode(current.mode)) {
+      try {
+        deliveryPlan = await prepareRunDelivery(tx, { ...current, gh: persistedGh }, input.git);
+      } catch (prepareError) {
+        deliveryPreparationError = errorMessage(prepareError);
+        claimedStatus = "failed";
+        claimedError = `delivery_repo_unresolvable:${deliveryPreparationError}`;
+      }
+    }
+    const aggregate = await gatewayAggregate(tx, current.id);
+    // A delivery receipt names the published range. Runs without a delivery
+    // still expose the prepared workspace base they actually inspected.
+    const receiptBaseSha = input.git?.baseSha ?? current.workspaceBaseSha;
+    const receipt = await canonicalRunReceipt(
+      tx,
+      current,
+      input.receipt,
+      aggregate,
+      claimedStatus,
+      receiptBaseSha,
+    );
     const terminal = (
       await tx
         .update(runs)
         .set({
-          status,
+          status: claimedStatus,
           receipt,
-          error,
+          error: claimedError,
           gh: persistedGh,
           engineSessionId: input.engineSessionId,
           endedAt: new Date(),
-          sandbox: { ...sandbox, finishedAt: new Date().toISOString() },
+          // Provider launch and /hello own other sandbox fields. Merge only
+          // the terminal marker so a concurrently attached ref cannot be lost.
+          sandbox: sql`${runs.sandbox} || ${JSON.stringify({
+            finishedAt: new Date().toISOString(),
+          })}::jsonb`,
           updatedAt: new Date(),
         })
         // Terminal status, durable PR delivery intent, and the Architect Gate
@@ -581,18 +616,36 @@ export async function finishRun(
         .returning()
     )[0];
     if (!terminal) return null;
-    if (status === "succeeded" && deliveryPlan) {
+    // Revoke both gateway and platform authority in the same commit that makes
+    // the run terminal. Provider destruction is deliberately post-commit.
+    await revokeRunKeys(tx, readSandbox(terminal.sandbox));
+    if (claimedStatus === "succeeded" && deliveryPlan) {
       await tx.insert(runDeliveries).values(deliveryPlan);
     }
     const architectProposal =
-      status === "succeeded" && isArchitectMode(terminal.mode)
+      claimedStatus === "succeeded" && isArchitectMode(terminal.mode)
         ? await ensureArchitectPlanAcceptance(tx, terminal, receipt)
         : undefined;
     if (architectProposal) await deps?.afterArchitectPlanOutboxWrite?.();
-    return { run: terminal, architectProposalId: architectProposal?.id };
+    return {
+      run: terminal,
+      architectProposalId: architectProposal?.id,
+      status: claimedStatus,
+      error: claimedError,
+      receipt,
+      receiptBaseSha,
+      aggregate,
+      deliveryPlan,
+      deliveryPreparationError,
+    };
   });
   if (!claim) return run;
   const claimed = claim.run;
+  status = claim.status;
+  error = claim.error;
+  let { receipt } = claim;
+  const { aggregate, deliveryPlan, deliveryPreparationError, receiptBaseSha } = claim;
+  const sandbox = readSandbox(claimed.sandbox);
   if (sandbox.driver && sandbox.ref) {
     const driver = await sandboxDriver(sandbox.driver);
     const destroyed = await driver
@@ -601,7 +654,6 @@ export async function finishRun(
       .catch(() => false);
     if (destroyed) await markSandboxDestroyed(db, run.id);
   }
-  await revokeRunKeys(db, sandbox);
   if (status === "succeeded" && deliveryPlan) {
     await deps?.enqueue?.("deliveries.deliver", { runId: run.id }).catch(() => undefined);
   } else if (deliveryPreparationError) {
@@ -670,16 +722,28 @@ export async function finishRun(
       error = `security_issue_sync_failed:${message}`;
       receipt = await canonicalRunReceipt(
         db,
-        run,
+        claimed,
         input.receipt,
         aggregate,
         status,
         receiptBaseSha,
       );
-      await db
-        .update(runs)
-        .set({ status, receipt, error, updatedAt: new Date() })
-        .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id)));
+      await db.transaction(async (transaction) => {
+        const tx = transaction as unknown as ReturnType<typeof createDb>["db"];
+        await acquireExclusiveRunTransitionTransactionLease(tx, run.id);
+        const [downgraded] = await tx
+          .update(runs)
+          .set({ status, receipt, error, updatedAt: new Date() })
+          .where(and(eq(runs.orgId, run.orgId), eq(runs.id, run.id), eq(runs.status, "succeeded")))
+          .returning({ id: runs.id });
+        if (!downgraded) {
+          throw new ApiError(
+            409,
+            "run_terminal_state_changed",
+            "Security synchronization could not update the claimed terminal state",
+          );
+        }
+      });
       await appendRunEvents(db, run.orgId, run.id, [
         { type: "artifact_error", data: { kind: "security_issue_sync_failed", error: message } },
       ]);
@@ -2923,24 +2987,30 @@ export async function failRun(
   runId: string,
   message: string,
   kind: string,
+  transitionDb: ReturnType<typeof createDb>["db"] = db,
 ) {
   // Claim the failure atomically: only a non-terminal run transitions, so a
   // concurrent finish/cancel/fail cannot be clobbered and cleanup runs once.
-  const [failed] = await db
-    .update(runs)
-    .set({ status: "failed", error: message, endedAt: new Date(), updatedAt: new Date() })
-    .where(
-      and(
-        eq(runs.orgId, orgId),
-        eq(runs.id, runId),
-        notInArray(runs.status, [...TERMINAL_RUN_STATUSES]),
-      ),
-    )
-    .returning({ projectId: runs.projectId, sandbox: runs.sandbox, trigger: runs.trigger });
+  const failed = await transitionDb.transaction(async (transaction) => {
+    const tx = transaction as unknown as ReturnType<typeof createDb>["db"];
+    await acquireExclusiveRunTransitionTransactionLease(tx, runId);
+    const failed = (
+      await tx
+        .update(runs)
+        .set({ status: "failed", error: message, endedAt: new Date(), updatedAt: new Date() })
+        .where(
+          and(
+            eq(runs.orgId, orgId),
+            eq(runs.id, runId),
+            notInArray(runs.status, [...TERMINAL_RUN_STATUSES]),
+          ),
+        )
+        .returning({ projectId: runs.projectId, sandbox: runs.sandbox, trigger: runs.trigger })
+    )[0];
+    if (failed) await revokeRunKeys(tx, readSandbox(failed.sandbox));
+    return failed;
+  });
   if (!failed) return; // already terminal — another path handled it.
-  // Reclaim the run's credentials + sandbox so a failed run can't keep calling
-  // the gateway or the platform API.
-  await revokeRunKeys(db, readSandbox(failed.sandbox));
   // A conversation turn holds its thread's "running" lock (new messages are
   // rejected while running). If the run failed BEFORE finishRun could release it
   // (bad image, provisioning error), the thread would deadlock forever — so free

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -50,6 +50,12 @@ export type AppConfig = {
    * old /push-token handler and create unrecorded write authority.
    */
   repositoryWriteTrackingPromotionEnabled?: boolean;
+  /**
+   * Phase-two rollout gate for creating governed Builder successor rows. Keep
+   * false until every worker understands and revalidates immutable retry
+   * lineage. Existing successor rows remain enforceable when this is false.
+   */
+  governedBuilderRetryPromotionEnabled?: boolean;
   // Driver the seeded default sandbox profile uses.
   sandboxDriver: "docker" | "aws" | "vercel";
   authIdentityProvider?: "github" | "oidc";

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -15,6 +15,8 @@ export type Principal = {
   githubLogin?: string;
   avatarUrl?: string;
   projectId?: string | null;
+  /** Present only for short-lived platform keys minted for one run. */
+  runId?: string | null;
   permissions: string[];
 };
 
@@ -42,6 +44,12 @@ export type AppConfig = {
   gatewayUrl: string;
   // Image the seeded default sandbox profile uses to run the platform runner.
   sandboxRunnerImage: string;
+  /**
+   * Phase-two rollout gate. Keep false until every API replica understands
+   * durable repository-write leases; otherwise a tracked run could reach an
+   * old /push-token handler and create unrecorded write authority.
+   */
+  repositoryWriteTrackingPromotionEnabled?: boolean;
   // Driver the seeded default sandbox profile uses.
   sandboxDriver: "docker" | "aws" | "vercel";
   authIdentityProvider?: "github" | "oidc";
@@ -98,11 +106,25 @@ declare module "fastify" {
     githubClientFactory?: GithubClientFactory;
     githubInstallationTokenFactory?: GithubInstallationTokenFactory;
     githubAppMetadataReader?: GithubAppMetadataReader;
+    /** Dedicated low-cardinality DB pool for terminal/retry transactions. */
+    runTransitionDb: FacilityDb;
+    acquireRunTransitionLease: (runId: string) => Promise<() => Promise<void>>;
+    acquireRunRequestLease: (runId: string) => Promise<() => Promise<void>>;
+    beginRunRequestOperation: (request: FastifyRequest) => () => Promise<void>;
   }
   interface FastifyRequest {
     principal?: Principal;
     idempotencyId?: string;
     idempotencyReplayed?: boolean;
+    releasePlatformRunRequestLease?: () => Promise<void>;
+    releaseRunnerRunRequestLease?: () => Promise<void>;
+    releaseRunTransitionLease?: () => Promise<void>;
+    runRequestOperationCount?: number;
+    runRequestAborted?: boolean;
+    runRequestAbortReleaseDeferred?: boolean;
+    runRequestAbortCleanupPromise?: Promise<void>;
+    runRequestHandlerStarted?: boolean;
+    runRequestHandlerSettled?: boolean;
     audit: (
       action: string,
       target: AuditInsert["target"],
@@ -115,5 +137,7 @@ declare module "fastify" {
     public?: boolean;
     orgAdmin?: boolean;
     idempotent?: boolean;
+    /** Terminal/retry run control is never callable by a run-scoped platform key. */
+    runLifecycle?: boolean;
   }
 }

--- a/services/api/test/api.test.ts
+++ b/services/api/test/api.test.ts
@@ -296,7 +296,7 @@ describe("api", async () => {
             : 0),
         0,
       ),
-    ).toBe(140);
+    ).toBe(141);
     expect(document.paths["/v1/projects"]?.get?.security).toEqual([
       { bearerAuth: [] },
       { sessionCookie: [] },
@@ -310,6 +310,13 @@ describe("api", async () => {
       ]),
     );
     expect(document.paths["/v1/projects"]?.post?.parameters).toContainEqual(
+      expect.objectContaining({ name: "Idempotency-Key", in: "header" }),
+    );
+    expect(document.paths["/v1/runs/{runId}/retry"]?.post).toMatchObject({
+      "x-facility-permission": "runs:trigger",
+      tags: ["Runs"],
+    });
+    expect(document.paths["/v1/runs/{runId}/retry"]?.post?.parameters).toContainEqual(
       expect.objectContaining({ name: "Idempotency-Key", in: "header" }),
     );
     expect(document.paths["/health"]?.get?.security).toEqual([]);
@@ -2132,26 +2139,77 @@ describe("api", async () => {
       data: { source: "plan_acceptance", architectRunId: architectRun.id },
     });
 
-    // Optional projects preserve the legacy resume shape: provenance is used
-    // only for the policy preflight and is not copied into the new row, where
-    // the plan-acceptance uniqueness indexes would reject it.
+    // Builder attempts are immutable even while the project policy is optional.
+    // Generic session resume must never bypass the governed successor route.
     await db
       .update(runs)
       .set({ status: "failed", engine: "claude_code", engineSessionId: "plan-resume-session" })
       .where(eq(runs.id, builderRuns[0]?.id ?? ""));
+
+    const originalRetryEnqueue = app.enqueue;
+    const originalRetryFactory = app.githubClientFactory;
+    const retryEnqueues: Array<{ queue: string; data: Record<string, unknown> }> = [];
+    let retryGithubCalls = 0;
+    app.enqueue = async (queue, data) => {
+      retryEnqueues.push({ queue, data });
+      return null;
+    };
+    app.githubClientFactory = async () => {
+      retryGithubCalls += 1;
+      throw new Error("legacy retry reached GitHub");
+    };
+    try {
+      const promotionDisabled = await app.inject({
+        method: "POST",
+        url: `/v1/runs/${builderRuns[0]?.id}/retry`,
+        headers: { cookie, "idempotency-key": `retry-disabled-${Date.now()}` },
+      });
+      expect(promotionDisabled.statusCode, promotionDisabled.body).toBe(409);
+      expect(promotionDisabled.json().error.code).toBe("governed_retry_promotion_disabled");
+      expect(
+        await db
+          .select({ id: runs.id })
+          .from(runs)
+          .where(eq(runs.retryOfRunId, builderRuns[0]?.id ?? "")),
+      ).toHaveLength(0);
+      expect(retryEnqueues).toHaveLength(0);
+
+      config.governedBuilderRetryPromotionEnabled = true;
+      const legacyDenied = await app.inject({
+        method: "POST",
+        url: `/v1/runs/${builderRuns[0]?.id}/retry`,
+        headers: { cookie, "idempotency-key": `retry-legacy-${Date.now()}` },
+      });
+      expect(legacyDenied.statusCode, legacyDenied.body).toBe(409);
+      expect(legacyDenied.json().error).toMatchObject({
+        code: "governed_retry_requires_fresh_gate1",
+        details: {
+          reason: "legacy_repository_write_tracking_unavailable",
+          requiredAction: "run_architect_and_approve_new_plan",
+        },
+      });
+      expect(retryGithubCalls).toBe(0);
+      expect(retryEnqueues).toHaveLength(0);
+      expect(
+        await db
+          .select({ id: runs.id })
+          .from(runs)
+          .where(eq(runs.retryOfRunId, builderRuns[0]?.id ?? "")),
+      ).toHaveLength(0);
+    } finally {
+      config.governedBuilderRetryPromotionEnabled = false;
+      app.enqueue = originalRetryEnqueue;
+      app.githubClientFactory = originalRetryFactory;
+    }
+
     const resumedPlanRun = await app.inject({
       method: "POST",
       url: `/v1/runs/${builderRuns[0]?.id}/resume`,
       headers: { cookie },
       payload: { message: "Continue the optional legacy run" },
     });
-    expect(resumedPlanRun.statusCode).toBe(200);
-    expect(resumedPlanRun.json().trigger).toMatchObject({
-      type: "resume",
-      resumeOf: builderRuns[0]?.id,
-    });
-    expect(resumedPlanRun.json().trigger).not.toHaveProperty("source");
-    expect(resumedPlanRun.json().trigger).not.toHaveProperty("proposalId");
+    expect(resumedPlanRun.statusCode).toBe(409);
+    expect(resumedPlanRun.json().error.code).toBe("builder_resume_forbidden");
 
     const duplicateProposal = await createInternalPlanProposal(
       architectRun.id,
@@ -3067,7 +3125,11 @@ describe("api", async () => {
       throw new Error("MCP Builder denial reached GitHub");
     }) as unknown as GithubClientFactory;
 
-    const executeDenied = async (toolName: string, args: Record<string, unknown>) => {
+    const executeDenied = async (
+      toolName: string,
+      args: Record<string, unknown>,
+      expectedError = "builder_plan_required",
+    ) => {
       const before = await db
         .select({ id: runs.id })
         .from(runs)
@@ -3094,7 +3156,7 @@ describe("api", async () => {
       expect(approved.statusCode, approved.body).toBe(200);
       expect(approved.json()).toMatchObject({
         state: "execution_failed",
-        executionError: "builder_plan_required",
+        executionError: expectedError,
       });
       expect(
         await db.select({ id: runs.id }).from(runs).where(eq(runs.projectId, target.projectId)),
@@ -3113,14 +3175,79 @@ describe("api", async () => {
         number: 204,
         agentName: "builder",
       });
-      await executeDenied("facility_resume_run", {
-        runId: terminalBuilder.id,
-        message: "Attempt governed MCP resume",
+      await executeDenied(
+        "facility_resume_run",
+        {
+          runId: terminalBuilder.id,
+          message: "Attempt governed MCP resume",
+        },
+        "builder_resume_forbidden",
+      );
+      await db
+        .update(conversations)
+        .set({
+          lastRunId: terminalBuilder.id,
+          engineSessionId: terminalBuilder.engineSessionId,
+          status: "idle",
+        })
+        .where(eq(conversations.id, governedConversation.id));
+      // Conversation continuation is an implicit session resume. Verify both
+      // producers reject it synchronously even while Gate 1 is optional, and
+      // leave no message/run/status churn for a worker to clean up later.
+      await db
+        .update(projects)
+        .set({ builderPlanPolicy: "optional" })
+        .where(and(eq(projects.orgId, orgId), eq(projects.id, target.projectId)));
+      const conversationRunsBefore = await db
+        .select({ id: runs.id })
+        .from(runs)
+        .where(eq(runs.projectId, target.projectId));
+      const conversationMessagesBefore = await db
+        .select({ id: conversationMessages.id })
+        .from(conversationMessages)
+        .where(eq(conversationMessages.conversationId, governedConversation.id));
+      await executeDenied(
+        "facility_send_conversation_message",
+        {
+          conversationId: governedConversation.id,
+          body: "Attempt governed Builder conversation turn",
+        },
+        "builder_resume_forbidden",
+      );
+      const restConversationDenied = await app.inject({
+        method: "POST",
+        url: `/v1/conversations/${governedConversation.id}/messages`,
+        headers: { cookie },
+        payload: { body: "Attempt governed Builder REST conversation turn" },
       });
-      await executeDenied("facility_send_conversation_message", {
-        conversationId: governedConversation.id,
-        body: "Attempt governed Builder conversation turn",
+      expect(restConversationDenied.statusCode, restConversationDenied.body).toBe(409);
+      expect(restConversationDenied.json().error.code).toBe("builder_resume_forbidden");
+      expect(
+        await db.select({ id: runs.id }).from(runs).where(eq(runs.projectId, target.projectId)),
+      ).toHaveLength(conversationRunsBefore.length);
+      expect(
+        await db
+          .select({ id: conversationMessages.id })
+          .from(conversationMessages)
+          .where(eq(conversationMessages.conversationId, governedConversation.id)),
+      ).toHaveLength(conversationMessagesBefore.length);
+      expect(
+        (
+          await db
+            .select()
+            .from(conversations)
+            .where(eq(conversations.id, governedConversation.id))
+            .limit(1)
+        )[0],
+      ).toMatchObject({
+        status: "idle",
+        lastRunId: terminalBuilder.id,
+        engineSessionId: terminalBuilder.engineSessionId,
       });
+      await db
+        .update(projects)
+        .set({ builderPlanPolicy: "required" })
+        .where(and(eq(projects.orgId, orgId), eq(projects.id, target.projectId)));
       const beforeRepos = await db
         .select({ id: repos.id })
         .from(repos)
@@ -3167,13 +3294,9 @@ describe("api", async () => {
         .filter((event) => event.action === "run.builder_plan_denied")
         .map((event) => (event.payload as { source?: unknown }).source);
       expect(sources).toEqual(
-        expect.arrayContaining([
-          "mcp_trigger_run",
-          "mcp_trigger_github_issue",
-          "mcp_resume_run",
-          "mcp_conversation_message",
-        ]),
+        expect.arrayContaining(["mcp_trigger_run", "mcp_trigger_github_issue"]),
       );
+      expect(sources).not.toContain("mcp_conversation_message");
     } finally {
       app.enqueue = originalEnqueue;
       app.githubClientFactory = originalFactory;
@@ -3259,8 +3382,7 @@ describe("api", async () => {
             id: newId("run"),
             orgId,
             projectId: target.projectId,
-            agentDefId: target.agent.id,
-            mode: "builder",
+            mode: "analyst",
             engine: "claude_code",
             status: "running",
             createdBy: { type: "test", id: "mcp-interactive" },
@@ -3282,16 +3404,11 @@ describe("api", async () => {
             id: newId("run"),
             orgId,
             projectId: target.projectId,
-            agentDefId: target.agent.id,
-            mode: "builder",
+            mode: "analyst",
             engine: "claude_code",
             engineSessionId: "session_mcp_resume",
             status: "succeeded",
-            trigger: {
-              source: "plan_acceptance",
-              proposalId: newId("prop"),
-              architectRunId: newId("run"),
-            },
+            trigger: { type: "manual" },
             createdBy: { type: "test", id: "mcp-interactive" },
           })
           .returning()
@@ -4669,7 +4786,7 @@ describe("api", async () => {
             orgId,
             projectId: target.projectId,
             agentDefId: target.agent.id,
-            mode: "builder",
+            mode: "analyst",
             engine: "claude_code",
             status: "running",
             sandbox: { runnerTokenHash: await hashKey(parentToken) },
@@ -6957,7 +7074,7 @@ describe("api", async () => {
             orgId,
             projectId: target.projectId,
             agentDefId: target.agent.id,
-            mode: "builder",
+            mode: "analyst",
             engine: "claude_code",
             status: "succeeded",
             engineSessionId: "sess_resume_1",
@@ -6983,7 +7100,7 @@ describe("api", async () => {
         { queue: "runs.dispatch", data: { runId: resumed.json().id, orgId } },
       ]);
 
-      const runningParent = (
+      const builderParent = (
         await db
           .insert(runs)
           .values({
@@ -6992,6 +7109,29 @@ describe("api", async () => {
             projectId: target.projectId,
             agentDefId: target.agent.id,
             mode: "builder",
+            engine: "claude_code",
+            status: "failed",
+            engineSessionId: "sess_builder_resume_forbidden",
+            createdBy: { type: "user", id: "test" },
+          })
+          .returning()
+      )[0];
+      const optionalBuilderResume = await app.inject({
+        method: "POST",
+        url: `/v1/runs/${builderParent?.id}/resume`,
+        headers: { cookie },
+      });
+      expect(optionalBuilderResume.statusCode).toBe(409);
+      expect(optionalBuilderResume.json().error.code).toBe("builder_resume_forbidden");
+
+      const runningParent = (
+        await db
+          .insert(runs)
+          .values({
+            id: newId("run"),
+            orgId,
+            projectId: target.projectId,
+            mode: "analyst",
             engine: "claude_code",
             status: "running",
             engineSessionId: "sess_resume_2",
@@ -7013,8 +7153,7 @@ describe("api", async () => {
             id: newId("run"),
             orgId,
             projectId: target.projectId,
-            agentDefId: target.agent.id,
-            mode: "builder",
+            mode: "analyst",
             engine: "codex",
             status: "succeeded",
             engineSessionId: "sess_codex",
@@ -7030,9 +7169,7 @@ describe("api", async () => {
       expect(codex.statusCode).toBe(409);
       expect(codex.json().error.code).toBe("not_resumable");
 
-      // A resume is a new Builder row, not a second consumption of the
-      // parent's plan acceptance. Required projects therefore deny it before
-      // insertion instead of copying provenance into a non-canonical trigger.
+      // The same Builder guard is independent of project policy.
       await db
         .update(projects)
         .set({ builderPlanPolicy: "required" })
@@ -7044,12 +7181,12 @@ describe("api", async () => {
       const dispatchedBeforeRequiredResume = dispatched.length;
       const governedResume = await app.inject({
         method: "POST",
-        url: `/v1/runs/${parent?.id}/resume`,
+        url: `/v1/runs/${builderParent?.id}/resume`,
         headers: { cookie },
         payload: { message: "attempt a governed resume" },
       });
       expect(governedResume.statusCode, governedResume.body).toBe(409);
-      expect(governedResume.json().error.code).toBe("builder_plan_required");
+      expect(governedResume.json().error.code).toBe("builder_resume_forbidden");
       expect(
         await db.select({ id: runs.id }).from(runs).where(eq(runs.projectId, target.projectId)),
       ).toHaveLength(beforeRequiredResume.length);

--- a/services/api/test/builder-plan-policy.integration.test.ts
+++ b/services/api/test/builder-plan-policy.integration.test.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto";
-import { newId, sealFacilityReceipt } from "@facility/core";
+import { generateApiKey, newId, sealFacilityReceipt } from "@facility/core";
 import {
   actionTypes,
   agentDefs,
+  apiKeys,
   auditEvents,
   createDb,
   type FacilityDb,
@@ -13,12 +14,19 @@ import {
   proposalEvents,
   proposals,
   registryItems,
+  registryVersions,
   repos,
+  roles,
+  runEvents,
+  runRepositoryWriteLeases,
   runs,
+  sandboxProfiles,
+  virtualKeys,
 } from "@facility/db";
 import { and, desc, eq } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../src/app.js";
 import {
   assertBuilderPlanDispatch,
   lockBuilderPlanPolicy,
@@ -28,6 +36,11 @@ import { ApiError } from "../src/errors.js";
 import { githubIssueRevisionSha256 } from "../src/github/issue-revision.js";
 import { syncRepoFacilityConfig } from "../src/github/kickstart.js";
 import { routeTrigger, type TriggerPayload } from "../src/github/router.js";
+import {
+  createGovernedBuilderRetry,
+  validateGovernedRetryForDispatch,
+} from "../src/governed-builder-retry.js";
+import type { SandboxDriver } from "../src/sandbox/driver.js";
 import { dispatchRun } from "../src/sandbox/orchestrator.js";
 import type { AppConfig } from "../src/types.js";
 
@@ -652,6 +665,967 @@ describe("builder plan policy integration", async () => {
     ).toEqual({ status: "failed", error: expected });
     await expect(lastDenialCode(fixture.orgId)).resolves.toBe(expected);
   });
+
+  it("creates one clean governed successor under concurrent retry requests and revalidates it for dispatch", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("governed retry root was not created");
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+
+    const repository = fixture.payload.repository;
+    const owner = repository?.owner?.login;
+    const repo = repository?.name;
+    if (!owner || !repo) throw new Error("governed retry repository fixture missing");
+    const options = { githubClient: { owner, repo, client: fixture.client } };
+    const attempts = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        createGovernedBuilderRetry(
+          db,
+          db,
+          {
+            orgId: fixture.orgId,
+            projectId: fixture.projectId,
+            parentRunId: routed.runId as string,
+            actor: { type: "user", id: "approver" },
+            reason: "Retry the failed tracked Builder",
+          },
+          options,
+        ),
+      ),
+    );
+    expect(new Set(attempts.map((attempt) => attempt.run.id)).size).toBe(1);
+    expect(attempts.filter((attempt) => attempt.created)).toHaveLength(1);
+    const child = attempts[0]?.run;
+    if (!child) throw new Error("governed retry child missing");
+    expect(child).toMatchObject({
+      retryOfRunId: routed.runId,
+      status: "queued",
+      sandbox: {},
+      receipt: null,
+      engineSessionId: null,
+      transcriptUri: null,
+      sessionStateUri: null,
+      gh: { owner, repo, issueNumber: 204 },
+    });
+    expect(await db.select().from(runEvents).where(eq(runEvents.runId, child.id))).toEqual([
+      expect.objectContaining({ seq: 1, type: "queued" }),
+    ]);
+    const retryAudits = await db
+      .select()
+      .from(auditEvents)
+      .where(and(eq(auditEvents.orgId, fixture.orgId), eq(auditEvents.action, "run.retried")));
+    expect(
+      retryAudits.filter((event) => (event.target as { id?: unknown }).id === child.id),
+    ).toHaveLength(1);
+
+    const dispatchValidation = await validateGovernedRetryForDispatch(db, child, options);
+    expect(dispatchValidation.lineage).toMatchObject({
+      parent: { id: routed.runId, status: "failed" },
+      root: { id: routed.runId },
+      depth: 1,
+    });
+    await db
+      .update(runs)
+      .set({ gh: { owner, repo, issueNumber: 204, branch: "forged/output" } })
+      .where(eq(runs.id, child.id));
+    const forged = (await db.select().from(runs).where(eq(runs.id, child.id)).limit(1))[0];
+    if (!forged) throw new Error("forged governed retry child missing");
+    await expect(validateGovernedRetryForDispatch(db, forged, options)).rejects.toMatchObject({
+      code: "governed_retry_lineage_invalid",
+      details: { reason: "successor_not_clean" },
+    });
+    await db
+      .update(runs)
+      .set({ gh: { owner, repo, issueNumber: 204 } })
+      .where(eq(runs.id, child.id));
+
+    const retryConfig: AppConfig = {
+      databaseUrl,
+      secretMasterKey: Buffer.alloc(32, 7).toString("base64"),
+      port: 0,
+      publicUrl: "http://127.0.0.1:4400",
+      webUrl: "http://127.0.0.1:4400",
+      sandboxApiUrl: "http://127.0.0.1:4400",
+      sandboxGatewayUrl: "http://127.0.0.1:4410",
+      gatewayUrl: "http://127.0.0.1:4410",
+      sandboxRunnerImage: "facility-runner:test",
+      sandboxDriver: "docker",
+      facilityInsecureDev: true,
+      packageRegistryToken: "package-token",
+      governedBuilderRetryPromotionEnabled: true,
+      logLevel: "silent",
+    };
+    const roleId = newId("role");
+    await db.insert(roles).values({
+      id: roleId,
+      orgId: fixture.orgId,
+      name: `governed-retry-${crypto.randomUUID()}`,
+      permissions: ["runs:trigger"],
+    });
+    const retryKey = await generateApiKey("fak");
+    await db.insert(apiKeys).values({
+      id: retryKey.id,
+      orgId: fixture.orgId,
+      name: "governed retry integration",
+      prefix: retryKey.lookup,
+      last4: retryKey.last4,
+      hash: retryKey.hash,
+      scopeType: "project",
+      projectId: fixture.projectId,
+      roleId,
+      createdBy: "integration-test",
+    });
+    const foreignOrgId = newId("org");
+    const foreignProjectId = newId("proj");
+    const foreignRoleId = newId("role");
+    await db.insert(orgs).values({
+      id: foreignOrgId,
+      name: "Foreign retry tenant",
+      slug: `foreign-retry-${crypto.randomUUID()}`,
+    });
+    await db.insert(projects).values({
+      id: foreignProjectId,
+      orgId: foreignOrgId,
+      name: "Foreign retry project",
+      slug: `foreign-retry-${crypto.randomUUID()}`,
+    });
+    await db.insert(roles).values({
+      id: foreignRoleId,
+      orgId: foreignOrgId,
+      name: `foreign-retry-${crypto.randomUUID()}`,
+      permissions: ["runs:trigger"],
+    });
+    const foreignKey = await generateApiKey("fak");
+    await db.insert(apiKeys).values({
+      id: foreignKey.id,
+      orgId: foreignOrgId,
+      name: "foreign governed retry integration",
+      prefix: foreignKey.lookup,
+      last4: foreignKey.last4,
+      hash: foreignKey.hash,
+      scopeType: "project",
+      projectId: foreignProjectId,
+      roleId: foreignRoleId,
+      createdBy: "integration-test",
+    });
+    const app = await buildApp(retryConfig);
+    let enqueueAttempts = 0;
+    app.enqueue = async () => {
+      enqueueAttempts += 1;
+      if (enqueueAttempts === 1) throw new Error("simulated_broker_outage");
+      return `job_${enqueueAttempts}`;
+    };
+    await app.ready();
+    try {
+      const crossTenant = await app.inject({
+        method: "POST",
+        url: `/v1/runs/${routed.runId}/retry`,
+        headers: {
+          authorization: `Bearer ${foreignKey.secret}`,
+          "idempotency-key": `governed-retry-foreign-${crypto.randomUUID()}`,
+        },
+      });
+      expect(crossTenant.statusCode).toBe(404);
+      expect(crossTenant.json().error.code).toBe("run_not_found");
+      expect(enqueueAttempts).toBe(0);
+      const idempotencyKey = `governed-retry-adopt-${crypto.randomUUID()}`;
+      const failedEnqueue = await app.inject({
+        method: "POST",
+        url: `/v1/runs/${routed.runId}/retry`,
+        headers: {
+          authorization: `Bearer ${retryKey.secret}`,
+          "idempotency-key": idempotencyKey,
+        },
+      });
+      expect(failedEnqueue.statusCode).toBe(500);
+      const adopted = await app.inject({
+        method: "POST",
+        url: `/v1/runs/${routed.runId}/retry`,
+        headers: {
+          authorization: `Bearer ${retryKey.secret}`,
+          "idempotency-key": idempotencyKey,
+        },
+      });
+      expect(adopted.statusCode, adopted.body).toBe(200);
+      expect(adopted.json()).toMatchObject({ id: child.id, retryOfRunId: routed.runId });
+      expect(enqueueAttempts).toBe(2);
+      expect(
+        await db
+          .select({ id: runs.id })
+          .from(runs)
+          .where(eq(runs.retryOfRunId, routed.runId as string)),
+      ).toHaveLength(1);
+    } finally {
+      await app.close();
+    }
+
+    const builderAgent = (
+      await db
+        .select()
+        .from(agentDefs)
+        .where(eq(agentDefs.id, child.agentDefId ?? ""))
+        .limit(1)
+    )[0];
+    if (!builderAgent) throw new Error("governed retry Builder agent missing");
+    const profileId = newId("sbx");
+    await db.insert(sandboxProfiles).values({
+      id: profileId,
+      orgId: fixture.orgId,
+      projectId: fixture.projectId,
+      name: "Governed retry integration",
+      driver: "docker",
+      image: "facility-runner:test",
+      setup: {},
+      resources: {},
+      network: {},
+    });
+    await db
+      .update(agentDefs)
+      .set({ sandboxProfileId: profileId })
+      .where(eq(agentDefs.id, builderAgent.id));
+    await db.insert(registryVersions).values({
+      id: newId("ver"),
+      orgId: fixture.orgId,
+      itemId: builderAgent.contractItemId,
+      version: 1,
+      content: "Implement only the approved plan.",
+      contentHash: createHash("sha256").update("Implement only the approved plan.").digest("hex"),
+      status: "active",
+      createdBy: "integration-test",
+    });
+    let launches = 0;
+    const driver: SandboxDriver = {
+      name: "docker",
+      launch: async () => {
+        launches += 1;
+        return { ref: `governed-retry-${launches}` };
+      },
+      status: async () => "running",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+    await Promise.all([
+      dispatchRun(
+        retryConfig,
+        { runId: child.id, orgId: fixture.orgId },
+        {
+          githubClient: options.githubClient,
+          sandboxDriver: async () => driver,
+        },
+      ),
+      dispatchRun(
+        retryConfig,
+        { runId: child.id, orgId: fixture.orgId },
+        {
+          githubClient: options.githubClient,
+          sandboxDriver: async () => driver,
+        },
+      ),
+    ]);
+    expect(launches).toBe(1);
+    expect(
+      await db
+        .select({ id: virtualKeys.id })
+        .from(virtualKeys)
+        .where(eq(virtualKeys.runId, child.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select({ id: apiKeys.id }).from(apiKeys).where(eq(apiKeys.runId, child.id)),
+    ).toHaveLength(1);
+    expect(
+      (
+        await db
+          .select({ status: runs.status, sandbox: runs.sandbox })
+          .from(runs)
+          .where(eq(runs.id, child.id))
+          .limit(1)
+      )[0],
+    ).toMatchObject({ status: "provisioning", sandbox: { ref: "governed-retry-1" } });
+  });
+
+  it("fails a governed retry worker on post-creation drift before credentials or sandbox launch", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("governed retry drift root was not created");
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+    const owner = fixture.payload.repository?.owner?.login;
+    const repo = fixture.payload.repository?.name;
+    if (!owner || !repo) throw new Error("governed retry drift repository missing");
+    const child = (
+      await createGovernedBuilderRetry(
+        db,
+        db,
+        {
+          orgId: fixture.orgId,
+          projectId: fixture.projectId,
+          parentRunId: routed.runId,
+          actor: { type: "user", id: "approver" },
+        },
+        { githubClient: { owner, repo, client: fixture.client } },
+      )
+    ).run;
+    await db
+      .update(repos)
+      .set({ fingerprintStatus: "drifted", fingerprintVerifiedAt: new Date() })
+      .where(eq(repos.projectId, fixture.projectId));
+
+    let launches = 0;
+    const driver: SandboxDriver = {
+      name: "docker",
+      launch: async () => {
+        launches += 1;
+        return { ref: "must-not-launch" };
+      },
+      status: async () => "running",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+    await expect(
+      dispatchRun(
+        { databaseUrl } as AppConfig,
+        { runId: child.id, orgId: fixture.orgId },
+        {
+          githubClient: { owner, repo, client: fixture.client },
+          sandboxDriver: async () => driver,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "governed_retry_lane_invalid",
+      details: { reason: "repository_fingerprint_unverified" },
+    });
+    expect(launches).toBe(0);
+    expect(
+      await db
+        .select({ id: virtualKeys.id })
+        .from(virtualKeys)
+        .where(eq(virtualKeys.runId, child.id)),
+    ).toHaveLength(0);
+    expect(
+      await db.select({ id: apiKeys.id }).from(apiKeys).where(eq(apiKeys.runId, child.id)),
+    ).toHaveLength(0);
+    expect(
+      (
+        await db
+          .select({ status: runs.status, error: runs.error, sandbox: runs.sandbox })
+          .from(runs)
+          .where(eq(runs.id, child.id))
+          .limit(1)
+      )[0],
+    ).toEqual({
+      status: "failed",
+      error: "governed_retry_lane_invalid:repository_fingerprint_unverified",
+      sandbox: {},
+    });
+    const denials = await db
+      .select({ target: auditEvents.target, payload: auditEvents.payload })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.orgId, fixture.orgId),
+          eq(auditEvents.action, "run.governed_retry_denied"),
+        ),
+      );
+    expect(denials.filter((event) => (event.target as { id?: unknown }).id === child.id)).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          code: "governed_retry_lane_invalid",
+          reason: "repository_fingerprint_unverified",
+          source: "worker_claimed_governed_retry",
+        }),
+      }),
+    ]);
+  });
+
+  it("rejects a forged successor of a legacy tracking-zero run before GitHub or launch", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("legacy governed retry root was not created");
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+    const parent = (await db.select().from(runs).where(eq(runs.id, routed.runId)).limit(1))[0];
+    const repository = (
+      await db.select().from(repos).where(eq(repos.projectId, fixture.projectId)).limit(1)
+    )[0];
+    if (!parent || !repository) throw new Error("legacy governed retry fixture missing");
+    await db.insert(runRepositoryWriteLeases).values({
+      id: newId("rwl"),
+      orgId: fixture.orgId,
+      projectId: fixture.projectId,
+      runId: parent.id,
+      repoId: repository.id,
+      provider: "github_installation",
+      status: "issued",
+      requestedBranch: "facility/legacy-fabricated",
+      authorizedBranch: "facility/legacy-fabricated",
+      baseSha: String(
+        (parent.trigger as { planProvenance?: { workspaceBaseSha?: unknown } }).planProvenance
+          ?.workspaceBaseSha,
+      ),
+      permissions: ["contents"],
+      issuedAt: new Date(Date.now() - 60 * 60_000),
+      expiresAt: new Date(Date.now() - 30 * 60_000),
+    });
+    const child = (
+      await db
+        .insert(runs)
+        .values({
+          id: newId("run"),
+          orgId: parent.orgId,
+          projectId: parent.projectId,
+          retryOfRunId: parent.id,
+          agentDefId: parent.agentDefId,
+          mode: parent.mode,
+          engine: parent.engine,
+          trigger: parent.trigger,
+          gh: { owner: repository.owner, repo: repository.name, issueNumber: 204 },
+          createdBy: { type: "user", id: "forged-legacy-test" },
+        })
+        .returning()
+    )[0];
+    if (!child) throw new Error("forged legacy child missing");
+    let githubCalls = 0;
+    let launches = 0;
+    const githubClient = {
+      getDefaultBranchSha: async () => {
+        githubCalls += 1;
+        throw new Error("legacy retry reached GitHub");
+      },
+      getIssue: async () => {
+        githubCalls += 1;
+        throw new Error("legacy retry reached GitHub");
+      },
+      listIssueComments: async () => {
+        githubCalls += 1;
+        throw new Error("legacy retry reached GitHub");
+      },
+    } as never;
+    const driver: SandboxDriver = {
+      name: "docker",
+      launch: async () => {
+        launches += 1;
+        return { ref: "must-not-launch" };
+      },
+      status: async () => "running",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+    await expect(
+      dispatchRun(
+        { databaseUrl } as AppConfig,
+        { runId: child.id, orgId: child.orgId },
+        {
+          githubClient: { owner: repository.owner, repo: repository.name, client: githubClient },
+          sandboxDriver: async () => driver,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "governed_retry_requires_fresh_gate1",
+      details: {
+        reason: "legacy_repository_write_tracking_unavailable",
+        requiredAction: "run_architect_and_approve_new_plan",
+      },
+    });
+    expect(githubCalls).toBe(0);
+    expect(launches).toBe(0);
+    expect(
+      await db
+        .select({ id: virtualKeys.id })
+        .from(virtualKeys)
+        .where(eq(virtualKeys.runId, child.id)),
+    ).toHaveLength(0);
+    expect(
+      await db.select({ id: apiKeys.id }).from(apiKeys).where(eq(apiKeys.runId, child.id)),
+    ).toHaveLength(0);
+  });
+
+  it("revalidates repository output across every retry ancestor before worker credentials", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("ancestor evidence root was not created");
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+    const repository = (
+      await db.select().from(repos).where(eq(repos.projectId, fixture.projectId)).limit(1)
+    )[0];
+    const owner = fixture.payload.repository?.owner?.login;
+    const repo = fixture.payload.repository?.name;
+    if (!repository || !owner || !repo) throw new Error("ancestor evidence repository missing");
+    const baseSha = fixture.live.baseSha;
+    const authorizedBranch = `facility/ancestor-${crypto.randomUUID()}`;
+    await db.insert(runRepositoryWriteLeases).values({
+      id: newId("rwl"),
+      orgId: fixture.orgId,
+      projectId: fixture.projectId,
+      runId: routed.runId,
+      repoId: repository.id,
+      provider: "github_installation",
+      status: "issued",
+      requestedBranch: authorizedBranch,
+      authorizedBranch,
+      baseSha,
+      permissions: ["contents"],
+      issuedAt: new Date(Date.now() - 2 * 60 * 60_000),
+      expiresAt: new Date(Date.now() - 60 * 60_000),
+    });
+    let remoteHead = baseSha;
+    const repositoryWriteClient = {
+      repoId: repository.id,
+      client: {
+        assertRepositoryAccessible: async () => undefined,
+        getRef: async () => remoteHead,
+        listPullRequestsForHead: async () => ({ pullRequests: [], hasNextPage: false }),
+      },
+    };
+    const options = {
+      githubClient: { owner, repo, client: fixture.client },
+      repositoryWriteClient,
+    };
+    const firstChild = (
+      await createGovernedBuilderRetry(
+        db,
+        db,
+        {
+          orgId: fixture.orgId,
+          projectId: fixture.projectId,
+          parentRunId: routed.runId,
+          actor: { type: "user", id: "approver" },
+        },
+        options,
+      )
+    ).run;
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, firstChild.id));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, firstChild.id));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, firstChild.id));
+    const grandchild = (
+      await createGovernedBuilderRetry(
+        db,
+        db,
+        {
+          orgId: fixture.orgId,
+          projectId: fixture.projectId,
+          parentRunId: firstChild.id,
+          actor: { type: "user", id: "approver" },
+        },
+        options,
+      )
+    ).run;
+
+    remoteHead = "b".repeat(40);
+    let launches = 0;
+    const driver: SandboxDriver = {
+      name: "docker",
+      launch: async () => {
+        launches += 1;
+        return { ref: "must-not-launch" };
+      },
+      status: async () => "running",
+      async *logs() {},
+      stop: async () => undefined,
+      destroy: async () => undefined,
+    };
+    await expect(
+      dispatchRun(
+        { databaseUrl } as AppConfig,
+        { runId: grandchild.id, orgId: fixture.orgId },
+        {
+          githubClient: options.githubClient,
+          repositoryWriteClient,
+          sandboxDriver: async () => driver,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "governed_retry_durable_output",
+      details: { reason: "remote_branch_or_pull_request_exists" },
+    });
+    expect(launches).toBe(0);
+    expect(
+      await db
+        .select({ id: virtualKeys.id })
+        .from(virtualKeys)
+        .where(eq(virtualKeys.runId, grandchild.id)),
+    ).toHaveLength(0);
+    expect(
+      await db.select({ id: apiKeys.id }).from(apiKeys).where(eq(apiKeys.runId, grandchild.id)),
+    ).toHaveLength(0);
+    expect(
+      (
+        await db
+          .select({ status: runs.status, error: runs.error, sandbox: runs.sandbox })
+          .from(runs)
+          .where(eq(runs.id, grandchild.id))
+          .limit(1)
+      )[0],
+    ).toEqual({
+      status: "failed",
+      error: "governed_retry_durable_output:remote_branch_or_pull_request_exists",
+      sandbox: {},
+    });
+    const denial = (
+      await db
+        .select({ payload: auditEvents.payload })
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.orgId, fixture.orgId),
+            eq(auditEvents.action, "run.governed_retry_denied"),
+          ),
+        )
+        .orderBy(desc(auditEvents.seq))
+        .limit(1)
+    )[0];
+    expect(denial?.payload).toMatchObject({
+      code: "governed_retry_durable_output",
+      reason: "remote_branch_or_pull_request_exists",
+      source: "worker_initial_governed_retry",
+    });
+  });
+
+  it("denies a parallel governed retry when a legacy resume descendant already exists", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("legacy descendant root was not created");
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+    const parent = (await db.select().from(runs).where(eq(runs.id, routed.runId)).limit(1))[0];
+    if (!parent) throw new Error("legacy descendant parent missing");
+    await db.insert(runs).values({
+      id: newId("run"),
+      orgId: parent.orgId,
+      projectId: parent.projectId,
+      agentDefId: parent.agentDefId,
+      mode: parent.mode,
+      engine: parent.engine,
+      status: "succeeded",
+      trigger: { type: "resume", resumeOf: parent.id },
+      gh: {
+        owner: fixture.payload.repository?.owner?.login,
+        repo: fixture.payload.repository?.name,
+        issueNumber: 204,
+        branch: "facility/legacy-resume",
+        pr: { number: 991 },
+      },
+      createdBy: { type: "user", id: "legacy-resume-user" },
+      endedAt: new Date(),
+    });
+    const owner = fixture.payload.repository?.owner?.login;
+    const repo = fixture.payload.repository?.name;
+    if (!owner || !repo) throw new Error("legacy descendant repository missing");
+    let githubCalls = 0;
+    const noNetworkClient = {
+      getDefaultBranchSha: async () => {
+        githubCalls += 1;
+        return fixture.live.baseSha;
+      },
+      getIssue: async () => {
+        githubCalls += 1;
+        return null;
+      },
+      listIssueComments: async () => {
+        githubCalls += 1;
+        return [];
+      },
+    } as never;
+
+    await expect(
+      createGovernedBuilderRetry(
+        db,
+        db,
+        {
+          orgId: fixture.orgId,
+          projectId: fixture.projectId,
+          parentRunId: parent.id,
+          actor: { type: "user", id: "approver" },
+        },
+        { githubClient: { owner, repo, client: noNetworkClient } },
+      ),
+    ).rejects.toMatchObject({
+      code: "governed_retry_durable_output",
+      details: { reason: "legacy_resume_descendant_exists" },
+    });
+    expect(githubCalls).toBe(0);
+    expect(
+      await db.select({ id: runs.id }).from(runs).where(eq(runs.retryOfRunId, parent.id)),
+    ).toHaveLength(0);
+  });
+
+  it("persists one sanitized Gate 1 denial after the retry transaction rolls back", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("stale retry root was not created");
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+    fixture.live.issueBody = "The issue changed after the approved plan";
+    const owner = fixture.payload.repository?.owner?.login;
+    const repo = fixture.payload.repository?.name;
+    if (!owner || !repo) throw new Error("stale retry repository missing");
+
+    await expect(
+      createGovernedBuilderRetry(
+        db,
+        db,
+        {
+          orgId: fixture.orgId,
+          projectId: fixture.projectId,
+          parentRunId: routed.runId,
+          actor: { type: "user", id: "approver" },
+        },
+        { githubClient: { owner, repo, client: fixture.client } },
+      ),
+    ).rejects.toMatchObject({ code: "builder_plan_stale" });
+    expect(
+      await db.select({ id: runs.id }).from(runs).where(eq(runs.retryOfRunId, routed.runId)),
+    ).toHaveLength(0);
+    const denials = await db
+      .select({ target: auditEvents.target, payload: auditEvents.payload })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.orgId, fixture.orgId),
+          eq(auditEvents.action, "run.builder_plan_denied"),
+        ),
+      );
+    expect(
+      denials.filter((event) => (event.target as { id?: unknown }).id === routed.runId),
+    ).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          code: "builder_plan_stale",
+          reason: "base_or_issue_revision_changed",
+          source: "governed_retry_admission",
+        }),
+      }),
+    ]);
+  });
+
+  it("allows the bounded lineage depth and rejects the next successor before GitHub", async () => {
+    const fixture = await githubRouteFixture("open");
+    await db
+      .update(projects)
+      .set({ builderPlanPolicy: "required" })
+      .where(eq(projects.id, fixture.projectId));
+    await db
+      .update(repos)
+      .set({
+        fingerprint: { files: [] },
+        fingerprintStatus: "ok",
+        fingerprintVerifiedAt: new Date(),
+      })
+      .where(eq(repos.projectId, fixture.projectId));
+    const routed = await routeTrigger(db, fixture.orgId, fixture.client, fixture.payload);
+    if (!routed.runId) throw new Error("depth retry root was not created");
+    await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, routed.runId));
+    await db
+      .update(runs)
+      .set({ status: "failed", endedAt: new Date() })
+      .where(eq(runs.id, routed.runId));
+    const owner = fixture.payload.repository?.owner?.login;
+    const repo = fixture.payload.repository?.name;
+    if (!owner || !repo) throw new Error("depth retry repository missing");
+    let githubCalls = 0;
+    const countingClient = {
+      getDefaultBranchSha: async () => {
+        githubCalls += 1;
+        return fixture.live.baseSha;
+      },
+      getIssue: async (number: number) => {
+        githubCalls += 1;
+        return {
+          number,
+          title: "Require a plan",
+          body: "Implement it",
+          state: "open",
+          user: { login: "requester" },
+          labels: [],
+          html_url: `https://github.test/${owner}/${repo}/issues/${number}`,
+        };
+      },
+      listIssueComments: async () => {
+        githubCalls += 1;
+        return [
+          {
+            id: 204,
+            author: "maintainer",
+            authorType: "User",
+            body: "/builder",
+            createdAt: "2026-08-26T10:00:00Z",
+            url: "https://github.test/comments/204",
+          },
+        ];
+      },
+    } as never;
+    let parentRunId = routed.runId;
+    for (let depth = 1; depth <= 100; depth += 1) {
+      const next = (
+        await createGovernedBuilderRetry(
+          db,
+          db,
+          {
+            orgId: fixture.orgId,
+            projectId: fixture.projectId,
+            parentRunId,
+            actor: { type: "user", id: "approver" },
+            reason: `bounded depth ${depth}`,
+          },
+          { githubClient: { owner, repo, client: countingClient } },
+        )
+      ).run;
+      await db.update(runs).set({ status: "provisioning" }).where(eq(runs.id, next.id));
+      await db
+        .update(runs)
+        .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+        .where(eq(runs.id, next.id));
+      await db
+        .update(runs)
+        .set({ status: "failed", endedAt: new Date() })
+        .where(eq(runs.id, next.id));
+      parentRunId = next.id;
+    }
+    const githubCallsAtLimit = githubCalls;
+    await expect(
+      createGovernedBuilderRetry(
+        db,
+        db,
+        {
+          orgId: fixture.orgId,
+          projectId: fixture.projectId,
+          parentRunId,
+          actor: { type: "user", id: "approver" },
+        },
+        { githubClient: { owner, repo, client: countingClient } },
+      ),
+    ).rejects.toMatchObject({
+      code: "governed_retry_lineage_invalid",
+      details: { reason: "lineage_depth_exceeded" },
+    });
+    expect(githubCalls).toBe(githubCallsAtLimit);
+    expect(
+      await db.select({ id: runs.id }).from(runs).where(eq(runs.retryOfRunId, parentRunId)),
+    ).toHaveLength(0);
+  }, 60_000);
 
   it("recovers an executing GitHub plan and a crash after the exact row was created", async () => {
     const executing = await githubRouteFixture("executing");

--- a/services/api/test/builder-plan-producer-inventory.test.ts
+++ b/services/api/test/builder-plan-producer-inventory.test.ts
@@ -8,6 +8,7 @@ const expectedProducerCounts = new Map([
   ["executors.ts", 5],
   ["github/processor.ts", 1],
   ["github/router.ts", 1],
+  ["governed-builder-retry.ts", 1],
   ["integrations/inbound.ts", 1],
   ["learning.ts", 1],
   ["routes/v1/assistant.ts", 1],
@@ -54,7 +55,7 @@ describe("Builder plan producer inventory", () => {
       });
     }
 
-    expect(inserts).toHaveLength(19);
+    expect(inserts).toHaveLength(20);
     expect(
       new Map(
         [...new Set(inserts.map((insert) => insert.relativeFile))].map((file) => [
@@ -117,6 +118,16 @@ function persistsAdmissionMode(
         /admittedMode\s*=\s*admission\.mode\b/.test(body) && /mode\s*:\s*admittedMode\b/.test(body)
       );
     }
+    if (
+      relativeFile === "governed-builder-retry.ts" &&
+      ts.isPropertyAccessExpression(call.expression) &&
+      call.expression.name.text === "transaction"
+    ) {
+      return (
+        body.includes("assertGovernedRetryLockedAdmission(") &&
+        /mode\s*:\s*lockedParent\.mode\b/.test(body)
+      );
+    }
   }
   return false;
 }
@@ -140,6 +151,17 @@ function hasTransactionalAdmissionAncestor(
     ) {
       const body = current.getText(sourceFile);
       return body.includes("lockBuilderPlanPolicy(") && body.includes("assertBuilderPlanDispatch(");
+    }
+    if (
+      relativeFile === "governed-builder-retry.ts" &&
+      ts.isPropertyAccessExpression(call.expression) &&
+      call.expression.name.text === "transaction"
+    ) {
+      const body = current.getText(sourceFile);
+      return (
+        body.includes("lockBuilderPlanPolicy(") &&
+        body.includes("assertGovernedRetryLockedAdmission(")
+      );
     }
   }
   return false;

--- a/services/api/test/config.test.ts
+++ b/services/api/test/config.test.ts
@@ -27,6 +27,16 @@ const validProductionOauthEnv = {
 };
 
 describe("API configuration", () => {
+  it("keeps governed Builder retry promotion fail-closed until explicitly enabled", () => {
+    expect(readConfig(validEnv).governedBuilderRetryPromotionEnabled).toBe(false);
+    expect(
+      readConfig({
+        ...validEnv,
+        FACILITY_GOVERNED_BUILDER_RETRY_PROMOTION: "1",
+      }).governedBuilderRetryPromotionEnabled,
+    ).toBe(true);
+  });
+
   it("accepts a master key that decodes to exactly 32 bytes", () => {
     expect(readConfig(validEnv).secretMasterKey).toBe(validEnv.SECRET_MASTER_KEY);
   });

--- a/services/api/test/github-platform-lane.test.ts
+++ b/services/api/test/github-platform-lane.test.ts
@@ -29,7 +29,7 @@ import {
   seed,
   userIdentities,
 } from "@facility/db";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../src/app.js";
@@ -3879,7 +3879,10 @@ describe("github platform lane", async () => {
     const calls: Parameters<GithubInstallationTokenFactory>[0][] = [];
     app.githubInstallationTokenFactory = async (input) => {
       calls.push(input);
-      return `issued-token-${calls.length}`;
+      return {
+        token: `issued-token-${calls.length}`,
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      };
     };
     const request = (payload?: Record<string, unknown>) =>
       app.inject({
@@ -3895,11 +3898,11 @@ describe("github platform lane", async () => {
       const workflow = await request({ workflowWrite: true });
 
       expect(absent.statusCode, JSON.stringify(absent.json())).toBe(200);
-      expect(absent.json()).toEqual({ token: "issued-token-1" });
+      expect(absent.json()).toEqual({ token: "issued-token-1", authorizedBranch: null });
       expect(explicitFalse.statusCode).toBe(200);
-      expect(explicitFalse.json()).toEqual({ token: "issued-token-2" });
+      expect(explicitFalse.json()).toEqual({ token: "issued-token-2", authorizedBranch: null });
       expect(workflow.statusCode).toBe(200);
-      expect(workflow.json()).toEqual({ token: "issued-token-3" });
+      expect(workflow.json()).toEqual({ token: "issued-token-3", authorizedBranch: null });
       expect(calls).toEqual([
         {
           installationId: installation.installationId,
@@ -3940,11 +3943,33 @@ describe("github platform lane", async () => {
             eq(auditEvents.action, "run.push_token_issued"),
             sql`${auditEvents.target}->>'id' = ${run.id}`,
           ),
-        );
+        )
+        .orderBy(asc(auditEvents.createdAt), asc(auditEvents.id));
       expect(audit.map((event) => event.payload)).toEqual([
-        { repoId: repo.id, permissions: ["contents"] },
-        { repoId: repo.id, permissions: ["contents"] },
-        { repoId: repo.id, permissions: ["contents", "workflows"] },
+        expect.objectContaining({
+          repoId: repo.id,
+          provider: "github_installation",
+          permissions: ["contents"],
+          repositoryWriteTrackingVersion: 0,
+          issuedAt: expect.any(String),
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        }),
+        expect.objectContaining({
+          repoId: repo.id,
+          provider: "github_installation",
+          permissions: ["contents"],
+          repositoryWriteTrackingVersion: 0,
+          issuedAt: expect.any(String),
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        }),
+        expect.objectContaining({
+          repoId: repo.id,
+          provider: "github_installation",
+          permissions: ["contents", "workflows"],
+          repositoryWriteTrackingVersion: 0,
+          issuedAt: expect.any(String),
+          expiresAt: "2099-01-01T00:00:00.000Z",
+        }),
       ]);
       expect(JSON.stringify(audit)).not.toContain("issued-token");
       expect(JSON.stringify(audit)).not.toContain("foreign/repository");
@@ -3958,7 +3983,7 @@ describe("github platform lane", async () => {
     const factoryCalls: Parameters<GithubInstallationTokenFactory>[0][] = [];
     app.githubInstallationTokenFactory = async (input) => {
       factoryCalls.push(input);
-      return "must-not-be-issued";
+      return { token: "must-not-be-issued", expiresAt: "2099-01-01T00:00:00.000Z" };
     };
 
     try {
@@ -4071,7 +4096,10 @@ describe("github platform lane", async () => {
     const factoryCalls: Parameters<GithubInstallationTokenFactory>[0][] = [];
     app.githubInstallationTokenFactory = async (input) => {
       factoryCalls.push(input);
-      return "issued-for-case-equivalent-owner";
+      return {
+        token: "issued-for-case-equivalent-owner",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      };
     };
 
     try {
@@ -4083,7 +4111,10 @@ describe("github platform lane", async () => {
       });
 
       expect(response.statusCode, JSON.stringify(response.json())).toBe(200);
-      expect(response.json()).toEqual({ token: "issued-for-case-equivalent-owner" });
+      expect(response.json()).toEqual({
+        token: "issued-for-case-equivalent-owner",
+        authorizedBranch: null,
+      });
       expect(factoryCalls).toEqual([
         {
           installationId: installation.installationId,
@@ -4128,9 +4159,12 @@ describe("github platform lane", async () => {
         payload: { workflowWrite: true },
       });
 
-      expect(response.statusCode).toBe(500);
+      expect(response.statusCode).toBe(503);
       expect(response.json()).toEqual({
-        error: { code: "internal_error", message: "Internal server error" },
+        error: {
+          code: "repository_write_credential_indeterminate",
+          message: "Repository write credential issuance is indeterminate",
+        },
       });
       expect(calls).toHaveLength(1);
       expect(calls[0]?.permissions).toEqual({ contents: "write", workflows: "write" });

--- a/services/api/test/repository-write-lease.test.ts
+++ b/services/api/test/repository-write-lease.test.ts
@@ -1,0 +1,684 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  inspectRemoteRepositoryWriteOutput,
+  repositoryWriteLeaseEligibility,
+  selectAvailableRepositoryWriteBranch,
+} from "../src/repository-write-lease.js";
+
+const NOW = new Date("2026-09-01T12:00:00.000Z");
+const ISSUED_AT = new Date("2026-09-01T10:00:00.000Z");
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+
+function issuedLease(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "lease_issued",
+    repoId: "repo_primary",
+    provider: "github_installation",
+    status: "issued",
+    requestedBranch: "feature/tracked-delivery",
+    authorizedBranch: "feature/tracked-delivery",
+    baseSha: SHA_A,
+    permissions: ["contents"],
+    issuedAt: ISSUED_AT,
+    expiresAt: new Date("2026-09-01T11:05:00.000Z"),
+    failureReason: null,
+    ...overrides,
+  };
+}
+
+function reservedLease(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "lease_reserved",
+    repoId: "repo_primary",
+    provider: "github_installation",
+    status: "reserved",
+    requestedBranch: "feature/tracked-delivery",
+    authorizedBranch: "feature/tracked-delivery",
+    baseSha: SHA_A,
+    permissions: ["contents"],
+    issuedAt: null,
+    expiresAt: null,
+    failureReason: null,
+    ...overrides,
+  };
+}
+
+function failedLease(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "lease_failed",
+    repoId: "repo_primary",
+    provider: "github_installation",
+    status: "failed",
+    requestedBranch: "feature/tracked-delivery",
+    authorizedBranch: "feature/tracked-delivery",
+    baseSha: SHA_A,
+    permissions: ["contents"],
+    issuedAt: null,
+    expiresAt: null,
+    failureReason: "token_factory_failed",
+    ...overrides,
+  };
+}
+
+function eligibility(values: readonly unknown[], trackingVersion = 1) {
+  return repositoryWriteLeaseEligibility(values, NOW, { trackingVersion });
+}
+
+function githubError(status: number, message = `GitHub returned ${status}`) {
+  return Object.assign(new Error(message), { status });
+}
+
+describe("repository write lease eligibility", () => {
+  it("requires the authenticated runner tracking marker even when no token was requested", () => {
+    expect(eligibility([], 0)).toEqual({
+      eligible: false,
+      reason: "repository_write_tracking_unavailable",
+    });
+    expect(eligibility([], 2)).toEqual({
+      eligible: false,
+      reason: "repository_write_tracking_unavailable",
+    });
+    expect(eligibility([], 1)).toEqual({ eligible: true, remoteInspections: [] });
+  });
+
+  it("accepts only the two canonical permission sets", () => {
+    expect(eligibility([issuedLease({ permissions: ["contents"] })])).toMatchObject({
+      eligible: true,
+    });
+    expect(eligibility([issuedLease({ permissions: ["contents", "workflows"] })])).toMatchObject({
+      eligible: true,
+    });
+
+    for (const permissions of [
+      undefined,
+      null,
+      "contents",
+      [],
+      ["workflows"],
+      ["contents", "contents"],
+      ["workflows", "contents"],
+      ["contents", "administration"],
+      ["contents", "workflows", "metadata"],
+    ]) {
+      expect(eligibility([issuedLease({ permissions })]), JSON.stringify(permissions)).toEqual({
+        eligible: false,
+        reason: "repository_write_lease_malformed",
+      });
+    }
+  });
+
+  it.each([
+    ["unknown provider", issuedLease({ provider: "personal_access_token" })],
+    ["unknown status", issuedLease({ status: "complete" })],
+    ["invalid base SHA", issuedLease({ baseSha: "not-a-sha" })],
+    ["missing requested branch", issuedLease({ requestedBranch: "" })],
+    ["missing authorized branch", issuedLease({ authorizedBranch: "" })],
+    ["padded requested branch", issuedLease({ requestedBranch: " feature/task" })],
+    ["padded authorized branch", issuedLease({ authorizedBranch: "feature/task " })],
+    ["control character in branch", issuedLease({ authorizedBranch: "feature/task\nother" })],
+    ["oversized branch", issuedLease({ authorizedBranch: "a".repeat(256) })],
+    ["leading slash branch", issuedLease({ authorizedBranch: "/feature/task" })],
+    ["trailing slash branch", issuedLease({ authorizedBranch: "feature/task/" })],
+    ["trailing dot branch", issuedLease({ authorizedBranch: "feature/task." })],
+    ["lone at-sign branch", issuedLease({ authorizedBranch: "@" })],
+    ["double-dot branch", issuedLease({ authorizedBranch: "feature/../task" })],
+    ["reflog syntax branch", issuedLease({ authorizedBranch: "feature/@{task" })],
+    ["empty path component branch", issuedLease({ authorizedBranch: "feature//task" })],
+    ["forbidden ref character branch", issuedLease({ authorizedBranch: "feature/task?" })],
+    ["lockfile component branch", issuedLease({ authorizedBranch: "feature/task.lock" })],
+    ["invalid issued date", issuedLease({ issuedAt: "not-a-date" })],
+    ["invalid expiry date", issuedLease({ expiresAt: "not-a-date" })],
+    ["GitHub lease without expiry", issuedLease({ expiresAt: null })],
+    ["GitHub lease expiring at issue time", issuedLease({ expiresAt: ISSUED_AT })],
+    [
+      "persistent fallback carrying an expiry",
+      issuedLease({
+        provider: "configured_fallback",
+        expiresAt: new Date("2026-09-01T13:00:00.000Z"),
+      }),
+    ],
+    ["reserved lease with issue time", reservedLease({ issuedAt: ISSUED_AT })],
+    ["reserved lease with a failure", reservedLease({ failureReason: "unexpected" })],
+    ["failed lease without a reason", failedLease({ failureReason: null })],
+    ["failed lease with an issue time", failedLease({ issuedAt: ISSUED_AT })],
+  ])("fails closed for a malformed %s", (_name, row) => {
+    expect(eligibility([row])).toEqual({
+      eligible: false,
+      reason: "repository_write_lease_malformed",
+    });
+  });
+
+  it("normalizes canonical string dates and SHA casing", () => {
+    const result = eligibility([
+      issuedLease({
+        baseSha: SHA_A.toUpperCase(),
+        issuedAt: "2026-09-01T10:00:00.000Z",
+        expiresAt: "2026-09-01T11:54:59.000Z",
+        requestedBranch: "feature/requested",
+        authorizedBranch: "feature/requested-run12345",
+      }),
+    ]);
+
+    expect(result).toEqual({
+      eligible: true,
+      remoteInspections: [
+        {
+          leaseId: "lease_issued",
+          repoId: "repo_primary",
+          authorizedBranch: "feature/requested-run12345",
+          baseSha: SHA_A,
+        },
+      ],
+    });
+  });
+
+  it("returns every expired issued lease and inspects the authorized branch", () => {
+    const result = eligibility([
+      issuedLease({
+        id: "lease_first",
+        repoId: "repo_first",
+        requestedBranch: "feature/task",
+        authorizedBranch: "feature/task-run00001",
+      }),
+      issuedLease({
+        id: "lease_second",
+        repoId: "repo_second",
+        requestedBranch: "fix/task",
+        authorizedBranch: "fix/task-run00002",
+        baseSha: SHA_B,
+        permissions: ["contents", "workflows"],
+      }),
+    ]);
+
+    expect(result).toEqual({
+      eligible: true,
+      remoteInspections: [
+        {
+          leaseId: "lease_first",
+          repoId: "repo_first",
+          authorizedBranch: "feature/task-run00001",
+          baseSha: SHA_A,
+        },
+        {
+          leaseId: "lease_second",
+          repoId: "repo_second",
+          authorizedBranch: "fix/task-run00002",
+          baseSha: SHA_B,
+        },
+      ],
+    });
+  });
+
+  it("does not let a later expiring lease hide an earlier persistent fallback", () => {
+    expect(
+      eligibility([
+        issuedLease({
+          id: "lease_persistent",
+          provider: "configured_fallback",
+          expiresAt: null,
+        }),
+        issuedLease({
+          id: "lease_later",
+          issuedAt: new Date("2026-09-01T11:00:00.000Z"),
+          expiresAt: new Date("2026-09-01T12:30:00.000Z"),
+        }),
+      ]),
+    ).toEqual({
+      eligible: false,
+      reason: "repository_write_credential_persistent",
+      leaseId: "lease_persistent",
+    });
+  });
+
+  it("blocks an unresolved reservation wherever it appears in the lease history", () => {
+    expect(
+      eligibility([
+        issuedLease({ id: "lease_expired" }),
+        reservedLease({ id: "lease_unresolved" }),
+      ]),
+    ).toEqual({
+      eligible: false,
+      reason: "repository_write_lease_reserved",
+      leaseId: "lease_unresolved",
+    });
+  });
+
+  it("treats a failed issuance as ambiguous rather than assuming no credential escaped", () => {
+    expect(
+      eligibility([issuedLease({ id: "lease_expired" }), failedLease({ id: "lease_failed" })]),
+    ).toEqual({
+      eligible: false,
+      reason: "repository_write_lease_ambiguous",
+      leaseId: "lease_failed",
+    });
+  });
+
+  it("blocks on the furthest live expiry through the conservative clock-skew window", () => {
+    const nearer = new Date("2026-09-01T12:00:00.001Z");
+    const furthest = new Date("2026-09-01T13:00:00.000Z");
+    expect(
+      eligibility([
+        issuedLease({ id: "lease_boundary", expiresAt: NOW }),
+        issuedLease({ id: "lease_nearer", expiresAt: nearer }),
+        issuedLease({ id: "lease_furthest", expiresAt: furthest }),
+      ]),
+    ).toEqual({
+      eligible: false,
+      reason: "repository_write_credential_unexpired",
+      leaseId: "lease_furthest",
+      expiresAt: furthest,
+    });
+
+    expect(eligibility([issuedLease({ expiresAt: NOW })])).toMatchObject({
+      eligible: false,
+      reason: "repository_write_credential_unexpired",
+    });
+    expect(
+      eligibility([issuedLease({ expiresAt: new Date(NOW.getTime() - 5 * 60_000 + 1) })]),
+    ).toMatchObject({
+      eligible: false,
+      reason: "repository_write_credential_unexpired",
+    });
+    expect(
+      eligibility([issuedLease({ expiresAt: new Date(NOW.getTime() - 5 * 60_000) })]),
+    ).toMatchObject({ eligible: true });
+  });
+
+  it("gives malformed evidence precedence over otherwise recognizable blockers", () => {
+    expect(
+      eligibility([
+        issuedLease({
+          id: "lease_persistent",
+          provider: "configured_fallback",
+          expiresAt: null,
+        }),
+        reservedLease({ id: "lease_malformed", permissions: ["workflows"] }),
+      ]),
+    ).toEqual({
+      eligible: false,
+      reason: "repository_write_lease_malformed",
+    });
+  });
+});
+
+describe("remote repository write inspection", () => {
+  function client(input: {
+    accessError?: unknown;
+    headSha?: string;
+    refError?: unknown;
+    pullRequests?: unknown[];
+    hasNextPage?: boolean;
+    pullError?: unknown;
+  }) {
+    return {
+      assertRepositoryAccessible: vi.fn(async () => {
+        if (input.accessError) throw input.accessError;
+      }),
+      getRef: vi.fn(async () => {
+        if (input.refError) throw input.refError;
+        return input.headSha ?? SHA_A;
+      }),
+      listPullRequestsForHead: vi.fn(async () => {
+        if (input.pullError) throw input.pullError;
+        return {
+          pullRequests: input.pullRequests ?? [],
+          hasNextPage: input.hasNextPage ?? false,
+        };
+      }),
+    };
+  }
+
+  it("reports a safely absent branch only after repository access and PR lookup succeed", async () => {
+    const github = client({ refError: githubError(404), pullRequests: [] });
+    await expect(
+      inspectRemoteRepositoryWriteOutput(github, "feature/task", SHA_A),
+    ).resolves.toEqual({ state: "safe_absent", pullRequestCount: 0 });
+    expect(github.assertRepositoryAccessible).toHaveBeenCalledOnce();
+    expect(github.getRef).toHaveBeenCalledWith("feature/task");
+    expect(github.listPullRequestsForHead).toHaveBeenCalledWith("feature/task");
+  });
+
+  it("distinguishes a safely unchanged branch from durable PR output", async () => {
+    await expect(
+      inspectRemoteRepositoryWriteOutput(
+        client({ headSha: SHA_A.toUpperCase(), pullRequests: [] }),
+        "feature/task",
+        SHA_A,
+      ),
+    ).resolves.toEqual({ state: "safe_unchanged", headSha: SHA_A, pullRequestCount: 0 });
+
+    await expect(
+      inspectRemoteRepositoryWriteOutput(
+        client({ headSha: SHA_A, pullRequests: [{ number: 71 }] }),
+        "feature/task",
+        SHA_A,
+      ),
+    ).resolves.toEqual({
+      state: "durable_output",
+      refState: "unchanged",
+      headSha: SHA_A,
+      pullRequestCount: 1,
+    });
+  });
+
+  it("treats a changed branch as durable output even without a pull request", async () => {
+    await expect(
+      inspectRemoteRepositoryWriteOutput(
+        client({ headSha: SHA_B, pullRequests: [] }),
+        "feature/task",
+        SHA_A,
+      ),
+    ).resolves.toEqual({
+      state: "durable_output",
+      refState: "changed",
+      headSha: SHA_B,
+      pullRequestCount: 0,
+    });
+  });
+
+  it("treats a pull request as durable output even when the branch is absent", async () => {
+    await expect(
+      inspectRemoteRepositoryWriteOutput(
+        client({ refError: githubError(404), pullRequests: [{ number: 72 }] }),
+        "feature/task",
+        SHA_A,
+      ),
+    ).resolves.toEqual({
+      state: "durable_output",
+      refState: "absent",
+      pullRequestCount: 1,
+    });
+  });
+
+  it.each([
+    ["invalid approved base", client({}), "invalid-sha"],
+    ["malformed remote head", client({ headSha: "short" }), SHA_A],
+    ["inaccessible repository", client({ accessError: githubError(404) }), SHA_A],
+    ["permission or provider error", client({ refError: githubError(403) }), SHA_A],
+    ["transport error", client({ refError: new Error("network unavailable") }), SHA_A],
+    ["pull-request lookup error", client({ pullError: new Error("PR lookup unavailable") }), SHA_A],
+    ["pagination ambiguity", client({ hasNextPage: true }), SHA_A],
+  ])("fails closed as indeterminate on %s", async (_name, github, baseSha) => {
+    await expect(
+      inspectRemoteRepositoryWriteOutput(github, "feature/task", baseSha),
+    ).resolves.toEqual({ state: "indeterminate" });
+  });
+
+  it("does not consult GitHub when the approved base is malformed", async () => {
+    const github = client({});
+    await inspectRemoteRepositoryWriteOutput(github, "feature/task", "invalid");
+    expect(github.assertRepositoryAccessible).not.toHaveBeenCalled();
+    expect(github.getRef).not.toHaveBeenCalled();
+    expect(github.listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+
+  it("does not consult GitHub when the authorized branch is malformed", async () => {
+    const github = client({});
+    await expect(
+      inspectRemoteRepositoryWriteOutput(github, " feature/task", SHA_A),
+    ).resolves.toEqual({ state: "indeterminate" });
+    expect(github.assertRepositoryAccessible).not.toHaveBeenCalled();
+    expect(github.getRef).not.toHaveBeenCalled();
+    expect(github.listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+
+  it("does not inspect refs or pull requests unless repository access is proven", async () => {
+    const github = client({ accessError: githubError(404) });
+    await expect(
+      inspectRemoteRepositoryWriteOutput(github, "feature/task", SHA_A),
+    ).resolves.toEqual({ state: "indeterminate" });
+    expect(github.assertRepositoryAccessible).toHaveBeenCalledOnce();
+    expect(github.getRef).not.toHaveBeenCalled();
+    expect(github.listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+});
+
+describe("repository write branch selection", () => {
+  it("rejects a malformed requested branch before consulting GitHub", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async () => SHA_A);
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task?",
+        "run_12345678",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "repository_write_branch_unavailable",
+    });
+    expect(assertRepositoryAccessible).not.toHaveBeenCalled();
+    expect(getRef).not.toHaveBeenCalled();
+    expect(listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+
+  it("authorizes a run-scoped first candidate when it is absent", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async () => {
+      throw githubError(404);
+    });
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_12345678",
+      ),
+    ).resolves.toBe("feature/task-run12345678");
+    expect(assertRepositoryAccessible).toHaveBeenCalledOnce();
+    expect(getRef).toHaveBeenCalledTimes(1);
+    expect(getRef).toHaveBeenCalledWith("feature/task-run12345678");
+    expect(listPullRequestsForHead).toHaveBeenCalledWith("feature/task-run12345678");
+  });
+
+  it("selects a deterministic numeric suffix after run-scoped collisions", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async (branch: string) => {
+      if (branch === "feature/task-runabcdefgh" || branch === "feature/task-runabcdefgh-2") {
+        return SHA_B;
+      }
+      throw githubError(404);
+    });
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_abcdefgh",
+      ),
+    ).resolves.toBe("feature/task-runabcdefgh-3");
+    expect(getRef.mock.calls.map(([branch]) => branch)).toEqual([
+      "feature/task-runabcdefgh",
+      "feature/task-runabcdefgh-2",
+      "feature/task-runabcdefgh-3",
+    ]);
+    expect(listPullRequestsForHead).toHaveBeenCalledWith("feature/task-runabcdefgh-3");
+  });
+
+  it("gives distinct runs distinct first candidates for the same requested branch", async () => {
+    const newClient = () => ({
+      assertRepositoryAccessible: vi.fn(async () => undefined),
+      getRef: vi.fn(async (_branch: string) => {
+        throw githubError(404);
+      }),
+      listPullRequestsForHead: vi.fn(async (_branch: string) => ({
+        pullRequests: [],
+        hasNextPage: false,
+      })),
+    });
+    const firstClient = newClient();
+    const secondClient = newClient();
+
+    const candidates = await Promise.all([
+      selectAvailableRepositoryWriteBranch(firstClient, "feature/task", "run_alpha-123"),
+      selectAvailableRepositoryWriteBranch(secondClient, "feature/task", "run_beta-456"),
+    ]);
+
+    expect(candidates).toEqual(["feature/task-runalpha123", "feature/task-runbeta456"]);
+    expect(new Set(candidates).size).toBe(2);
+    expect(firstClient.getRef).toHaveBeenCalledWith(candidates[0]);
+    expect(secondClient.getRef).toHaveBeenCalledWith(candidates[1]);
+  });
+
+  it("does not reuse an absent branch with durable pull-request history", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async (_branch: string) => {
+      throw githubError(404);
+    });
+    const listPullRequestsForHead = vi.fn(async (branch: string) => ({
+      pullRequests: branch === "feature/task-runabcdefgh" ? [{ number: 71 }] : [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_abcdefgh",
+      ),
+    ).resolves.toBe("feature/task-runabcdefgh-2");
+    expect(getRef.mock.calls.map(([branch]) => branch)).toEqual([
+      "feature/task-runabcdefgh",
+      "feature/task-runabcdefgh-2",
+    ]);
+    expect(listPullRequestsForHead.mock.calls.map(([branch]) => branch)).toEqual([
+      "feature/task-runabcdefgh",
+      "feature/task-runabcdefgh-2",
+    ]);
+  });
+
+  it("fails closed immediately when branch availability cannot be proven", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async () => {
+      throw githubError(503);
+    });
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_abcdefgh",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "repository_write_branch_unavailable",
+    });
+    expect(getRef).toHaveBeenCalledTimes(1);
+    expect(listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["incomplete pull-request pagination", async () => ({ pullRequests: [], hasNextPage: true })],
+    ["pull-request lookup failure", async () => Promise.reject(new Error("unavailable"))],
+  ])("fails closed on %s for an absent ref", async (_name, lookup) => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async () => {
+      throw githubError(404);
+    });
+    const listPullRequestsForHead = vi.fn(lookup);
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_abcdefgh",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "repository_write_branch_unavailable",
+    });
+    expect(getRef).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after the bounded collision budget", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async (_branch: string) => SHA_B);
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_abcdefgh",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "repository_write_branch_unavailable",
+    });
+    expect(getRef).toHaveBeenCalledTimes(10);
+    expect(getRef.mock.calls.at(-1)?.[0]).toBe("feature/task-runabcdefgh-10");
+    expect(listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+
+  it("never returns a collision suffix outside the durable branch bound", async () => {
+    const requestedBranch = `feature/${"a".repeat(247)}`;
+    expect(requestedBranch).toHaveLength(255);
+    const assertRepositoryAccessible = vi.fn(async () => undefined);
+    const getRef = vi.fn(async (branch: string) => {
+      if (branch === requestedBranch) return SHA_A;
+      throw githubError(404);
+    });
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        requestedBranch,
+        "run_abcdefgh",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "repository_write_branch_unavailable",
+    });
+    expect(getRef).not.toHaveBeenCalled();
+    expect(listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before ref inspection when repository access cannot be proven", async () => {
+    const assertRepositoryAccessible = vi.fn(async () => {
+      throw githubError(404);
+    });
+    const getRef = vi.fn(async () => SHA_A);
+    const listPullRequestsForHead = vi.fn(async (_branch: string) => ({
+      pullRequests: [],
+      hasNextPage: false,
+    }));
+
+    await expect(
+      selectAvailableRepositoryWriteBranch(
+        { assertRepositoryAccessible, getRef, listPullRequestsForHead },
+        "feature/task",
+        "run_abcdefgh",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "repository_write_branch_unavailable",
+    });
+    expect(getRef).not.toHaveBeenCalled();
+    expect(listPullRequestsForHead).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/test/run-request-leases.integration.test.ts
+++ b/services/api/test/run-request-leases.integration.test.ts
@@ -1,0 +1,1003 @@
+import { request as httpRequest } from "node:http";
+import { generateApiKey, hashKey, newId, seal } from "@facility/core";
+import {
+  actionTypes,
+  apiKeys,
+  createDb,
+  githubInstallations,
+  idempotencyRecords,
+  migrate,
+  orgs,
+  poTasks,
+  projects,
+  proposalEvents,
+  proposals,
+  repos,
+  roles,
+  runEvents,
+  runRepositoryWriteLeases,
+  runs,
+  seed,
+  steerMessages,
+} from "@facility/db";
+import { and, eq } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../src/app.js";
+import type { AppConfig } from "../src/types.js";
+
+const databaseUrl =
+  process.env.DATABASE_URL ?? "postgres://facility:facility@127.0.0.1:5461/facility_test";
+const masterKey = Buffer.alloc(32, 19).toString("base64");
+
+async function canConnect() {
+  const client = postgres(databaseUrl, { max: 1, connect_timeout: 10 });
+  try {
+    await client`select 1`;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function outcomeWithin<T>(promise: Promise<T>, timeoutMs: number) {
+  const pending = Symbol("pending");
+  return Promise.race([
+    promise,
+    new Promise<typeof pending>((resolve) => setTimeout(() => resolve(pending), timeoutMs)),
+  ]);
+}
+
+describe("active-run request leases", async () => {
+  const reachable = await canConnect();
+  if (!reachable) {
+    it.skip("Postgres is unreachable at DATABASE_URL; request lease tests skipped", () =>
+      undefined);
+    return;
+  }
+
+  const config = (promotion: boolean): AppConfig => ({
+    databaseUrl,
+    secretMasterKey: masterKey,
+    port: 4419,
+    publicUrl: "http://127.0.0.1:0",
+    sandboxApiUrl: "http://127.0.0.1:0",
+    sandboxGatewayUrl: "http://127.0.0.1:0",
+    gatewayUrl: "http://127.0.0.1:0",
+    sandboxRunnerImage: "facility-runner:test",
+    sandboxDriver: "docker",
+    repositoryWriteTrackingPromotionEnabled: promotion,
+    facilityInsecureDev: true,
+    logLevel: "silent",
+  });
+
+  const { db, client } = createDb(databaseUrl);
+  const defaultApp = await buildApp(config(false));
+  const promotedApp = await buildApp(config(true));
+  let handlerCommitBarrier:
+    | { entered: ReturnType<typeof deferred>; release: ReturnType<typeof deferred> }
+    | undefined;
+  defaultApp.post(
+    "/__test/run-mutation-after-commit",
+    { config: { permission: "tasks:write", auditAction: "test.run_mutation" } },
+    async (request, reply) => {
+      const body = request.body as { projectId: string; title: string };
+      await db.insert(poTasks).values({
+        id: newId("task"),
+        orgId: request.principal?.orgId ?? "",
+        projectId: body.projectId,
+        title: body.title,
+        bodyMd: "committed before disconnect",
+        status: "draft",
+        wsjf: {},
+      });
+      handlerCommitBarrier?.entered.resolve();
+      await handlerCommitBarrier?.release.promise;
+      // Model a transport pipeline that is gone before onSend: the production
+      // request wrapper must seal the idempotency key in its handler-finally
+      // fallback rather than rely on response hooks that will never execute.
+      reply.hijack();
+      return reply;
+    },
+  );
+  defaultApp.post(
+    "/__test/run-mutation-server-error",
+    { config: { permission: "tasks:write", auditAction: "test.run_mutation_error" } },
+    async (request, reply) => {
+      const body = request.body as { projectId: string; title: string };
+      await db.insert(poTasks).values({
+        id: newId("task"),
+        orgId: request.principal?.orgId ?? "",
+        projectId: body.projectId,
+        title: body.title,
+        bodyMd: "committed before server error",
+        status: "draft",
+        wsjf: {},
+      });
+      return reply.status(503).send({
+        error: { code: "test_post_commit_failure", message: "Post-commit failure" },
+      });
+    },
+  );
+  let barrier: ((request: { url: string }) => Promise<void>) | undefined;
+  for (const app of [defaultApp, promotedApp]) {
+    app.addHook("onSend", async (request, _reply, payload) => {
+      await barrier?.(request);
+      return payload;
+    });
+  }
+
+  let orgId = "";
+  let projectId = "";
+  let cookie = "";
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    await migrate(databaseUrl);
+    await seed(databaseUrl);
+    await defaultApp.ready();
+    await promotedApp.ready();
+    const login = await defaultApp.inject({
+      method: "POST",
+      url: "/__test/session",
+      payload: { email: `run-lease-${Date.now()}@example.com` },
+    });
+    expect(login.statusCode).toBe(200);
+    cookie = login.cookies.map((item) => `${item.name}=${item.value}`).join("; ");
+    orgId = login.json().orgId;
+    const [project] = await db
+      .insert(projects)
+      .values({
+        id: newId("proj"),
+        orgId,
+        name: "Run request lease integration",
+        slug: `run-request-lease-${Date.now()}`,
+        settings: {},
+      })
+      .returning();
+    if (!project) throw new Error("project fixture missing");
+    projectId = project.id;
+    const address = await defaultApp.listen({ host: "127.0.0.1", port: 0 });
+    baseUrl = address;
+  });
+
+  afterAll(async () => {
+    barrier = undefined;
+    // The abort regression intentionally destroys a response socket while a
+    // pre-handler is blocked. Do not let Node's test server keep that dead
+    // transport in its graceful-close accounting after the lease assertion.
+    defaultApp.server.closeAllConnections();
+    await defaultApp.close();
+    await promotedApp.close();
+    await client.end();
+  });
+
+  async function insertRunnerRun(
+    token: string,
+    status: "provisioning" | "running" = "provisioning",
+    overrides: Partial<typeof runs.$inferInsert> = {},
+  ) {
+    const runId = newId("run");
+    const [run] = await db
+      .insert(runs)
+      .values({
+        id: runId,
+        orgId,
+        projectId,
+        mode: "builder",
+        engine: "byo",
+        status,
+        trigger: {},
+        sandbox: {
+          runnerTokenHash: await hashKey(token),
+          sealedVirtualKey: await seal(`fvk_${runId}`, masterKey),
+          bundle: {
+            runId,
+            mode: "builder",
+            engine: "byo",
+            contract: "Build the requested change.",
+            skills: [],
+            engineConfig: {},
+            repo: {
+              cloneUrl: null,
+              branch: null,
+              expectedHeadSha: null,
+              installationTokenRef: null,
+            },
+            packageInstallCmd: null,
+            provisionCmd: null,
+            checkCmds: [],
+            gatewayUrls: { anthropic: "http://gateway/anthropic", openai: "http://gateway/openai" },
+            scope: {},
+            timeoutMin: 10,
+          },
+        },
+        createdBy: { type: "user", id: "test" },
+        ...overrides,
+      })
+      .returning();
+    if (!run) throw new Error("run fixture missing");
+    return run;
+  }
+
+  it("negotiates tracking only after promotion and preserves legacy null/no-body hello", async () => {
+    const legacyToken = `frt_legacy_null_${Date.now()}`;
+    const legacyRun = await insertRunnerRun(legacyToken);
+    const legacy = await defaultApp.inject({
+      method: "POST",
+      url: `/internal/runs/${legacyRun.id}/hello`,
+      headers: {
+        authorization: `Bearer ${legacyToken}`,
+        "content-type": "application/json",
+      },
+      payload: "null",
+    });
+    expect(legacy.statusCode, legacy.body).toBe(200);
+    expect(legacy.json().repositoryWriteTrackingVersion).toBe(0);
+
+    const disabledToken = `frt_disabled_promotion_${Date.now()}`;
+    const disabledRun = await insertRunnerRun(disabledToken);
+    const disabled = await defaultApp.inject({
+      method: "POST",
+      url: `/internal/runs/${disabledRun.id}/hello`,
+      headers: { authorization: `Bearer ${disabledToken}` },
+      payload: { repositoryWriteTrackingVersion: 1 },
+    });
+    expect(disabled.statusCode, disabled.body).toBe(200);
+    expect(disabled.json().repositoryWriteTrackingVersion).toBe(0);
+
+    const promotedToken = `frt_enabled_promotion_${Date.now()}`;
+    const promotedRun = await insertRunnerRun(promotedToken);
+    const promoted = await promotedApp.inject({
+      method: "POST",
+      url: `/internal/runs/${promotedRun.id}/hello`,
+      headers: { authorization: `Bearer ${promotedToken}` },
+      payload: { repositoryWriteTrackingVersion: 1 },
+    });
+    expect(promoted.statusCode, promoted.body).toBe(200);
+    expect(promoted.json().repositoryWriteTrackingVersion).toBe(1);
+
+    const stored = await db
+      .select({ id: runs.id, version: runs.repositoryWriteTrackingVersion })
+      .from(runs)
+      .where(eq(runs.projectId, projectId));
+    expect(stored.find((run) => run.id === legacyRun.id)?.version).toBe(0);
+    expect(stored.find((run) => run.id === disabledRun.id)?.version).toBe(0);
+    expect(stored.find((run) => run.id === promotedRun.id)?.version).toBe(1);
+  });
+
+  it("keeps the hello credential lease through onSend before cancel can win", async () => {
+    const token = `frt_hello_barrier_${Date.now()}`;
+    const run = await insertRunnerRun(token);
+    const entered = deferred();
+    const release = deferred();
+    barrier = async (request) => {
+      if (request.url !== `/internal/runs/${run.id}/hello`) return;
+      entered.resolve();
+      await release.promise;
+    };
+
+    const helloPromise = promotedApp.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/hello`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { repositoryWriteTrackingVersion: 1 },
+    });
+    await entered.promise;
+    const cancelPromise = promotedApp.inject({
+      method: "POST",
+      url: `/v1/runs/${run.id}/cancel`,
+      headers: { cookie },
+    });
+    expect(await outcomeWithin(cancelPromise, 100)).toBeTypeOf("symbol");
+
+    release.resolve();
+    const hello = await helloPromise;
+    const cancel = await cancelPromise;
+    barrier = undefined;
+    expect(hello.statusCode, hello.body).toBe(200);
+    expect(hello.json().virtualKey).toMatch(/^fvk_/);
+    expect(cancel.statusCode, cancel.body).toBe(200);
+    expect(cancel.json().status).toBe("canceled");
+  });
+
+  it("keeps the repository write lease through onSend before cancel can win", async () => {
+    const owner = `write-lease-${Date.now()}`;
+    const [installation] = await db
+      .insert(githubInstallations)
+      .values({
+        id: newId("int"),
+        orgId,
+        installationId: Date.now(),
+        accountLogin: owner,
+        targetType: "Organization",
+      })
+      .returning();
+    if (!installation) throw new Error("installation fixture missing");
+    const [repo] = await db
+      .insert(repos)
+      .values({
+        id: newId("repo"),
+        orgId,
+        projectId,
+        installationId: installation.id,
+        owner,
+        name: "repo",
+        defaultBranch: "main",
+      })
+      .returning();
+    if (!repo) throw new Error("repo fixture missing");
+    const token = `frt_push_barrier_${Date.now()}`;
+    const baseSha = "a".repeat(40);
+    const run = await insertRunnerRun(token, "provisioning", {
+      workspaceBaseSha: baseSha,
+      sandbox: {
+        runnerTokenHash: await hashKey(token),
+        bundle: {
+          repo: {
+            cloneUrl: `https://github.com/${owner}/repo.git`,
+            branch: "main",
+            expectedHeadSha: baseSha,
+            installationTokenRef: installation.id,
+          },
+        },
+      },
+    });
+    await db
+      .update(runs)
+      .set({ status: "running", repositoryWriteTrackingVersion: 1 })
+      .where(eq(runs.id, run.id));
+    promotedApp.githubClientFactory = async () =>
+      ({
+        rest: {
+          repos: {
+            get: async () => ({ data: { name: "repo", owner: { login: owner } } }),
+          },
+          git: {
+            getRef: async () => {
+              throw Object.assign(new Error("Not Found"), { status: 404 });
+            },
+          },
+          pulls: {
+            list: async () => ({ data: [], headers: {} }),
+          },
+        },
+      }) as never;
+    const mintEntered = deferred();
+    const releaseMint = deferred();
+    promotedApp.githubInstallationTokenFactory = async () => {
+      mintEntered.resolve();
+      await releaseMint.promise;
+      return {
+        token: "github-write-token",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      };
+    };
+    const entered = deferred();
+    const release = deferred();
+    barrier = async (request) => {
+      if (request.url !== `/internal/runs/${run.id}/push-token`) return;
+      entered.resolve();
+      await release.promise;
+    };
+
+    const pushPromise = promotedApp.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/push-token`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { requestedBranch: "feature/task", baseSha },
+    });
+    await mintEntered.promise;
+    expect(
+      await db
+        .select({ status: runRepositoryWriteLeases.status })
+        .from(runRepositoryWriteLeases)
+        .where(eq(runRepositoryWriteLeases.runId, run.id)),
+    ).toEqual([{ status: "reserved" }]);
+    releaseMint.resolve();
+    await entered.promise;
+    const cancelPromise = promotedApp.inject({
+      method: "POST",
+      url: `/v1/runs/${run.id}/cancel`,
+      headers: { cookie },
+    });
+    expect(await outcomeWithin(cancelPromise, 100)).toBeTypeOf("symbol");
+
+    release.resolve();
+    const push = await pushPromise;
+    const cancel = await cancelPromise;
+    barrier = undefined;
+    promotedApp.githubInstallationTokenFactory = undefined;
+    promotedApp.githubClientFactory = undefined;
+    expect(push.statusCode, push.body).toBe(200);
+    const authorizedBranch = `feature/task-${run.id.toLowerCase().replace(/[^a-z0-9]/g, "")}`;
+    expect(push.json()).toEqual({ token: "github-write-token", authorizedBranch });
+    expect(
+      await db
+        .select()
+        .from(runRepositoryWriteLeases)
+        .where(eq(runRepositoryWriteLeases.runId, run.id)),
+    ).toEqual([
+      expect.objectContaining({
+        status: "issued",
+        requestedBranch: "feature/task",
+        authorizedBranch,
+        baseSha,
+        permissions: ["contents"],
+      }),
+    ]);
+    expect(cancel.statusCode, cancel.body).toBe(200);
+    expect(cancel.json().status).toBe("canceled");
+  });
+
+  it("denies legacy repository-write tokens to read-only run modes", async () => {
+    const owner = `read-only-write-denied-${crypto.randomUUID().slice(0, 8)}`;
+    const [installation] = await db
+      .insert(githubInstallations)
+      .values({
+        id: newId("int"),
+        orgId,
+        installationId: Date.now() + 10_000,
+        accountLogin: owner,
+        targetType: "Organization",
+      })
+      .returning();
+    if (!installation) throw new Error("read-only installation fixture missing");
+    await db.insert(repos).values({
+      id: newId("repo"),
+      orgId,
+      projectId,
+      installationId: installation.id,
+      owner,
+      name: "repo",
+      defaultBranch: "main",
+    });
+    const token = `frt_read_only_write_denied_${Date.now()}`;
+    const run = await insertRunnerRun(token, "running", {
+      mode: "architect",
+      sandbox: {
+        runnerTokenHash: await hashKey(token),
+        bundle: {
+          repo: {
+            cloneUrl: `https://github.com/${owner}/repo.git`,
+            branch: "main",
+            expectedHeadSha: "a".repeat(40),
+            installationTokenRef: installation.id,
+          },
+        },
+      },
+    });
+    let tokenFactoryCalls = 0;
+    defaultApp.githubInstallationTokenFactory = async () => {
+      tokenFactoryCalls += 1;
+      return { token: "must-not-be-issued", expiresAt: "2099-01-01T00:00:00.000Z" };
+    };
+    const response = await defaultApp.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/push-token`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    defaultApp.githubInstallationTokenFactory = undefined;
+    expect(response.statusCode, response.body).toBe(409);
+    expect(response.json().error.code).toBe("repository_write_mode_forbidden");
+    expect(tokenFactoryCalls).toBe(0);
+  });
+
+  it("reads terminal evidence only after shared mutations drain and never deadlocks with cancel", async () => {
+    const token = `frt_terminal_evidence_${Date.now()}`;
+    const run = await insertRunnerRun(token, "running");
+    const releaseMutation = await defaultApp.acquireRunRequestLease(run.id);
+    const resultPromise = defaultApp.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/result`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { status: "failed", error: "test terminal boundary" },
+    });
+    expect(await outcomeWithin(resultPromise, 100)).toBeTypeOf("symbol");
+    await db.insert(runEvents).values({
+      orgId,
+      runId: run.id,
+      seq: 1,
+      type: "check",
+      data: { command: "late shared check", status: "passed", self_reported: false },
+    });
+    await releaseMutation();
+    const result = await outcomeWithin(resultPromise, 2_000);
+    expect(result).not.toBeTypeOf("symbol");
+    if (typeof result !== "symbol") expect(result.statusCode, result.body).toBe(200);
+    const [stored] = await db.select().from(runs).where(eq(runs.id, run.id));
+    expect(stored?.status).toBe("failed");
+    expect((stored?.receipt as { events?: { count?: number } })?.events?.count).toBe(1);
+
+    const raceToken = `frt_result_cancel_race_${Date.now()}`;
+    const raceRun = await insertRunnerRun(raceToken, "running");
+    const raced = Promise.all([
+      defaultApp.inject({
+        method: "POST",
+        url: `/internal/runs/${raceRun.id}/result`,
+        headers: { authorization: `Bearer ${raceToken}` },
+        payload: { status: "failed", error: "runner terminal race" },
+      }),
+      defaultApp.inject({
+        method: "POST",
+        url: `/v1/runs/${raceRun.id}/cancel`,
+        headers: { cookie },
+      }),
+    ]);
+    const raceResult = await outcomeWithin(raced, 2_000);
+    expect(raceResult).not.toBeTypeOf("symbol");
+    if (typeof raceResult !== "symbol") {
+      const statuses = raceResult.map((response) => response.statusCode);
+      expect(statuses).toContain(200);
+      expect(statuses.every((status) => status === 200 || status === 409)).toBe(true);
+    }
+    const [racedStored] = await db.select().from(runs).where(eq(runs.id, raceRun.id));
+    expect(["failed", "canceled"]).toContain(racedStored?.status);
+  });
+
+  it("keeps callbacks live while the dedicated transition pool is saturated", async () => {
+    const blockedRuns = await Promise.all(
+      Array.from({ length: 2 }, async (_, index) => {
+        const token = `frt_transition_pool_blocked_${index}_${Date.now()}`;
+        const run = await insertRunnerRun(token, "running");
+        const release = await defaultApp.acquireRunRequestLease(run.id);
+        return { run, token, release };
+      }),
+    );
+    const terminalWaiters = blockedRuns.map(({ run, token }) =>
+      defaultApp.inject({
+        method: "POST",
+        url: `/internal/runs/${run.id}/result`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { status: "failed", error: "transition pool saturation fixture" },
+      }),
+    );
+    let released = false;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(await outcomeWithin(Promise.all(terminalWaiters), 100)).toBeTypeOf("symbol");
+
+      const callbackToken = `frt_transition_pool_callback_${Date.now()}`;
+      const callbackRun = await insertRunnerRun(callbackToken, "running");
+      const callback = defaultApp.inject({
+        method: "POST",
+        url: `/internal/runs/${callbackRun.id}/events`,
+        headers: { authorization: `Bearer ${callbackToken}` },
+        payload: [{ type: "phase", data: { name: "main-pool-still-live" } }],
+      });
+      const callbackResult = await outcomeWithin(callback, 2_000);
+      expect(callbackResult).not.toBeTypeOf("symbol");
+      if (typeof callbackResult !== "symbol") {
+        expect(callbackResult.statusCode, callbackResult.body).toBe(200);
+      }
+
+      const queuedTerminal = defaultApp.inject({
+        method: "POST",
+        url: `/v1/runs/${callbackRun.id}/cancel`,
+        headers: { cookie },
+      });
+      expect(await outcomeWithin(queuedTerminal, 100)).toBeTypeOf("symbol");
+      await Promise.all(blockedRuns.map(({ release }) => release()));
+      released = true;
+      const completed = await outcomeWithin(
+        Promise.all([...terminalWaiters, queuedTerminal]),
+        2_000,
+      );
+      expect(completed).not.toBeTypeOf("symbol");
+      if (typeof completed !== "symbol") {
+        expect(completed.map((response) => response.statusCode)).toEqual([200, 200, 200]);
+      }
+    } finally {
+      if (!released) await Promise.all(blockedRuns.map(({ release }) => release()));
+    }
+  });
+
+  it("releases an aborted callback that was waiting in its pre-handler", async () => {
+    const token = `frt_abort_prehandler_${Date.now()}`;
+    const run = await insertRunnerRun(token, "running");
+    const releaseBlocker = await defaultApp.acquireRunTransitionLease(run.id);
+    const requestFinished = new Promise<void>((resolve) => {
+      const request = httpRequest(
+        `${baseUrl}/internal/runs/${run.id}/events`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            "content-type": "application/json",
+          },
+        },
+        (response) => {
+          response.resume();
+          response.on("end", resolve);
+        },
+      );
+      request.on("error", () => resolve());
+      request.end(JSON.stringify([{ type: "phase", data: { shouldNotPersist: true } }]));
+      setTimeout(() => request.destroy(), 75);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 125));
+    await releaseBlocker();
+    await requestFinished;
+
+    const secondExclusive = defaultApp.acquireRunTransitionLease(run.id);
+    const acquired = await outcomeWithin(secondExclusive, 2_000);
+    expect(acquired).not.toBeTypeOf("symbol");
+    if (typeof acquired === "function") await acquired();
+    const persisted = await db.select().from(runEvents).where(eq(runEvents.runId, run.id));
+    expect(persisted.some((event) => event.type === "phase")).toBe(false);
+  });
+
+  it("abandons idempotency before releasing an aborted run-scoped platform request", async () => {
+    const run = await insertRunnerRun(`frt_platform_abort_${Date.now()}`, "running");
+    const [role] = await db
+      .insert(roles)
+      .values({
+        id: newId("key"),
+        orgId,
+        name: `run-platform-writer-${Date.now()}`,
+        permissions: ["org:read", "tasks:write"],
+      })
+      .returning();
+    if (!role) throw new Error("role fixture missing");
+    const key = await generateApiKey("fak");
+    await db.insert(apiKeys).values({
+      id: key.id,
+      orgId,
+      projectId,
+      roleId: role.id,
+      runId: run.id,
+      name: "aborted run platform key",
+      prefix: key.lookup,
+      last4: key.last4,
+      hash: key.hash,
+      scopeType: "project",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const releaseBlocker = await defaultApp.acquireRunTransitionLease(run.id);
+    const title = `must-not-persist-${Date.now()}`;
+    const idempotencyKey = `abort-platform-${crypto.randomUUID()}`;
+    const requestFinished = new Promise<void>((resolve) => {
+      const request = httpRequest(
+        `${baseUrl}/v1/projects/${projectId}/tasks`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${key.secret}`,
+            "content-type": "application/json",
+            "idempotency-key": idempotencyKey,
+          },
+        },
+        (response) => {
+          response.resume();
+          response.on("end", resolve);
+        },
+      );
+      request.on("error", () => resolve());
+      request.end(JSON.stringify({ title, bodyMd: "must not persist", status: "draft" }));
+      setTimeout(() => request.destroy(), 100);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await releaseBlocker();
+    await requestFinished;
+
+    const secondExclusive = defaultApp.acquireRunTransitionLease(run.id);
+    const acquired = await outcomeWithin(secondExclusive, 2_000);
+    expect(acquired).not.toBeTypeOf("symbol");
+    if (typeof acquired === "function") await acquired();
+    expect(await db.select().from(poTasks).where(eq(poTasks.title, title))).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(idempotencyRecords)
+        .where(eq(idempotencyRecords.principalId, `key:${key.id}`)),
+    ).toHaveLength(0);
+
+    const committedTitle = `committed-before-disconnect-${Date.now()}`;
+    const committedIdempotencyKey = `committed-disconnect-${crypto.randomUUID()}`;
+    handlerCommitBarrier = { entered: deferred(), release: deferred() };
+    let committedRequest: ReturnType<typeof httpRequest> | undefined;
+    const disconnected = new Promise<void>((resolve) => {
+      committedRequest = httpRequest(
+        `${baseUrl}/__test/run-mutation-after-commit`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${key.secret}`,
+            "content-type": "application/json",
+            "idempotency-key": committedIdempotencyKey,
+          },
+        },
+        (response) => {
+          response.resume();
+          response.on("end", resolve);
+        },
+      );
+      committedRequest.on("error", () => resolve());
+      committedRequest.end(JSON.stringify({ projectId, title: committedTitle }));
+    });
+    await handlerCommitBarrier.entered.promise;
+    committedRequest?.destroy();
+    await disconnected;
+    handlerCommitBarrier.release.resolve();
+    const exclusiveAfterCommit = defaultApp.acquireRunTransitionLease(run.id);
+    const acquiredAfterCommit = await outcomeWithin(exclusiveAfterCommit, 2_000);
+    expect(acquiredAfterCommit).not.toBeTypeOf("symbol");
+    if (typeof acquiredAfterCommit === "function") await acquiredAfterCommit();
+    handlerCommitBarrier = undefined;
+
+    const sealed = await db
+      .select()
+      .from(idempotencyRecords)
+      .where(eq(idempotencyRecords.principalId, `key:${key.id}`));
+    expect(sealed).toEqual([
+      expect.objectContaining({
+        state: "completed",
+        statusCode: 409,
+        responseBody: expect.objectContaining({
+          error: expect.objectContaining({ code: "idempotency_outcome_indeterminate" }),
+        }),
+      }),
+    ]);
+    const replay = await defaultApp.inject({
+      method: "POST",
+      url: "/__test/run-mutation-after-commit",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "idempotency-key": committedIdempotencyKey,
+      },
+      payload: { projectId, title: committedTitle },
+    });
+    expect(replay.statusCode, replay.body).toBe(409);
+    expect(replay.json().error.code).toBe("idempotency_outcome_indeterminate");
+    expect(await db.select().from(poTasks).where(eq(poTasks.title, committedTitle))).toHaveLength(
+      1,
+    );
+
+    const failedTitle = `committed-before-5xx-${Date.now()}`;
+    const failedIdempotencyKey = `committed-5xx-${crypto.randomUUID()}`;
+    const failed = await defaultApp.inject({
+      method: "POST",
+      url: "/__test/run-mutation-server-error",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "idempotency-key": failedIdempotencyKey,
+      },
+      payload: { projectId, title: failedTitle },
+    });
+    expect(failed.statusCode, failed.body).toBe(503);
+    const failedReplay = await defaultApp.inject({
+      method: "POST",
+      url: "/__test/run-mutation-server-error",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "idempotency-key": failedIdempotencyKey,
+      },
+      payload: { projectId, title: failedTitle },
+    });
+    expect(failedReplay.statusCode, failedReplay.body).toBe(503);
+    expect(failedReplay.headers["idempotency-status"]).toBe("replayed");
+    expect(await db.select().from(poTasks).where(eq(poTasks.title, failedTitle))).toHaveLength(1);
+
+    // Even if a run-key pending row is older than the ordinary 15-minute
+    // reclaim window, the same key must remain fail closed: the original
+    // handler may have committed before losing its transport.
+    const sealedId = sealed[0]?.id;
+    if (!sealedId) throw new Error("sealed idempotency fixture missing");
+    await db
+      .update(idempotencyRecords)
+      .set({
+        state: "pending",
+        statusCode: null,
+        responseBody: null,
+        updatedAt: new Date(Date.now() - 16 * 60_000),
+      })
+      .where(eq(idempotencyRecords.id, sealedId));
+    const staleReplay = await defaultApp.inject({
+      method: "POST",
+      url: "/__test/run-mutation-after-commit",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "idempotency-key": committedIdempotencyKey,
+      },
+      payload: { projectId, title: committedTitle },
+    });
+    expect(staleReplay.statusCode, staleReplay.body).toBe(409);
+    expect(staleReplay.json().error.code).toBe("idempotency_in_progress");
+    expect(await db.select().from(poTasks).where(eq(poTasks.title, committedTitle))).toHaveLength(
+      1,
+    );
+
+    const proposedTitle = `run-key-proposal-${Date.now()}`;
+    const deniedProposal = await defaultApp.inject({
+      method: "POST",
+      url: "/v1/mcp/tool-proposals",
+      headers: { authorization: `Bearer ${key.secret}` },
+      payload: {
+        toolName: "facility_create_task",
+        permission: "tasks:write",
+        projectId,
+        summary: "This deferred mutation must be denied",
+        args: { projectId, title: proposedTitle, bodyMd: "denied" },
+      },
+    });
+    expect(deniedProposal.statusCode, deniedProposal.body).toBe(403);
+    expect(deniedProposal.json().error.code).toBe("run_key_deferred_mcp_forbidden");
+    expect(await db.select().from(proposals).where(eq(proposals.runId, run.id))).toHaveLength(0);
+
+    const actionType = (
+      await db
+        .select()
+        .from(actionTypes)
+        .where(and(eq(actionTypes.orgId, orgId), eq(actionTypes.name, "mcp_tool_call")))
+        .limit(1)
+    )[0];
+    if (!actionType) throw new Error("mcp_tool_call action type missing");
+    const historicalTitle = `historical-run-key-proposal-${Date.now()}`;
+    const [historical] = await db
+      .insert(proposals)
+      .values({
+        id: newId("prop"),
+        orgId,
+        projectId,
+        runId: run.id,
+        actionTypeId: actionType.id,
+        payload: {
+          toolName: "facility_create_task",
+          permission: "tasks:write",
+          args: { projectId, title: historicalTitle, bodyMd: "must not execute" },
+          targetProjectId: projectId,
+          requestedBy: { type: "key", id: key.id },
+        },
+        contextMd: "Historical run-key proposal",
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!historical) throw new Error("historical proposal missing");
+    await db.insert(proposalEvents).values({
+      orgId,
+      proposalId: historical.id,
+      seq: 1,
+      type: "open",
+      actor: { type: "key", id: key.id },
+      data: {},
+    });
+    const decision = await defaultApp.inject({
+      method: "POST",
+      url: `/v1/proposals/${historical.id}/decide`,
+      headers: { cookie },
+      payload: { decision: "approve" },
+    });
+    expect(decision.statusCode, decision.body).toBe(200);
+    expect(decision.json().state).toBe("execution_failed");
+    expect(await db.select().from(poTasks).where(eq(poTasks.title, historicalTitle))).toHaveLength(
+      0,
+    );
+  });
+
+  it("binds hello clone tokens to the run tenant, repository owner, and live installation", async () => {
+    const scopeSuffix = crypto.randomUUID().replaceAll("-", "").slice(0, 10);
+    const [foreignOrg] = await db
+      .insert(orgs)
+      .values({
+        id: newId("org"),
+        name: "Foreign clone-token org",
+        slug: `foreign-clone-token-${Date.now()}`,
+      })
+      .returning();
+    if (!foreignOrg) throw new Error("foreign org fixture missing");
+    let tokenFactoryCalls = 0;
+    defaultApp.githubInstallationTokenFactory = async () => {
+      tokenFactoryCalls += 1;
+      return { token: "must-not-be-issued", expiresAt: "2099-01-01T00:00:00.000Z" };
+    };
+    const cases = [
+      { name: "foreign tenant", installationOrgId: foreignOrg.id, accountLogin: "bound-owner" },
+      { name: "wrong owner", installationOrgId: orgId, accountLogin: "other-owner" },
+      {
+        name: "suspended",
+        installationOrgId: orgId,
+        accountLogin: "bound-owner",
+        suspendedAt: new Date(),
+      },
+    ];
+    for (const [index, fixture] of cases.entries()) {
+      const owner = `bound-owner-${scopeSuffix}-${index}`;
+      const [installation] = await db
+        .insert(githubInstallations)
+        .values({
+          id: newId("int"),
+          orgId: fixture.installationOrgId,
+          installationId: Date.now() + 100 + index,
+          accountLogin: fixture.name === "wrong owner" ? "other-owner" : owner,
+          targetType: "Organization",
+          suspendedAt: fixture.suspendedAt,
+        })
+        .returning();
+      if (!installation) throw new Error(`${fixture.name} installation missing`);
+      await db.insert(repos).values({
+        id: newId("repo"),
+        orgId,
+        projectId,
+        installationId: installation.id,
+        owner,
+        name: `repo-${scopeSuffix}-${index}`,
+        defaultBranch: "main",
+      });
+      const token = `frt_clone_scope_${index}_${Date.now()}`;
+      const run = await insertRunnerRun(token, "provisioning", {
+        sandbox: {
+          runnerTokenHash: await hashKey(token),
+          sealedVirtualKey: await seal(`fvk_clone_scope_${index}`, masterKey),
+          bundle: {
+            repo: {
+              cloneUrl: `https://github.com/${owner}/repo-${scopeSuffix}-${index}.git`,
+              branch: "main",
+              expectedHeadSha: null,
+              installationTokenRef: installation.id,
+            },
+          },
+        },
+      });
+      const response = await defaultApp.inject({
+        method: "POST",
+        url: `/internal/runs/${run.id}/hello`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(response.statusCode, `${fixture.name}: ${response.body}`).toBe(200);
+      expect(response.json().repoToken).toBeNull();
+    }
+    defaultApp.githubInstallationTokenFactory = undefined;
+    expect(tokenFactoryCalls).toBe(0);
+  });
+
+  it("does not hold shared leases while steering polls are idle", async () => {
+    const pollingRuns = await Promise.all(
+      Array.from({ length: 4 }, async (_, index) => {
+        const token = `frt_steer_poll_${index}_${Date.now()}`;
+        return { token, run: await insertRunnerRun(token, "running") };
+      }),
+    );
+    const callbackToken = `frt_callback_after_polls_${Date.now()}`;
+    const callbackRun = await insertRunnerRun(callbackToken, "running");
+    const polls = pollingRuns.map(({ run, token }) =>
+      defaultApp.inject({
+        method: "GET",
+        url: `/internal/runs/${run.id}/steer`,
+        headers: { authorization: `Bearer ${token}` },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const callback = defaultApp.inject({
+      method: "POST",
+      url: `/internal/runs/${callbackRun.id}/events`,
+      headers: { authorization: `Bearer ${callbackToken}` },
+      payload: [{ type: "phase", data: { name: "not-starved" } }],
+    });
+    const completed = await outcomeWithin(callback, 2_000);
+    expect(completed).not.toBeTypeOf("symbol");
+    if (typeof completed !== "symbol") expect(completed.statusCode, completed.body).toBe(200);
+
+    await db.insert(steerMessages).values(
+      pollingRuns.map(({ run }, index) => ({
+        id: newId("evt"),
+        orgId,
+        runId: run.id,
+        kind: "steer",
+        body: `wake-${index}`,
+      })),
+    );
+    const responses = await Promise.all(polls);
+    expect(responses.every((response) => response.statusCode === 200)).toBe(true);
+  });
+});

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -22,6 +22,7 @@ import {
   registryVersions,
   repos,
   roles,
+  runDeliveries,
   runEvents,
   runs,
   sandboxProfiles,
@@ -1159,6 +1160,137 @@ describe("sandbox api", async () => {
     expect(stored?.engineSessionId).toBe("sess_finish_123");
   });
 
+  it("claims terminal evidence after the lease, preserves provider state, and revokes atomically", async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 12);
+    const owner = `terminal-atomic-${suffix}`;
+    const [installation] = await db
+      .insert(githubInstallations)
+      .values({
+        id: newId("int"),
+        orgId,
+        installationId: Date.now() + 20_000,
+        accountLogin: owner,
+        targetType: "Organization",
+      })
+      .returning();
+    if (!installation) throw new Error("terminal installation fixture missing");
+    const [repo] = await db
+      .insert(repos)
+      .values({
+        id: newId("repo"),
+        orgId,
+        projectId,
+        installationId: installation.id,
+        owner,
+        name: `repo-${suffix}`,
+        defaultBranch: "main",
+      })
+      .returning();
+    if (!repo) throw new Error("terminal repository fixture missing");
+    const runId = newId("run");
+    const staleRun = await insertRunnerRun(`frt_terminal_atomic_${suffix}`, "running", runId);
+    const virtualKeyId = newId("vkey");
+    await db.insert(virtualKeys).values({
+      id: virtualKeyId,
+      orgId,
+      projectId,
+      runId,
+      name: "terminal atomic virtual key",
+      prefix: `terminal_v_${suffix}`,
+      last4: "0000",
+      hash: `terminal-v-hash-${suffix}`,
+    });
+    const roleId = newId("key");
+    await db.insert(roles).values({
+      id: roleId,
+      orgId,
+      name: `terminal-atomic-role-${suffix}`,
+      permissions: [],
+    });
+    const platformKeyId = newId("key");
+    await db.insert(apiKeys).values({
+      id: platformKeyId,
+      orgId,
+      projectId,
+      roleId,
+      runId,
+      name: "terminal atomic platform key",
+      prefix: `terminal_p_${suffix}`,
+      last4: "0000",
+      hash: `terminal-p-hash-${suffix}`,
+      scopeType: "project",
+    });
+    const providerRef = `provider-ref-${suffix}`;
+    await db
+      .update(runs)
+      .set({
+        gh: { owner, repo: repo.name, issueNumber: 91 },
+        // This ref is deliberately attached after staleRun was read, matching
+        // a fast provider whose launch() returns after /result authenticated.
+        sandbox: sql`${runs.sandbox} || ${JSON.stringify({
+          virtualKeyId,
+          platformKeyId,
+          ref: providerRef,
+          launchedAt: new Date().toISOString(),
+        })}::jsonb`,
+      })
+      .where(eq(runs.id, runId));
+    const delivery = {
+      runId,
+      orgId,
+      projectId,
+      repoId: repo.id,
+      owner,
+      repoName: repo.name,
+      headBranch: `feature/${suffix}`,
+      expectedHeadSha: "b".repeat(40),
+      baseSha: "a".repeat(40),
+      baseBranch: "main",
+      title: "feat: prove terminal atomicity",
+      body: "Conflict row used to force a rollback after key revocation.",
+      issueNumber: 91,
+    } satisfies typeof runDeliveries.$inferInsert;
+    await db.insert(runDeliveries).values(delivery);
+    const result = {
+      status: "succeeded" as const,
+      git: {
+        changed: true,
+        branch: delivery.headBranch,
+        headSha: delivery.expectedHeadSha,
+        baseSha: delivery.baseSha,
+        pullRequestTitle: delivery.title,
+        pullRequestBody: delivery.body,
+      },
+    };
+    await expect(finishRun(db, staleRun, result)).rejects.toMatchObject({
+      cause: { code: "23505" },
+    });
+    const [rolledBack] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(rolledBack?.status).toBe("running");
+    expect(readSandbox(rolledBack?.sandbox).ref).toBe(providerRef);
+    expect(
+      (await db.select().from(virtualKeys).where(eq(virtualKeys.id, virtualKeyId)))[0]?.revokedAt,
+    ).toBeNull();
+    expect(
+      (await db.select().from(apiKeys).where(eq(apiKeys.id, platformKeyId)))[0]?.revokedAt,
+    ).toBeNull();
+
+    await db.delete(runDeliveries).where(eq(runDeliveries.runId, runId));
+    const finished = await finishRun(db, staleRun, result);
+    expect(finished.status).toBe("succeeded");
+    const [stored] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(readSandbox(stored?.sandbox)).toMatchObject({
+      ref: providerRef,
+      finishedAt: expect.any(String),
+    });
+    expect(
+      (await db.select().from(virtualKeys).where(eq(virtualKeys.id, virtualKeyId)))[0]?.revokedAt,
+    ).not.toBeNull();
+    expect(
+      (await db.select().from(apiKeys).where(eq(apiKeys.id, platformKeyId)))[0]?.revokedAt,
+    ).not.toBeNull();
+  });
+
   it("persists the first engine session event before the runner reaches a result", async () => {
     const token = "frt_early_session";
     const run = await insertRunnerRun(token, "running");
@@ -1683,7 +1815,7 @@ describe("sandbox api", async () => {
     let tokenInput: Record<string, unknown> | undefined;
     app.githubInstallationTokenFactory = async (input) => {
       tokenInput = input;
-      return "installation-token";
+      return { token: "installation-token", expiresAt: "2099-01-01T00:00:00.000Z" };
     };
     const previousGithubFactory = app.githubClientFactory;
     app.githubClientFactory = async (actualInstallationId) => {


### PR DESCRIPTION
## What changes

- Fence mutating runner callbacks and run-scoped platform-key requests for the
  complete authenticated request lifetime.
- Reserve append-only repository-write evidence before token minting, including
  exact repository, base, unique authorized branch, permissions, provider, and
  expiry.
- Negotiate tracked repository writes during runner hello while retaining a
  rolling-upgrade path that permanently fails closed for legacy runs.
- Revoke run-scoped keys atomically with terminal status changes, preserve the
  latest sandbox provider reference, and isolate transition capacity from the
  main request pool.
- Seal abort and replay boundaries so duplicate finish, cancel, or platform
  mutations cannot execute twice or starve the transition path.

This PR is stacked on `codex/fix-workflow-delivery-token` because the tracked
write lease records the exact conditional permission set introduced there.

## Why

A failed agent attempt can leave callbacks, platform requests, or short-lived
repository credentials in flight after the run becomes terminal. A later
governed recovery needs durable proof that those effects are quiescent and that
no ambiguous remote output exists. These primitives provide that proof without
mutating or reusing the failed run.

This PR deliberately does not add the retry endpoint. Immutable successor
lineage and operator controls are separate follow-ups.

## Verification

- [ ] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite: abort, replay, terminal races,
  duplicate callbacks, write-token ambiguity, run-unique branches, provider
  reference preservation, atomic revocation, and transition-pool saturation
  were exercised.
- [x] Documentation updated for the two-phase tracking rollout and rollback
  restriction.

Executed checks:

- request-lease integration: `10/10` passed;
- sandbox: `40/40` passed;
- GitHub platform lane: `67/67` passed;
- API: `97/97` passed;
- assistant: `8/8` passed;
- DB with a fresh migration: `17/17` passed;
- repository-write logic: `61/61` passed;
- runner workspace: `73/73` passed;
- API, runner, and DB typechecks, Biome, and `git diff --check`: passed.

The complete core workspace suite was `33/34` in this worktree because the
local `packages/cli` dependency graph did not contain `postgres`; the new core
ID regression passed and the failure is outside the changed packages.

An independent consolidated security review found no P0, P1, or P2 issue.
