### PR TITLE
fix(runner): rebuild Go tools with patched modules

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -33,7 +33,9 @@ RUN archive=/tmp/moby.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
   && VERSION="$MOBY_VERSION" DOCKER_GITCOMMIT="$MOBY_COMMIT" \
     EXCLUDE_AUTO_BUILDTAG_JOURNALD=1 SOURCE_DATE_EPOCH=1785456000 \
     GOFLAGS=-mod=mod ./hack/make.sh binary-daemon binary-proxy \
@@ -73,9 +75,10 @@ RUN archive=/tmp/containerd.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
-  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.55.0 \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
   && make VERSION="v${CONTAINERD_VERSION}" REVISION="$CONTAINERD_COMMIT" STATIC=1 \
     GO_BUILD_FLAGS='-mod=mod -trimpath' \
     bin/containerd bin/containerd-shim-runc-v2 bin/ctr \
@@ -94,7 +97,7 @@ RUN archive=/tmp/rootlesskit.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
-  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.55.0 \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
   && CGO_ENABLED=0 go build -mod=mod -trimpath -ldflags='-s -w' -o /out/rootlesskit ./cmd/rootlesskit \
   && test "$(/out/rootlesskit --version | awk '{print $3}')" = "3.0.2" \
@@ -112,7 +115,9 @@ RUN archive=/tmp/buildx.tar.gz \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
   && go mod edit -replace=github.com/moby/go-archive=github.com/moby/go-archive@v0.3.0 \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
   && CGO_ENABLED=0 go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/docker/buildx/version.Version=${BUILDX_VERSION} \
       -X github.com/docker/buildx/version.Revision=${BUILDX_COMMIT} \
@@ -132,8 +137,9 @@ RUN archive=/tmp/compose.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
-  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.55.0 \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
   && CGO_ENABLED=0 GOMAXPROCS=1 go build -p=1 -mod=mod -trimpath -tags=e2e \
     -ldflags="-s -w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
     -o /out/docker-compose ./cmd \
@@ -166,7 +172,9 @@ RUN archive=/tmp/gh.tar.gz \
   && mkdir -p /src /out \
   && tar -xzf "$archive" --strip-components=1 -C /src \
   && cd /src \
+  && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
   && CGO_ENABLED=0 GOTOOLCHAIN=local go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/cli/cli/v2/internal/build.Version=${GH_VERSION} \
       -X github.com/cli/cli/v2/internal/build.Date=2026-07-31" \
@@ -185,9 +193,13 @@ RUN for binary in /out/*; do \
     go version -m "$binary" | awk \
       '$1 == "=>" && $2 == "golang.org/x/net" && $3 == "v0.56.0" { found = 1 } END { exit !found }' || exit 1; \
   done \
-  && for binary in /out/containerd /out/rootlesskit /out/docker-compose; do \
+  && for binary in /out/dockerd /out/containerd /out/rootlesskit /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \
-      '$1 == "=>" && $2 == "golang.org/x/crypto" && $3 == "v0.55.0" { found = 1 } END { exit !found }' || exit 1; \
+      '$1 == "=>" && $2 == "golang.org/x/crypto" && $3 == "v0.56.0" { found = 1 } END { exit !found }' || exit 1; \
+  done \
+  && for binary in /out/dockerd /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
+    go version -m "$binary" | awk \
+      '$1 == "=>" && $2 == "google.golang.org/grpc" && $3 == "v1.83.1" { found = 1 } END { exit !found }' || exit 1; \
   done \
   && for binary in /out/dockerd /out/containerd /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \

--- a/runner/grype.yaml
+++ b/runner/grype.yaml
@@ -6,7 +6,7 @@
 # path. A Docker-tool digest or embedded-version change therefore fails closed
 # and requires this evidence to be reviewed again.
 #
-# Reviewed 2026-08-07 with Grype 0.110.0 and govulncheck 1.6.0. runc and
+# Reviewed 2026-09-04 with Grype 0.110.0 and govulncheck 1.6.0. runc and
 # RootlessKit have no reachable vulnerable symbols. The containerd findings are
 # limited to its rootless, local-UNIX-socket runtime behind Facility's Docker
 # proxy; it does not use Docker AuthZ plugins or xDS RBAC. Remove these rules as
@@ -85,23 +85,5 @@ ignore:
     package:
       name: golang.org/x/text
       version: v0.38.0
-      type: go-module
-      location: /usr/local/bin/ctr
-  - vulnerability: GHSA-hrxh-6v49-42gf
-    package:
-      name: google.golang.org/grpc
-      version: v1.80.0
-      type: go-module
-      location: /usr/local/bin/containerd
-  - vulnerability: GHSA-hrxh-6v49-42gf
-    package:
-      name: google.golang.org/grpc
-      version: v1.80.0
-      type: go-module
-      location: /usr/local/bin/containerd-shim-runc-v2
-  - vulnerability: GHSA-hrxh-6v49-42gf
-    package:
-      name: google.golang.org/grpc
-      version: v1.80.0
       type: go-module
       location: /usr/local/bin/ctr

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -20,6 +20,7 @@ const imagesWorkflow = readFileSync(
   "utf8",
 );
 const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+const runnerDockerfile = readFileSync(new URL("../runner/Dockerfile", import.meta.url), "utf8");
 
 test("manual publication is SHA-only even when dispatch targets a tag", () => {
   for (const ref of ["refs/heads/main", "refs/heads/feature", "refs/tags/v0.3.0"]) {
@@ -231,4 +232,16 @@ test("workspace CI runs the persistent Docker acceptance path", () => {
   assert.match(workspaceJob, /FACILITY_WORKSPACE_TEST_IMAGE: facility-runner:dev/);
   assert.match(workspaceJob, /run: pnpm test:e2e-workspace/);
   assert.doesNotMatch(workspaceJob, /CodeBuild|run-objective|sandbox\.e2e/);
+});
+
+test("runner Go binaries resolve the fixed cryptography and gRPC modules", () => {
+  assert.doesNotMatch(runnerDockerfile, /golang\.org\/x\/crypto@v0\.55\.0/);
+  assert.match(
+    runnerDockerfile,
+    /for binary in \/out\/dockerd \/out\/containerd \/out\/rootlesskit \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*golang\.org\/x\/crypto" && \$3 == "v0\.56\.0"/,
+  );
+  assert.match(
+    runnerDockerfile,
+    /for binary in \/out\/dockerd \/out\/containerd \/out\/containerd-shim-runc-v2 \/out\/ctr \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*google\.golang\.org\/grpc" && \$3 == "v1\.83\.1"/,
+  );
 });


### PR DESCRIPTION
## What changes

Rebuild the runner's embedded Docker/Moby, containerd, RootlessKit, Buildx, Compose, and GitHub CLI binaries with patched `golang.org/x/crypto` and `google.golang.org/grpc` modules. The image audit stage now asserts those module versions for every affected binary, and obsolete exact gRPC scan exceptions are removed.

## Why

The 0.12.0 runner image release is blocked by fixed high-severity Go module advisories in those embedded binaries. This keeps the fix at the build boundary instead of suppressing reachable fixed vulnerabilities.

Fixes #297

## Verification

- `pnpm verify` passed locally.
- `docker build --target go-tools-audit -f runner/Dockerfile .` passed on arm64.
- `docker build --platform linux/amd64 --target runner -f runner/Dockerfile .` built the release-platform image and exercised the embedded module assertions.
- `grype docker:facility-runner:v012-hotfix-amd64 --only-fixed --fail-on high --config runner/grype.yaml` exited 0 with Grype 0.110.0 and no fixed high/critical findings.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (release-platform runner build and policy-identical image scan)
- [x] Documentation updated, or no user-facing change