### PR TITLE
feat(turns): warn when active stories touch the same files

### DIFF
--- a/apps/docs/docs/guides/operate-story.md
+++ b/apps/docs/docs/guides/operate-story.md
@@ -44,7 +44,10 @@ session, workspace, branch, and initial SHA started each turn; the final SHA, co
 dirty state; artifacts and attention; and the mirrored branch, pull request, reviews, and checks.
 An entry linked to a `turn_id` has an exact Facility attribution. An `external` GitHub actor means
 Facility associated the event with the story but could not prove that a particular turn produced
-it.
+it. A `story.collision_detected` entry means another open story in the project has changed the
+same files; the agent was told which paths overlap before its turn started, and the two pull
+requests are likely to conflict. Nothing is blocked, but it is worth deciding early which one
+lands first.
 
 When the story needs attention:
 

--- a/apps/docs/docs/reference/lifecycle.md
+++ b/apps/docs/docs/reference/lifecycle.md
@@ -54,6 +54,15 @@ reconciliation. A matching final SHA links the fact to an exact turn. Facts that
 only through the story's branch, pull request, or closing issue remain story-level external changes
 rather than being attributed to an agent.
 
+Before the engine starts, Facility also compares the changed files recorded for this story with
+the changed files of every other active story in the project that has an open branch. Stories that
+are done, archived, deleted, or whose branch belongs to a merged pull request are ignored. When two
+stories touched the same paths, a `story.collision_detected` fact is recorded on the timeline for
+each overlapping story, with up to 20 overlapping paths and the total count, and the prompt tells
+the agent which paths other open branches are changing. The check is advisory: it never blocks or
+fails a turn, does not create attention, and a story with no completed evidence yet cannot collide
+because its files are not known. A detection failure is recorded as `turn.collision_check_failed`.
+
 The story response orders these facts with turn activity, artifacts, attention, and creation in a
 single timeline. Source time and observation time are both retained because an event discovered by
 reconciliation may be older than the time Facility first saw it.

--- a/apps/docs/test/documentation-contract.test.mjs
+++ b/apps/docs/test/documentation-contract.test.mjs
@@ -146,6 +146,7 @@ test("project capabilities and delivery evidence are inspectable", () => {
     "commits",
     "changed files",
     "periodic reconciliation",
+    "story.collision_detected",
     "single timeline",
   ]) {
     assert.match(

--- a/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/stories/[number]/page.tsx
@@ -365,6 +365,10 @@ function timelineSummary(type: string, data: Record<string, unknown>) {
   if (type === "github.check_observed") {
     return `${text("name") ?? "check"} · ${text("conclusion") ?? text("status") ?? "unknown"}`;
   }
+  if (type === "story.collision_detected") {
+    const extra = Number(data.overlapCount ?? 0) - count("overlappingPaths");
+    return `overlaps "${text("title") ?? "another story"}" on ${String(data.overlapCount ?? "?")} files · ${text("branch") ?? "unknown branch"}${extra > 0 ? ` · ${extra} not listed` : ""}`;
+  }
   if (type === "artifact.recorded") return text("label") ?? "Artifact recorded.";
   if (type.startsWith("attention.")) return text("title") ?? type;
   if (type === "turn.failed") return text("error") ?? "Turn failed.";

--- a/services/api/src/turns/collisions.ts
+++ b/services/api/src/turns/collisions.ts
@@ -1,0 +1,172 @@
+import { type FacilityDb, githubPullRequests, stories, turnGitEvidence } from "@facility/db";
+import { and, eq, inArray, isNotNull, isNull, ne, sql } from "drizzle-orm";
+
+/** Paths listed per colliding story in the prompt and the evidence event. */
+export const MAX_COLLISION_PATHS = 20;
+/** Colliding stories reported per turn; the rest are counted. */
+export const MAX_COLLISION_STORIES = 10;
+
+const ACTIVE_STORY_STATUSES = ["ready", "working", "attention", "review"] as const;
+
+export type StoryCollision = {
+  storyId: string;
+  title: string;
+  provider: string;
+  externalId: string;
+  branch: string;
+  status: string;
+  overlappingPaths: string[];
+  overlapCount: number;
+};
+
+/**
+ * Detects other active stories in the same project whose recorded Git evidence changed files this
+ * story also changed. It is advisory only: it reads evidence that already exists and never blocks
+ * dispatch. A story with no completed evidence yet cannot collide, because its files are unknown.
+ */
+export class StoryCollisionService {
+  constructor(private readonly db: FacilityDb) {}
+
+  async detect(input: {
+    orgId: string;
+    projectId: string;
+    storyId: string;
+  }): Promise<StoryCollision[]> {
+    const mine = (await this.changedPaths(input.orgId, input.projectId, [input.storyId])).get(
+      input.storyId,
+    );
+    if (!mine || mine.size === 0) return [];
+
+    const candidates = await this.db
+      .select({
+        id: stories.id,
+        title: stories.title,
+        provider: stories.provider,
+        externalId: stories.externalId,
+        branch: stories.branch,
+        status: stories.status,
+      })
+      .from(stories)
+      .where(
+        and(
+          eq(stories.orgId, input.orgId),
+          eq(stories.projectId, input.projectId),
+          ne(stories.id, input.storyId),
+          inArray(stories.status, [...ACTIVE_STORY_STATUSES]),
+          isNull(stories.deletedAt),
+          isNull(stories.archivedAt),
+          isNotNull(stories.branch),
+        ),
+      );
+    const open = candidates.filter(
+      (candidate): candidate is typeof candidate & { branch: string } => candidate.branch !== null,
+    );
+    if (open.length === 0) return [];
+
+    const merged = new Set(
+      (
+        await this.db
+          .select({ headRef: githubPullRequests.headRef })
+          .from(githubPullRequests)
+          .where(
+            and(
+              eq(githubPullRequests.orgId, input.orgId),
+              eq(githubPullRequests.projectId, input.projectId),
+              eq(githubPullRequests.state, "merged"),
+              inArray(
+                githubPullRequests.headRef,
+                open.map((candidate) => candidate.branch),
+              ),
+            ),
+          )
+      ).map((row) => row.headRef),
+    );
+    const live = open.filter((candidate) => !merged.has(candidate.branch));
+    if (live.length === 0) return [];
+
+    const theirs = await this.changedPaths(
+      input.orgId,
+      input.projectId,
+      live.map((candidate) => candidate.id),
+    );
+    const collisions: StoryCollision[] = [];
+    for (const candidate of live) {
+      const paths = theirs.get(candidate.id);
+      if (!paths) continue;
+      const overlap = overlappingPaths(mine, paths);
+      if (overlap.length === 0) continue;
+      collisions.push({
+        storyId: candidate.id,
+        title: candidate.title,
+        provider: candidate.provider,
+        externalId: candidate.externalId,
+        branch: candidate.branch,
+        status: candidate.status,
+        overlappingPaths: overlap.slice(0, MAX_COLLISION_PATHS),
+        overlapCount: overlap.length,
+      });
+    }
+    return collisions.sort(
+      (left, right) =>
+        right.overlapCount - left.overlapCount || left.storyId.localeCompare(right.storyId),
+    );
+  }
+
+  /**
+   * Unions the changed paths of every completed, successfully captured turn per story. Only the
+   * path column is pulled out of the JSON so the control plane never loads full evidence rows.
+   */
+  private async changedPaths(orgId: string, projectId: string, storyIds: string[]) {
+    const rows = await this.db
+      .select({
+        storyId: turnGitEvidence.storyId,
+        paths: sql<unknown>`jsonb_path_query_array(${turnGitEvidence.changedFiles}, '$[*].path')`,
+      })
+      .from(turnGitEvidence)
+      .where(
+        and(
+          eq(turnGitEvidence.orgId, orgId),
+          eq(turnGitEvidence.projectId, projectId),
+          inArray(turnGitEvidence.storyId, storyIds),
+          isNotNull(turnGitEvidence.completedAt),
+          isNull(turnGitEvidence.captureError),
+        ),
+      );
+    const byStory = new Map<string, Set<string>>();
+    for (const row of rows) {
+      const paths = byStory.get(row.storyId) ?? new Set<string>();
+      if (Array.isArray(row.paths)) {
+        for (const path of row.paths) if (typeof path === "string" && path) paths.add(path);
+      }
+      byStory.set(row.storyId, paths);
+    }
+    return byStory;
+  }
+}
+
+/** Sorted intersection of two path sets. */
+export function overlappingPaths(mine: Iterable<string>, theirs: Iterable<string>): string[] {
+  const other = theirs instanceof Set ? theirs : new Set(theirs);
+  const overlap = new Set<string>();
+  for (const path of mine) if (other.has(path)) overlap.add(path);
+  return [...overlap].sort((left, right) => left.localeCompare(right));
+}
+
+/** Prompt section that tells the agent which files other open branches are also changing. */
+export function collisionPromptBlock(collisions: StoryCollision[]): string {
+  if (collisions.length === 0) return "";
+  const listed = collisions.slice(0, MAX_COLLISION_STORIES);
+  const lines = listed.map((collision) => {
+    const shown = collision.overlappingPaths.slice(0, MAX_COLLISION_PATHS);
+    const remainder = collision.overlapCount - shown.length;
+    const suffix = remainder > 0 ? ` (+${remainder} more)` : "";
+    return `- "${collision.title}" (${collision.provider}:${collision.externalId}, branch ${collision.branch}): ${shown.join(", ")}${suffix}`;
+  });
+  const omitted = collisions.length - listed.length;
+  if (omitted > 0) lines.push(`- ${omitted} more stories overlap with this one.`);
+  return [
+    "# Other active stories touch files you changed",
+    "The following stories in this project have open branches that changed files this story also changed. Their pull requests will conflict with yours if both keep editing the same regions. Keep your edits to these paths minimal and focused, do not reformat or reorganize them, and mention the overlap in your commit or pull request description when it matters. Do not modify the other branches.",
+    ...lines,
+  ].join("\n");
+}

--- a/services/api/src/turns/dispatcher.ts
+++ b/services/api/src/turns/dispatcher.ts
@@ -13,12 +13,14 @@ import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { type AgentCatalogService, manifestFromProjection } from "../agents/catalog.js";
 import type { GithubWorkspaceCredentialBroker } from "../github/workspace-credentials.js";
 import { CostBudgetService } from "../insights/costs.js";
+import { appendStoryEvidence } from "../stories/evidence.js";
 import type { StoryWorkspaceService } from "../stories/service.js";
 import type {
   ProjectEnvironmentService,
   ProjectManifestSource,
 } from "../workspaces/project-environment.js";
 import type { WorkspaceLocator } from "../workspaces/runtime.js";
+import { collisionPromptBlock, type StoryCollision, StoryCollisionService } from "./collisions.js";
 import type { AgentEngineRegistry, AgentTurnResult } from "./engines.js";
 import { AgentEngineError } from "./engines.js";
 import { appendTurnEvent } from "./events.js";
@@ -35,6 +37,7 @@ export class TurnDispatcher {
     private readonly engines: AgentEngineRegistry,
     private readonly evidence: TurnGitEvidenceService,
     private readonly costs = new CostBudgetService(db),
+    private readonly collisions = new StoryCollisionService(db),
   ) {}
 
   async dispatch(input: { orgId: string; projectId: string; turnId: string }) {
@@ -195,12 +198,13 @@ export class TurnDispatcher {
         engine: manifest.engine,
         model: manifest.model,
       });
+      const collisions = await this.detectCollisions(eventBase);
       const engine = this.engines.get(manifest.engine);
       const engineRequest = {
         turnId: turn.id,
         manifest,
         workspace: workspaceLocator(workspace),
-        prompt: buildPrompt(manifest, story, conversation.summary, messages, turn.id),
+        prompt: buildPrompt(manifest, story, conversation.summary, messages, turn.id, collisions),
         cwd: prepared.primaryCwd,
         nativeSessionId: session?.nativeSessionId,
         environment: prepared.processEnvironment,
@@ -350,6 +354,65 @@ export class TurnDispatcher {
     } finally {
       clearInterval(leaseHeartbeat);
     }
+  }
+
+  /**
+   * Advisory only. Records which other open branches changed the same files and hands the list to
+   * the prompt. A detection failure is recorded on the turn and never prevents the engine from
+   * running.
+   */
+  private async detectCollisions(eventBase: {
+    orgId: string;
+    projectId: string;
+    storyId: string;
+    turnId: string;
+  }): Promise<StoryCollision[]> {
+    let collisions: StoryCollision[];
+    try {
+      collisions = await this.collisions.detect(eventBase);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await appendTurnEvent(this.db, {
+        ...eventBase,
+        type: "turn.collision_check_failed",
+        data: { error: detail.slice(0, 8_000) },
+      });
+      return [];
+    }
+    if (collisions.length === 0) return [];
+    const occurredAt = new Date();
+    for (const collision of collisions) {
+      await appendStoryEvidence(this.db, {
+        ...eventBase,
+        source: "facility",
+        type: "story.collision_detected",
+        externalKey: `turn:${eventBase.turnId}:collision:${collision.storyId}`,
+        occurredAt,
+        data: {
+          storyId: collision.storyId,
+          title: collision.title,
+          provider: collision.provider,
+          externalId: collision.externalId,
+          branch: collision.branch,
+          status: collision.status,
+          overlappingPaths: collision.overlappingPaths,
+          overlapCount: collision.overlapCount,
+          truncated: collision.overlapCount > collision.overlappingPaths.length,
+        },
+      });
+    }
+    await appendTurnEvent(this.db, {
+      ...eventBase,
+      type: "turn.collisions_detected",
+      data: {
+        stories: collisions.map((collision) => ({
+          storyId: collision.storyId,
+          branch: collision.branch,
+          overlapCount: collision.overlapCount,
+        })),
+      },
+    });
+    return collisions;
   }
 
   private async isCanceled(orgId: string, projectId: string, turnId: string) {
@@ -592,6 +655,7 @@ function buildPrompt(
   summary: string | null,
   messages: Array<typeof storyMessages.$inferSelect>,
   turnId: string,
+  collisions: StoryCollision[] = [],
 ) {
   const currentSequence = messages.find(
     (message) => message.turnId === turnId && message.role === "user",
@@ -607,6 +671,7 @@ function buildPrompt(
   return [
     manifest.prompt,
     `# Story\n${story.title}\nExternal identity: ${story.provider}:${story.externalId}`,
+    collisionPromptBlock(collisions),
     summary ? `# Conversation summary\n${summary}` : "",
     `# Shared conversation\n${truncateStart(transcript, 120_000)}`,
     "Continue in the existing worktree. You have full workspace, network, Docker, browser, git, and GitHub maintainer access. Preserve useful uncommitted work. Commit and push coherent changes when the task calls for it. Never merge the pull request or publish packages.",

--- a/services/api/test/story-collisions.integration.test.ts
+++ b/services/api/test/story-collisions.integration.test.ts
@@ -1,0 +1,379 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseAgentManifest } from "@facility/agents";
+import { newId } from "@facility/core";
+import {
+  attentionItems,
+  createDb,
+  githubInstallations,
+  githubPullRequests,
+  migrate,
+  orgs,
+  projectRepositories,
+  projects,
+  stories,
+  storyEvidenceEvents,
+  turnEvents,
+} from "@facility/db";
+import { and, asc, eq } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { AgentCatalogService, type AgentCatalogSource } from "../src/agents/catalog.js";
+import { GithubWorkspaceCredentialBroker } from "../src/github/workspace-credentials.js";
+import { StoryWorkspaceService } from "../src/stories/service.js";
+import { TurnDispatcher } from "../src/turns/dispatcher.js";
+import {
+  type AgentEngine,
+  AgentEngineRegistry,
+  type AgentTurnRequest,
+  type AgentTurnResult,
+} from "../src/turns/engines.js";
+import { TurnGitEvidenceService } from "../src/turns/git-evidence.js";
+import { FakeWorkspaceRuntime } from "../src/workspaces/fake.js";
+import {
+  ProjectEnvironmentService,
+  type ProjectManifestSource,
+  parseProjectManifest,
+} from "../src/workspaces/project-environment.js";
+
+const databaseUrl =
+  process.env.DATABASE_URL ?? "postgres://facility:facility@localhost:5461/facility_test";
+
+async function canConnect() {
+  const client = postgres(databaseUrl, { max: 1, connect_timeout: 10 });
+  try {
+    await client`select 1`;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+describe("cross-story collision guard", async () => {
+  const reachable = await canConnect();
+  if (!reachable) {
+    it.skip("Postgres is unreachable at DATABASE_URL; collision tests skipped", () => undefined);
+    return;
+  }
+
+  const { db, client } = createDb(databaseUrl);
+  const root = await mkdtemp(join(tmpdir(), "facility-collisions-"));
+  const remotes = join(root, "remotes");
+  const runtime = new FakeWorkspaceRuntime(join(root, "workspaces"));
+  const suffix = randomUUID().slice(0, 8);
+  const owner = "acme";
+  const repository = `app-${suffix}`;
+  const orgId = newId("org");
+  const projectId = newId("proj");
+  const installationRowId = newId("ghi");
+  const repositoryId = newId("repo");
+  const builderSource = `---
+name: builder
+description: Implements stories.
+engine: codex
+model: gpt-5.5
+enabled: true
+triggers:
+  - type: manual
+---
+Implement the request and verify it.
+`;
+  const builder = parseAgentManifest(builderSource, ".agents/builder.md");
+  const projectManifest = parseProjectManifest(`
+version: 1
+repositories:
+  primary: github.com/${owner}/${repository}
+  related: []
+environment:
+  setup: "true"
+  start: "true"
+  ready: "true"
+`);
+
+  /** Writes the files requested for the next turn so Git evidence records exactly those paths. */
+  class FileWritingEngine implements AgentEngine {
+    readonly name = "codex" as const;
+    requests: AgentTurnRequest[] = [];
+    nextFiles: string[] = [];
+    async run(request: AgentTurnRequest): Promise<AgentTurnResult> {
+      this.requests.push(request);
+      const script = this.nextFiles
+        .map(
+          (path) =>
+            `mkdir -p "$(dirname ${JSON.stringify(path)})" && printf 'x' >> ${JSON.stringify(path)}`,
+        )
+        .join(" && ");
+      const result = await runtime.exec(request.workspace, {
+        command: "sh",
+        args: ["-lc", script || "true"],
+        cwd: request.cwd,
+        signal: request.signal,
+      });
+      return {
+        nativeSessionId: request.nativeSessionId ?? `session-${this.requests.length}`,
+        output: "done",
+        events: [],
+        exitCode: 0,
+        stderr: "",
+        durationMs: result.durationMs,
+        usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      };
+    }
+  }
+  const engine = new FileWritingEngine();
+
+  let storiesService: StoryWorkspaceService;
+  let dispatcher: TurnDispatcher;
+
+  async function startStory(name: string) {
+    const started = await storiesService.start({
+      orgId,
+      projectId,
+      provider: "github",
+      externalId: `${name}-${suffix}`,
+      title: `Story ${name}`,
+      agent: builder,
+      message: `Work on ${name}`,
+      messageDedupeKey: `start-${name}-${suffix}`,
+      actor: { type: "user", id: "user_test" },
+      workspace: { image: "facility-runner:test", ports: [] },
+    });
+    if (!started.queued.turn) throw new Error("expected initial queued turn");
+    return { story: started.story, turnId: started.queued.turn.id };
+  }
+
+  async function runTurn(storyId: string, files: string[], turnId?: string) {
+    let id = turnId;
+    if (!id) {
+      const queued = await storiesService.queueMessage({
+        orgId,
+        projectId,
+        storyId,
+        body: `Touch ${files.join(", ")}`,
+        dedupeKey: `msg-${randomUUID()}`,
+        agent: builder,
+        actor: { type: "user", id: "user_test" },
+        trigger: { type: "manual" },
+      });
+      if (!queued.turn) throw new Error("expected a queued turn");
+      id = queued.turn.id;
+    }
+    engine.nextFiles = files;
+    const result = await dispatcher.dispatch({ orgId, projectId, turnId: id });
+    expect(result).toMatchObject({ claimed: true, state: "succeeded" });
+    const request = engine.requests.at(-1);
+    if (!request) throw new Error("expected an engine request");
+    return { turnId: id, prompt: request.prompt };
+  }
+
+  async function collisionFacts(turnId: string) {
+    return db
+      .select({
+        type: storyEvidenceEvents.type,
+        externalKey: storyEvidenceEvents.externalKey,
+        data: storyEvidenceEvents.data,
+      })
+      .from(storyEvidenceEvents)
+      .where(
+        and(
+          eq(storyEvidenceEvents.turnId, turnId),
+          eq(storyEvidenceEvents.type, "story.collision_detected"),
+        ),
+      )
+      .orderBy(asc(storyEvidenceEvents.externalKey));
+  }
+
+  beforeAll(async () => {
+    await migrate(databaseUrl);
+    await createBareRepository(remotes, owner, repository);
+    await db
+      .insert(orgs)
+      .values({ id: orgId, name: "Collisions", slug: `collisions-${suffix}`, settings: {} });
+    await db.insert(projects).values({
+      id: projectId,
+      orgId,
+      name: "Collisions",
+      slug: `collisions-${suffix}`,
+      settings: {},
+    });
+    await db.insert(githubInstallations).values({
+      id: installationRowId,
+      orgId,
+      installationId: Math.floor(Math.random() * 1_000_000_000) + 20_000,
+      accountId: 123,
+      accountLogin: owner,
+      targetType: "Organization",
+    });
+    await db.insert(projectRepositories).values({
+      id: repositoryId,
+      orgId,
+      projectId,
+      installationId: installationRowId,
+      owner,
+      name: repository,
+      defaultBranch: "main",
+      role: "primary",
+    });
+    storiesService = new StoryWorkspaceService(db, runtime, async () => undefined);
+    const catalogSource: AgentCatalogSource = {
+      load: async () => ({
+        commitSha: "a".repeat(40),
+        sources: [{ file: builder.file, source: builderSource }],
+      }),
+    };
+    const manifestSource: ProjectManifestSource = { load: async () => projectManifest };
+    dispatcher = new TurnDispatcher(
+      db,
+      storiesService,
+      new AgentCatalogService(db, catalogSource),
+      new GithubWorkspaceCredentialBroker(db, async () => ({
+        token: "secret-installation-token",
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      })),
+      manifestSource,
+      new ProjectEnvironmentService(db, runtime, `file://${remotes}`, () => undefined),
+      new AgentEngineRegistry([engine]),
+      new TurnGitEvidenceService(db, runtime),
+    );
+  });
+
+  afterAll(async () => {
+    await client.end();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("warns a story whose recorded files overlap another open story, without blocking or attention", async () => {
+    const alpha = await startStory("alpha");
+    const beta = await startStory("beta");
+
+    const alphaFirst = await runTurn(
+      alpha.story.id,
+      ["src/shared.ts", "src/alpha.ts"],
+      alpha.turnId,
+    );
+    expect(alphaFirst.prompt).not.toContain("Other active stories touch files you changed");
+    expect(await collisionFacts(alphaFirst.turnId)).toEqual([]);
+
+    // Beta has no completed evidence yet, so its first turn cannot collide.
+    const betaFirst = await runTurn(beta.story.id, ["src/shared.ts", "src/beta.ts"], beta.turnId);
+    expect(betaFirst.prompt).not.toContain("Other active stories touch files you changed");
+    expect(await collisionFacts(betaFirst.turnId)).toEqual([]);
+
+    const betaSecond = await runTurn(beta.story.id, ["src/beta.ts"]);
+    expect(betaSecond.prompt).toContain("# Other active stories touch files you changed");
+    expect(betaSecond.prompt).toContain(`"Story alpha" (github:alpha-${suffix}, branch `);
+    expect(betaSecond.prompt).toContain("src/shared.ts");
+    expect(betaSecond.prompt).not.toContain("src/alpha.ts");
+    const facts = await collisionFacts(betaSecond.turnId);
+    expect(facts).toEqual([
+      {
+        type: "story.collision_detected",
+        externalKey: `turn:${betaSecond.turnId}:collision:${alpha.story.id}`,
+        data: expect.objectContaining({
+          storyId: alpha.story.id,
+          title: "Story alpha",
+          overlappingPaths: ["src/shared.ts"],
+          overlapCount: 1,
+          truncated: false,
+        }),
+      },
+    ]);
+    expect(
+      await db
+        .select({ type: turnEvents.type })
+        .from(turnEvents)
+        .where(
+          and(
+            eq(turnEvents.turnId, betaSecond.turnId),
+            eq(turnEvents.type, "turn.collisions_detected"),
+          ),
+        ),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(attentionItems).where(eq(attentionItems.storyId, beta.story.id)),
+    ).toEqual([]);
+    const betaRow = (await db.select().from(stories).where(eq(stories.id, beta.story.id)))[0];
+    expect(betaRow?.status).not.toBe("attention");
+
+    // The overlap is symmetric: alpha's next turn learns about beta.
+    const alphaSecond = await runTurn(alpha.story.id, ["src/alpha.ts"]);
+    expect(alphaSecond.prompt).toContain(`"Story beta"`);
+    expect(await collisionFacts(alphaSecond.turnId)).toHaveLength(1);
+  });
+
+  it("ignores archived stories and branches whose pull request already merged", async () => {
+    const gamma = await startStory("gamma");
+    const delta = await startStory("delta");
+    const epsilon = await startStory("epsilon");
+    await runTurn(gamma.story.id, ["lib/core.ts"], gamma.turnId);
+    await runTurn(delta.story.id, ["lib/core.ts"], delta.turnId);
+    await runTurn(epsilon.story.id, ["lib/core.ts"], epsilon.turnId);
+
+    const before = await runTurn(gamma.story.id, ["lib/core.ts"]);
+    expect(before.prompt).toContain(`"Story delta"`);
+    expect(before.prompt).toContain(`"Story epsilon"`);
+    expect(await collisionFacts(before.turnId)).toHaveLength(2);
+
+    await storiesService.archive(orgId, projectId, delta.story.id);
+    const epsilonRow = (await db.select().from(stories).where(eq(stories.id, epsilon.story.id)))[0];
+    if (!epsilonRow?.branch) throw new Error("expected epsilon branch");
+    await db.insert(githubPullRequests).values({
+      id: newId("ghp"),
+      orgId,
+      projectId,
+      repositoryId,
+      number: 77,
+      title: "Epsilon",
+      state: "merged",
+      headRef: epsilonRow.branch,
+      headSha: "b".repeat(40),
+      baseRef: "main",
+      htmlUrl: `https://github.com/${owner}/${repository}/pull/77`,
+      mergedAt: new Date(),
+    });
+
+    const after = await runTurn(gamma.story.id, ["lib/core.ts"]);
+    expect(after.prompt).not.toContain("Other active stories touch files you changed");
+    expect(await collisionFacts(after.turnId)).toEqual([]);
+  });
+});
+
+async function createBareRepository(root: string, owner: string, name: string) {
+  const bare = join(root, owner, `${name}.git`);
+  const work = join(root, "seed", name);
+  await mkdir(join(root, owner), { recursive: true });
+  await mkdir(work, { recursive: true });
+  await command("git", ["init", "--bare", "--initial-branch=main", bare]);
+  await command("git", ["init", "--initial-branch=main"], work);
+  await writeFile(join(work, "README.md"), "# collisions\n");
+  await command("git", ["add", "README.md"], work);
+  await command(
+    "git",
+    [
+      "-c",
+      "user.name=Facility Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "-m",
+      "initial",
+    ],
+    work,
+  );
+  await command("git", ["remote", "add", "origin", bare], work);
+  await command("git", ["push", "origin", "main"], work);
+}
+
+async function command(executable: string, args: string[], cwd?: string) {
+  await new Promise<void>((resolve, reject) => {
+    execFile(executable, args, { cwd }, (error, _stdout, stderr) => {
+      if (error) reject(new Error(stderr || error.message));
+      else resolve();
+    });
+  });
+}

--- a/services/api/test/story-collisions.test.ts
+++ b/services/api/test/story-collisions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  collisionPromptBlock,
+  MAX_COLLISION_PATHS,
+  MAX_COLLISION_STORIES,
+  overlappingPaths,
+} from "../src/turns/collisions.js";
+
+describe("story collision helpers", () => {
+  it("intersects path sets in a stable order", () => {
+    expect(
+      overlappingPaths(
+        ["src/b.ts", "src/a.ts", "README.md"],
+        new Set(["src/a.ts", "src/b.ts", "other"]),
+      ),
+    ).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(overlappingPaths(["src/a.ts"], [])).toEqual([]);
+  });
+
+  it("renders nothing without collisions and caps paths and stories in the prompt", () => {
+    expect(collisionPromptBlock([])).toBe("");
+    const paths = Array.from({ length: MAX_COLLISION_PATHS + 5 }, (_, index) => `src/${index}.ts`);
+    const collision = {
+      storyId: "story_a",
+      title: "Rework billing",
+      provider: "github",
+      externalId: "41",
+      branch: "facility/rework-billing-story_a",
+      status: "working",
+      overlappingPaths: paths.slice(0, MAX_COLLISION_PATHS),
+      overlapCount: paths.length,
+    };
+    const block = collisionPromptBlock([collision]);
+    expect(block).toContain("# Other active stories touch files you changed");
+    expect(block).toContain('"Rework billing" (github:41, branch facility/rework-billing-story_a)');
+    expect(block).toContain(`src/${MAX_COLLISION_PATHS - 1}.ts (+5 more)`);
+    expect(block).not.toContain(`src/${MAX_COLLISION_PATHS}.ts`);
+
+    const many = Array.from({ length: MAX_COLLISION_STORIES + 3 }, (_, index) => ({
+      ...collision,
+      storyId: `story_${index}`,
+      overlappingPaths: ["src/shared.ts"],
+      overlapCount: 1,
+    }));
+    const crowded = collisionPromptBlock(many);
+    expect(crowded.split("\n").filter((line) => line.startsWith('- "'))).toHaveLength(
+      MAX_COLLISION_STORIES,
+    );
+    expect(crowded).toContain("- 3 more stories overlap with this one.");
+  });
+});


### PR DESCRIPTION
## What changes

Closes #303

Before the engine starts, the dispatcher compares the changed files recorded for the story with the recorded changed files of every other active story in the project that has an open branch. When they overlap:

- one `story.collision_detected` fact per overlapping story is appended to the timeline (external key `turn:<turnId>:collision:<otherStoryId>`, so a retried turn does not duplicate it), carrying the other story's id, title, provider identity, branch, status, up to 20 overlapping paths, and the total count;
- one `turn.collisions_detected` turn event summarizes the affected stories;
- the prompt gains a section headed "Other active stories touch files you changed" listing those stories and paths, asking the agent to keep edits to them minimal and to mention the overlap in its commit or pull request description.

Stories that are `done`, archived, deleted, without a branch, or whose branch belongs to a merged pull request in the mirror are ignored. Overlapping stories are sorted by overlap size; at most 10 are listed in the prompt and the rest are counted.

The check is advisory. It never blocks or fails a turn, never creates attention, and a detection failure is recorded as `turn.collision_check_failed` and the turn continues without the block.

The story page's timeline summary line renders the new fact as `overlaps "<title>" on N files · <branch>`.

## Why

A story is serial inside itself, but stories run in parallel, and two agents editing the same file on two branches discover it as a merge conflict on the second pull request, after both have been reviewed. `turn_git_evidence.changed_files` already holds every path each turn changed; nothing compared one story's evidence with another's. This makes that evidence useful before the conflict instead of after.

### Design notes

- **Evidence, not attention.** `flagAttention` moves the story to `attention` and clears the active agent, and an open attention item keeps the story out of `ready` after the turn. That is the right signal for "a human must act", and the wrong one for "be careful with these paths". The timeline already carries per-turn facts and is exposed through the story `GET`, the UI, and `facility_get_story` without new fields.
- **Only completed, cleanly captured evidence counts.** Rows with `capture_error` or without `completed_at` are skipped, so the current turn's own freshly inserted row and any failed capture cannot produce a false overlap.
- **A story with no completed evidence cannot collide.** Its files are unknown. The first turn of a new story is therefore unwarned; every later turn is covered. Documented in the lifecycle reference.
- **Exact paths.** Directory-level or module-level overlap would catch more and also warn more; exact paths are the conservative first step and the data model does not preclude a coarser mode later.
- **`detectCollisions` is isolated in the dispatcher** with its own try/catch so a query problem is recorded on the turn rather than turning into a failed dispatch.

## Persistence, compatibility, and release classification

- No migration and no schema change. New fact type `story.collision_detected` on `story_evidence_events` (source `facility`) and new turn event types `turn.collisions_detected` / `turn.collision_check_failed`.
- No manifest, API, SDK, or MCP contract change. The timeline entries flow through existing shapes.
- Cost: three bounded queries per dispatch, all on existing indexes (`stories_org_project_status_idx`, `github_pull_requests_project_state_idx`, `turn_git_evidence_story_completed_idx`). Only the `path` column is extracted from the JSON (`jsonb_path_query_array`), so the control plane never loads full evidence rows. Runs once per turn, before the engine; the engine's own runtime dominates by orders of magnitude.
- Prompt size: at most 10 stories × 20 paths plus two sentences, well under the existing transcript budget.
- No cost, budget, credential, or security implication. The prompt lists file paths that the same principal can already read from the timeline of every story in the project.
- Suggested title classification: `feat` (patch in 0.x). Not breaking: existing stories, manifests, and clients are unaffected.

## Verification

- [x] `pnpm verify` passes locally (Node 24.13.1, pnpm 11.20.0, Docker 29.2.1): lint, typecheck, clean build, both isolated databases recreated, all 25 critical API suites (each in its own process, skips forbidden), remaining package tests, removed-component check, guards, audit (2 high, both pre-existing and ignored by repo config).
- [x] Behaviour verified beyond the test suite: the new integration suite drives the real `TurnDispatcher`, `StoryWorkspaceService`, `TurnGitEvidenceService`, and `StoryCollisionService` against Postgres with the fake workspace runtime, with an engine that writes exactly the files each turn should be blamed for, so the evidence rows the guard reads are produced by the same capture path as production.
- [x] Documentation updated: `reference/lifecycle.md` (turn evidence section), `guides/operate-story.md` (what the timeline entry means), and the documentation contract test now requires `story.collision_detected` to be documented.

Commands run:

```bash
DATABASE_URL=postgres://facility:facility@127.0.0.1:5461/facility_test \
  pnpm --filter @facility/api exec vitest run test/story-collisions.test.ts               # 2 passed
DATABASE_URL=postgres://facility:facility@127.0.0.1:5461/facility_test \
  pnpm --filter @facility/api exec vitest run test/story-collisions.integration.test.ts   # 2 passed
pnpm verify                                                                               # exit 0
```

Coverage added:

- `services/api/test/story-collisions.test.ts`: sorted intersection; empty block without collisions; path cap with `(+N more)`; story cap with the "N more stories" line.
- `services/api/test/story-collisions.integration.test.ts`:
  - two stories change `src/shared.ts`; the first turn of each is unwarned (no evidence yet); the next turn of the second story gets the prompt block naming the first story and only the shared path, one `story.collision_detected` fact with the expected external key and data, one `turn.collisions_detected` event, no attention item, and the story is not in `attention`;
  - the overlap is symmetric: the first story's next turn is warned about the second;
  - three stories share `lib/core.ts`; after one is archived and another's branch is recorded as a merged pull request, the remaining story's next turn has no block and no facts.

Not run: the Docker-backed workspace E2E tier. This change does not touch workspace execution boundaries.

## Open questions

- Should merged-branch exclusion also honour `github_branches.deleted_at`, for branches deleted without a mirrored pull request? Left out to keep the rule explainable in one sentence; it is a one-clause change.
- Would you rather the prompt block ask the agent to add an explicit note to the PR body, instead of "when it matters"? I kept the softer wording to avoid noisy PR descriptions for trivial overlaps.
