### PR TITLE
fix(agents): preserve explicit issue command acceptance

### DIFF
--- a/apps/docs/docs/reference/agent-manifest.md
+++ b/apps/docs/docs/reference/agent-manifest.md
@@ -104,6 +104,28 @@ Declaring one does not imply the others. A request from an undeclared surface is
 an optional non-empty string array that filters labeled work. Each string is bounded by the schema.
 Only events subscribed on the GitHub App can reach these triggers.
 
+Issue and issue-comment triggers require a human sender with current repository write, maintain, or admin
+access. Facility checks GitHub through the repository's active installation before creating a
+workspace or queuing a turn. Bot senders, missing installations, and revoked access are rejected.
+This admission check does not change the capability available to an admitted agent.
+
+To require explicit acceptance on an issue, add `command`:
+
+```yaml
+- type: github
+  name: build-command
+  event: issue_comment
+  actions: [created]
+  command: /builder
+```
+
+Commands apply to new comments on open issues. They do not activate from issue assignment, comment
+edits, or pull-request comments. Put the command at the start of a line; prose, quoted text, indented
+code, and fenced code examples do not count. A comment containing multiple distinct commands from
+the agent catalog is rejected, so `/architect` and `/builder` can represent separate planning and
+acceptance steps. Command names begin with `/` followed by a lowercase letter and may contain
+lowercase letters, digits, and hyphens.
+
 Duplicate webhook deliveries do not create duplicate turns. Check and workflow events are attached
 to the matching pull request only when their head SHA is current.
 

--- a/apps/docs/docs/reference/webhooks.md
+++ b/apps/docs/docs/reference/webhooks.md
@@ -39,6 +39,22 @@ The GitHub trigger `event` must match one of those event names, and optional `ac
 must match the payload. The manifest must be enabled at the current primary-repository commit.
 Facility records the trigger identity and manifest snapshot on the resulting turn.
 
+Before starting an agent from an issue or issue comment, Facility checks the human sender's current
+repository permission using the connected repository's active GitHub App installation. The sender
+must have write access or higher (including maintain and admin). Bots cannot start agents through
+these issue events. PR, review, and CI triggers retain their event-specific behavior, including bot
+senders.
+Webhook `author_association` fields do not replace that check. GitHub's permission endpoint supports
+installation tokens with [Metadata read access](https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user).
+Provider outages retry the affected delivery independently without granting permission. Processing
+failures are recorded in the webhook event; authorization denials are recorded as
+`github.agent_trigger.denied` audit events without provider response bodies or credentials.
+
+An optional `command` on an `issue_comment` trigger restricts activation to a new explicit command
+on an open issue. See [the agent manifest reference](agent-manifest.md) for command syntax and
+ambiguous-command rejection. Event filters still need to express the project's intended workflow;
+permission to write a repository does not make every completed workflow an eligible repair request.
+
 Delivery deduplication and story message deduplication are separate. A repeated GitHub delivery id
 is ignored; distinct deliveries that represent the same logical event are also constrained by the
 stable trigger/story identity before dispatch.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -49,8 +49,26 @@ const GithubTrigger = z
     ]),
     actions: z.array(z.string().min(1).max(64)).min(1).optional(),
     labels: z.array(z.string().min(1).max(128)).min(1).optional(),
+    command: z
+      .string()
+      .regex(/^\/[a-z][a-z0-9-]{0,63}$/)
+      .optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((trigger, context) => {
+    if (
+      trigger.command &&
+      (trigger.event !== "issue_comment" ||
+        trigger.actions?.length !== 1 ||
+        trigger.actions[0] !== "created")
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["command"],
+        message: "commands require issue_comment with actions: [created]",
+      });
+    }
+  });
 
 export const AgentTriggerSchema = z.union([InteractiveTrigger, ScheduleTrigger, GithubTrigger]);
 

--- a/packages/agents/test/agents.test.ts
+++ b/packages/agents/test/agents.test.ts
@@ -79,6 +79,26 @@ Implement the requested story in the persistent workspace.
 }
 
 describe("agent manifests", () => {
+  it("accepts explicit issue commands and rejects incompatible event actions", () => {
+    const command = manifest()
+      .replace("event: issues", "event: issue_comment")
+      .replace("actions: [assigned]", "actions: [created]\n    command: /builder");
+    expect(parseAgentManifest(command, "builder.md").triggers[3]).toMatchObject({
+      type: "github",
+      event: "issue_comment",
+      actions: ["created"],
+      command: "/builder",
+    });
+    for (const source of [
+      command.replace("event: issue_comment", "event: issues"),
+      command.replace("actions: [created]", "actions: [edited]"),
+      command.replace("actions: [created]", "actions: [created, edited]"),
+      command.replace("command: /builder", "command: builder"),
+    ]) {
+      expect(() => parseAgentManifest(source, "builder.md")).toThrow();
+    }
+  });
+
   it("parses the engine, model, triggers, prompt, and stable content hash", () => {
     const first = parseAgentManifest(manifest(), "builder.md");
     const second = parseAgentManifest(manifest().replace(/\n/g, "\r\n"), "builder.md");

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9329,6 +9329,10 @@
                                 "minLength": 1,
                                 "maxLength": 128
                               }
+                            },
+                            "command": {
+                              "type": "string",
+                              "pattern": "^\\/[a-z][a-z0-9-]{0,63}$"
                             }
                           },
                           "required": [

--- a/packages/sdk/src/schema.d.ts
+++ b/packages/sdk/src/schema.d.ts
@@ -6328,6 +6328,7 @@ export interface operations {
                         event: "issues" | "issue_comment" | "pull_request" | "pull_request_review" | "check_suite" | "workflow_run";
                         actions?: string[];
                         labels?: string[];
+                        command?: string;
                     })[];
                     prompt: string;
                 };

--- a/services/api/src/agents/github-command-policy.ts
+++ b/services/api/src/agents/github-command-policy.ts
@@ -1,0 +1,83 @@
+import type { GithubClientFactory } from "../github/client.js";
+
+type GithubObject = Record<string, unknown>;
+
+/** Commands inside quoted or fenced examples are data, not requests. */
+export function requestedGithubCommands(body: string): Set<string> {
+  const commands = new Set<string>();
+  let fence: { character: string; length: number } | undefined;
+  for (const line of body.split(/\r?\n/)) {
+    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fence) {
+      if (
+        marker?.[1]?.startsWith(fence.character) &&
+        marker[1].length >= fence.length &&
+        marker[2]?.trim() === ""
+      ) {
+        fence = undefined;
+      }
+      continue;
+    }
+    if (marker?.[1]) {
+      fence = { character: marker[1][0] ?? "", length: marker[1].length };
+      continue;
+    }
+    const command = /^ {0,3}(\/[a-z][a-z0-9-]*)(?=$|[\s,.:;!?)])/.exec(line)?.[1];
+    if (command) commands.add(command);
+  }
+  return commands;
+}
+
+export function githubIssueCommandMatches(
+  command: string,
+  configuredCommands: ReadonlySet<string>,
+  eventType: string,
+  payload: GithubObject,
+): boolean {
+  if (eventType !== "issue_comment" || payload.action !== "created") return false;
+  const issue = object(payload.issue);
+  if (issue.pull_request !== undefined || issue.state !== "open") return false;
+  const comment = object(payload.comment);
+  if (typeof comment.body !== "string") return false;
+  const requested = [...requestedGithubCommands(comment.body)].filter((value) =>
+    configuredCommands.has(value),
+  );
+  return requested.length === 1 && requested[0] === command;
+}
+
+export async function githubSenderCanStartAgent(input: {
+  factory: GithubClientFactory;
+  installationId: number;
+  owner: string;
+  repo: string;
+  sender: unknown;
+}): Promise<boolean> {
+  const sender = object(input.sender);
+  if (
+    sender.type !== "User" ||
+    typeof sender.login !== "string" ||
+    !/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(sender.login)
+  ) {
+    return false;
+  }
+  try {
+    const client = await input.factory(input.installationId);
+    if (!client.request) return false;
+    const result = await client.request(
+      "GET /repos/{owner}/{repo}/collaborators/{username}/permission",
+      { owner: input.owner, repo: input.repo, username: sender.login },
+    );
+    const permission = object(result.data).permission;
+    // GitHub reports maintain as "write" here; the distinct role is in role_name.
+    return permission === "admin" || permission === "write";
+  } catch (error) {
+    const status = object(error).status;
+    if (status === 401 || status === 403 || status === 404) return false;
+    // Retry transient provider failures; never interpret them as permission.
+    throw error;
+  }
+}
+
+function object(value: unknown): GithubObject {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as GithubObject) : {};
+}

--- a/services/api/src/agents/github-triggers.ts
+++ b/services/api/src/agents/github-triggers.ts
@@ -1,16 +1,20 @@
 import type { AgentTrigger } from "@facility/agents";
 import {
+  auditEvents,
   type FacilityDb,
+  githubInstallations,
   githubWebhookEvents,
   projectRepositories,
   projects,
   stories,
 } from "@facility/db";
 import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import type { GithubClientFactory } from "../github/client.js";
 import type { GithubMirrorService } from "../github/mirror.js";
 import type { StoryWorkspaceService } from "../stories/service.js";
 import type { ProjectManifest, ProjectManifestSource } from "../workspaces/project-environment.js";
 import { type AgentCatalogService, manifestFromProjection } from "./catalog.js";
+import { githubIssueCommandMatches, githubSenderCanStartAgent } from "./github-command-policy.js";
 
 const SUPPORTED_EVENTS = new Set([
   "issues",
@@ -38,6 +42,7 @@ export class GithubAgentTriggerService {
     private readonly projectManifests: ProjectManifestSource,
     private readonly defaultImage: string,
     private readonly mirror?: GithubMirrorService,
+    private readonly githubFactory?: GithubClientFactory,
   ) {}
 
   async handleInbound(inboundEventId: string) {
@@ -49,23 +54,32 @@ export class GithubAgentTriggerService {
         .limit(1)
     )[0];
     if (!event?.verified) return { matched: 0, queued: 0, merged: 0 };
-    await this.mirror?.handleWebhook({
-      id: event.id,
-      orgId: event.orgId,
-      eventType: event.eventType,
-      payload: event.payload as Record<string, unknown>,
-    });
-    const result = await this.handle({
-      id: event.id,
-      orgId: event.orgId,
-      eventType: event.eventType,
-      payload: event.payload as Record<string, unknown>,
-    });
-    await this.db
-      .update(githubWebhookEvents)
-      .set({ processedAt: new Date(), error: null })
-      .where(eq(githubWebhookEvents.id, inboundEventId));
-    return result;
+    try {
+      await this.mirror?.handleWebhook({
+        id: event.id,
+        orgId: event.orgId,
+        eventType: event.eventType,
+        payload: event.payload as Record<string, unknown>,
+      });
+      const result = await this.handle({
+        id: event.id,
+        orgId: event.orgId,
+        eventType: event.eventType,
+        payload: event.payload as Record<string, unknown>,
+      });
+      await this.db
+        .update(githubWebhookEvents)
+        .set({ processedAt: new Date(), error: null })
+        .where(eq(githubWebhookEvents.id, inboundEventId));
+      return result;
+    } catch (error) {
+      // Provider errors may contain credential-bearing request headers; persist only a safe code.
+      await this.db
+        .update(githubWebhookEvents)
+        .set({ processedAt: null, error: "github_webhook_processing_failed" })
+        .where(eq(githubWebhookEvents.id, inboundEventId));
+      throw error;
+    }
   }
 
   async handle(event: GithubEvent) {
@@ -82,6 +96,7 @@ export class GithubAgentTriggerService {
           id: projects.id,
           orgId: projects.orgId,
           repositoryId: projectRepositories.id,
+          installationId: projectRepositories.installationId,
         })
         .from(projectRepositories)
         .innerJoin(
@@ -128,6 +143,67 @@ export class GithubAgentTriggerService {
         branch: safeEventBranch,
       });
     }
+    const requiresHumanPermission =
+      event.eventType === "issues" || event.eventType === "issue_comment";
+    if (requiresHumanPermission && !this.githubFactory) {
+      return this.deny(event, project.id, "github_credentials_unavailable");
+    }
+    const installation =
+      requiresHumanPermission && project.installationId
+        ? (
+            await this.db
+              .select()
+              .from(githubInstallations)
+              .where(
+                and(
+                  eq(githubInstallations.orgId, event.orgId),
+                  eq(githubInstallations.id, project.installationId),
+                ),
+              )
+              .limit(1)
+          )[0]
+        : undefined;
+    if (requiresHumanPermission && (!installation || installation.suspendedAt)) {
+      return this.deny(event, project.id, "github_installation_unavailable");
+    }
+    const projections = await this.catalog.list(event.orgId, project.id);
+    const manifests = projections.map(manifestFromProjection);
+    const configuredCommands = new Set(
+      manifests.flatMap((manifest) =>
+        manifest.triggers.flatMap((trigger) =>
+          trigger.type === "github" && trigger.command ? [trigger.command] : [],
+        ),
+      ),
+    );
+    const matches = manifests
+      .filter((manifest) => manifest.enabled)
+      .flatMap((manifest) =>
+        manifest.triggers
+          .filter(
+            (trigger): trigger is Extract<AgentTrigger, { type: "github" }> =>
+              trigger.type === "github" && triggerMatches(trigger, event, configuredCommands),
+          )
+          .map((trigger) => ({ manifest, trigger })),
+      );
+    if (matches.length === 0) {
+      return { matched: 0, queued: 0, merged: 0 };
+    }
+    if (requiresHumanPermission) {
+      if (
+        !installation ||
+        !this.githubFactory ||
+        !(await githubSenderCanStartAgent({
+          factory: this.githubFactory,
+          installationId: installation.installationId,
+          owner,
+          repo: name,
+          sender: event.payload.sender,
+        }))
+      ) {
+        return this.deny(event, project.id, "github_sender_not_authorized");
+      }
+    }
+
     const identity = linkedStory
       ? {
           provider: linkedStory.provider as "github" | "manual" | "schedule",
@@ -141,20 +217,6 @@ export class GithubAgentTriggerService {
           title: eventIdentity.title,
           branch: safeEventBranch,
         };
-    const projections = await this.catalog.list(event.orgId, project.id);
-    const matches = projections
-      .map(manifestFromProjection)
-      .filter((manifest) => manifest.enabled)
-      .flatMap((manifest) =>
-        manifest.triggers
-          .filter(
-            (trigger): trigger is Extract<AgentTrigger, { type: "github" }> =>
-              trigger.type === "github" && triggerMatches(trigger, event),
-          )
-          .map((trigger) => ({ manifest, trigger })),
-      );
-    if (matches.length === 0) return { matched: 0, queued: 0, merged: 0 };
-
     const projectManifest = await this.projectManifests.load(event.orgId, project.id);
     let queued = 0;
     for (const { manifest, trigger } of matches) {
@@ -186,6 +248,22 @@ export class GithubAgentTriggerService {
       if (result.queued.created) queued += 1;
     }
     return { matched: matches.length, queued, merged: 0 };
+  }
+
+  private async deny(event: GithubEvent, projectId: string, reason: string) {
+    await this.db
+      .insert(auditEvents)
+      .values({
+        id: `github-trigger-denied:${event.orgId}:${event.id}`,
+        orgId: event.orgId,
+        projectId,
+        actor: { type: "service", id: `github:${sender(event.payload)}` },
+        action: "github.agent_trigger.denied",
+        target: { type: "github_webhook", id: event.id },
+        payload: { reason, eventType: event.eventType },
+      })
+      .onConflictDoNothing();
+    return { matched: 0, queued: 0, merged: 0 };
   }
 
   private async markMerged(projectId: string, repositoryId: string, event: GithubEvent) {
@@ -260,10 +338,19 @@ export class GithubAgentTriggerService {
   }
 }
 
-function triggerMatches(trigger: Extract<AgentTrigger, { type: "github" }>, event: GithubEvent) {
+function triggerMatches(
+  trigger: Extract<AgentTrigger, { type: "github" }>,
+  event: GithubEvent,
+  configuredCommands: ReadonlySet<string>,
+) {
   if (trigger.event !== event.eventType) return false;
   const action = string(event.payload.action);
   if (trigger.actions && (!action || !trigger.actions.includes(action))) return false;
+  if (
+    trigger.command &&
+    !githubIssueCommandMatches(trigger.command, configuredCommands, event.eventType, event.payload)
+  )
+    return false;
   if (trigger.labels) {
     const labels = eventLabels(event.payload);
     if (!trigger.labels.every((label) => labels.has(label.toLowerCase()))) return false;

--- a/services/api/src/github/webhook-worker.ts
+++ b/services/api/src/github/webhook-worker.ts
@@ -1,0 +1,31 @@
+import type PgBoss from "pg-boss";
+import type { Logger } from "pino";
+
+export function registerGithubWebhookWorker(
+  boss: Pick<PgBoss, "work">,
+  handleInbound: (inboundEventId: string) => Promise<unknown>,
+  logger: Pick<Logger, "info">,
+) {
+  return boss.work<{ inboundEventId?: string }>(
+    "github.webhook",
+    // pg-boss retries the entire callback batch on rejection. Keep each delivery independent.
+    { batchSize: 1, includeMetadata: true, pollingIntervalSeconds: 0.5 },
+    async (jobs) => {
+      const job = jobs[0];
+      if (!job) return;
+      const startedAt = Date.now();
+      if (job.data.inboundEventId) {
+        await handleInbound(job.data.inboundEventId);
+      }
+      logger.info(
+        {
+          queue: "github.webhook",
+          jobId: job.id,
+          queueWaitMs: Math.max(0, startedAt - job.createdOn.getTime()),
+          handlerMs: Date.now() - startedAt,
+        },
+        "worker completed GitHub webhook delivery",
+      );
+    },
+  );
+}

--- a/services/api/src/story-domain.ts
+++ b/services/api/src/story-domain.ts
@@ -115,6 +115,7 @@ export function createStoryDomain(input: {
     projectManifests,
     input.config.workspaceImage,
     mirror,
+    githubFactory === unavailableGithubFactory ? undefined : githubFactory,
   );
   return {
     runtime,

--- a/services/api/src/worker.ts
+++ b/services/api/src/worker.ts
@@ -4,6 +4,7 @@ import PgBoss from "pg-boss";
 import pino from "pino";
 import { readConfig } from "./config.js";
 import { createGithubClientFactory } from "./github/client.js";
+import { registerGithubWebhookWorker } from "./github/webhook-worker.js";
 import type { StoryWorkspaceService } from "./stories/service.js";
 import { createStoryDomain } from "./story-domain.js";
 
@@ -46,27 +47,10 @@ export async function startWorker() {
   }
   for (const queue of queues) {
     if (queue === "github.webhook") {
-      await boss.work<{ inboundEventId?: string }>(
-        queue,
-        { batchSize: 1_000, includeMetadata: true, pollingIntervalSeconds: 0.5 },
-        async (jobs) => {
-          const startedAt = Date.now();
-          for (const job of jobs) {
-            if (job.data.inboundEventId) {
-              await storyDomain.githubTriggers.handleInbound(job.data.inboundEventId);
-            }
-          }
-          const oldestCreatedAt = Math.min(...jobs.map((job) => job.createdOn.getTime()));
-          logger.info(
-            {
-              queue,
-              batchSize: jobs.length,
-              queueWaitMs: Math.max(0, startedAt - oldestCreatedAt),
-              handlerMs: Date.now() - startedAt,
-            },
-            "worker completed GitHub webhook batch",
-          );
-        },
+      await registerGithubWebhookWorker(
+        boss,
+        (inboundEventId) => storyDomain.githubTriggers.handleInbound(inboundEventId),
+        logger,
       );
       continue;
     }

--- a/services/api/test/agent-automation.integration.test.ts
+++ b/services/api/test/agent-automation.integration.test.ts
@@ -6,7 +6,10 @@ import { parseAgentManifest } from "@facility/agents";
 import { newId } from "@facility/core";
 import {
   agentSchedules,
+  auditEvents,
   createDb,
+  githubInstallations,
+  githubWebhookEvents,
   migrate,
   orgs,
   projectRepositories,
@@ -17,11 +20,14 @@ import {
   workspaces,
 } from "@facility/db";
 import { and, eq } from "drizzle-orm";
+import PgBoss from "pg-boss";
 import postgres from "postgres";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { AgentCatalogService, type AgentCatalogSource } from "../src/agents/catalog.js";
 import { GithubAgentTriggerService } from "../src/agents/github-triggers.js";
 import { AgentScheduler } from "../src/agents/scheduler.js";
+import type { GithubClientFactory } from "../src/github/client.js";
+import { registerGithubWebhookWorker } from "../src/github/webhook-worker.js";
 import { StoryWorkspaceService } from "../src/stories/service.js";
 import { FakeWorkspaceRuntime } from "../src/workspaces/fake.js";
 import type {
@@ -77,16 +83,39 @@ describe("agent automations use persistent story workspaces", async () => {
   const orgId = newId("org");
   const projectId = newId("proj");
   const repositoryId = newId("repo");
+  const installationRowId = newId("ghi");
+  const otherOrgId = newId("org");
+  const otherInstallationRowId = newId("ghi");
+  const installationNumber = 12_000_000 + Math.floor(Math.random() * 100_000);
+  let permission = "write";
+  let failPermissionFor: string | undefined;
+  const permissionRequests: Array<Record<string, unknown> | undefined> = [];
+  const githubFactory: GithubClientFactory = async (requestedInstallation) => {
+    if (requestedInstallation !== installationNumber)
+      throw new Error("cross-installation credential request");
+    return {
+      request: async (route, args) => {
+        if (route !== "GET /repos/{owner}/{repo}/collaborators/{username}/permission")
+          throw new Error("unexpected GitHub route");
+        permissionRequests.push(args);
+        if (args?.username === failPermissionFor) {
+          failPermissionFor = undefined;
+          throw Object.assign(new Error("provider failure with private headers"), { status: 503 });
+        }
+        return { data: { permission } };
+      },
+    } as Awaited<ReturnType<GithubClientFactory>>;
+  };
   const dispatched: string[] = [];
   const agents = [
     manifest(
       "architect",
-      "  - type: github\n    name: plan-ready-issue\n    event: issues\n    actions: [opened]\n    labels: [ready]",
+      "  - type: github\n    name: plan-ready-issue\n    event: issues\n    actions: [opened]\n    labels: [ready]\n  - type: github\n    name: plan-command\n    event: issue_comment\n    actions: [created]\n    command: /architect",
       "claude_code",
     ),
     manifest(
       "builder",
-      "  - type: github\n    name: build-ready-issue\n    event: issues\n    actions: [opened]\n    labels: [ready]",
+      "  - type: github\n    name: build-ready-issue\n    event: issues\n    actions: [opened]\n    labels: [ready]\n  - type: github\n    name: build-command\n    event: issue_comment\n    actions: [created]\n    command: /builder",
     ),
     manifest(
       "pr-reviewer",
@@ -149,6 +178,8 @@ describe("agent automations use persistent story workspaces", async () => {
     storiesService,
     projectManifests,
     "facility-runner:test",
+    undefined,
+    githubFactory,
   );
   const scheduler = new AgentScheduler(
     db,
@@ -173,10 +204,35 @@ describe("agent automations use persistent story workspaces", async () => {
       slug: `agent-automation-${suffix}`,
       settings: {},
     });
+    await db.insert(orgs).values({
+      id: otherOrgId,
+      name: "Other tenant",
+      slug: `other-automation-${suffix}`,
+      settings: {},
+    });
+    await db.insert(githubInstallations).values([
+      {
+        id: installationRowId,
+        orgId,
+        installationId: installationNumber,
+        accountId: 1,
+        accountLogin: "acme",
+        targetType: "Organization",
+      },
+      {
+        id: otherInstallationRowId,
+        orgId: otherOrgId,
+        installationId: installationNumber + 1,
+        accountId: 2,
+        accountLogin: "other",
+        targetType: "Organization",
+      },
+    ]);
     await db.insert(projectRepositories).values({
       id: repositoryId,
       orgId,
       projectId,
+      installationId: installationRowId,
       owner: "acme",
       name: `app-${suffix}`,
       defaultBranch: "main",
@@ -203,7 +259,7 @@ describe("agent automations use persistent story workspaces", async () => {
           body: "Implement the requested behavior",
           labels: [{ name: "ready" }],
         },
-        sender: { login: "contributor" },
+        sender: { type: "User", login: "contributor" },
       },
     };
     await expect(github.handle(event)).resolves.toEqual({ matched: 2, queued: 2, merged: 0 });
@@ -232,6 +288,329 @@ describe("agent automations use persistent story workspaces", async () => {
         payload: { ...event.payload, issue: { ...event.payload.issue, number: 73, labels: [] } },
       }),
     ).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+  });
+
+  function commandEvent(body: string, number = 501) {
+    return {
+      id: `delivery-${randomUUID()}`,
+      orgId,
+      eventType: "issue_comment",
+      payload: {
+        action: "created",
+        repository: { owner: { login: "acme" }, name: `app-${suffix}` },
+        issue: { number, state: "open", title: "Command-driven work", labels: [] },
+        comment: { id: number + 1000, body },
+        sender: { type: "User", login: "maintainer" },
+      },
+    };
+  }
+
+  async function persistedCounts() {
+    return {
+      stories: (
+        await db.select({ id: stories.id }).from(stories).where(eq(stories.projectId, projectId))
+      ).length,
+      workspaces: (
+        await db
+          .select({ id: workspaces.id })
+          .from(workspaces)
+          .where(eq(workspaces.projectId, projectId))
+      ).length,
+      messages: (
+        await db
+          .select({ id: storyMessages.id })
+          .from(storyMessages)
+          .where(eq(storyMessages.projectId, projectId))
+      ).length,
+      turns: (await db.select({ id: turns.id }).from(turns).where(eq(turns.projectId, projectId)))
+        .length,
+      dispatched: dispatched.length,
+    };
+  }
+
+  it("rejects ineligible commands before creating any workspace, message, or turn", async () => {
+    const before = await persistedCounts();
+    const event = commandEvent("/builder");
+    for (const denied of [
+      commandEvent("Please use /builder later"),
+      commandEvent("/architect\n/builder"),
+      commandEvent("```\n/builder\n```"),
+      { ...event, eventType: "issues", payload: { ...event.payload, action: "assigned" } },
+      { ...event, payload: { ...event.payload, action: "edited" } },
+      {
+        ...event,
+        payload: { ...event.payload, sender: { type: "Bot", login: "automation[bot]" } },
+      },
+      {
+        ...event,
+        payload: { ...event.payload, issue: { ...event.payload.issue, state: "closed" } },
+      },
+      { ...event, orgId: otherOrgId },
+    ]) {
+      await expect(github.handle(denied)).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+    }
+    try {
+      permission = "read";
+      await expect(github.handle(event)).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+      permission = "triage";
+      await expect(github.handle(event)).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+    } finally {
+      permission = "write";
+    }
+    expect(await persistedCounts()).toEqual(before);
+  });
+
+  it("does not admit an unverified inbound delivery", async () => {
+    const event = commandEvent("/builder");
+    const before = await persistedCounts();
+    const requestsBefore = permissionRequests.length;
+    await db.insert(githubWebhookEvents).values({
+      id: event.id,
+      orgId,
+      projectId,
+      repositoryId,
+      installationId: installationRowId,
+      eventType: event.eventType,
+      payload: event.payload,
+      verified: false,
+    });
+    await expect(github.handleInbound(event.id)).resolves.toEqual({
+      matched: 0,
+      queued: 0,
+      merged: 0,
+    });
+    expect(permissionRequests).toHaveLength(requestsBefore);
+    expect(await persistedCounts()).toEqual(before);
+  });
+
+  it("denies missing credentials before loading the catalog and records replay-safe audit evidence", async () => {
+    const before = await persistedCounts();
+    const unavailableCatalog = { list: vi.fn().mockRejectedValue(new Error("must not load")) };
+    const withoutCredentials = new GithubAgentTriggerService(
+      db,
+      unavailableCatalog as unknown as AgentCatalogService,
+      storiesService,
+      projectManifests,
+      "facility-runner:test",
+    );
+    const event = commandEvent("/builder", 503);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await expect(withoutCredentials.handle(event)).resolves.toEqual({
+        matched: 0,
+        queued: 0,
+        merged: 0,
+      });
+    }
+    expect(unavailableCatalog.list).not.toHaveBeenCalled();
+    expect(await persistedCounts()).toEqual(before);
+    const denial = await db
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.id, `github-trigger-denied:${orgId}:${event.id}`));
+    expect(denial).toHaveLength(1);
+    expect(denial[0]).toMatchObject({
+      action: "github.agent_trigger.denied",
+      payload: { reason: "github_credentials_unavailable" },
+    });
+  });
+
+  it("records transient failures and retries only their own queued delivery", async () => {
+    const schema = `webhook_${suffix.replaceAll("-", "")}`;
+    const boss = new PgBoss({ connectionString: databaseUrl, schema });
+    const queueErrors: unknown[] = [];
+    boss.on("error", (error) => queueErrors.push(error));
+    const retryEvent = commandEvent("/architect", 504);
+    retryEvent.payload.sender.login = "retry-contributor";
+    const otherEvent = commandEvent("/architect", 505);
+    for (const event of [retryEvent, otherEvent]) {
+      await db.insert(githubWebhookEvents).values({
+        id: event.id,
+        orgId,
+        projectId,
+        repositoryId,
+        installationId: installationRowId,
+        eventType: event.eventType,
+        payload: event.payload,
+        verified: true,
+      });
+    }
+    const failureEvidence: unknown[] = [];
+    try {
+      await boss.start();
+      await boss.createQueue("github.webhook", {
+        name: "github.webhook",
+        retryLimit: 2,
+        retryDelay: 1,
+      });
+      const retryJob = await boss.send("github.webhook", { inboundEventId: retryEvent.id });
+      const otherJob = await boss.send("github.webhook", { inboundEventId: otherEvent.id });
+      if (!retryJob || !otherJob) throw new Error("expected queued webhook jobs");
+      failPermissionFor = "retry-contributor";
+      await registerGithubWebhookWorker(
+        boss,
+        async (id) => {
+          try {
+            return await github.handleInbound(id);
+          } catch (error) {
+            failureEvidence.push(
+              (
+                await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, id))
+              )[0],
+            );
+            throw error;
+          }
+        },
+        { info: () => undefined },
+      );
+      await vi.waitFor(
+        async () => {
+          expect((await boss.getJobById("github.webhook", retryJob))?.state).toBe("completed");
+          expect((await boss.getJobById("github.webhook", otherJob))?.state).toBe("completed");
+        },
+        { timeout: 15_000, interval: 100 },
+      );
+      expect((await boss.getJobById("github.webhook", retryJob))?.retryCount).toBe(1);
+      expect((await boss.getJobById("github.webhook", otherJob))?.retryCount).toBe(0);
+      expect(failureEvidence).toEqual([
+        expect.objectContaining({
+          id: retryEvent.id,
+          processedAt: null,
+          error: "github_webhook_processing_failed",
+        }),
+      ]);
+      expect(
+        (
+          await db
+            .select()
+            .from(githubWebhookEvents)
+            .where(eq(githubWebhookEvents.id, retryEvent.id))
+        )[0],
+      ).toMatchObject({ error: null, processedAt: expect.any(Date) });
+      expect(queueErrors).toEqual([]);
+    } finally {
+      failPermissionFor = undefined;
+      await boss.stop({ graceful: true, timeout: 5_000 });
+      await client.unsafe(`DROP SCHEMA "${schema}" CASCADE`);
+    }
+  }, 25_000);
+
+  it("maintains linked PR metadata on comments that match no agent", async () => {
+    const agent = agents[0];
+    if (!agent) throw new Error("expected agent fixture");
+    const linked = await storiesService.start({
+      orgId,
+      projectId,
+      repositoryId,
+      provider: "github",
+      externalId: "pull-request:506",
+      title: "Existing PR",
+      agent,
+      message: "Plan the work",
+      messageDedupeKey: `pr-comment-${suffix}`,
+      actor: { type: "service", id: "github:maintainer" },
+      workspace: workspaceInput(projectManifest),
+      trigger: { type: "github", key: "issues:opened" },
+    });
+    await storiesService.associatePullRequest({
+      orgId,
+      projectId,
+      storyId: linked.story.id,
+      pullRequestNumber: 506,
+    });
+    const before = await persistedCounts();
+    const event = commandEvent("Ordinary PR discussion", 506);
+    await expect(
+      github.handle({
+        ...event,
+        payload: {
+          ...event.payload,
+          issue: {
+            ...event.payload.issue,
+            pull_request: { html_url: "https://github.test/acme/app/pull/506" },
+          },
+        },
+      }),
+    ).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+    expect((await storiesService.get(orgId, projectId, linked.story.id)).story.pullRequestUrl).toBe(
+      "https://github.test/acme/app/pull/506",
+    );
+    expect(await persistedCounts()).toEqual(before);
+  });
+
+  it("denies suspended, cross-tenant, and unlinked installations before requesting credentials", async () => {
+    const before = await persistedCounts();
+    const requestsBefore = permissionRequests.length;
+    const event = commandEvent("/builder");
+    try {
+      await db
+        .update(githubInstallations)
+        .set({ suspendedAt: new Date() })
+        .where(eq(githubInstallations.id, installationRowId));
+      await expect(github.handle(event)).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+      await expect(
+        db
+          .update(projectRepositories)
+          .set({ installationId: otherInstallationRowId })
+          .where(eq(projectRepositories.id, repositoryId)),
+      ).rejects.toMatchObject({
+        cause: { code: "23503", constraint_name: "project_repositories_installation_scope_fk" },
+      });
+      await expect(github.handle(event)).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+      await db
+        .update(projectRepositories)
+        .set({ installationId: null })
+        .where(eq(projectRepositories.id, repositoryId));
+      await expect(github.handle(event)).resolves.toEqual({ matched: 0, queued: 0, merged: 0 });
+    } finally {
+      await db
+        .update(githubInstallations)
+        .set({ suspendedAt: null })
+        .where(eq(githubInstallations.id, installationRowId));
+      await db
+        .update(projectRepositories)
+        .set({ installationId: installationRowId })
+        .where(eq(projectRepositories.id, repositoryId));
+    }
+    expect(permissionRequests).toHaveLength(requestsBefore);
+    expect(await persistedCounts()).toEqual(before);
+  });
+
+  it("starts the requested role once and keeps builder acceptance in the same issue workspace", async () => {
+    const plan = commandEvent("/architect plan this work", 502);
+    await expect(github.handle(plan)).resolves.toEqual({ matched: 1, queued: 1, merged: 0 });
+    await expect(github.handle(plan)).resolves.toEqual({ matched: 1, queued: 0, merged: 0 });
+    const build = commandEvent("/builder implement the accepted plan", 502);
+    await expect(github.handle(build)).resolves.toEqual({ matched: 1, queued: 1, merged: 0 });
+    const issueStories = await db
+      .select()
+      .from(stories)
+      .where(and(eq(stories.projectId, projectId), eq(stories.externalId, "issue:502")));
+    expect(issueStories).toHaveLength(1);
+    const story = issueStories[0];
+    if (!story) throw new Error("expected command story");
+    expect(await db.select().from(workspaces).where(eq(workspaces.storyId, story.id))).toHaveLength(
+      1,
+    );
+    const messages = await db
+      .select()
+      .from(storyMessages)
+      .where(eq(storyMessages.storyId, story.id));
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.requestedAgentName)).toEqual(
+      expect.arrayContaining(["architect", "builder"]),
+    );
+    const before = await persistedCounts();
+    try {
+      permission = "read";
+      await expect(github.handle(commandEvent("/builder", 502))).resolves.toEqual({
+        matched: 0,
+        queued: 0,
+        merged: 0,
+      });
+    } finally {
+      permission = "write";
+    }
+    expect(await persistedCounts()).toEqual(before);
   });
 
   it("reuses an issue workspace for its pull request and only suspends it after merge", async () => {
@@ -266,7 +645,7 @@ describe("agent automations use persistent story workspaces", async () => {
           head: { ref: "feature/review-me" },
           merged: false,
         },
-        sender: { login: "contributor" },
+        sender: { type: "User", login: "contributor" },
       },
     };
     await expect(github.handle(opened)).resolves.toEqual({ matched: 1, queued: 1, merged: 0 });
@@ -338,7 +717,7 @@ describe("agent automations use persistent story workspaces", async () => {
             body: "Please cover the empty input path.",
             html_url: "https://github.test/acme/app/pull/141#review-901",
           },
-          sender: { login: "reviewer" },
+          sender: { type: "User", login: "reviewer" },
         },
       }),
     ).resolves.toEqual({ matched: 1, queued: 1, merged: 0 });
@@ -362,7 +741,7 @@ describe("agent automations use persistent story workspaces", async () => {
             head_sha: "f".repeat(40),
             pull_requests: [{ number: 142 }],
           },
-          sender: { login: "github-actions" },
+          sender: { type: "Bot", login: "github-actions" },
         },
       }),
     ).resolves.toEqual({ matched: 1, queued: 1, merged: 0 });
@@ -447,7 +826,8 @@ function render(agent: ReturnType<typeof manifest>) {
       }
       const actions = trigger.actions ? `\n    actions: [${trigger.actions.join(", ")}]` : "";
       const labels = trigger.labels ? `\n    labels: [${trigger.labels.join(", ")}]` : "";
-      return `  - type: github\n    name: ${trigger.name}\n    event: ${trigger.event}${actions}${labels}`;
+      const command = trigger.command ? `\n    command: ${trigger.command}` : "";
+      return `  - type: github\n    name: ${trigger.name}\n    event: ${trigger.event}${actions}${labels}${command}`;
     })
     .join("\n");
   return `---

--- a/services/api/test/github-command-policy.test.ts
+++ b/services/api/test/github-command-policy.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  githubIssueCommandMatches,
+  githubSenderCanStartAgent,
+  requestedGithubCommands,
+} from "../src/agents/github-command-policy.js";
+import type { GithubClientFactory } from "../src/github/client.js";
+
+const commands = new Set(["/architect", "/builder"]);
+const payload = (body: string) => ({
+  action: "created",
+  issue: { number: 42, state: "open" },
+  comment: { body },
+});
+
+describe("GitHub issue command admission", () => {
+  it.each([
+    "/builder",
+    "/builder: implement the accepted plan",
+    "Context\n /builder please",
+  ])("accepts a single explicit command: %s", (body) => {
+    expect(githubIssueCommandMatches("/builder", commands, "issue_comment", payload(body))).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    "Please use /builder later",
+    "/builder-extra",
+    "/architect\n/builder",
+    "> /builder",
+    "    /builder",
+    "\t/builder",
+    "```text\n/builder\n```",
+    "~~~\n/builder\n~~~",
+    "`/builder`",
+  ])("does not interpret prose, examples, or ambiguous commands as acceptance: %s", (body) => {
+    expect(githubIssueCommandMatches("/builder", commands, "issue_comment", payload(body))).toBe(
+      false,
+    );
+  });
+
+  it("reads a real command after a fenced example", () => {
+    expect(requestedGithubCommands("````text\n/architect\n```\n/builder\n````\n/builder")).toEqual(
+      new Set(["/builder"]),
+    );
+  });
+
+  it("refuses assignment replays, edits, closed issues, and PR comments", () => {
+    const event = payload("/builder");
+    expect(
+      githubIssueCommandMatches("/builder", commands, "issues", { ...event, action: "assigned" }),
+    ).toBe(false);
+    expect(
+      githubIssueCommandMatches("/builder", commands, "issue_comment", {
+        ...event,
+        action: "edited",
+      }),
+    ).toBe(false);
+    expect(
+      githubIssueCommandMatches("/builder", commands, "issue_comment", {
+        ...event,
+        issue: { ...event.issue, state: "closed" },
+      }),
+    ).toBe(false);
+    expect(
+      githubIssueCommandMatches("/builder", commands, "issue_comment", {
+        ...event,
+        issue: { ...event.issue, pull_request: { url: "https://example.test/pulls/42" } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("authoritative GitHub sender permission", () => {
+  function fixture(permission: unknown = "write") {
+    const request = vi.fn().mockResolvedValue({ data: { permission } });
+    const factory = vi.fn().mockResolvedValue({ request }) as unknown as GithubClientFactory;
+    return {
+      request,
+      factory,
+      input: {
+        factory,
+        installationId: 123,
+        owner: "acme",
+        repo: "app",
+        sender: { type: "User", login: "contributor" },
+      },
+    };
+  }
+
+  it.each([
+    "write",
+    "admin",
+  ])("admits current %s access through the scoped installation", async (permission) => {
+    const { request, factory, input } = fixture(permission);
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(true);
+    expect(factory).toHaveBeenCalledWith(123);
+    expect(request).toHaveBeenCalledWith(
+      "GET /repos/{owner}/{repo}/collaborators/{username}/permission",
+      {
+        owner: "acme",
+        repo: "app",
+        username: "contributor",
+      },
+    );
+  });
+
+  it.each([
+    "read",
+    "triage",
+    "none",
+    "",
+    undefined,
+    {},
+    true,
+  ])("denies insufficient or malformed permission %s", async (permission) => {
+    const { input, request } = fixture();
+    request.mockResolvedValue({ data: { permission } });
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(false);
+  });
+
+  it("rechecks access after revocation and never trusts webhook association", async () => {
+    const { request, input } = fixture();
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(true);
+    request.mockResolvedValue({ data: { permission: "read" } });
+    await expect(
+      githubSenderCanStartAgent({
+        ...input,
+        sender: { ...input.sender, author_association: "OWNER" },
+      }),
+    ).resolves.toBe(false);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("admits maintainers through GitHub's base permission mapping, not role_name", async () => {
+    const { request, input } = fixture();
+    request.mockResolvedValue({ data: { permission: "write", role_name: "maintain" } });
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(true);
+    request.mockResolvedValue({ data: { permission: "read", role_name: "maintain" } });
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(false);
+  });
+
+  it.each([
+    { type: "Bot", login: "automation[bot]" },
+    { login: "contributor" },
+    { type: "User", login: "../other" },
+    null,
+  ])("denies bots and malformed senders before calling GitHub", async (sender) => {
+    const { factory, input } = fixture();
+    await expect(githubSenderCanStartAgent({ ...input, sender })).resolves.toBe(false);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    401, 403, 404,
+  ])("denies revoked credentials or unavailable membership (%s)", async (status) => {
+    const { request, input } = fixture();
+    request.mockRejectedValue({ status });
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(false);
+    const factory = vi.fn().mockRejectedValue({ status });
+    await expect(githubSenderCanStartAgent({ ...input, factory })).resolves.toBe(false);
+  });
+
+  it("retries provider failures without admitting a turn", async () => {
+    const { request, input } = fixture();
+    const failure = Object.assign(new Error("GitHub unavailable"), { status: 503 });
+    request.mockRejectedValue(failure);
+    await expect(githubSenderCanStartAgent(input)).rejects.toBe(failure);
+  });
+});

--- a/services/api/test/github-webhook-worker.test.ts
+++ b/services/api/test/github-webhook-worker.test.ts
@@ -1,0 +1,26 @@
+import type PgBoss from "pg-boss";
+import { describe, expect, it, vi } from "vitest";
+import { registerGithubWebhookWorker } from "../src/github/webhook-worker.js";
+
+describe("GitHub webhook retry boundary", () => {
+  it("gives pg-boss one delivery per callback and propagates failures for retry", async () => {
+    const work = vi.fn().mockResolvedValue("worker-id");
+    const handle = vi.fn().mockResolvedValue({ queued: 1 });
+    const logger = { info: vi.fn() };
+    await registerGithubWebhookWorker({ work } as unknown as Pick<PgBoss, "work">, handle, logger);
+    expect(work).toHaveBeenCalledWith(
+      "github.webhook",
+      expect.objectContaining({ batchSize: 1, includeMetadata: true }),
+      expect.any(Function),
+    );
+    const callback = work.mock.calls[0]?.[2];
+    const job = { id: "job-1", data: { inboundEventId: "delivery-1" }, createdOn: new Date() };
+    const failure = new Error("provider unavailable");
+    handle.mockRejectedValueOnce(failure);
+    await expect(callback([job])).rejects.toBe(failure);
+    expect(logger.info).not.toHaveBeenCalled();
+    await callback([{ ...job, id: "job-2", data: { inboundEventId: "delivery-2" } }]);
+    expect(handle).toHaveBeenLastCalledWith("delivery-2");
+    expect(logger.info).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changes

Add an optional `command` filter for new issue comments so `/architect` can request planning and `/builder` can explicitly accept it. Issue-driven agent starts now require a human with current repository write access through the active installation. Quoted examples, ambiguous commands, edits, closed issues, PR comments, and unauthorized senders cannot activate command triggers.

Preserve bot-generated PR and CI triggers and existing PR lifecycle updates. Process webhook deliveries independently so a transient permission-provider failure retries only its own delivery; record safe failure codes and replay-safe denial audit events.

## Why

Issue assignment must not implicitly accept a plan, and webhook text or author-association labels cannot establish current permission to start a privileged agent. Projects also need the existing PR/CI behavior to remain available while migrating command-driven work.

## Verification

- `pnpm verify`: passed, including database-backed critical integration tests, build, typecheck, lint, repository guards, and the existing dependency-audit policy.
- Focused command, automation, and worker tests: 45 passed. Real local PostgreSQL and pg-boss prove a failed delivery retries once while its adjacent delivery retries zero times; denial cases create no story, workspace, message, or turn.
- Regression coverage includes permission revocation, bots/malformed senders, suspended/unlinked/cross-tenant installations, unverified deliveries, duplicate commands, command parsing, bot CI, PR association without activation, and missing credentials.
- The installed GitHub App successfully read an authorized user's current permission; an unknown user returned 404. No live agent turn was submitted for this check.
- SDK regeneration preserves the existing OAuth and development-login endpoints; generated artifacts add only the command field.
- Claude read-only final review: no shipping blockers. Actual project automatic-flow acceptance remains a separate deployment check.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
