### PR TITLE
fix(runner): provision and audit Vercel runtime dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,9 @@ jobs:
           SECRET_MASTER_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
         run: docker compose build --pull
 
+      - name: Verify Vercel runner user switching without live credentials
+        run: docker build --target vercel-runner -f runner/Dockerfile .
+
   workspace-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/apps/docs/docs/self-host/aws.md
+++ b/apps/docs/docs/self-host/aws.md
@@ -95,9 +95,11 @@ docker buildx build --platform linux/amd64 --file ../../../apps/web/Dockerfile \
 Set `image_tag` to the same value in `production.tfvars`. If the ECS tasks use ARM64, build both
 images for `linux/arm64` and set `task_cpu_architecture = "ARM64"`.
 
-The runner image is separate because Vercel, not ECS, pulls it. Build `runner/Dockerfile`, publish
-it to the registry used by your Vercel project, and put that exact image reference in
-`workspace_image`.
+The runner image is separate because Vercel, not ECS, pulls it. Build `runner/Dockerfile` with
+`--target vercel-runner --platform linux/amd64`, publish it to the registry used by your Vercel
+project, and put that exact image reference in `workspace_image`. This target starts as root for
+trusted initialization and includes the SDK's `sudo` user-switch dependency. The default `runner`
+target is for Docker workspaces.
 
 ## 3. Populate the runtime secret
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -351,6 +351,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends sudo \
   && rm -rf /var/lib/apt/lists/* \
   && sudo -n -u node -- sh -c 'test "$(id -un)" = node' \
+  && test -u /usr/bin/sudo \
+  && runuser -u node -- sh -c 'test "$(id -un)" = node' \
   && ! runuser -u node -- sudo -n -u root -- true
 
 # The default image runs interactively as node. DockerWorkspaceRuntime overrides

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -347,6 +347,11 @@ CMD ["sleep", "infinity"]
 # Vercel invokes trusted initialization with sudo and agent commands as node.
 FROM runner-base AS vercel-runner
 USER root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends sudo \
+  && rm -rf /var/lib/apt/lists/* \
+  && sudo -n -u node -- sh -c 'test "$(id -un)" = node' \
+  && ! runuser -u node -- sudo -n -u root -- true
 
 # The default image runs interactively as node. DockerWorkspaceRuntime overrides
 # the bootstrap process to root only while it starts the nested Docker daemon.

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -219,7 +219,7 @@ FROM node:24-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf23286
 # Bump this audited epoch only when a scanner identifies a distro fix that the
 # official image has not incorporated yet; using it in the command makes that
 # refresh explicit and reproducible instead of disabling the whole build cache.
-ARG DEBIAN_SECURITY_REFRESH=20260828
+ARG DEBIAN_SECURITY_REFRESH=20260905
 RUN test -n "$DEBIAN_SECURITY_REFRESH" \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \

--- a/runner/README.md
+++ b/runner/README.md
@@ -49,7 +49,9 @@ without becoming an administrator of every Facility workspace on the host.
 - `runner` is the default Docker workspace image and runs normal commands as
   the `node` user.
 - `vercel-runner` leaves Vercel's trusted initialization path as root; Facility
-  runs agent commands as `node` after initialization.
+  runs agent commands as `node` after initialization. This target includes
+  `sudo` for the Vercel SDK's user switch. Its build verifies that root can
+  switch to `node` and that `node` cannot use sudo to become root.
 
 The default command sleeps because lifecycle and agent commands arrive through
 the workspace provider. The image is not the Facility API or worker image.

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -253,6 +253,8 @@ test("Vercel runner supports SDK user switching without granting node sudo privi
   assert.ok(vercelStage);
   assert.match(vercelStage, /apt-get install -y --no-install-recommends sudo/);
   assert.match(vercelStage, /sudo -n -u node -- sh -c/);
+  assert.match(vercelStage, /test -u \/usr\/bin\/sudo/);
+  assert.match(vercelStage, /runuser -u node -- sh -c/);
   assert.match(vercelStage, /! runuser -u node -- sudo -n -u root -- true/);
   assert.doesNotMatch(vercelStage, /NOPASSWD/);
   assert.match(ciWorkflow, /docker build --target vercel-runner -f runner\/Dockerfile \./);

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -245,3 +245,15 @@ test("runner Go binaries resolve the fixed cryptography and gRPC modules", () =>
     /for binary in \/out\/dockerd \/out\/containerd \/out\/containerd-shim-runc-v2 \/out\/ctr \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*google\.golang\.org\/grpc" && \$3 == "v1\.83\.1"/,
   );
 });
+
+test("Vercel runner supports SDK user switching without granting node sudo privileges", () => {
+  const vercelStage = runnerDockerfile
+    .split("FROM runner-base AS vercel-runner")[1]
+    ?.split("FROM runner-base AS runner")[0];
+  assert.ok(vercelStage);
+  assert.match(vercelStage, /apt-get install -y --no-install-recommends sudo/);
+  assert.match(vercelStage, /sudo -n -u node -- sh -c/);
+  assert.match(vercelStage, /! runuser -u node -- sudo -n -u root -- true/);
+  assert.doesNotMatch(vercelStage, /NOPASSWD/);
+  assert.match(ciWorkflow, /docker build --target vercel-runner -f runner\/Dockerfile \./);
+});


### PR DESCRIPTION
## What changes

Install `sudo` in the Vercel runner target so the SDK can switch from root initialization to the `node` workspace user. Build assertions exercise positive sudo/runuser controls and denied node-to-root sudo, and CI builds that target without live credentials. The AWS instructions now explicitly select `vercel-runner`.

Refresh the shared Debian package layer after the arm64 image scan found cached Chromium 151 packages with fixed critical advisories. The default Docker target keeps its existing user model.

## Why

The SDK implements `asUser("node")` by executing `sudo -u node`. Workspace creation fails with `executable file not found in $PATH: sudo` when that binary is absent, even though the default Docker workspace tests pass. Building the provider-specific target and executing its user-switch assertions catches this missing dependency before deployment.

## Verification

- `pnpm verify` passed locally.
- `node --test scripts/images.test.mjs`: 10 passed, zero failures or skips.
- Final amd64 and arm64 Vercel target builds passed, including user-switch and denial assertions.
- Grype 0.110.0 passed on both final architectures with `--only-fixed --fail-on high --config runner/grype.yaml`.
- Docker workspace E2E on the refreshed default runner: 2 files, 3 tests passed (94.55s), exercising persistence, Chromium, and runtime behavior.
- Claude review identified missing positive controls and ambiguous AWS target instructions; both were addressed. Follow-up Claude review found no correctness blockers.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (actual image user-switch assertions and Docker workspace E2E)
- [x] Documentation updated, or no user-facing change
