### PR TITLE
fix(turns): preserve predecessor responses in queued review context

### DIFF
--- a/apps/docs/docs/concepts/method.md
+++ b/apps/docs/docs/concepts/method.md
@@ -51,6 +51,11 @@ Only one turn is active for a story at a time. Later messages wait in order. If 
 instance fails, Facility keeps the message, turn, worktree, and native engine session needed to
 continue or retry.
 
+When a queued turn starts, its shared conversation context includes available responses from
+preceding turns, even when those responses were recorded after its request was queued. The current
+request follows that history; later queued requests remain excluded. This lets a newly selected
+reviewer receive the builder's final explanation and verification limitations along with the worktree.
+
 ## Broad agent access, narrow merge authority
 
 Every agent gets the same project capability. Facility does not maintain separate tool allowlists

--- a/services/api/src/turns/dispatcher.ts
+++ b/services/api/src/turns/dispatcher.ts
@@ -23,6 +23,7 @@ import type { AgentEngineRegistry, AgentTurnResult } from "./engines.js";
 import { AgentEngineError } from "./engines.js";
 import { appendTurnEvent } from "./events.js";
 import type { StartedGitEvidence, TurnGitEvidenceService } from "./git-evidence.js";
+import { buildPrompt } from "./prompt.js";
 
 export class TurnDispatcher {
   constructor(
@@ -586,42 +587,6 @@ function workspaceLocator(row: typeof workspaces.$inferSelect): WorkspaceLocator
   };
 }
 
-function buildPrompt(
-  manifest: AgentManifest,
-  story: typeof stories.$inferSelect,
-  summary: string | null,
-  messages: Array<typeof storyMessages.$inferSelect>,
-  turnId: string,
-) {
-  const currentSequence = messages.find(
-    (message) => message.turnId === turnId && message.role === "user",
-  )?.seq;
-  const relevant = messages.filter(
-    (message) => currentSequence === undefined || message.seq <= currentSequence,
-  );
-  const transcript = relevant
-    .map(
-      (message) => `${message.role.toUpperCase()} (${actorLabel(message.actor)}):\n${message.body}`,
-    )
-    .join("\n\n");
-  return [
-    manifest.prompt,
-    `# Story\n${story.title}\nExternal identity: ${story.provider}:${story.externalId}`,
-    summary ? `# Conversation summary\n${summary}` : "",
-    `# Shared conversation\n${truncateStart(transcript, 120_000)}`,
-    "Continue in the existing worktree. You have full workspace, network, Docker, browser, git, and GitHub maintainer access. Preserve useful uncommitted work. Commit and push coherent changes when the task calls for it. Never merge the pull request or publish packages.",
-    "If you cannot continue without a human answer, end with exactly <facility-needs-attention>your concise question</facility-needs-attention>. Do not use that marker for a recoverable command or environment failure.",
-  ]
-    .filter(Boolean)
-    .join("\n\n");
-}
-
-function actorLabel(actor: unknown) {
-  if (!actor || typeof actor !== "object") return "unknown";
-  const value = actor as { type?: unknown; id?: unknown };
-  return `${String(value.type ?? "unknown")}:${String(value.id ?? "unknown")}`;
-}
-
 function storyBranch(title: string, storyId: string) {
   const slug =
     title
@@ -666,10 +631,6 @@ function boundedEvent(value: Record<string, unknown>): Record<string, unknown> {
   return serialized.length <= 64_000
     ? value
     : { truncated: true, payload: `${serialized.slice(0, 63_900)}…` };
-}
-
-function truncateStart(value: string, limit: number) {
-  return value.length <= limit ? value : `[Earlier transcript omitted]\n${value.slice(-limit)}`;
 }
 
 function agentOutcome(output: string): { output: string; attention?: string } {

--- a/services/api/src/turns/prompt.ts
+++ b/services/api/src/turns/prompt.ts
@@ -1,0 +1,57 @@
+import type { AgentManifest } from "@facility/agents";
+import type { stories, storyMessages } from "@facility/db";
+
+export function buildPrompt(
+  manifest: AgentManifest,
+  story: typeof stories.$inferSelect,
+  summary: string | null,
+  messages: Array<typeof storyMessages.$inferSelect>,
+  turnId: string,
+) {
+  const currentMessage = messages.find(
+    (message) => message.turnId === turnId && message.role === "user",
+  );
+  let relevant = messages;
+  if (currentMessage) {
+    const predecessors = new Set(
+      messages
+        .filter((message) => message.seq < currentMessage.seq && message.role === "user")
+        .flatMap((message) => (message.turnId ? [message.turnId] : [])),
+    );
+    // A predecessor can finish after this request was queued. Include its response,
+    // but keep later requests out and place this turn's request after the handoff.
+    relevant = [
+      ...messages.filter(
+        (message) =>
+          message.seq < currentMessage.seq ||
+          (message.role === "agent" && message.turnId !== null && predecessors.has(message.turnId)),
+      ),
+      currentMessage,
+    ];
+  }
+  const transcript = relevant
+    .map(
+      (message) => `${message.role.toUpperCase()} (${actorLabel(message.actor)}):\n${message.body}`,
+    )
+    .join("\n\n");
+  return [
+    manifest.prompt,
+    `# Story\n${story.title}\nExternal identity: ${story.provider}:${story.externalId}`,
+    summary ? `# Conversation summary\n${summary}` : "",
+    `# Shared conversation\n${truncateStart(transcript, 120_000)}`,
+    "Continue in the existing worktree. You have full workspace, network, Docker, browser, git, and GitHub maintainer access. Preserve useful uncommitted work. Commit and push coherent changes when the task calls for it. Never merge the pull request or publish packages.",
+    "If you cannot continue without a human answer, end with exactly <facility-needs-attention>your concise question</facility-needs-attention>. Do not use that marker for a recoverable command or environment failure.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function actorLabel(actor: unknown) {
+  if (!actor || typeof actor !== "object") return "unknown";
+  const value = actor as { type?: unknown; id?: unknown };
+  return `${String(value.type ?? "unknown")}:${String(value.id ?? "unknown")}`;
+}
+
+function truncateStart(value: string, limit: number) {
+  return value.length <= limit ? value : `[Earlier transcript omitted]\n${value.slice(-limit)}`;
+}

--- a/services/api/test/turn-dispatcher.integration.test.ts
+++ b/services/api/test/turn-dispatcher.integration.test.ts
@@ -108,6 +108,7 @@ environment:
     app:
       port: 3000
 `);
+  const reviewer = parseAgentManifest(agentSource("pr-reviewer"), ".agents/pr-reviewer.md");
 
   class FakeCodexEngine implements AgentEngine {
     readonly name = "codex" as const;
@@ -157,7 +158,10 @@ environment:
       const projectSecret = request.environment?.FACILITY_DISPATCH_SECRET ?? "missing";
       const nativeSessionId = this.replacementPending
         ? "codex-replacement-session"
-        : (request.nativeSessionId ?? "codex-native-session");
+        : (request.nativeSessionId ??
+          (request.manifest.name === "builder"
+            ? "codex-native-session"
+            : `codex-${request.manifest.name}-session`));
       this.replacementPending = false;
       return {
         nativeSessionId,
@@ -220,7 +224,10 @@ environment:
     const catalogSource: AgentCatalogSource = {
       load: async () => ({
         commitSha: "a".repeat(40),
-        sources: [{ file: builder.file, source: agentSource(builder.name) }],
+        sources: [builder, reviewer].map((agent) => ({
+          file: agent.file,
+          source: agentSource(agent.name),
+        })),
       }),
     };
     const manifestSource: ProjectManifestSource = { load: async () => projectManifest };
@@ -554,6 +561,83 @@ environment:
         "Continue after the native session was lost",
       ]),
     );
+  });
+
+  it("passes the builder handoff to a queued reviewer without exposing a later request", async () => {
+    const handoff = "Implementation complete; integration tests could not run.";
+    const reviewRequest = "Review the builder result and its verification limitations.";
+    const futureRequest = "FUTURE REQUEST: implement an unrelated feature.";
+    const started = await storiesService.start({
+      orgId,
+      projectId,
+      provider: "manual",
+      externalId: `queued-review-${suffix}`,
+      title: "Review a queued builder result",
+      agent: builder,
+      message: "Implement the requested change.",
+      messageDedupeKey: `queued-review-start-${suffix}`,
+      actor: { type: "user", id: "user_test" },
+      workspace: { image: "facility-runner:test", ports: [] },
+    });
+    if (!started.queued.turn) throw new Error("expected builder turn");
+
+    const queuedReview = await storiesService.queueMessage({
+      orgId,
+      projectId,
+      storyId: started.story.id,
+      body: reviewRequest,
+      dedupeKey: `queued-review-message-${suffix}`,
+      agent: reviewer,
+      actor: { type: "user", id: "user_test" },
+      trigger: { type: "manual" },
+    });
+    expect(queuedReview).toMatchObject({ queued: true, turn: undefined });
+    await storiesService.queueMessage({
+      orgId,
+      projectId,
+      storyId: started.story.id,
+      body: futureRequest,
+      dedupeKey: `queued-future-message-${suffix}`,
+      agent: builder,
+      actor: { type: "user", id: "user_test" },
+      trigger: { type: "manual" },
+    });
+
+    engine.outputOverride = handoff;
+    try {
+      await expect(
+        dispatcher.dispatch({ orgId, projectId, turnId: started.queued.turn.id }),
+      ).resolves.toMatchObject({ state: "succeeded" });
+    } finally {
+      engine.outputOverride = undefined;
+    }
+    expect(engine.requests.at(-1)?.prompt).not.toContain(reviewRequest);
+    expect(engine.requests.at(-1)?.prompt).not.toContain(futureRequest);
+
+    const afterBuilder = await storiesService.get(orgId, projectId, started.story.id);
+    const next = afterBuilder.turns.find((turn) => turn.state === "queued");
+    if (!next) throw new Error("expected queued reviewer turn");
+    expect(next.agentName).toBe(reviewer.name);
+    await expect(dispatcher.dispatch({ orgId, projectId, turnId: next.id })).resolves.toMatchObject(
+      { state: "succeeded" },
+    );
+
+    const request = engine.requests.at(-1);
+    expect(request?.nativeSessionId).toBeUndefined();
+    expect(request?.manifest.name).toBe(reviewer.name);
+    expect(request?.prompt).toContain(handoff);
+    expect(request?.prompt).toContain(reviewRequest);
+    expect(request?.prompt).not.toContain(futureRequest);
+    expect(request?.prompt.indexOf(handoff)).toBeLessThan(
+      request?.prompt.indexOf(reviewRequest) ?? -1,
+    );
+    const afterReview = await storiesService.get(orgId, projectId, started.story.id);
+    const futureTurn = afterReview.turns.find((turn) => turn.state === "queued");
+    if (!futureTurn) throw new Error("expected future request to remain queued");
+    await expect(
+      dispatcher.dispatch({ orgId, projectId, turnId: futureTurn.id }),
+    ).resolves.toMatchObject({ state: "succeeded" });
+    expect(engine.requests.at(-1)?.prompt).toContain(futureRequest);
   });
 
   it("cancels a running agent process while preserving the workspace and future turns", async () => {

--- a/services/api/test/turn-prompt.test.ts
+++ b/services/api/test/turn-prompt.test.ts
@@ -1,0 +1,101 @@
+import type { AgentManifest } from "@facility/agents";
+import type { stories, storyMessages } from "@facility/db";
+import { describe, expect, it } from "vitest";
+import { buildPrompt } from "../src/turns/prompt.js";
+
+const manifest = { prompt: "Review the implementation." } as AgentManifest;
+const story = {
+  title: "A story",
+  provider: "manual",
+  externalId: "test",
+} as typeof stories.$inferSelect;
+
+function message(seq: number, role: "user" | "agent", body: string, turnId: string | null) {
+  return {
+    seq,
+    role,
+    body,
+    turnId,
+    actor: { type: "user", id: "test" },
+  } as typeof storyMessages.$inferSelect;
+}
+
+function prompt(messages: Array<typeof storyMessages.$inferSelect>, turnId = "reviewer") {
+  return buildPrompt(manifest, story, null, messages, turnId);
+}
+
+describe("turn conversation context", () => {
+  it("includes a predecessor response appended after a review was queued, before the review request", () => {
+    const result = prompt([
+      message(1, "user", "Build the change", "builder"),
+      message(2, "user", "Review the result", "reviewer"),
+      message(3, "agent", "Integration tests were not run", "builder"),
+    ]);
+    expect(result).toContain("Integration tests were not run");
+    expect(result.indexOf("Integration tests were not run")).toBeLessThan(
+      result.indexOf("Review the result"),
+    );
+  });
+
+  it("excludes later queued requests and their responses, even from the same actor", () => {
+    const result = prompt([
+      message(1, "user", "Build the change", "builder"),
+      message(2, "user", "Review the result", "reviewer"),
+      message(3, "user", "FUTURE_REQUEST", "future"),
+      message(4, "agent", "Builder handoff", "builder"),
+      message(5, "agent", "FUTURE_RESPONSE", "future"),
+      message(6, "user", "UNASSIGNED_REQUEST", null),
+    ]);
+    expect(result).toContain("Builder handoff");
+    expect(result).not.toContain("FUTURE_REQUEST");
+    expect(result).not.toContain("FUTURE_RESPONSE");
+    expect(result).not.toContain("UNASSIGNED_REQUEST");
+  });
+
+  it("includes every completed predecessor when multiple requests were queued before their responses", () => {
+    const result = prompt([
+      message(1, "user", "Plan the change", "architect"),
+      message(2, "user", "Build the plan", "builder"),
+      message(3, "user", "Review the result", "reviewer"),
+      message(4, "agent", "Architect decision", "architect"),
+      message(5, "agent", "Builder limitation", "builder"),
+    ]);
+    expect(result).toContain("Architect decision");
+    expect(result).toContain("Builder limitation");
+    expect(result.indexOf("Builder limitation")).toBeLessThan(result.indexOf("Review the result"));
+  });
+
+  it("preserves normal sequential conversation ordering without duplicating messages", () => {
+    const messages = [
+      message(1, "user", "Build the change", "builder"),
+      message(2, "agent", "Unique builder response", "builder"),
+      message(3, "user", "Review the result", "reviewer"),
+    ];
+    const original = structuredClone(messages);
+    const result = prompt(messages);
+    expect(result.match(/Unique builder response/g)).toHaveLength(1);
+    expect(result.indexOf("Unique builder response")).toBeLessThan(
+      result.indexOf("Review the result"),
+    );
+    expect(messages).toEqual(original);
+  });
+
+  it("does not include unrelated or current-turn responses beyond the request boundary", () => {
+    const result = prompt([
+      message(1, "user", "Build the change", "builder"),
+      message(2, "user", "Review the result", "reviewer"),
+      message(3, "agent", "UNRELATED_RESPONSE", "unknown"),
+      message(4, "agent", "CURRENT_RESPONSE", "reviewer"),
+      message(5, "agent", "UNASSIGNED_RESPONSE", null),
+    ]);
+    expect(result).not.toContain("UNRELATED_RESPONSE");
+    expect(result).not.toContain("CURRENT_RESPONSE");
+    expect(result).not.toContain("UNASSIGNED_RESPONSE");
+  });
+
+  it("preserves the existing fallback when there is no matching user request", () => {
+    expect(prompt([message(1, "agent", "Existing context", "builder")], "missing")).toContain(
+      "Existing context",
+    );
+  });
+});


### PR DESCRIPTION
## What changes

A reviewer queued before a builder finishes now receives the builder's final response, including verification limitations. Previously, `buildPrompt` cut the conversation off at the review request's sequence, so a builder response appended afterward was omitted.

The prompt includes responses linked to earlier requests' turns, keeps the current request last, and excludes later queued requests and their responses. Prompt construction is extracted into a pure module for focused regression coverage. The operating-model documentation explains the queue semantics.

Closes #306.

## Why

A new reviewer session should receive both the changed worktree and the available predecessor handoff. Asking for review before the builder finishes should not lose information that would be present if the same review were requested after completion.

## Verification

- [x] `pnpm verify` passes locally (Node 24.15.0, pnpm 11.20.0): lint, typecheck, clean builds, critical integration suites with skips forbidden, remaining tests, guards, and the dependency audit under the repository's existing advisory exceptions. No dependency or audit-policy changes.
- [x] `pnpm --filter @facility/api exec vitest run test/turn-prompt.test.ts test/turn-dispatcher.integration.test.ts --fileParallelism=false` with `DATABASE_URL=postgres://facility:facility@127.0.0.1:5461/facility_test`: 15 tests passed.
- [x] The six focused prompt tests were run before changing the selection logic: three failed on the missing predecessor response and three controls passed; all six pass with the fix.
- [x] The PostgreSQL-backed regression exercises actual story queueing, predecessor completion, automatic successor activation, a different agent without a prior native session, and a later queued request that remains excluded until its own turn. Native engines and workspace execution use the existing deterministic fake infrastructure.
- [x] Documentation updated.
- [ ] Docker-backed workspace E2E: the runner-image build and additional acceptance check are in progress locally. This PR remains a draft until their result is recorded.

The original investigation also reproduced the cutoff using the unchanged prompt function and controlled message histories. No live-model, browser, or external-provider validation was performed for this patch.

## Scope and compatibility

User-visible bug fix (`fix`, patch release under the current 0.x policy). No schema migration, API or manifest change, permission expansion, workspace lifecycle change, or new provider call. Persisted conversation ordering remains unchanged; only the transcript supplied to the current turn changes. Costs and delivery analytics keep their existing accounting, although the previously omitted handoff adds legitimate context tokens.

The existing transcript-size limit and optional summary behavior remain in place. Long-history context preservation is follow-up work; this patch specifically fixes queued predecessor handoffs. Reviewers still need to independently verify the builder's claims.
