### PR TITLE
fix(oauth): drop key_ops from derived JWK verification keys

### DIFF
--- a/apps/docs/docs/self-host/authentication.md
+++ b/apps/docs/docs/self-host/authentication.md
@@ -76,3 +76,19 @@ audience-bound and revocable within that instance. Supply a persistent private E
 `FACILITY_OAUTH_JWKS`; put a new signing key first and retain old signing keys through the maximum
 token lifetime when rotating them. The configured set contains private keys; Facility publishes only
 their public parameters from `/oauth/jwks`.
+
+Generate a key set with Node alone:
+
+```bash
+node -e '
+const { generateKeyPairSync, randomUUID } = require("node:crypto");
+const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+const jwk = privateKey.export({ format: "jwk" });
+console.log(JSON.stringify({ keys: [{ ...jwk, kid: randomUUID(), alg: "ES256", use: "sig" }] }));
+'
+```
+
+A key exported through WebCrypto (`crypto.subtle.exportKey("jwk", ...)`) also works. It carries
+`key_ops` and `ext` members describing how it was exported; Facility drops those on load, because a
+set marked `"key_ops": ["sign"]` describes the private half and would otherwise be rejected as a
+verification key by this instance and by anyone else reading `/oauth/jwks`.

--- a/apps/docs/docs/self-host/authentication.md
+++ b/apps/docs/docs/self-host/authentication.md
@@ -89,6 +89,8 @@ console.log(JSON.stringify({ keys: [{ ...jwk, kid: randomUUID(), alg: "ES256", u
 ```
 
 A key exported through WebCrypto (`crypto.subtle.exportKey("jwk", ...)`) also works. It carries
-`key_ops` and `ext` members describing how it was exported; Facility drops those on load, because a
-set marked `"key_ops": ["sign"]` describes the private half and would otherwise be rejected as a
-verification key by this instance and by anyone else reading `/oauth/jwks`.
+`key_ops` and `ext` members; Facility drops those on load, because a set marked
+`"key_ops": ["sign"]` describes the private half and would otherwise be rejected as a verification
+key by this instance and by anyone else reading `/oauth/jwks`. A `key_ops` that does not permit
+`sign` is refused at startup: this variable holds the keys the instance signs with, so a set that
+forbids signing is a contradiction rather than a restriction to honour.

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -337,19 +337,38 @@ function parseJwks(value: string | undefined): { keys: Record<string, unknown>[]
     ) {
       throw new Error("FACILITY_OAUTH_JWKS keys must be private ES256 JWKs with unique kid values");
     }
+    // `key_ops` states the operations a key may be used for (RFC 7517 section
+    // 4.3). This variable holds the keys the instance signs its own MCP tokens
+    // with, so a set that forbids signing is a contradiction rather than a
+    // policy. Name it at startup: left alone it surfaces later as an unexplained
+    // "no signing key" at token issuance, and stripped it would silently grant
+    // an operation the operator wrote down as not permitted.
+    if (key.key_ops !== undefined && !asSigningOps(key.key_ops)) {
+      throw new Error('FACILITY_OAUTH_JWKS keys with key_ops must permit "sign"');
+    }
   }
   if (new Set((keys as Record<string, unknown>[]).map((key) => key.kid)).size !== keys.length) {
     throw new Error("FACILITY_OAUTH_JWKS key ids must be unique");
   }
-  // `crypto.subtle.exportKey("jwk", ...)` — the most direct way to produce this
-  // value — annotates a signing key with `key_ops: ["sign"]` and `ext`. Those
-  // record how the key was exported, not what it is, and both the published JWKS
-  // and the derived verification set read these objects, so normalize them away
-  // once here instead of leaving every consumer to reason about provenance.
-  // Accepting the export verbatim is what operators actually paste in.
+  // Past that check `key_ops` only repeats what this variable already means,
+  // and it cannot survive: `oauthConfigFromApp` derives the verification keys
+  // from these objects, and a set carrying "sign" makes jose skip the derived
+  // key as a verification candidate. `ext` is a WebCrypto export artifact with
+  // no meaning in a stored JWK. Drop both here, where the published JWKS and
+  // the local verifier read one shape, so an operator can paste the output of
+  // `crypto.subtle.exportKey("jwk", ...)` verbatim.
   return {
     keys: (keys as Record<string, unknown>[]).map(({ key_ops: _keyOps, ext: _ext, ...key }) => key),
   };
+}
+
+function asSigningOps(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => typeof entry === "string") &&
+    value.includes("sign")
+  );
 }
 
 function canonicalMcpResourceUrl(value: string) {

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -341,7 +341,15 @@ function parseJwks(value: string | undefined): { keys: Record<string, unknown>[]
   if (new Set((keys as Record<string, unknown>[]).map((key) => key.kid)).size !== keys.length) {
     throw new Error("FACILITY_OAUTH_JWKS key ids must be unique");
   }
-  return { keys: keys as Record<string, unknown>[] };
+  // `crypto.subtle.exportKey("jwk", ...)` — the most direct way to produce this
+  // value — annotates a signing key with `key_ops: ["sign"]` and `ext`. Those
+  // record how the key was exported, not what it is, and both the published JWKS
+  // and the derived verification set read these objects, so normalize them away
+  // once here instead of leaving every consumer to reason about provenance.
+  // Accepting the export verbatim is what operators actually paste in.
+  return {
+    keys: (keys as Record<string, unknown>[]).map(({ key_ops: _keyOps, ext: _ext, ...key }) => key),
+  };
 }
 
 function canonicalMcpResourceUrl(value: string) {

--- a/services/api/src/oauth.ts
+++ b/services/api/src/oauth.ts
@@ -22,8 +22,25 @@ export function oauthConfigFromApp(config: AppConfig): OauthConfig | null {
     issuer: config.oauthIssuer,
     audience: config.mcpPublicUrl,
     jwks: {
+      // This derives a verification set from signing keys, so an operation the
+      // source key declares cannot carry over: `key_ops: ["sign"]` describes the
+      // private half, and jose skips any candidate whose `key_ops` omits
+      // "verify", which leaves the instance unable to verify the tokens it just
+      // signed. Drop it with the private members rather than translating it, so
+      // the derived set constrains nothing beyond `kid`, `alg`, and `use`.
       keys: config.oauthJwks.keys.map(
-        ({ d: _d, p: _p, q: _q, dp: _dp, dq: _dq, qi: _qi, oth: _oth, ...publicKey }) => publicKey,
+        ({
+          d: _d,
+          p: _p,
+          q: _q,
+          dp: _dp,
+          dq: _dq,
+          qi: _qi,
+          oth: _oth,
+          key_ops: _keyOps,
+          ext: _ext,
+          ...publicKey
+        }) => publicKey,
       ),
     } as JSONWebKeySet,
   };

--- a/services/api/test/config.test.ts
+++ b/services/api/test/config.test.ts
@@ -278,6 +278,35 @@ describe("API configuration", () => {
     });
   });
 
+  it("keeps a WebCrypto export usable by dropping its provenance members", () => {
+    // What `crypto.subtle.exportKey("jwk", signingKey)` hands an operator. The
+    // annotations must not survive into the loaded set: the verification keys are
+    // derived from these objects, and a "sign"-only key cannot verify anything.
+    const exported = {
+      kty: "EC",
+      crv: "P-256",
+      x: "x",
+      y: "y",
+      d: "d",
+      kid: "key-1",
+      key_ops: ["sign"],
+      ext: true,
+    };
+    const loaded = readConfig({
+      ...validEnv,
+      PUBLIC_URL: "https://api.example.com",
+      WEB_URL: "https://app.example.com",
+      AUTH_CALLBACK_URL: "https://app.example.com/api/auth/callback",
+      FACILITY_OAUTH_ISSUER: "https://app.example.com",
+      MCP_PUBLIC_URL: "https://mcp.example.com/mcp",
+      FACILITY_OAUTH_JWKS: JSON.stringify({ keys: [exported] }),
+    }).oauthJwks;
+
+    expect(loaded?.keys).toEqual([
+      { kty: "EC", crv: "P-256", x: "x", y: "y", d: "d", kid: "key-1" },
+    ]);
+  });
+
   it("canonicalizes the MCP resource and rejects an unrelated path", () => {
     expect(readConfig({ ...validEnv, MCP_PUBLIC_URL: "https://mcp.example.com" })).toMatchObject({
       mcpPublicUrl: "https://mcp.example.com/mcp",

--- a/services/api/test/config.test.ts
+++ b/services/api/test/config.test.ts
@@ -278,20 +278,14 @@ describe("API configuration", () => {
     });
   });
 
-  it("keeps a WebCrypto export usable by dropping its provenance members", () => {
-    // What `crypto.subtle.exportKey("jwk", signingKey)` hands an operator. The
-    // annotations must not survive into the loaded set: the verification keys are
-    // derived from these objects, and a "sign"-only key cannot verify anything.
-    const exported = {
-      kty: "EC",
-      crv: "P-256",
-      x: "x",
-      y: "y",
-      d: "d",
-      kid: "key-1",
-      key_ops: ["sign"],
-      ext: true,
-    };
+  it.each([
+    ["a WebCrypto signing export", ["sign"], true],
+    ["a set that also permits verification", ["sign", "verify"], undefined],
+  ])("loads %s without its key_ops or ext members", (_label, key_ops, ext) => {
+    // `["sign"]` plus `ext` is what `crypto.subtle.exportKey("jwk", signingKey)`
+    // hands an operator. Neither member may survive into the loaded set: the
+    // verification keys are derived from these objects, and jose skips a
+    // candidate whose key_ops omits "verify".
     const loaded = readConfig({
       ...validEnv,
       PUBLIC_URL: "https://api.example.com",
@@ -299,12 +293,38 @@ describe("API configuration", () => {
       AUTH_CALLBACK_URL: "https://app.example.com/api/auth/callback",
       FACILITY_OAUTH_ISSUER: "https://app.example.com",
       MCP_PUBLIC_URL: "https://mcp.example.com/mcp",
-      FACILITY_OAUTH_JWKS: JSON.stringify({ keys: [exported] }),
+      FACILITY_OAUTH_JWKS: JSON.stringify({
+        keys: [{ kty: "EC", crv: "P-256", x: "x", y: "y", d: "d", kid: "key-1", key_ops, ext }],
+      }),
     }).oauthJwks;
 
     expect(loaded?.keys).toEqual([
       { kty: "EC", crv: "P-256", x: "x", y: "y", d: "d", kid: "key-1" },
     ]);
+  });
+
+  it.each([
+    ["verification only", ["verify"]],
+    ["an empty operation list", []],
+    ["a non-array value", "sign"],
+    ["a non-string entry", [1]],
+  ])("refuses a signing key whose key_ops declares %s", (_label, key_ops) => {
+    // Dropping key_ops must never widen what the operator permitted: a signing
+    // key set that forbids signing is a contradiction, and startup is where it
+    // gets a name instead of an unexplained "no signing key" at issuance.
+    expect(() =>
+      readConfig({
+        ...validEnv,
+        PUBLIC_URL: "https://api.example.com",
+        WEB_URL: "https://app.example.com",
+        AUTH_CALLBACK_URL: "https://app.example.com/api/auth/callback",
+        FACILITY_OAUTH_ISSUER: "https://app.example.com",
+        MCP_PUBLIC_URL: "https://mcp.example.com/mcp",
+        FACILITY_OAUTH_JWKS: JSON.stringify({
+          keys: [{ kty: "EC", crv: "P-256", x: "x", y: "y", d: "d", kid: "key-1", key_ops }],
+        }),
+      }),
+    ).toThrow('FACILITY_OAUTH_JWKS keys with key_ops must permit "sign"');
   });
 
   it("canonicalizes the MCP resource and rejects an unrelated path", () => {

--- a/services/api/test/oauth.test.ts
+++ b/services/api/test/oauth.test.ts
@@ -9,7 +9,7 @@ import {
   userIdentities,
   users,
 } from "@facility/db";
-import { createLocalJWKSet, decodeJwt, exportJWK, generateKeyPair, SignJWT } from "jose";
+import { decodeJwt, exportJWK, generateKeyPair, SignJWT } from "jose";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp, mintSessionCookie } from "../src/app.js";
@@ -22,6 +22,7 @@ import { pkceChallenge } from "../src/auth/identity-provider.js";
 import {
   AccessTokenError,
   looksLikeJwt,
+  type OauthConfig,
   oauthConfigFromApp,
   verifyAccessToken,
 } from "../src/oauth.js";
@@ -35,6 +36,10 @@ const audience = "https://mcp.facility.test/mcp";
 const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
 const privateJwk = { ...(await exportJWK(privateKey)), kid: "test-key", alg: "ES256", use: "sig" };
 const publicJwk = { ...(await exportJWK(publicKey)), kid: "test-key", alg: "ES256", use: "sig" };
+// `exportJWK` emits no `key_ops`, so it cannot reproduce what an operator gets
+// out of `crypto.subtle.exportKey`. The integration below configures this shape
+// instead, so the flow runs on the key derivation production actually uses.
+const webCryptoPrivateJwk = { ...privateJwk, key_ops: ["sign"], ext: true };
 const foreign = await generateKeyPair("ES256");
 type SignKey = Awaited<ReturnType<typeof generateKeyPair>>["privateKey"];
 const base: AppConfig = {
@@ -96,6 +101,25 @@ describe("Facility OAuth access-token verification", () => {
       userId: "user_test",
       orgId: "org_test",
       scope: "facility:mcp",
+    });
+  });
+
+  it("verifies its own tokens against keys derived from a WebCrypto signing key", async () => {
+    const derived = oauthConfigFromApp({
+      ...base,
+      oauthIssuer: issuer,
+      mcpPublicUrl: audience,
+      oauthJwks: { keys: [webCryptoPrivateJwk] },
+    });
+
+    // Carrying `key_ops: ["sign"]` into the verification set makes jose reject the
+    // key as a candidate, and the instance stops trusting anything it signs.
+    expect(derived?.jwks.keys[0]).not.toHaveProperty("key_ops");
+    expect(derived?.jwks.keys[0]).not.toHaveProperty("ext");
+    expect(derived?.jwks.keys[0]).not.toHaveProperty("d");
+    await expect(verifyAccessToken(await token(), derived as OauthConfig)).resolves.toMatchObject({
+      userId: "user_test",
+      orgId: "org_test",
     });
   });
 
@@ -196,9 +220,12 @@ describe("Facility OAuth resource-server integration", async () => {
     ...base,
     oauthIssuer: issuer,
     mcpPublicUrl: audience,
-    oauthJwks: { keys: [privateJwk] },
+    oauthJwks: { keys: [webCryptoPrivateJwk] },
   };
-  const app = await buildApp(config, { oauthJwks: createLocalJWKSet({ keys: [publicJwk] }) });
+  // Deliberately no `oauthJwks` override: injecting a hand-built verification set
+  // here is what hid this bug, because it skips the derivation that turns the
+  // configured signing keys into the keys the running instance verifies with.
+  const app = await buildApp(config);
   const { db, client } = createDb(databaseUrl);
   const userId = newId("user");
   let orgId = "";


### PR DESCRIPTION
## The bug

A Facility instance can sign MCP access tokens that it then refuses to verify, depending only on how the operator exported the signing key.

`FACILITY_OAUTH_JWKS` wants a private ES256 JWK set. Exporting one with `crypto.subtle.exportKey("jwk", ...)` — the most direct way to get a JWK out of a signing key — adds `key_ops: ["sign"]` and `ext: true`. `oauthConfigFromApp` derives the verification set from those objects by stripping the private members, so `key_ops` came along, and jose skips any JWKS candidate whose `key_ops` omits `"verify"`:

```js
// jose/dist/webapi/jwks/local.js
if (candidate && Array.isArray(jwk.key_ops)) {
  candidate = jwk.key_ops.includes('verify');
}
```

The key is then never selected. `verifyAccessToken` fails with `ERR_JWKS_NO_MATCHING_KEY` on a token that is otherwise perfect — right `iss`, `aud`, `kid`, `alg`, `scope`, `org_id`, unexpired — and `app.ts` turns that into `401 unauthorized / Invalid access token`. The MCP server reads the 401 from `/v1/me` and reports the credential as invalid, so an interactive client completes the whole OAuth flow, receives a token, reconnects, and is rejected. The observable symptom is a client looping through re-authentication with no diagnosable error anywhere.

Two things make it easy to miss:

- `fak_` API keys never touch the JWKS, so non-interactive use keeps working and only interactive MCP OAuth breaks.
- The same annotation reaches `/oauth/jwks`, so the instance publishes a public key marked sign-only. Any third-party verifier applying the same RFC 7517 semantics rejects it too.

## The fix

Drop `key_ops` and `ext` in `parseJwks` when loading the configured set, and again in `oauthConfigFromApp` when deriving verification keys from signing keys. The two are not redundant: the first makes the published JWKS correct and normalizes what every consumer reads, the second keeps the derivation correct for any `AppConfig` built by other means.

Neither member carries key material or constrains signing — oidc-provider only applies a `key_ops` check when the member is present, so removing it leaves the key selectable for signing. Stripping rather than rejecting also means an operator can paste a WebCrypto export verbatim, which is what they do.

`apps/docs/docs/self-host/authentication.md` gains a dependency-free generation snippet, since the page previously asked for a JWK set without saying how to make one.

## Why no test caught it

`services/api/test/oauth.test.ts` built the app with an explicit `oauthJwks` override, so the full OAuth integration flow ran against a hand-constructed verification set and never exercised the derivation that production depends on. And `exportJWK` emits no `key_ops`, so no fixture ever had the shape operators actually configure.

The integration now configures a WebCrypto-shaped private key and passes no override, letting the app derive its own verification keys. With the source fix reverted, three tests fail, including the full PKCE flow reproducing the exact production signature:

```
× resolves a current member and rejects cross-tenant claims
× completes PKCE authorization, rotates refresh tokens, and rejects reuse
  AssertionError: {"body":"{\"error\":{\"code\":\"unauthorized\",\"message\":\"Invalid access token\"}}",
  "claims":{"org_id":"...","scope":"facility:mcp","sub":"...","iss":"https://facility.test",
  "aud":"https://mcp.facility.test/mcp"}}: expected 401 to be 200
```

## Verification

`pnpm lint`, `pnpm typecheck` and `pnpm guards` pass. `test/oauth.test.ts` and `test/config.test.ts` pass against an isolated Postgres, including the resource-server integration describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F97d9BXUagnfr8CjdS1gmT
