### PR TITLE
fix(init): create a junction for .agents/skills on Windows and report link failures honestly

### DIFF
--- a/packages/cli/src/init.mjs
+++ b/packages/cli/src/init.mjs
@@ -6,7 +6,7 @@
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { detect } from "./detect.mjs";
 import { render, hasManagedBlock, appendManagedBlock } from "./render.mjs";
 import { ask, confirm, closePrompts } from "./prompts.mjs";
@@ -518,12 +518,26 @@ export async function init(flags, pkgRoot, version) {
     lstatSync(agentsSkillsLink);
     skip(".agents/skills exists — left untouched");
   } catch {
+    mkdirSync(join(dir, ".agents"), { recursive: true });
     try {
-      mkdirSync(join(dir, ".agents"), { recursive: true });
       symlinkSync("../.claude/skills", agentsSkillsLink, "dir");
       ok(".agents/skills → .claude/skills");
-    } catch {
-      warn(".agents/skills symlink could not be created (filesystem without symlink support) — skipped.");
+    } catch (error) {
+      // On Windows, plain symlinks need Developer Mode or elevation (EPERM).
+      // Directory junctions need neither — they just require an absolute
+      // target — so fall back to one instead of misreporting the cause.
+      if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EINVAL")) {
+        try {
+          symlinkSync(resolve(dir, ".claude/skills"), agentsSkillsLink, "junction");
+          ok(".agents/skills → .claude/skills (junction — absolute; recreate after moving the repo)");
+        } catch {
+          warn(
+            ".agents/skills link could not be created: Windows symlinks need Developer Mode or an elevated shell, and the junction fallback also failed — skipped.",
+          );
+        }
+      } else {
+        warn(".agents/skills symlink could not be created (filesystem without symlink support) — skipped.");
+      }
     }
   }
 

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -11,7 +11,11 @@ import { parse as parseYaml } from "yaml";
 
 const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const cli = join(pkgRoot, "bin", "facility.mjs");
-const biome = resolve(pkgRoot, "..", "..", "node_modules", ".bin", "biome");
+// Biome's .bin shim is a POSIX script that spawnSync cannot execute on
+// Windows (status null); its JS entry runs through node on every platform.
+const biomeJs = resolve(pkgRoot, "..", "..", "node_modules", "@biomejs", "biome", "bin", "biome");
+const biome = process.execPath;
+const biomeArgs = (args) => [biomeJs, ...args];
 
 function makeTargetRepo() {
   const dir = mkdtempSync(join(tmpdir(), "facility-test-"));
@@ -445,12 +449,12 @@ test("init installs the method end to end", async (t) => {
       2,
     )}\n`,
   );
-  const formatConfig = spawnSync(biome, ["format", "--write", "biome.json"], {
+  const formatConfig = spawnSync(biome, biomeArgs(["format", "--write", "biome.json"]), {
     cwd: dir,
     encoding: "utf8",
   });
   assert.equal(formatConfig.status, 0, formatConfig.stdout + formatConfig.stderr);
-  const strictBiome = spawnSync(biome, ["check", "."], { cwd: dir, encoding: "utf8" });
+  const strictBiome = spawnSync(biome, biomeArgs(["check", "."]), { cwd: dir, encoding: "utf8" });
   assert.equal(strictBiome.status, 0, strictBiome.stdout + strictBiome.stderr);
 
   const doctor = runCli(["doctor", `--dir=${dir}`], dir);


### PR DESCRIPTION
Closes #230 — credit to @Julian-Genuario for the precise report: EPERM on Windows without Developer Mode, blamed on "filesystem without symlink support." Claimed in-thread with right of way offered; the courtesy window has passed, so here is the fix, verified on the reporting platform.

## The fix

- **Directory junctions need no privileges on Windows**, so on EPERM/EINVAL init now falls back to one (absolute target — the ok line says so honestly: *"junction — absolute; recreate after moving the repo"*) instead of failing.
- When even the junction fails, the warn names the **two real remedies** — Developer Mode, or an elevated shell — instead of misdiagnosing the filesystem.
- Every other platform keeps the original relative symlink path, byte-identical.

## Found underneath (masked until now)

The init end-to-end test also spawned Biome through its POSIX `.bin` shim, which `spawnSync` cannot execute on Windows (status `null`) — invisible before because the symlink death always came first. It now runs Biome's JS entry through node, same behavior everywhere.

## Verified

`init.test.mjs`: **8/8 on Windows 11 — the first time that file has ever passed there** — and 8/8 on Linux, unchanged.

Interplay with #245, stated plainly: that PR's `verify-windows` CI job currently skips the init e2e naming this issue as its unskip criterion. Once both land, a one-line follow-up removes the skip and the whole init flow is guarded on `windows-latest` forever. Happy to push that follow-up the moment the second of the two merges.
