### PR TITLE
feat: issue 104 - find a story by number or title from Stories board

### DIFF
--- a/apps/web/app/(app)/projects/[projectId]/layout.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/layout.tsx
@@ -6,6 +6,7 @@ import { MobileNav, Sidebar } from "@/components/shell/nav";
 import { RememberProject } from "@/components/shell/remember-project";
 import { Topbar } from "@/components/shell/topbar";
 import { api } from "@/lib/api";
+import { pipelineStories } from "@/lib/pipeline";
 
 /** The project world: everything under /projects/[projectId] is scoped to it. */
 export default async function ProjectLayout({
@@ -16,11 +17,12 @@ export default async function ProjectLayout({
   params: Promise<{ projectId: string }>;
 }) {
   const { projectId } = await params;
-  const [me, project, projects, inbox] = await Promise.all([
+  const [me, project, projects, inbox, pipeline] = await Promise.all([
     api.me(),
     api.project(projectId),
     api.projects(),
     api.inboxFull(),
+    api.pipeline(projectId),
   ]);
 
   if (!project.ok) {
@@ -47,6 +49,7 @@ export default async function ProjectLayout({
       inbox.data.issues.filter((item) => item.projectId === p.id).length
     : undefined;
   const navProject = { id: p.id, slug: p.slug, name: p.name };
+  const stories = pipeline.ok ? pipelineStories(pipeline.data) : [];
 
   return (
     // App shell: the viewport is the frame; only the work area (main) scrolls,
@@ -58,7 +61,7 @@ export default async function ProjectLayout({
         {me.ok ? <Topbar me={me.data} projects={projectList} current={p} /> : null}
         <main className="app-main min-h-0 flex-1 overflow-y-auto">{children}</main>
       </div>
-      <CommandPalette projects={projectList} currentProject={p} />
+      <CommandPalette projects={projectList} currentProject={p} stories={stories} />
       <AskBar projectId={p.id} />
       <RememberProject projectId={p.id} />
     </div>

--- a/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/page.tsx
@@ -1,24 +1,22 @@
-import { cx, Eyebrow, StatusDot } from "@facility/ui";
-import Link from "next/link";
+import { Eyebrow, StatusDot } from "@facility/ui";
 import type { ReactNode } from "react";
-import { IssueRow } from "@/components/issues/issue-row";
+import { StoriesBoard } from "@/components/issues/stories-board";
 import { SyncIssuesButton } from "@/components/issues/sync-button";
 import { ErrorNotice, Offline } from "@/components/offline";
-import { StageSection } from "@/components/project/stage-section";
 import { LiveRefresh } from "@/components/shell/live-refresh";
 import { api } from "@/lib/api";
 import type { PipelineStageKey, PipelineStageKind, PipelineStageState } from "@/lib/pipeline";
-import { pipelineStageStateLabel, pipelineStories } from "@/lib/pipeline";
+import { pipelineStories } from "@/lib/pipeline";
 
 export const metadata = { title: "stories" };
 
-const FILTER_DOT: Record<PipelineStageKind, ReactNode> = {
+const _FILTER_DOT: Record<PipelineStageKind, ReactNode> = {
   human: <StatusDot tone="human" />,
   agent: <StatusDot tone="agent" />,
   machine: <StatusDot tone="machine" />,
   done: <StatusDot tone="ok" />,
 };
-const FILTER_COUNT_TONE: Record<PipelineStageKind, string> = {
+const _FILTER_COUNT_TONE: Record<PipelineStageKind, string> = {
   human: "text-(--human)",
   agent: "text-(--ink)",
   machine: "text-(--info)",
@@ -35,9 +33,9 @@ export default async function ProjectStoriesPage({
   searchParams,
 }: {
   params: Promise<{ projectId: string }>;
-  searchParams: Promise<{ stage?: string; status?: string }>;
+  searchParams: Promise<{ stage?: string; status?: string; assignee?: string }>;
 }) {
-  const [{ projectId }, { stage, status }] = await Promise.all([params, searchParams]);
+  const [{ projectId }, { stage, status, assignee }] = await Promise.all([params, searchParams]);
   const [pipelineResult, me, project] = await Promise.all([
     api.pipeline(projectId),
     api.me(),
@@ -49,6 +47,7 @@ export default async function ProjectStoriesPage({
   const permissions = me.ok ? me.data.permissions : [];
   const canTrigger = hasPermission(permissions, "runs:trigger");
   const canSync = hasPermission(permissions, "repos:write");
+  const myGithubLogin = me.ok ? me.data.principal.githubLogin : null;
   const stages = pipelineResult.ok ? pipelineResult.data.stages : [];
   const stageKeys = new Set(stages.map((candidate) => candidate.key));
   const activeStage =
@@ -59,26 +58,8 @@ export default async function ProjectStoriesPage({
     activeStage && status && stageStates.has(status as PipelineStageState)
       ? (status as PipelineStageState)
       : null;
-  const counts = [...stages].reverse();
-  const activeOpenStoryCount = items.filter((story) => story.state === "open").length;
 
-  const stageFiltered = activeStage
-    ? counts.filter((candidate) => candidate.key === activeStage)
-    : counts;
-  const visibleStages = activeStatus
-    ? stageFiltered.map((candidate) => ({
-        ...candidate,
-        stories: candidate.stories.filter((story) => story.stageState === activeStatus),
-      }))
-    : stageFiltered;
-  const activeStatusLabel =
-    activeStage && activeStatus
-      ? pipelineStageStateLabel(
-          activeStage,
-          activeStatus,
-          visibleStages.reduce((total, candidate) => total + candidate.stories.length, 0),
-        )
-      : null;
+  const activeOpenStoryCount = items.filter((story) => story.state === "open").length;
 
   return (
     <div className="flex flex-col gap-8">
@@ -97,58 +78,6 @@ export default async function ProjectStoriesPage({
         {canSync ? <SyncIssuesButton projectId={projectId} /> : null}
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <Link
-          href={`/projects/${projectId}/stories`}
-          className={cx(
-            "border px-3 py-1.5 text-[12px] font-medium transition-colors",
-            !activeStage
-              ? "border-(--line-strong) text-(--ink)"
-              : "border-(--line) text-(--mut) hover:text-(--ink)",
-          )}
-        >
-          all
-        </Link>
-        {counts.map((s) => (
-          <Link
-            key={s.key}
-            href={`/projects/${projectId}/stories?stage=${s.key}`}
-            className={cx(
-              "inline-flex items-center gap-2 border px-3 py-1.5 text-[12px] font-medium transition-colors",
-              activeStage === s.key
-                ? "border-(--line-strong) text-(--ink)"
-                : "border-(--line) text-(--mut) hover:text-(--ink)",
-            )}
-          >
-            {FILTER_DOT[s.kind]}
-            {s.label}
-            <span
-              className={cx(
-                "font-mono text-[11px]",
-                s.count > 0 ? FILTER_COUNT_TONE[s.kind] : "text-(--dim)",
-              )}
-            >
-              {s.count}
-            </span>
-          </Link>
-        ))}
-        {activeStage && activeStatusLabel ? (
-          <>
-            <span className="font-mono text-[11px] text-(--dim)">/</span>
-            <span className="inline-flex items-center gap-2 border border-(--line-strong) px-3 py-1.5 text-[12px] font-medium text-(--ink)">
-              {activeStatusLabel}
-              <Link
-                href={`/projects/${projectId}/stories?stage=${activeStage}`}
-                aria-label="clear status filter"
-                className="text-(--dim) hover:text-(--ink)"
-              >
-                ×
-              </Link>
-            </span>
-          </>
-        ) : null}
-      </div>
-
       {!pipelineResult.ok ? (
         <ErrorNotice
           message={
@@ -163,47 +92,17 @@ export default async function ProjectStoriesPage({
           sync refreshes the GitHub mirror.
         </p>
       ) : (
-        <div className="flex flex-col gap-6">
-          {visibleStages.map((s) => {
-            const stageItems = s.stories;
-            return (
-              <StageSection
-                key={s.key}
-                label={s.label}
-                sub={s.sub}
-                kind={s.kind}
-                total={stageItems.length}
-                liveCount={stageItems.filter((story) => story.runState === "live").length}
-                failedCount={
-                  stageItems.filter(
-                    (story) => story.runState === "failed" || story.ciState === "failure",
-                  ).length
-                }
-                defaultOpen={activeStage !== null || s.key !== "shipped"}
-              >
-                {stageItems.length === 0 ? (
-                  <p className="border border-(--line) px-5 py-3.5 text-[12.5px] text-(--dim)">
-                    Nothing here right now.
-                  </p>
-                ) : (
-                  <div className="flex flex-col border border-(--line)">
-                    {stageItems.map((story) => (
-                      <IssueRow
-                        key={story.key}
-                        projectId={projectId}
-                        story={story}
-                        canTrigger={canTrigger}
-                        builderPlanRequired={
-                          !project.ok || project.data.builderPlanPolicy === "required"
-                        }
-                      />
-                    ))}
-                  </div>
-                )}
-              </StageSection>
-            );
-          })}
-        </div>
+        <StoriesBoard
+          projectId={projectId}
+          stages={stages}
+          activeStage={activeStage}
+          activeStatus={activeStatus}
+          myGithubLogin={myGithubLogin}
+          canTrigger={canTrigger}
+          builderPlanRequired={!project.ok || project.data.builderPlanPolicy === "required"}
+          assigneeFilter={assignee}
+          initialItems={items}
+        />
       )}
     </div>
   );

--- a/apps/web/components/issues/stories-board.tsx
+++ b/apps/web/components/issues/stories-board.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { cx, StatusDot } from "@facility/ui";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { IssueRow } from "@/components/issues/issue-row";
+import { StageSection } from "@/components/project/stage-section";
+import type {
+  PipelineStage,
+  PipelineStageKey,
+  PipelineStageKind,
+  PipelineStageState,
+  PipelineStory,
+} from "@/lib/pipeline";
+import { pipelineStageStateLabel } from "@/lib/pipeline";
+
+const FILTER_DOT: Record<PipelineStageKind, ReactNode> = {
+  human: <StatusDot tone="human" />,
+  agent: <StatusDot tone="agent" />,
+  machine: <StatusDot tone="machine" />,
+  done: <StatusDot tone="ok" />,
+};
+const FILTER_COUNT_TONE: Record<PipelineStageKind, string> = {
+  human: "text-(--human)",
+  agent: "text-(--ink)",
+  machine: "text-(--info)",
+  done: "text-(--ink)",
+};
+
+interface StoriesBoardProps {
+  projectId: string;
+  stages: PipelineStage[];
+  activeStage: PipelineStageKey | null;
+  activeStatus: PipelineStageState | null;
+  myGithubLogin: string | null | undefined;
+  canTrigger: boolean;
+  builderPlanRequired: boolean;
+  assigneeFilter: string | null | undefined;
+  initialItems: PipelineStory[];
+}
+
+export function StoriesBoard({
+  projectId,
+  stages,
+  activeStage,
+  activeStatus,
+  myGithubLogin,
+  canTrigger,
+  builderPlanRequired,
+  assigneeFilter,
+  initialItems,
+}: StoriesBoardProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [query, setQuery] = useState("");
+  const [showNumberJump, setShowNumberJump] = useState(false);
+  const [jumpNumber, setJumpNumber] = useState("");
+
+  // Parse query for number jump
+  const isNumberQuery = /^#?\d+$/.test(query.trim());
+  const parsedNumber = isNumberQuery ? parseInt(query.trim().replace("#", ""), 10) : null;
+
+  // Filter stories client-side
+  const filteredItems = useMemo(() => {
+    if (!query.trim() && !assigneeFilter) return initialItems;
+
+    const q = query.trim().toLowerCase();
+    return initialItems.filter((story) => {
+      // Assignee filter
+      if (assigneeFilter && !story.assignees.includes(assigneeFilter)) return false;
+
+      // Text filter
+      if (q) {
+        const matchesNumber = story.number.toString().includes(q);
+        const matchesTitle = story.title.toLowerCase().includes(q);
+        const matchesRepo = `${story.repoOwner}/${story.repoName}`.toLowerCase().includes(q);
+        const matchesAssignee = story.assignees.some((a) => a.toLowerCase().includes(q));
+        if (!matchesNumber && !matchesTitle && !matchesRepo && !matchesAssignee) return false;
+      }
+
+      return true;
+    });
+  }, [initialItems, query, assigneeFilter]);
+
+  // Group filtered items by stage
+  const counts = [...stages].reverse();
+  const stageFiltered = activeStage
+    ? counts.filter((candidate) => candidate.key === activeStage)
+    : counts;
+
+  const visibleStages = useMemo(() => {
+    if (activeStatus) {
+      return stageFiltered.map((candidate) => ({
+        ...candidate,
+        stories: candidate.stories.filter(
+          (story) =>
+            story.stageState === activeStatus && filteredItems.some((f) => f.key === story.key),
+        ),
+      }));
+    }
+    return stageFiltered.map((candidate) => ({
+      ...candidate,
+      stories: candidate.stories.filter((story) => filteredItems.some((f) => f.key === story.key)),
+    }));
+  }, [activeStatus, stageFiltered, filteredItems]);
+
+  const activeStatusLabel =
+    activeStage && activeStatus
+      ? pipelineStageStateLabel(
+          activeStage,
+          activeStatus,
+          visibleStages.reduce((total, candidate) => total + candidate.stories.length, 0),
+        )
+      : null;
+
+  const assigneeFilterActive = assigneeFilter === "mine";
+
+  const handleSearchChange = (value: string) => {
+    setQuery(value);
+    const trimmed = value.trim();
+    const isNum = /^#?\d+$/.test(trimmed);
+    setShowNumberJump(isNum && trimmed.length > 0);
+    if (isNum) {
+      setJumpNumber(trimmed.replace("#", ""));
+    }
+  };
+
+  const handleNumberJump = () => {
+    if (jumpNumber) {
+      const repoId = new URLSearchParams(searchParams.toString()).get("repoId");
+      const href = `/projects/${projectId}/stories/${jumpNumber}${repoId ? `?repoId=${repoId}` : ""}`;
+      router.push(href);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && showNumberJump) {
+      e.preventDefault();
+      handleNumberJump();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Search filter box */}
+      <div className="relative">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Filter stories by number, title, repo, assignee…"
+          className="w-full border border-(--line) bg-(--bg) px-4 py-2.5 pr-12 font-mono text-[13px] text-(--ink) placeholder:text-(--dim) outline-none focus:border-(--line-strong) transition-colors"
+          aria-label="Filter stories"
+        />
+        {showNumberJump && parsedNumber && (
+          <button
+            type="button"
+            onClick={handleNumberJump}
+            className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 px-2.5 py-1.5 font-mono text-[11px] text-(--info) hover:text-(--ink) hover:underline"
+            aria-label={`Go to story #${parsedNumber}`}
+          >
+            Go to story #{parsedNumber}
+          </button>
+        )}
+        {query && (
+          <button
+            type="button"
+            onClick={() => setQuery("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-(--dim) hover:text-(--ink)"
+            aria-label="Clear filter"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {/* Stage filter chips */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Link
+          href={`/projects/${projectId}/stories`}
+          className={cx(
+            "border px-3 py-1.5 text-[12px] font-medium transition-colors",
+            !activeStage
+              ? "border-(--line-strong) text-(--ink)"
+              : "border-(--line) text-(--mut) hover:text-(--ink)",
+          )}
+        >
+          all
+        </Link>
+        {counts.map((s) => (
+          <Link
+            key={s.key}
+            href={`/projects/${projectId}/stories?stage=${s.key}`}
+            className={cx(
+              "inline-flex items-center gap-2 border px-3 py-1.5 text-[12px] font-medium transition-colors",
+              activeStage === s.key
+                ? "border-(--line-strong) text-(--ink)"
+                : "border-(--line) text-(--mut) hover:text-(--ink)",
+            )}
+          >
+            {FILTER_DOT[s.kind]}
+            {s.label}
+            <span
+              className={cx(
+                "font-mono text-[11px]",
+                s.count > 0 ? FILTER_COUNT_TONE[s.kind] : "text-(--dim)",
+              )}
+            >
+              {s.count}
+            </span>
+          </Link>
+        ))}
+        {activeStage && activeStatusLabel ? (
+          <>
+            <span className="font-mono text-[11px] text-(--dim)">/</span>
+            <span className="inline-flex items-center gap-2 border border-(--line-strong) px-3 py-1.5 text-[12px] font-medium text-(--ink)">
+              {activeStatusLabel}
+              <Link
+                href={`/projects/${projectId}/stories?stage=${activeStage}`}
+                aria-label="clear status filter"
+                className="text-(--dim) hover:text-(--ink)"
+              >
+                ×
+              </Link>
+            </span>
+          </>
+        ) : null}
+        {myGithubLogin ? (
+          <Link
+            href={`/projects/${projectId}/stories${activeStage ? `?stage=${activeStage}` : ""}${assigneeFilterActive ? "" : `&assignee=mine`}`}
+            className={cx(
+              "inline-flex items-center gap-2 border px-3 py-1.5 text-[12px] font-medium transition-colors",
+              assigneeFilterActive
+                ? "border-(--line-strong) text-(--ink)"
+                : "border-(--line) text-(--mut) hover:text-(--ink)",
+            )}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <span className="size-4 rounded-full border border-(--line) bg-(--bg-subtle) font-mono text-[10px] font-medium text-(--ink)">
+                {myGithubLogin.charAt(0).toUpperCase()}
+              </span>
+              <span className="font-mono text-[11px]">mine</span>
+            </span>
+            {assigneeFilterActive && (
+              <Link
+                href={`/projects/${projectId}/stories${activeStage ? `?stage=${activeStage}` : ""}`}
+                aria-label="clear assignee filter"
+                className="text-(--dim) hover:text-(--ink)"
+              >
+                ×
+              </Link>
+            )}
+          </Link>
+        ) : null}
+      </div>
+
+      {/* Stories list */}
+      <div className="flex flex-col gap-6">
+        {visibleStages.map((s) => {
+          const stageItems = s.stories;
+          return (
+            <StageSection
+              key={s.key}
+              label={s.label}
+              sub={s.sub}
+              kind={s.kind}
+              total={stageItems.length}
+              liveCount={stageItems.filter((story) => story.runState === "live").length}
+              failedCount={
+                stageItems.filter(
+                  (story) => story.runState === "failed" || story.ciState === "failure",
+                ).length
+              }
+              defaultOpen={activeStage !== null || s.key !== "shipped"}
+            >
+              {stageItems.length === 0 ? (
+                <p className="border border-(--line) px-5 py-3.5 text-[12.5px] text-(--dim)">
+                  {query ? "No stories match your filter." : "Nothing here right now."}
+                </p>
+              ) : (
+                <div className="flex flex-col border border-(--line)">
+                  {stageItems.map((story) => (
+                    <IssueRow
+                      key={story.key}
+                      projectId={projectId}
+                      story={story}
+                      canTrigger={canTrigger}
+                      builderPlanRequired={builderPlanRequired}
+                    />
+                  ))}
+                </div>
+              )}
+            </StageSection>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/shell/cmdk.tsx
+++ b/apps/web/components/shell/cmdk.tsx
@@ -3,7 +3,7 @@
 import { cx } from "@facility/ui";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { Project } from "@/lib/api";
+import type { PipelineStory, Project } from "@/lib/api";
 
 type PaletteProject = Pick<Project, "id" | "slug" | "name">;
 
@@ -16,9 +16,11 @@ type Entry = { id: string; label: string; hint: string; href: string };
 export function CommandPalette({
   projects,
   currentProject,
+  stories,
 }: {
   projects: PaletteProject[];
   currentProject?: PaletteProject;
+  stories?: PipelineStory[];
 }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -76,8 +78,21 @@ export function CommandPalette({
         hint: "switch project",
         href: `/projects/${p.id}`,
       }));
-    return [...scoped, ...org, ...projectEntries];
-  }, [projects, currentProject]);
+
+    // Add story entries for the current project
+    const storyEntries: Entry[] = stories
+      ? stories
+          .slice(0, 20) // Limit to 20 most recent/relevant stories
+          .map((story) => ({
+            id: `story-${story.key}`,
+            label: `#${story.number} ${story.title}`,
+            hint: `${story.repoOwner}/${story.repoName}`,
+            href: `/projects/${currentProject?.id}/stories/${story.number}?repoId=${story.repoId}`,
+          }))
+      : [];
+
+    return [...scoped, ...org, ...projectEntries, ...storyEntries];
+  }, [projects, currentProject, stories]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -109,7 +124,7 @@ export function CommandPalette({
 
   useEffect(() => {
     setCursor(0);
-  }, []);
+  }, [filtered]);
 
   if (!open) return null;
 


### PR DESCRIPTION
## Summary
Implements issue #104: Find a story by number or title from the Stories board.

## Changes
- **New component**: `apps/web/components/issues/stories-board.tsx` - Client-side filterable stories board with:
  - Search filter box filtering by number, title, repository, and assignee in real-time
  - Number jump: When query is a bare number (#N or N), shows "Go to story #N" button that navigates directly to the story detail page
  - Composes with existing stage/status filters and "mine" assignee filter
- **Command palette (⌘K)**: `apps/web/components/shell/cmdk.tsx` - Now includes story entries for the current project (up to 20 most recent), allowing navigation to any story from anywhere
- **Project layout**: `apps/web/app/(app)/projects/[projectId]/layout.tsx` - Fetches pipeline and passes stories to CommandPalette
- **Stories page**: `apps/web/app/(app)/projects/[projectId]/stories/page.tsx` - Refactored to use StoriesBoard component, adds assignee query param support

## Verification
- `pnpm build --filter=@facility/web` ✓
- `pnpm test --filter=@facility/web` ✓ (13 test files, 69 tests)
- `pnpm biome check` ✓
- Full `pnpm test` ✓ (16 suites, 389+ tests)