### PR TITLE
fix(deps): clear the open qs and fastify advisories

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   webpack-dev-server@<=5.2.5: 5.2.6
   dompurify@<=3.4.12: 3.4.13
   nanoid@>=3.0.0 <3.3.18: 3.3.18
+  qs@<6.16.0: 6.16.0
 
 patchedDependencies:
   image-size@2.0.2: 91c116f6f63aa8ff1be47af798f33721d884b495bae00fdf2adfe313bfbad42a
@@ -396,11 +397,11 @@ importers:
         specifier: ^0.45.1
         version: 0.45.2(pg@8.22.0)(postgres@3.4.9)
       fastify:
-        specifier: ^5.6.2
-        version: 5.9.0
+        specifier: ^5.12.1
+        version: 5.12.1
       fastify-type-provider-zod:
         specifier: ^6.1.0
-        version: 6.1.0(@fastify/swagger@9.7.0(supports-color@10.2.2))(fastify@5.9.0)(openapi-types@12.1.3)(zod@4.4.3)
+        version: 6.1.0(@fastify/swagger@9.7.0(supports-color@10.2.2))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.4.3)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -463,8 +464,8 @@ importers:
         specifier: ^0.45.1
         version: 0.45.2(pg@8.22.0)(postgres@3.4.9)
       fastify:
-        specifier: ^5.6.2
-        version: 5.9.0
+        specifier: ^5.12.1
+        version: 5.12.1
       pino:
         specifier: ^10.1.0
         version: 10.3.1
@@ -4999,6 +5000,9 @@ packages:
   fast-json-stringify@6.4.0:
     resolution: {integrity: sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==}
 
+  fast-json-stringify@7.0.1:
+    resolution: {integrity: sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==}
+
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
@@ -5007,6 +5011,9 @@ packages:
 
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -5022,8 +5029,8 @@ packages:
       openapi-types: ^12.1.3
       zod: '>=4.1.5'
 
-  fastify@5.9.0:
-    resolution: {integrity: sha512-VMS5lE0zj+MZlJpQa3Qv5iGjfun0H2N7VRgoBwpcTNQ2bdIQpv7fDpb+HGteGbicBsGkzGS+X+hdx9mmrfWuHQ==}
+  fastify@5.12.1:
+    resolution: {integrity: sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -7072,6 +7079,9 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -7170,8 +7180,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -13456,7 +13466,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -13471,7 +13481,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -13603,7 +13613,7 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.7
-      caniuse-lite: 1.0.30001800
+      caniuse-lite: 1.0.30001810
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -14421,7 +14431,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2(supports-color@10.2.2)
@@ -14456,7 +14466,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@10.2.2)
       send: 1.2.1(supports-color@10.2.2)
@@ -14498,6 +14508,15 @@ snapshots:
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
+  fast-json-stringify@7.0.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 4.1.3
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
@@ -14506,19 +14525,21 @@ snapshots:
 
   fast-uri@3.1.5: {}
 
+  fast-uri@4.1.3: {}
+
   fastify-plugin@5.1.0: {}
 
   fastify-plugin@6.0.0: {}
 
-  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0(supports-color@10.2.2))(fastify@5.9.0)(openapi-types@12.1.3)(zod@4.4.3):
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0(supports-color@10.2.2))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.4.3):
     dependencies:
       '@fastify/error': 4.2.0
       '@fastify/swagger': 9.7.0(supports-color@10.2.2)
-      fastify: 5.9.0
+      fastify: 5.12.1
       openapi-types: 12.1.3
       zod: 4.4.3
 
-  fastify@5.9.0:
+  fastify@5.12.1:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -14526,11 +14547,11 @@ snapshots:
       '@fastify/proxy-addr': 5.1.0
       abstract-logging: 2.0.1
       avvio: 9.2.0
-      fast-json-stringify: 6.4.0
+      fast-json-stringify: 7.0.1
       find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
-      process-warning: 5.0.0
+      process-warning: 5.1.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
       semver: 7.8.5
@@ -16913,6 +16934,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  process-warning@5.1.0: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -17056,7 +17079,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.1.4: 2.1.4
   brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   '@fastify/static@<10.1.2': 10.1.2
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   find-my-way@<9.6.1: 9.7.0
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
@@ -5009,8 +5009,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-uri@4.1.3:
     resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
@@ -11207,7 +11207,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
 
   '@fastify/cookie@11.0.2':
     dependencies:
@@ -13273,7 +13273,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14504,7 +14504,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -14523,7 +14523,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-uri@4.1.3: {}
 
@@ -15226,7 +15226,7 @@ snapshots:
   json-schema-resolver@3.0.0(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,9 @@ overrides:
   "webpack-dev-server@<=5.2.5": 5.2.6
   "dompurify@<=3.4.12": 3.4.13
   "nanoid@>=3.0.0 <3.3.18": 3.3.18
+  # Only reached through the Docusaurus dev server's Express stack. One floor
+  # covers both open advisories; the later one supersedes the 6.15.4 fix.
+  "qs@<6.16.0": 6.16.0
 
 # Postinstall build-script allowlist — nothing builds unless named here.
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ overrides:
   "brace-expansion@>=2.0.0 <2.1.4": 2.1.4
   "brace-expansion@>=5.0.0 <5.0.9": 5.0.9
   "@fastify/static@<10.1.2": 10.1.2
-  "fast-uri@>=3.0.0 <3.1.5": 3.1.5
+  "fast-uri@>=3.0.0 <3.1.6": 3.1.6
   "find-my-way@<9.6.1": 9.7.0
   "js-yaml@>=3.0.0 <3.15.1": 3.15.1
   "js-yaml@>=4.0.0 <4.3.1": 4.3.1

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -43,7 +43,7 @@
     "dockerode": "^5.0.1",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.1",
-    "fastify": "^5.6.2",
+    "fastify": "^5.12.1",
     "fastify-type-provider-zod": "^6.1.0",
     "jose": "^6.2.3",
     "oidc-provider": "^9.8.2",

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -20,7 +20,7 @@
     "@facility/db": "workspace:*",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.1",
-    "fastify": "^5.6.2",
+    "fastify": "^5.12.1",
     "pino": "^10.1.0",
     "postgres": "^3.4.7",
     "uuidv7": "^1.0.2",


### PR DESCRIPTION
## Why

`pnpm audit --audit-level low` — the last step of `pnpm verify` — began failing on three advisories published today. Nothing in the dependency graph changed: the same commit passed `verify` earlier in the day and failed a few minutes later, so this currently fails CI on `main` and on every open branch.

| Advisory | Package | Reached through |
|---|---|---|
| [GHSA-w2qp-rph6-63g4](https://github.com/advisories/GHSA-w2qp-rph6-63g4) | `fastify` | direct dependency of `services/api` and `services/gateway` |
| [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) | `qs` | `apps/docs` → Docusaurus → webpack-dev-server → Express |
| [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) | `qs` | same |

The fastify one is the one that matters beyond CI: it is a direct dependency, so it ships in the self-host images.

## What

**fastify 5.9.0 → 5.12.1.** 5.12.1 is a security release covering GHSA-w2qp-rph6-63g4 and GHSA-3m5p-2c4r-xxw2; 5.10, 5.11 and 5.12.0 declare no breaking change. The declared range moves from `^5.6.2` to `^5.12.1` in both services rather than only refreshing the lockfile entry, so a fresh resolution cannot land back below the fix.

**`qs` floor at 6.16.0**, as a workspace override in the shape this repository already uses for transitive security floors. One floor covers both advisories — the `isBuffer` one patches at 6.16.0 and supersedes the 6.15.4 fix for the array-limit bypass.

The lockfile change is confined to those two packages plus the transitive dependencies fastify itself pulls in (`process-warning`, `fast-uri`, `fast-json-stringify`). `pnpm audit --audit-level low` now exits 0, leaving only the two highs already listed in `auditConfig.ignoreGhsas`.

## Verification

`pnpm lint`, `pnpm typecheck` and `pnpm build:clean` pass, the last one including the docs site with the new `qs`.

The test suites are the honest part. On the machine this was prepared on, the Docker-backed Postgres is slow enough that the API, gateway and db suites fail and skip non-deterministically — a control run on an unmodified lockfile fails too, differently on each pass, so local runs cannot say anything trustworthy about a framework bump. The gateway suite did produce one clean 57/57 pass on 5.12.1, which the control never managed, but that is a hint and not a verdict. `verify` in CI is the real gate here: it runs the whole critical suite with skips forbidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F97d9BXUagnfr8CjdS1gmT
