### PR TITLE
fix(doctor): notice receipts destroyed after run.finished was audited

### DIFF
--- a/services/api/src/doctor.ts
+++ b/services/api/src/doctor.ts
@@ -740,7 +740,7 @@ async function checkReceiptIntegrity(db: Db, orgId: string): Promise<DoctorCheck
     return fail(
       "receipt_integrity",
       "Agent receipt integrity",
-      `${report.invalidRunIds.length} invalid and ${report.unauditedRunIds.length} unaudited receipts found across ${report.checked} runs.`,
+      `${report.invalidRunIds.length} invalid, ${report.unauditedRunIds.length} unaudited, and ${report.missingReceiptRunIds.length} audited-but-missing receipts found across ${report.checked} runs.`,
       "Stop outcome and learning jobs, preserve audit_events and runs, then investigate receipt mutation or an outdated runner.",
     );
   }

--- a/services/api/src/doctor.ts
+++ b/services/api/src/doctor.ts
@@ -740,7 +740,7 @@ async function checkReceiptIntegrity(db: Db, orgId: string): Promise<DoctorCheck
     return fail(
       "receipt_integrity",
       "Agent receipt integrity",
-      `${report.invalidRunIds.length} invalid, ${report.unauditedRunIds.length} unaudited, and ${report.missingReceiptRunIds.length} audited-but-missing receipts found across ${report.checked} runs.`,
+      `${report.invalidRunIds.length} invalid, ${report.unauditedRunIds.length} unaudited, and ${report.missingReceiptRunIds.length} audited-but-missing receipts found across ${report.checked + report.missingReceiptRunIds.length} audited runs.`,
       "Stop outcome and learning jobs, preserve audit_events and runs, then investigate receipt mutation or an outdated runner.",
     );
   }

--- a/services/api/src/receipt-integrity.ts
+++ b/services/api/src/receipt-integrity.ts
@@ -7,6 +7,12 @@ export type ReceiptIntegrityReport = {
   checked: number;
   invalidRunIds: string[];
   unauditedRunIds: string[];
+  /** Audited run.finished digests whose run no longer carries a receipt —
+   * the receipt was destroyed or the run row deleted after the fact. Every
+   * terminal run writes its receipt and its audit event together, so this
+   * can only be an anomaly; it is reported distinctly from "never audited"
+   * so the two failure stories stay distinguishable. */
+  missingReceiptRunIds: string[];
 };
 
 export async function verifyStoredReceipts(
@@ -15,7 +21,7 @@ export async function verifyStoredReceipts(
   runIds?: string[],
 ): Promise<ReceiptIntegrityReport> {
   if (runIds?.length === 0) {
-    return { ok: true, checked: 0, invalidRunIds: [], unauditedRunIds: [] };
+    return { ok: true, checked: 0, invalidRunIds: [], unauditedRunIds: [], missingReceiptRunIds: [] };
   }
   const stored = await db
     .select({ id: runs.id, receipt: runs.receipt })
@@ -41,6 +47,11 @@ export async function verifyStoredReceipts(
   }
   const invalidRunIds: string[] = [];
   const unauditedRunIds: string[] = [];
+  const storedIds = new Set(stored.map((row) => row.id));
+  const scope = runIds ? new Set(runIds) : null;
+  const missingReceiptRunIds = [...auditedDigests.keys()].filter(
+    (id) => !storedIds.has(id) && (!scope || scope.has(id)),
+  );
   for (const row of stored) {
     const parsed = FacilityReceiptSchema.safeParse(row.receipt);
     if (!parsed.success || !verifyFacilityReceipt(parsed.data)) {
@@ -52,10 +63,14 @@ export async function verifyStoredReceipts(
     }
   }
   return {
-    ok: invalidRunIds.length === 0 && unauditedRunIds.length === 0,
+    ok:
+      invalidRunIds.length === 0 &&
+      unauditedRunIds.length === 0 &&
+      missingReceiptRunIds.length === 0,
     checked: stored.length,
     invalidRunIds,
     unauditedRunIds,
+    missingReceiptRunIds,
   };
 }
 

--- a/services/api/src/receipt-integrity.ts
+++ b/services/api/src/receipt-integrity.ts
@@ -21,7 +21,13 @@ export async function verifyStoredReceipts(
   runIds?: string[],
 ): Promise<ReceiptIntegrityReport> {
   if (runIds?.length === 0) {
-    return { ok: true, checked: 0, invalidRunIds: [], unauditedRunIds: [], missingReceiptRunIds: [] };
+    return {
+      ok: true,
+      checked: 0,
+      invalidRunIds: [],
+      unauditedRunIds: [],
+      missingReceiptRunIds: [],
+    };
   }
   const stored = await db
     .select({ id: runs.id, receipt: runs.receipt })

--- a/services/api/test/sandbox.test.ts
+++ b/services/api/test/sandbox.test.ts
@@ -1741,6 +1741,40 @@ describe("sandbox api", async () => {
     await expect(verifyStoredReceipts(db, orgId, [run.id])).resolves.toMatchObject({ ok: true });
   });
 
+  it("receipt integrity notices a receipt destroyed after run.finished was audited", async () => {
+    // #226: verifyStoredReceipts only walked runs that still HAVE a receipt,
+    // so nulling one (or deleting the run) silently shrank `checked` while ok
+    // stayed true. The reverse question — audited digest, no receipt behind
+    // it — must go red.
+    const token = "frt_receipt_destroyed";
+    const run = await insertRunnerRun(token, "running");
+    const response = await app.inject({
+      method: "POST",
+      url: `/internal/runs/${run.id}/result`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { status: "succeeded" },
+    });
+    expect(response.statusCode).toBe(200);
+    await expect(verifyStoredReceipts(db, orgId, [run.id])).resolves.toMatchObject({ ok: true });
+
+    await db.update(runs).set({ receipt: null }).where(eq(runs.id, run.id));
+    const nulled = await verifyStoredReceipts(db, orgId, [run.id]);
+    expect(nulled.ok).toBe(false);
+    expect(nulled.missingReceiptRunIds).toEqual([run.id]);
+    expect(nulled.invalidRunIds).toEqual([]);
+
+    // Scope is respected: asking about other runs stays clean.
+    const outOfScope = await verifyStoredReceipts(db, orgId, ["run_someone_else"]);
+    expect(outOfScope.missingReceiptRunIds).toEqual([]);
+
+    // A deleted run row is the same anomaly — the audit trail outlives it.
+    await db.delete(runEvents).where(eq(runEvents.runId, run.id));
+    await db.delete(runs).where(eq(runs.id, run.id));
+    const deleted = await verifyStoredReceipts(db, orgId);
+    expect(deleted.ok).toBe(false);
+    expect(deleted.missingReceiptRunIds).toContain(run.id);
+  });
+
   it("delivers run events over the NOTIFY-backed SSE path without safety polling", async () => {
     const token = "frt_stream";
     const run = await insertRunnerRun(token, "running");


### PR DESCRIPTION
Closes #226 — credit to @Julian-Genuario for spotting the missing reverse question. Claimed in-thread with right of way offered; the courtesy window has passed, so here is the fix in the shape the claim promised.

## The gap, closed

`verifyStoredReceipts()` proved every *surviving* receipt against the audit chain but never asked whether an audited `run.finished` digest still has a receipt behind it — so `UPDATE runs SET receipt = null` (or deleting the row) just shrank `checked` while `ok` stayed `true`, exactly as the issue demonstrated.

- The reverse pass now runs over the audited digests: any id with an audited digest and no stored receipt lands in a **new, distinct `missingReceiptRunIds` class** — kept separate from `invalidRunIds` and `unauditedRunIds` so "receipt destroyed" and "never audited" remain distinguishable stories, per the issue's point that in current code this state can only be an anomaly.
- The `runIds` scope is respected (asking about other runs stays clean), and the doctor's failure line now reports all three counts.

## The regression bites

The test finishes a real run through `/internal/runs/:id/result`, confirms `ok: true`, then nulls the receipt — doctor goes red with `missingReceiptRunIds: [run.id]` — and finally deletes the run row entirely, which trips the same wire because the audit trail outlives it. The "absence must fail loudly" shape, same family as the truncation disclosure above it in the suite.

`sandbox.test.ts`: 40 tests, 0 failures; tsc clean.
