### PR TITLE
fix(infra): retain tagged deployment images

### DIFF
--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -60,6 +60,20 @@ After deployment, wait for ECS stability, check `application_url/readyz`,
 inspect worker logs, configure the GitHub webhook from the output, connect MCP
 at `mcp_url`, and run the disposable workspace acceptance guide.
 
+## Image retention
+
+ECR expires only untagged images older than 30 days. Immutable tagged releases
+remain available for ECS restarts, scaling, and rollback even after newer images
+are published. Tagged images have no automatic age or count limit: operators
+must monitor ECR storage and image quotas and explicitly reclaim unused releases.
+A count-based expiration rule cannot know whether ECS still needs an old image.
+Remove a release tag only after confirming that no service, task definition, or
+retained rollback procedure still needs its image digest.
+
+ECR also preserves child images referenced by a retained manifest list. See the
+[AWS lifecycle evaluation rules](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)
+before changing retention for multi-platform images or attached artifacts.
+
 ## Recovery
 
 RDS backup and Vercel workspace snapshots are separate recovery layers. Preserve

--- a/infra/terraform/aws/ecs.tf
+++ b/infra/terraform/aws/ecs.tf
@@ -21,11 +21,12 @@ resource "aws_ecr_lifecycle_policy" "service" {
   policy = jsonencode({
     rules = [{
       rulePriority = 1
-      description  = "Keep the latest 25 releases"
+      description  = "Expire untagged images after 30 days; preserve tagged deployments"
       selection = {
-        tagStatus   = "any"
-        countType   = "imageCountMoreThan"
-        countNumber = 25
+        tagStatus   = "untagged"
+        countType   = "sinceImagePushed"
+        countUnit   = "days"
+        countNumber = 30
       }
       action = { type = "expire" }
     }]

--- a/infra/terraform/aws/tests/control_plane.tftest.hcl
+++ b/infra/terraform/aws/tests/control_plane.tftest.hcl
@@ -47,6 +47,19 @@ run "vercel_workspace_control_plane" {
   }
 
   assert {
+    condition = length(aws_ecr_lifecycle_policy.service) == 2 && alltrue([
+      for policy in aws_ecr_lifecycle_policy.service : length(jsondecode(policy.policy).rules) > 0 && alltrue([
+        for rule in jsondecode(policy.policy).rules :
+        rule.selection.tagStatus == "untagged" &&
+        rule.selection.countType == "sinceImagePushed" &&
+        rule.selection.countUnit == "days" &&
+        rule.selection.countNumber >= 30
+      ])
+    ])
+    error_message = "Image expiration must preserve tagged deployments and rollback images, removing only untagged images at least 30 days old."
+  }
+
+  assert {
     condition     = aws_db_instance.facility.skip_final_snapshot && aws_db_instance.facility.final_snapshot_identifier == null
     error_message = "Disposable deployments must skip the final snapshot without setting an incompatible identifier."
   }


### PR DESCRIPTION
## What changes

Retain tagged API and web deployment images in ECR. Expire only untagged images older than 30 days, with a mocked Terraform-plan regression covering both repositories and nonempty policies.

## Why

A release-count rule can expire an image that ECS still needs to restart, scale, or roll back a service. Tagged releases now require deliberate operator cleanup after checking references; the runbook states the storage and quota trade-off.

## Verification

- `terraform fmt -check -recursive`, `terraform validate`, and `terraform test`: passed (`1 passed, 0 failed`); the provider is mocked and no infrastructure was applied.
- `pnpm verify` and repository guards: passed.
- AWS's documented lifecycle evaluation confirms that retained manifest lists also protect referenced child images. The runbook links that source.
- Claude read-only review approved the policy semantics; the follow-up assertion now rejects absent policies and empty rule sets.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
