### PR TITLE
fix(workspaces): stop compute after failed initialization

### DIFF
--- a/apps/docs/docs/concepts/stories-and-workspaces.md
+++ b/apps/docs/docs/concepts/stories-and-workspaces.md
@@ -65,6 +65,12 @@ Workspace compute may be `creating`, `running`, `sleeping`, `error`, or `destroy
 error workspace can retain its durable volume. `destroyed` means the explicit deletion path has
 removed that durable workspace and it cannot be resumed.
 
+If Vercel workspace initialization fails after this operation allocates or resumes compute,
+Facility stops that compute while preserving the persistent disk. A failed wake of an already
+running workspace leaves its active compute alone. A later start reuses the same workspace identity. If the provider
+also refuses the stop, the `workspace_initialize_cleanup_failed` error names the sandbox that an
+operator must stop before retrying. Failed initialization does not queue an agent turn.
+
 Facility has no age-based deletion rule. Storage continues to accrue until an operator removes a
 workspace. Use budgets and observability to distinguish active compute cost from retained storage,
 then set an organizational retention policy outside the agent prompt.

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -29,9 +29,16 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
     assertWorkspaceId(input.id);
     const ports = validateWorkspacePorts(input.ports);
     const gatewayPorts = previewGatewayPorts(ports);
+    const bootstrapCommand = workspaceBootstrapCommand(input);
+    let startedCompute = false;
+    const onStarted = async () => {
+      startedCompute = true;
+    };
     const sandbox = await Sandbox.getOrCreate({
       ...this.credentials,
       name: input.id,
+      onCreate: onStarted,
+      onResume: onStarted,
       image: input.image,
       persistent: true,
       snapshotExpiration: 0,
@@ -43,14 +50,16 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
       tags: { facility: "workspace" },
       resume: true,
     });
-    await initializeSandbox(sandbox, input);
-    return this.handle(input, sandbox);
+    return this.initializeAndHandle(sandbox, input, bootstrapCommand, () => startedCompute);
   }
 
   async wake(workspace: WorkspaceLocator): Promise<WorkspaceHandle> {
-    const sandbox = await this.get(workspace, true);
-    await initializeSandbox(sandbox, workspace);
-    return this.handle(workspace, sandbox);
+    const bootstrapCommand = workspaceBootstrapCommand(workspace);
+    let startedCompute = false;
+    const sandbox = await this.get(workspace, true, async () => {
+      startedCompute = true;
+    });
+    return this.initializeAndHandle(sandbox, workspace, bootstrapCommand, () => startedCompute);
   }
 
   async exec(
@@ -175,7 +184,11 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
     }
   }
 
-  private get(workspace: WorkspaceLocator, resume: boolean) {
+  private get(
+    workspace: WorkspaceLocator,
+    resume: boolean,
+    onResume?: (sandbox: Sandbox) => Promise<void>,
+  ) {
     assertWorkspaceId(workspace.id);
     if (workspace.externalRef !== workspace.id) {
       throw new WorkspaceRuntimeError(
@@ -183,7 +196,12 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
         "Vercel workspace reference does not match its Facility identity",
       );
     }
-    return Sandbox.get({ ...this.credentials, name: workspace.externalRef, resume });
+    return Sandbox.get({
+      ...this.credentials,
+      name: workspace.externalRef,
+      resume,
+      ...(onResume ? { onResume } : {}),
+    });
   }
 
   private handle(input: CreateWorkspace, sandbox: Sandbox): WorkspaceHandle {
@@ -197,6 +215,32 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
     };
   }
 
+  private async initializeAndHandle(
+    sandbox: Sandbox,
+    input: CreateWorkspace,
+    bootstrapCommand: string,
+    startedCompute: () => boolean,
+  ): Promise<WorkspaceHandle> {
+    try {
+      await initializeSandbox(sandbox, bootstrapCommand);
+      return this.handle(input, sandbox);
+    } catch (initializationError) {
+      // Preview and restore may wake an already-running workspace. Leave its active turn alone.
+      if (!startedCompute()) throw initializationError;
+      try {
+        // Stop only compute this operation created or resumed; preserve the persistent disk.
+        if (sandbox.status !== "stopped") await sandbox.stop();
+      } catch (cleanupError) {
+        throw new WorkspaceRuntimeError(
+          "workspace_initialize_cleanup_failed",
+          `Workspace ${input.id} initialization failed and compute could not be stopped; stop this sandbox by its workspace name before retrying`,
+          { cause: new AggregateError([initializationError, cleanupError]) },
+        );
+      }
+      throw initializationError;
+    }
+  }
+
   private endpoints(sandbox: Sandbox, ports: CreateWorkspace["ports"] = []): PreviewEndpoint[] {
     const gatewayPorts = previewGatewayPorts(ports);
     return gatewayPorts.map(({ port, gatewayPort }) => ({
@@ -206,10 +250,10 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
   }
 }
 
-async function initializeSandbox(sandbox: Sandbox, input: CreateWorkspace) {
+async function initializeSandbox(sandbox: Sandbox, bootstrapCommand: string) {
   const result = await sandbox.runCommand({
     cmd: "sh",
-    args: ["-lc", workspaceBootstrapCommand(input)],
+    args: ["-lc", bootstrapCommand],
     sudo: true,
     timeoutMs: 180_000,
   });

--- a/services/api/test/workspace-vercel-lifecycle.integration.test.ts
+++ b/services/api/test/workspace-vercel-lifecycle.integration.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import { parseAgentManifest } from "@facility/agents";
+import { newId } from "@facility/core";
+import {
+  createDb,
+  migrate,
+  orgs,
+  projects,
+  stories,
+  storyMessages,
+  turns,
+  workspaces,
+} from "@facility/db";
+import { and, eq } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const sandboxApi = vi.hoisted(() => ({ get: vi.fn(), getOrCreate: vi.fn() }));
+vi.mock("@vercel/sandbox", () => ({ Sandbox: sandboxApi }));
+
+import { StoryWorkspaceService } from "../src/stories/service.js";
+import { VercelWorkspaceRuntime } from "../src/workspaces/vercel.js";
+
+const databaseUrl =
+  process.env.DATABASE_URL ?? "postgres://facility:facility@127.0.0.1:5461/facility_test";
+
+async function canConnect() {
+  const sql = postgres(databaseUrl, { max: 1, connect_timeout: 10 });
+  try {
+    await sql`select 1`;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await sql.end();
+  }
+}
+
+function sandboxFixture(name: string) {
+  const sandbox = {
+    name,
+    status: "running",
+    currentSnapshotId: "snap_original",
+    currentSession: () => ({ sessionId: `session_${name}` }),
+    files: new Map([[".facility/plan.md", "Keep this plan across failed starts"]]),
+    failNextInitialization: true,
+    failStop: false,
+    runCommand: vi.fn(async () => {
+      const exitCode = sandbox.failNextInitialization ? 1 : 0;
+      sandbox.failNextInitialization = false;
+      return { exitCode, stderr: async () => "Docker failed to initialize" };
+    }),
+    stop: vi.fn(async () => {
+      if (sandbox.failStop) throw new Error("provider stop unavailable");
+      sandbox.status = "stopped";
+      sandbox.currentSnapshotId = "snap_preserved";
+    }),
+    delete: vi.fn(),
+  };
+  return sandbox;
+}
+
+describe("Vercel startup cleanup through the story service", async () => {
+  if (!(await canConnect())) {
+    it.skip("Postgres is unreachable at DATABASE_URL; Vercel lifecycle integration tests skipped", () =>
+      undefined);
+    return;
+  }
+  const { db, client } = createDb(databaseUrl);
+  const orgId = newId("org");
+  const projectId = newId("proj");
+  const suffix = randomUUID().slice(0, 8);
+  const sandboxes = new Map<string, ReturnType<typeof sandboxFixture>>();
+  const runtime = new VercelWorkspaceRuntime();
+  const dispatched = vi.fn().mockResolvedValue(undefined);
+  const service = new StoryWorkspaceService(db, runtime, dispatched);
+  const agent = parseAgentManifest(
+    `---
+name: builder
+description: Builds the accepted plan.
+engine: codex
+model: gpt-5.5
+enabled: true
+triggers:
+  - type: manual
+---
+Implement and verify the plan.
+`,
+    "builder.md",
+  );
+
+  beforeAll(async () => {
+    await migrate(databaseUrl);
+    await db
+      .insert(orgs)
+      .values({ id: orgId, name: "Startup cleanup", slug: `cleanup-${suffix}`, settings: {} });
+    await db.insert(projects).values({
+      id: projectId,
+      orgId,
+      name: "Startup cleanup",
+      slug: `cleanup-${suffix}`,
+      settings: {},
+    });
+    sandboxApi.getOrCreate.mockImplementation(
+      async ({
+        name,
+        onCreate,
+        onResume,
+      }: {
+        name: string;
+        onCreate?: () => Promise<void>;
+        onResume?: () => Promise<void>;
+      }) => {
+        let sandbox = sandboxes.get(name);
+        if (!sandbox) {
+          sandbox = sandboxFixture(name);
+          sandboxes.set(name, sandbox);
+          await onCreate?.();
+        } else if (sandbox.status === "stopped") {
+          await onResume?.();
+        }
+        sandbox.status = "running";
+        return sandbox;
+      },
+    );
+    sandboxApi.get.mockImplementation(
+      async ({
+        name,
+        resume,
+        onResume,
+      }: {
+        name: string;
+        resume: boolean;
+        onResume?: () => Promise<void>;
+      }) => {
+        const sandbox = sandboxes.get(name);
+        if (!sandbox) throw Object.assign(new Error("unknown sandbox"), { status: 404 });
+        if (resume && sandbox.status === "stopped") {
+          sandbox.status = "running";
+          await onResume?.();
+        }
+        return sandbox;
+      },
+    );
+  });
+  afterAll(async () => {
+    await client.end();
+  });
+
+  function input(externalId: string) {
+    return {
+      orgId,
+      projectId,
+      provider: "github" as const,
+      externalId,
+      title: "Accepted plan",
+      agent,
+      message: "Build the plan",
+      messageDedupeKey: `build:${externalId}`,
+      actor: { type: "user" as const, id: "user_maintainer" },
+      workspace: { image: "facility-runner:test", ports: [] },
+    };
+  }
+
+  async function failedBundle(externalId: string) {
+    const story = (
+      await db
+        .select()
+        .from(stories)
+        .where(and(eq(stories.projectId, projectId), eq(stories.externalId, externalId)))
+    )[0];
+    if (!story) throw new Error("expected failed story");
+    const bundle = await service.get(orgId, projectId, story.id);
+    if (!bundle.workspace) throw new Error("expected retained workspace record");
+    const sandbox = sandboxes.get(bundle.workspace.id);
+    if (!sandbox) throw new Error("expected allocated sandbox");
+    return { ...bundle, workspace: bundle.workspace, sandbox };
+  }
+
+  it("stops failed create and wake attempts, keeps one workspace and disk, and resumes successfully", async () => {
+    const request = input(`issue:${randomUUID()}`);
+    await expect(service.start(request)).rejects.toMatchObject({ code: "workspace_start_failed" });
+    const failed = await failedBundle(request.externalId);
+    expect(failed.workspace.state).toBe("error");
+    expect(failed.sandbox.status).toBe("stopped");
+    expect(await db.select().from(turns).where(eq(turns.storyId, failed.story.id))).toHaveLength(0);
+    expect(
+      await db.select().from(storyMessages).where(eq(storyMessages.storyId, failed.story.id)),
+    ).toHaveLength(0);
+    expect(dispatched).not.toHaveBeenCalled();
+
+    const resumed = await service.start(request);
+    expect(resumed.workspace).toMatchObject({
+      id: failed.workspace.id,
+      externalRef: failed.workspace.id,
+      volumeRef: "snap_preserved",
+      state: "running",
+    });
+    expect(failed.sandbox.files.get(".facility/plan.md")).toBe(
+      "Keep this plan across failed starts",
+    );
+    expect(dispatched).toHaveBeenCalledOnce();
+
+    await service.suspend(orgId, projectId, failed.story.id);
+    failed.sandbox.failNextInitialization = true;
+    await expect(service.start(request)).rejects.toMatchObject({ code: "workspace_start_failed" });
+    expect(failed.sandbox.status).toBe("stopped");
+    expect((await service.get(orgId, projectId, failed.story.id)).workspace?.state).toBe("error");
+    await service.start(request);
+    expect(failed.sandbox.status).toBe("running");
+    expect(failed.sandbox.files.get(".facility/plan.md")).toBe(
+      "Keep this plan across failed starts",
+    );
+    expect(
+      await db.select().from(workspaces).where(eq(workspaces.storyId, failed.story.id)),
+    ).toHaveLength(1);
+    expect(await db.select().from(turns).where(eq(turns.storyId, failed.story.id))).toHaveLength(1);
+    expect(failed.sandbox.delete).not.toHaveBeenCalled();
+    const stopsBefore = failed.sandbox.stop.mock.calls.length;
+    failed.sandbox.failNextInitialization = true;
+    await expect(service.start(request)).rejects.toMatchObject({ code: "workspace_start_failed" });
+    expect(failed.sandbox.status).toBe("running");
+    expect(failed.sandbox.stop).toHaveBeenCalledTimes(stopsBefore);
+    expect(await db.select().from(turns).where(eq(turns.storyId, failed.story.id))).toHaveLength(1);
+  });
+
+  it("records failed cleanup with an operator-recoverable identity and queues no work", async () => {
+    sandboxApi.getOrCreate.mockImplementationOnce(
+      async ({ name, onCreate }: { name: string; onCreate?: () => Promise<void> }) => {
+        const sandbox = sandboxFixture(name);
+        sandbox.failStop = true;
+        sandboxes.set(name, sandbox);
+        await onCreate?.();
+        return sandbox;
+      },
+    );
+    const request = input(`issue:${randomUUID()}`);
+    await expect(service.start(request)).rejects.toMatchObject({
+      code: "workspace_start_failed",
+      cause: { code: "workspace_initialize_cleanup_failed" },
+    });
+    const failed = await failedBundle(request.externalId);
+    expect(failed.workspace).toMatchObject({
+      state: "error",
+      error: expect.stringContaining(failed.workspace.id),
+    });
+    expect(failed.sandbox.status).toBe("running");
+    expect(await db.select().from(turns).where(eq(turns.storyId, failed.story.id))).toHaveLength(0);
+    // The persisted error identifies the sandbox even when create never returned a handle.
+    failed.sandbox.failStop = false;
+    await runtime.suspend({
+      id: failed.workspace.id,
+      externalRef: failed.workspace.id,
+      volumeRef: failed.workspace.volumeRef,
+      image: request.workspace.image,
+    });
+    expect(failed.sandbox.status).toBe("stopped");
+    expect(failed.sandbox.delete).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -21,6 +21,8 @@ function fakeSandbox() {
       exitCode: 0,
       stderr: vi.fn().mockResolvedValue(""),
     }),
+    stop: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
     domain: (port: number) => `workspace-${port}.example.test`,
   };
 }
@@ -30,7 +32,10 @@ describe("Vercel persistent workspace runtime", () => {
 
   it("creates a non-expiring persistent sandbox and initializes it exactly once", async () => {
     const sandbox = fakeSandbox();
-    sandboxApi.getOrCreate.mockResolvedValue(sandbox);
+    sandboxApi.getOrCreate.mockImplementation(async (options) => {
+      await options.onCreate?.(sandbox);
+      return sandbox;
+    });
     const runtime = new VercelWorkspaceRuntime({
       token: "test-token",
       teamId: "team_test",
@@ -59,13 +64,18 @@ describe("Vercel persistent workspace runtime", () => {
         resume: true,
       }),
     );
-    expect(sandboxApi.getOrCreate.mock.calls[0]?.[0]).not.toHaveProperty("onCreate");
+    // The fake invokes the lifecycle hook: a bootstrap in both the hook and runtime would run twice.
+    expect(sandboxApi.getOrCreate.mock.calls[0]?.[0].onCreate).toEqual(expect.any(Function));
     expect(sandbox.runCommand).toHaveBeenCalledTimes(1);
+    expect(sandbox.stop).not.toHaveBeenCalled();
   });
 
   it("resumes by Facility identity and reinitializes transient services once", async () => {
     const sandbox = fakeSandbox();
-    sandboxApi.get.mockResolvedValue(sandbox);
+    sandboxApi.get.mockImplementation(async (options) => {
+      await options.onResume?.(sandbox);
+      return sandbox;
+    });
     const runtime = new VercelWorkspaceRuntime();
 
     await runtime.wake({
@@ -81,5 +91,126 @@ describe("Vercel persistent workspace runtime", () => {
       expect.objectContaining({ name: "ws_0123456789abcdef", resume: true }),
     );
     expect(sandbox.runCommand).toHaveBeenCalledTimes(1);
+    expect(sandbox.stop).not.toHaveBeenCalled();
+  });
+
+  const input = {
+    id: "ws_0123456789abcdef",
+    externalRef: "ws_0123456789abcdef",
+    volumeRef: "snap_original",
+    image: "facility-runner:test",
+    environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+    ports: [{ service: "web", port: 3000 }],
+  };
+
+  it.each([
+    "create",
+    "wake",
+  ] as const)("stops compute after %s initialization rejects, preserving the disk", async (operation) => {
+    const sandbox = fakeSandbox();
+    const failure = new Error("bootstrap connection failed");
+    sandbox.runCommand.mockRejectedValue(failure);
+    sandboxApi.getOrCreate.mockImplementation(async (options) => {
+      await options.onCreate?.(sandbox);
+      return sandbox;
+    });
+    sandboxApi.get.mockImplementation(async (options) => {
+      await options.onResume?.(sandbox);
+      return sandbox;
+    });
+    await expect(new VercelWorkspaceRuntime()[operation](input)).rejects.toBe(failure);
+    expect(sandbox.stop).toHaveBeenCalledOnce();
+    expect(sandbox.delete).not.toHaveBeenCalled();
+  });
+
+  it("stops compute on a nonzero bootstrap exit or a failed handle construction", async () => {
+    for (const handleFails of [false, true]) {
+      const sandbox = fakeSandbox();
+      if (handleFails)
+        sandbox.currentSession = () => {
+          throw new Error("session unavailable");
+        };
+      else
+        sandbox.runCommand.mockResolvedValue({
+          exitCode: 1,
+          stderr: vi.fn().mockResolvedValue("docker did not start"),
+        });
+      sandboxApi.getOrCreate.mockImplementation(async (options) => {
+        await options.onCreate?.(sandbox);
+        return sandbox;
+      });
+      await expect(new VercelWorkspaceRuntime().create(input)).rejects.toThrow(
+        handleFails ? "session unavailable" : "docker did not start",
+      );
+      expect(sandbox.stop).toHaveBeenCalledOnce();
+      expect(sandbox.delete).not.toHaveBeenCalled();
+    }
+  });
+
+  it("surfaces both failures and the recoverable workspace identity when stopping fails", async () => {
+    const sandbox = fakeSandbox();
+    const initializationError = new Error("bootstrap failed");
+    const cleanupError = new Error("stop failed");
+    sandbox.runCommand.mockRejectedValue(initializationError);
+    sandbox.stop.mockRejectedValue(cleanupError);
+    sandboxApi.getOrCreate.mockImplementation(async (options) => {
+      await options.onCreate?.(sandbox);
+      return sandbox;
+    });
+    await expect(new VercelWorkspaceRuntime().create(input)).rejects.toMatchObject({
+      code: "workspace_initialize_cleanup_failed",
+      message: expect.stringContaining(input.id),
+      cause: { errors: [initializationError, cleanupError] },
+    });
+    expect(sandbox.delete).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "create",
+    "wake",
+  ] as const)("rejects a missing preview credential before %s allocates or resumes compute", async (operation) => {
+    await expect(
+      new VercelWorkspaceRuntime()[operation]({ ...input, environment: {} }),
+    ).rejects.toMatchObject({ code: "preview_gateway_token_missing" });
+    expect(sandboxApi.get).not.toHaveBeenCalled();
+    expect(sandboxApi.getOrCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "create",
+    "wake",
+  ] as const)("does not stop an already-running workspace on a failed %s", async (operation) => {
+    const sandbox = fakeSandbox();
+    const failure = new Error("initialization failed beside an active agent turn");
+    sandbox.runCommand.mockRejectedValue(failure);
+    // Provider lifecycle hooks do not fire when acquiring already-running compute.
+    sandboxApi.getOrCreate.mockResolvedValue(sandbox);
+    sandboxApi.get.mockResolvedValue(sandbox);
+    await expect(new VercelWorkspaceRuntime()[operation](input)).rejects.toBe(failure);
+    expect(sandbox.stop).not.toHaveBeenCalled();
+    expect(sandbox.delete).not.toHaveBeenCalled();
+  });
+
+  it("does not stop a session that already stopped during initialization", async () => {
+    const sandbox = fakeSandbox();
+    sandbox.runCommand.mockImplementation(async () => {
+      sandbox.status = "stopped";
+      throw new Error("session already stopped");
+    });
+    sandboxApi.get.mockImplementation(async (options) => {
+      await options.onResume?.(sandbox);
+      return sandbox;
+    });
+    await expect(new VercelWorkspaceRuntime().wake(input)).rejects.toThrow(
+      "session already stopped",
+    );
+    expect(sandbox.stop).not.toHaveBeenCalled();
+  });
+
+  it("does not touch a sandbox with a mismatched workspace reference", async () => {
+    await expect(
+      new VercelWorkspaceRuntime().wake({ ...input, externalRef: "ws_abcdef0123456789" }),
+    ).rejects.toMatchObject({ code: "workspace_reference_invalid" });
+    expect(sandboxApi.get).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changes

Stop newly allocated or resumed Vercel compute when workspace initialization or handle construction fails, while preserving the persistent disk. Preview/restore calls that attach to an already-running workspace leave its active compute alone. Invalid preview configuration is rejected before allocation or resume.

If the provider also refuses cleanup, return a specific error with the recoverable workspace name and preserve both failure causes. A later start reuses the named workspace.

## Why

An initialization failure could leave billable compute running before the story service had received a workspace handle. Cleanup must cover that failure without terminating an existing agent turn or deleting durable files.

## Verification

- `pnpm verify`: passed, including the required database-backed integration suite, typecheck, build, lint, and repository guards.
- Focused Vercel runtime and story-service tests: `2 files, 14 passed`. Deterministic SDK fakes and real local PostgreSQL cover failed create/resume, no queued work on failure, one retained workspace and disk, successful retry, cleanup failure and operator recovery, pre-allocation denial, mismatched references, already-stopped sessions, and already-running compute.
- SDK lifecycle callbacks are exercised by the tests while bootstrap remains exactly once; the double-initialization regression remains protected.
- Claude read-only final review checked the installed SDK's creation/resume hooks and approved with no blockers.
- Actual provider deployment acceptance remains pending; no live workspace was started to validate this change.

- [x] `pnpm verify` passes locally
- [ ] Behaviour verified beyond the test suite (live provider acceptance remains a deployment gate)
- [x] Documentation updated, or no user-facing change
