### PR TITLE
feat: issue 101 - show who owns a story

### DIFF
--- a/apps/web/app/(app)/projects/[projectId]/layout.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/layout.tsx
@@ -6,6 +6,7 @@ import { MobileNav, Sidebar } from "@/components/shell/nav";
 import { RememberProject } from "@/components/shell/remember-project";
 import { Topbar } from "@/components/shell/topbar";
 import { api } from "@/lib/api";
+import { pipelineStories } from "@/lib/pipeline";
 
 /** The project world: everything under /projects/[projectId] is scoped to it. */
 export default async function ProjectLayout({
@@ -16,11 +17,12 @@ export default async function ProjectLayout({
   params: Promise<{ projectId: string }>;
 }) {
   const { projectId } = await params;
-  const [me, project, projects, inbox] = await Promise.all([
+  const [me, project, projects, inbox, pipeline] = await Promise.all([
     api.me(),
     api.project(projectId),
     api.projects(),
     api.inboxFull(),
+    api.pipeline(projectId),
   ]);
 
   if (!project.ok) {
@@ -47,6 +49,7 @@ export default async function ProjectLayout({
       inbox.data.issues.filter((item) => item.projectId === p.id).length
     : undefined;
   const navProject = { id: p.id, slug: p.slug, name: p.name };
+  const stories = pipeline.ok ? pipelineStories(pipeline.data) : [];
 
   return (
     // App shell: the viewport is the frame; only the work area (main) scrolls,

--- a/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
@@ -2,6 +2,7 @@ import { Eyebrow, PillTag, StatusDot } from "@facility/ui";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { CiStatusLink } from "@/components/ci-status";
+import { Assignees } from "@/components/issues/assignees";
 import { Markdown } from "@/components/markdown";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { LiveRefresh } from "@/components/shell/live-refresh";
@@ -167,6 +168,7 @@ export default async function StoryPage({
               {label}
             </span>
           ))}
+          <Assignees assignees={story.assignees} />
           <a
             href={story.htmlUrl}
             target="_blank"

--- a/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
@@ -35,9 +35,9 @@ export default async function ProjectStoriesPage({
   searchParams,
 }: {
   params: Promise<{ projectId: string }>;
-  searchParams: Promise<{ stage?: string; status?: string }>;
+  searchParams: Promise<{ stage?: string; status?: string; assignee?: string }>;
 }) {
-  const [{ projectId }, { stage, status }] = await Promise.all([params, searchParams]);
+  const [{ projectId }, { stage, status, assignee }] = await Promise.all([params, searchParams]);
   const [pipelineResult, me, project] = await Promise.all([
     api.pipeline(projectId),
     api.me(),
@@ -49,6 +49,7 @@ export default async function ProjectStoriesPage({
   const permissions = me.ok ? me.data.permissions : [];
   const canTrigger = hasPermission(permissions, "runs:trigger");
   const canSync = hasPermission(permissions, "repos:write");
+  const myGithubLogin = me.ok ? me.data.principal.githubLogin : null;
   const stages = pipelineResult.ok ? pipelineResult.data.stages : [];
   const stageKeys = new Set(stages.map((candidate) => candidate.key));
   const activeStage =
@@ -62,15 +63,25 @@ export default async function ProjectStoriesPage({
   const counts = [...stages].reverse();
   const activeOpenStoryCount = items.filter((story) => story.state === "open").length;
 
+  // Filter by assignee if specified
+  const assigneeFilteredItems = assignee && myGithubLogin
+    ? items.filter((story) => story.assignees.includes(assignee))
+    : items;
+
   const stageFiltered = activeStage
     ? counts.filter((candidate) => candidate.key === activeStage)
     : counts;
   const visibleStages = activeStatus
     ? stageFiltered.map((candidate) => ({
         ...candidate,
-        stories: candidate.stories.filter((story) => story.stageState === activeStatus),
+        stories: candidate.stories.filter(
+          (story) => story.stageState === activeStatus && (!assignee || story.assignees.includes(assignee)),
+        ),
       }))
-    : stageFiltered;
+    : stageFiltered.map((candidate) => ({
+        ...candidate,
+        stories: candidate.stories.filter((story) => !assignee || story.assignees.includes(assignee)),
+      }));
   const activeStatusLabel =
     activeStage && activeStatus
       ? pipelineStageStateLabel(
@@ -79,6 +90,8 @@ export default async function ProjectStoriesPage({
           visibleStages.reduce((total, candidate) => total + candidate.stories.length, 0),
         )
       : null;
+
+  const assigneeFilterActive = assignee === "mine";
 
   return (
     <div className="flex flex-col gap-8">
@@ -147,6 +160,33 @@ export default async function ProjectStoriesPage({
             </span>
           </>
         ) : null}
+        {myGithubLogin ? (
+          <Link
+            href={`/projects/${projectId}/stories${activeStage ? `?stage=${activeStage}` : ""}${assigneeFilterActive ? "" : `&assignee=mine`}`}
+            className={cx(
+              "inline-flex items-center gap-2 border px-3 py-1.5 text-[12px] font-medium transition-colors",
+              assigneeFilterActive
+                ? "border-(--line-strong) text-(--ink)"
+                : "border-(--line) text-(--mut) hover:text-(--ink)",
+            )}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <span className="size-4 rounded-full border border-(--line) bg-(--bg-subtle) font-mono text-[10px] font-medium text-(--ink)">
+                {myGithubLogin.charAt(0).toUpperCase()}
+              </span>
+              <span className="font-mono text-[11px]">mine</span>
+            </span>
+            {assigneeFilterActive && (
+              <Link
+                href={`/projects/${projectId}/stories${activeStage ? `?stage=${activeStage}` : ""}`}
+                aria-label="clear assignee filter"
+                className="text-(--dim) hover:text-(--ink)"
+              >
+                ×
+              </Link>
+            )}
+          </Link>
+        ) : null}
       </div>
 
       {!pipelineResult.ok ? (
@@ -157,7 +197,7 @@ export default async function ProjectStoriesPage({
               : `Couldn't load stories — ${pipelineResult.message}`
           }
         />
-      ) : items.length === 0 ? (
+      ) : assigneeFilteredItems.length === 0 ? (
         <p className="max-w-lg text-sm leading-relaxed text-(--dim)">
           No active stories right now. Closed and merged stories leave Shipped after seven days;
           sync refreshes the GitHub mirror.

--- a/apps/web/components/issues/assignees.tsx
+++ b/apps/web/components/issues/assignees.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { cx } from "@facility/ui";
+import Image from "next/image";
+
+/**
+ * Renders a single assignee avatar with GitHub avatar URL and initial-letter fallback.
+ * The avatar is a link to the GitHub profile.
+ */
+function AssigneeAvatar({ login }: { login: string }) {
+  const avatarUrl = `https://github.com/${login}.png?size=40`;
+  const initial = login.charAt(0).toUpperCase();
+
+  return (
+    <a
+      href={`https://github.com/${login}`}
+      target="_blank"
+      rel="noreferrer"
+      title={`@${login} on GitHub`}
+      className="relative flex-shrink-0"
+      aria-label={`@${login} on GitHub`}
+    >
+      <Image
+        src={avatarUrl}
+        alt=""
+        width={20}
+        height={20}
+        unoptimized
+        referrerPolicy="no-referrer"
+        className={cx(
+          "size-5 rounded-full border border-(--line)",
+          "transition-opacity duration-150",
+        )}
+        onError={(e) => {
+          // Fallback to initial letter when GitHub avatar fails to load
+          e.currentTarget.style.display = "none";
+          (
+            e.currentTarget.parentElement?.querySelector("[data-assignee-initial]") as HTMLElement
+          )?.style.setProperty("display", "flex");
+        }}
+      />
+      <span
+        data-assignee-initial
+        className={cx(
+          "absolute inset-0 flex items-center justify-center rounded-full border border-(--line) bg-(--bg-subtle) font-mono text-[10px] font-medium text-(--ink)",
+          "hidden",
+        )}
+      >
+        {initial}
+      </span>
+    </a>
+  );
+}
+
+/**
+ * Renders assignees for a story.
+ * - First assignee shows avatar + @login
+ * - Additional assignees show as "+N" with avatar stack on hover
+ * - Unassigned renders nothing
+ */
+export function Assignees({ assignees }: { assignees: string[] }) {
+  if (!assignees || assignees.length === 0) return null;
+
+  const first = assignees[0]!;
+  const rest = assignees.slice(1);
+  const restCount = rest.length;
+
+  return (
+    <span className="flex items-center gap-1.5">
+      {/* First assignee: avatar + @login */}
+      <span className="flex items-center gap-1">
+        <AssigneeAvatar login={first} />
+        <span className="font-mono text-[11px] text-(--dim)">@{first}</span>
+      </span>
+
+      {/* Additional assignees: +N with avatar stack on hover */}
+      {restCount > 0 && (
+        <span className="relative flex items-center gap-1">
+          <span className="font-mono text-[11px] text-(--dim)">+{restCount}</span>
+          {/* Avatar stack tooltip */}
+          <span
+            className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex gap-[-6px] opacity-0 pointer-events-none transition-opacity duration-150 group-hover:opacity-100"
+            role="tooltip"
+          >
+            {rest.slice(0, 3).map((login) => (
+              <AssigneeAvatar key={login} login={login} />
+            ))}
+            {rest.length > 3 && (
+              <span
+                className={cx(
+                  "flex size-5 items-center justify-center rounded-full border border-(--line) bg-(--bg-subtle) font-mono text-[10px] font-medium text-(--dim)",
+                )}
+              >
+                +{rest.length - 3}
+              </span>
+            )}
+            <span className="absolute bottom-[-4px] left-1/2 -translate-x-1/2 border-4 border-transparent border-t-(--bg)"></span>
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Compact assignees for dense rows - just avatar + @login for first, +N for rest
+ */
+export function CompactAssignees({ assignees }: { assignees: string[] }) {
+  if (!assignees || assignees.length === 0) return null;
+
+  const first = assignees[0]!;
+  const restCount = assignees.length - 1;
+
+  return (
+    <span className="flex items-center gap-1">
+      <AssigneeAvatar login={first} />
+      <span className="font-mono text-[11px] text-(--dim)">@{first}</span>
+      {restCount > 0 && <span className="font-mono text-[11px] text-(--dim)">+{restCount}</span>}
+    </span>
+  );
+}

--- a/apps/web/components/issues/issue-row.tsx
+++ b/apps/web/components/issues/issue-row.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { CiStatusLink } from "@/components/ci-status";
+import { CompactAssignees } from "@/components/issues/assignees";
 import { WsjfChip } from "@/components/issues/wsjf-chip";
 import type { PipelineStory } from "@/lib/pipeline";
 import { storyHref } from "@/lib/pipeline";
@@ -212,6 +213,7 @@ export function IssueRow({
           </span>
         ))}
         {story.wsjf ? <WsjfChip wsjf={story.wsjf} /> : null}
+        <CompactAssignees assignees={story.assignees} />
         <span className="font-mono text-[10.5px] text-(--dim)">{fmtAgo(story.ghUpdatedAt)}</span>
         {action()}
       </div>


### PR DESCRIPTION
## Summary
Implements issue #101: Show who owns a story — render the assignees Facility already mirrors.

## Changes
- **New component**: `apps/web/components/issues/assignees.tsx` with:
  - `AssigneeAvatar`: GitHub avatar URL with initial-letter fallback when image fails to load
  - `Assignees`: Full display with avatar + @login for first assignee, +N with avatar stack tooltip on hover for additional assignees
  - `CompactAssignees`: Dense row version (avatar + @login + +N)
- **Story row** (`apps/web/components/issues/issue-row.tsx`): Renders `CompactAssignees` alongside labels and timestamp
- **Story detail header** (`apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx`): Renders full `Assignees` component alongside labels
- **Stories board** (`apps/web/app/(app)/projects/[projectId]/stories/page.tsx`): Adds "mine" filter chip next to stage chips, filtering by current user's GitHub login

## Verification
- `pnpm build --filter=@facility/web` ✓
- `pnpm test --filter=@facility/web` ✓ (13 test files, 69 tests)
- `pnpm biome check` ✓
- Full `pnpm test` ✓ (16 suites, 389+ tests)