### PR TITLE
fix(workspaces): honor Vercel command and preview contracts

### DIFF
--- a/apps/docs/docs/concepts/stories-and-workspaces.md
+++ b/apps/docs/docs/concepts/stories-and-workspaces.md
@@ -71,6 +71,11 @@ running workspace leaves its active compute alone. A later start reuses the same
 also refuses the stop, the `workspace_initialize_cleanup_failed` error names the sandbox that an
 operator must stop before retrying. Failed initialization does not queue an agent turn.
 
+Vercel workspace sessions can last up to 24 hours, but its command API currently accepts at most
+five hours per command. Facility caps longer command timeouts at five hours and preserves shorter
+timeouts. A command reaching that limit fails its turn; the persistent workspace and any saved
+native agent session remain available for a later turn.
+
 Facility has no age-based deletion rule. Storage continues to accrue until an operator removes a
 workspace. Use budgets and observability to distinguish active compute cost from retained storage,
 then set an organizational retention policy outside the agent prompt.

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -17,6 +17,8 @@ import {
 } from "./runtime.js";
 
 const SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
+// The command API has a five-hour ceiling even for a 24-hour persistent session.
+const MAX_COMMAND_TIMEOUT_MS = 5 * 60 * 60 * 1_000;
 
 export class VercelWorkspaceRuntime implements WorkspaceRuntime {
   readonly provider = "vercel" as const;
@@ -90,7 +92,10 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
       args: command.args,
       cwd: command.cwd ?? "/workspace",
       env: { ...persistentWorkspaceEnvironment(), ...(command.env ?? {}) },
-      timeoutMs: command.timeoutMs,
+      timeoutMs:
+        command.timeoutMs === undefined
+          ? undefined
+          : Math.min(command.timeoutMs, MAX_COMMAND_TIMEOUT_MS),
       detached: true,
     });
     let canceled = command.signal?.aborted ?? false;
@@ -245,7 +250,7 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
     const gatewayPorts = previewGatewayPorts(ports);
     return gatewayPorts.map(({ port, gatewayPort }) => ({
       ...port,
-      url: `https://${sandbox.domain(gatewayPort)}`,
+      url: sandbox.domain(gatewayPort),
     }));
   }
 }

--- a/services/api/test/agent-vercel.integration.test.ts
+++ b/services/api/test/agent-vercel.integration.test.ts
@@ -1,0 +1,113 @@
+import { parseAgentManifest } from "@facility/agents";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sandboxApi = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("@vercel/sandbox", () => ({ Sandbox: sandboxApi }));
+
+import { ClaudeCodeEngine, CodexEngine } from "../src/turns/engines.js";
+import { VercelWorkspaceRuntime } from "../src/workspaces/vercel.js";
+
+const workspace = {
+  id: "ws_0123456789abcdef",
+  externalRef: "ws_0123456789abcdef",
+  volumeRef: "snap_retained",
+  image: "facility-runner:test",
+};
+
+function provider(engine: "claude_code" | "codex", exitCode = 0, onLog?: () => void) {
+  const kill = vi.fn().mockResolvedValue(undefined);
+  const events =
+    engine === "claude_code"
+      ? [{ type: "result", session_id: "native-session", result: "ready" }]
+      : [
+          { type: "thread.started", thread_id: "native-session" },
+          { type: "item.completed", item: { type: "agent_message", text: "ready" } },
+          { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
+        ];
+  const runCommand = vi.fn(async (params: { timeoutMs?: number; detached?: boolean }) => {
+    // Reproduce the provider contract that rejected the real default engine request.
+    if ((params.timeoutMs ?? 0) > 18_000_000) {
+      throw new Error("Invalid request: `timeout` should be <= 18000000.");
+    }
+    return {
+      kill,
+      logs: async function* () {
+        onLog?.();
+        for (const event of events) yield { stream: "stdout", data: `${JSON.stringify(event)}\n` };
+        if (exitCode) yield { stream: "stderr", data: "command terminated" };
+      },
+      wait: async () => ({ exitCode, durationMs: 10 }),
+    };
+  });
+  sandboxApi.get.mockResolvedValue({ asUser: () => ({ runCommand }) });
+  return { runCommand, kill };
+}
+
+function request(engine: "claude_code" | "codex") {
+  return {
+    turnId: "turn_provider_contract",
+    workspace,
+    cwd: "/workspace/repos/app",
+    prompt: "Continue the accepted work",
+    nativeSessionId: "native-session",
+    manifest: parseAgentManifest(
+      `---
+name: agent
+description: Provider contract test.
+engine: ${engine}
+model: ${engine === "codex" ? "gpt-5.5" : "claude-opus-4-8"}
+enabled: true
+triggers:
+  - type: manual
+---
+Continue the accepted work.
+`,
+      "agent.md",
+    ),
+  };
+}
+
+describe.each(["claude_code", "codex"] as const)("%s through the Vercel runtime", (engine) => {
+  beforeEach(() => vi.clearAllMocks());
+  const createEngine = () => {
+    const runtime = new VercelWorkspaceRuntime();
+    return engine === "codex" ? new CodexEngine(runtime) : new ClaudeCodeEngine(runtime);
+  };
+
+  it("starts the default agent command and resumes its native session within the provider ceiling", async () => {
+    const { runCommand, kill } = provider(engine);
+    await expect(createEngine().run(request(engine))).resolves.toMatchObject({
+      nativeSessionId: "native-session",
+      output: "ready",
+      exitCode: 0,
+    });
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(runCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 18_000_000,
+        detached: true,
+        cwd: "/workspace/repos/app",
+        args: expect.arrayContaining([engine === "codex" ? "codex" : "claude", "native-session"]),
+      }),
+    );
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("reports a provider-terminated command as a failed turn", async () => {
+    provider(engine, 137);
+    await expect(createEngine().run(request(engine))).rejects.toMatchObject({
+      code: "agent_engine_failed",
+      message: "command terminated",
+      details: { exitCode: 137 },
+    });
+  });
+
+  it("still terminates the running command when the turn is canceled", async () => {
+    const controller = new AbortController();
+    const { kill } = provider(engine, 0, () => controller.abort());
+    await expect(
+      createEngine().run({ ...request(engine), signal: controller.signal }),
+    ).rejects.toMatchObject({ code: "workspace_command_canceled" });
+    expect(kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+  });
+});

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -23,7 +23,7 @@ function fakeSandbox() {
     }),
     stop: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn(),
-    domain: (port: number) => `workspace-${port}.example.test`,
+    domain: (port: number) => `https://workspace-${port}.example.test`,
   };
 }
 
@@ -62,6 +62,7 @@ describe("Vercel persistent workspace runtime", () => {
         snapshotExpiration: 0,
         keepLastSnapshots: { count: 1, expiration: 0, deleteEvicted: true },
         resume: true,
+        timeout: 24 * 60 * 60 * 1_000,
       }),
     );
     // The fake invokes the lifecycle hook: a bootstrap in both the hook and runtime would run twice.
@@ -102,6 +103,51 @@ describe("Vercel persistent workspace runtime", () => {
     environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
     ports: [{ service: "web", port: 3000 }],
   };
+
+  it.each([
+    [undefined, undefined],
+    [60_000, 60_000],
+    [18_000_000, 18_000_000],
+    [18_000_001, 18_000_000],
+    [86_400_000, 18_000_000],
+  ])("bounds command timeout %s to the provider limit", async (requested, expected) => {
+    const runCommand = vi.fn().mockResolvedValue({
+      logs: async function* () {
+        yield { stream: "stdout", data: "ready" };
+        yield { stream: "stderr", data: "warning" };
+      },
+      wait: async () => ({ exitCode: 0, durationMs: 12 }),
+    });
+    const asUser = vi.fn().mockReturnValue({ runCommand });
+    sandboxApi.get.mockResolvedValue({ ...fakeSandbox(), asUser });
+    const onOutput = vi.fn();
+    await expect(
+      new VercelWorkspaceRuntime().exec(input, {
+        command: "node",
+        args: ["--version"],
+        timeoutMs: requested,
+        onOutput,
+      }),
+    ).resolves.toEqual({ exitCode: 0, stdout: "ready", stderr: "warning", durationMs: 12 });
+    expect(asUser).toHaveBeenCalledWith("node");
+    expect(runCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ cmd: "node", timeoutMs: expected, detached: true }),
+    );
+    expect(onOutput.mock.calls).toEqual([
+      [{ stream: "stdout", data: "ready" }],
+      [{ stream: "stderr", data: "warning" }],
+    ]);
+  });
+
+  it("uses the SDK's full HTTPS URL for exposed and inspected preview endpoints", async () => {
+    sandboxApi.get.mockResolvedValue(fakeSandbox());
+    const runtime = new VercelWorkspaceRuntime();
+    const endpoints = await runtime.expose(input, input.ports);
+    expect(endpoints).toHaveLength(1);
+    expect(endpoints[0]?.url).toMatch(/^https:\/\/workspace-\d+\.example\.test$/);
+    const inspected = await runtime.inspect(input);
+    expect(inspected.endpoints).toEqual(endpoints);
+  });
 
   it.each([
     "create",


### PR DESCRIPTION
## What changes

Keep Vercel command timeouts within its five-hour command API limit while preserving shorter timeouts and the separate 24-hour persistent workspace session. Use the full preview URL returned by Sandbox SDK 3.2.1 without prepending a second scheme.

## Why

A default agent turn completed workspace setup but failed before the agent started because the command API rejected its 24-hour timeout with `timeout should be <= 18000000`. The same SDK integration produced preview URLs beginning `https://https://`.

## Verification

- [x] `pnpm verify` passes locally (exit 0).
- [x] Behaviour verified beyond the test suite: traced the live command rejection and malformed preview URL to the installed SDK request/return contracts. Live retry follows deployment.
- [x] Documentation updated with the provider command ceiling and retained-workspace behavior.

Focused command: `pnpm --filter @facility/api exec vitest run test/agent-vercel.integration.test.ts test/workspace-vercel.test.ts --reporter=verbose`

```text
Test Files  2 passed (2)
     Tests  24 passed (24)
```

Unit coverage exercises shorter, omitted, boundary, and over-limit timeouts plus exposed/inspected HTTPS endpoints. Integration coverage runs both real agent engines through the Vercel adapter against a deterministic SDK fake that reproduces the provider rejection, including native-session reuse, command failure, and cancellation. No live credentials are required by the tests.
