### PR TITLE
fix: deliver credentials to native workspace processes

### DIFF
--- a/apps/docs/docs/concepts/stories-and-workspaces.md
+++ b/apps/docs/docs/concepts/stories-and-workspaces.md
@@ -56,6 +56,11 @@ the same workspace, agent name, engine, and model. Choosing another agent or cha
 model starts or resumes that configuration's own session while retaining every prior session and
 the shared worktree.
 
+For API-key authentication, Facility passes the current turn's `OPENAI_API_KEY` to native
+`codex exec` as `CODEX_API_KEY`. An explicitly supplied `CODEX_API_KEY` takes precedence. This
+alias applies only to the Codex invocation; it does not change project variables or Claude Code
+authentication. Without either key, Codex uses its saved native authentication.
+
 ## State and retention
 
 Story states are `ready`, `working`, `attention`, `review`, `done`, and `archived`. Archive is
@@ -70,6 +75,10 @@ Facility stops that compute while preserving the persistent disk. A failed wake 
 running workspace leaves its active compute alone. A later start reuses the same workspace identity. If the provider
 also refuses the stop, the `workspace_initialize_cleanup_failed` error names the sandbox that an
 operator must stop before retrying. Failed initialization does not queue an agent turn.
+
+Vercel initialization also waits for each authenticated preview gateway to listen. A gateway that
+exits or fails to listen causes initialization to fail, even if the application's own port is
+healthy. The project environment's readiness command checks the application separately.
 
 Vercel workspace sessions can last up to 24 hours, but its command API currently accepts at most
 five hours per command. Facility caps longer command timeouts at five hours and preserves shorter

--- a/services/api/src/turns/engines.ts
+++ b/services/api/src/turns/engines.ts
@@ -171,7 +171,13 @@ export class CodexEngine extends CliAgentEngine {
     const args = request.nativeSessionId
       ? ["exec", "resume", ...shared, request.nativeSessionId, request.prompt]
       : ["exec", ...shared, request.prompt];
-    return this.execute(request, "codex", args, new CodexEventParser());
+    // codex exec reads CODEX_API_KEY; project manifests conventionally declare OPENAI_API_KEY.
+    // Scope the alias to this invocation and preserve an explicitly supplied Codex credential.
+    const environment = { ...request.environment };
+    if (environment.CODEX_API_KEY === undefined && environment.OPENAI_API_KEY !== undefined) {
+      environment.CODEX_API_KEY = environment.OPENAI_API_KEY;
+    }
+    return this.execute({ ...request, environment }, "codex", args, new CodexEventParser());
   }
 }
 

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -227,7 +227,11 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
     startedCompute: () => boolean,
   ): Promise<WorkspaceHandle> {
     try {
-      await initializeSandbox(sandbox, bootstrapCommand);
+      await initializeSandbox(
+        sandbox,
+        bootstrapCommand,
+        input.environment?.FACILITY_PREVIEW_GATEWAY_TOKEN,
+      );
       return this.handle(input, sandbox);
     } catch (initializationError) {
       // Preview and restore may wake an already-running workspace. Leave its active turn alone.
@@ -255,11 +259,17 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
   }
 }
 
-async function initializeSandbox(sandbox: Sandbox, bootstrapCommand: string) {
-  const result = await sandbox.runCommand({
+async function initializeSandbox(
+  sandbox: Sandbox,
+  bootstrapCommand: string,
+  gatewayToken?: string,
+) {
+  // Inject the credential after sudo switches users; sudo: true discards the sandbox environment.
+  const result = await sandbox.asUser("root").runCommand({
     cmd: "sh",
     args: ["-lc", bootstrapCommand],
-    sudo: true,
+    cwd: "/",
+    env: gatewayToken === undefined ? {} : { FACILITY_PREVIEW_GATEWAY_TOKEN: gatewayToken },
     timeoutMs: 180_000,
   });
   if (result.exitCode !== 0) {
@@ -285,7 +295,25 @@ function workspaceBootstrapCommand(input: CreateWorkspace) {
     "chown root:node /var/run/docker.sock",
     "chmod 0660 /var/run/docker.sock",
     ...gatewayPorts.map(({ port, gatewayPort }) => {
-      return `runuser --user node --preserve-environment -- sh -lc 'pid_file=/workspace/.facility/preview-${gatewayPort}.pid; if test -f "$pid_file"; then kill "$(cat "$pid_file")" >/dev/null 2>&1 || true; fi; nohup facility-preview-gateway --listen ${gatewayPort} --target ${port.port} >>/workspace/.facility/preview-${gatewayPort}.log 2>&1 & echo $! > "$pid_file"'`;
+      return `runuser --user node --preserve-environment -- sh -lc '
+set -eu
+pid_file=/workspace/.facility/preview-${gatewayPort}.pid
+if test -f "$pid_file"; then kill "$(cat "$pid_file")" >/dev/null 2>&1 || true; fi
+nohup facility-preview-gateway --listen ${gatewayPort} --target ${port.port} >>/workspace/.facility/preview-${gatewayPort}.log 2>&1 &
+pid=$!
+echo "$pid" > "$pid_file"
+attempt=0
+until test "$(curl --silent --output /dev/null --write-out "%{http_code}" --max-time 1 http://127.0.0.1:${gatewayPort}/ || true)" = 401; do
+  if ! kill -0 "$pid" 2>/dev/null || test "$attempt" -ge 50; then
+    echo "Preview gateway on port ${gatewayPort} did not start" >&2
+    kill "$pid" 2>/dev/null || true
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+kill -0 "$pid" 2>/dev/null || { echo "Preview gateway on port ${gatewayPort} exited during startup" >&2; exit 1; }
+'`;
     }),
   ].join("\n");
 }

--- a/services/api/test/agent-credentials.integration.test.ts
+++ b/services/api/test/agent-credentials.integration.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseAgentManifest } from "@facility/agents";
+import { afterEach, expect, it } from "vitest";
+import { ClaudeCodeEngine, CodexEngine } from "../src/turns/engines.js";
+import { FakeWorkspaceRuntime } from "../src/workspaces/fake.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+it("authenticates native Codex starts and resumes with a project key, and rejects invalid credentials", async () => {
+  const root = await mkdtemp(join(tmpdir(), "facility-engine-auth-"));
+  roots.push(root);
+  const bin = join(root, "bin");
+  await mkdir(bin);
+  // Match the CLI's documented contract: OPENAI_API_KEY alone is not codex exec authentication.
+  await writeFile(
+    join(bin, "codex"),
+    `#!/bin/sh
+if test "$CODEX_API_KEY" != "project-a-key"; then echo "401 Unauthorized" >&2; exit 1; fi
+printf '%s\\n' '{"type":"thread.started","thread_id":"authenticated-thread"}'
+`,
+    { mode: 0o755 },
+  );
+  await writeFile(
+    join(bin, "claude"),
+    `#!/bin/sh
+if test -n "$CODEX_API_KEY"; then echo "unexpected Codex credential" >&2; exit 1; fi
+printf '%s\\n' '{"type":"result","session_id":"claude-session","result":"ready"}'
+`,
+    { mode: 0o755 },
+  );
+  const runtime = new FakeWorkspaceRuntime(join(root, "workspaces"));
+  const workspace = await runtime.create({ id: "ws_0123456789abcdef", image: "runner:test" });
+  const environment = { PATH: `${bin}:${process.env.PATH}`, OPENAI_API_KEY: "project-a-key" };
+  const request = {
+    turnId: "turn_credentials",
+    workspace,
+    prompt: "work",
+    cwd: ".",
+    environment,
+    manifest: parseAgentManifest(
+      `---
+name: builder
+description: Credential contract test.
+engine: codex
+model: gpt-5.5
+enabled: true
+triggers:
+  - type: manual
+---
+Work.`,
+      "builder.md",
+    ),
+  };
+  const engine = new CodexEngine(runtime);
+  const first = await engine.run(request);
+  expect(first.nativeSessionId).toBe("authenticated-thread");
+  await runtime.suspend(workspace);
+  await expect(
+    engine.run({ ...request, nativeSessionId: first.nativeSessionId }),
+  ).resolves.toMatchObject({ nativeSessionId: first.nativeSessionId });
+  for (const key of ["", "malformed", "revoked-key", "project-b-key"]) {
+    await expect(
+      engine.run({ ...request, environment: { ...environment, CODEX_API_KEY: key } }),
+    ).rejects.toMatchObject({ code: "agent_engine_failed", message: "401 Unauthorized" });
+  }
+  await expect(
+    engine.run({ ...request, environment: { ...environment, OPENAI_API_KEY: "" } }),
+  ).rejects.toMatchObject({ code: "agent_engine_failed" });
+  // A prior invocation must not leave its alias in the request or affect the other engine.
+  expect(environment).not.toHaveProperty("CODEX_API_KEY");
+  await expect(
+    new ClaudeCodeEngine(runtime).run({
+      ...request,
+      environment: { ...environment, CODEX_API_KEY: "" },
+    }),
+  ).resolves.toMatchObject({ nativeSessionId: "claude-session" });
+});

--- a/services/api/test/agent-engines.test.ts
+++ b/services/api/test/agent-engines.test.ts
@@ -86,6 +86,32 @@ class EngineRuntime implements WorkspaceRuntime {
 }
 
 describe("native agent engines", () => {
+  it.each([
+    [{ OPENAI_API_KEY: "project-key" }, "project-key"],
+    [{ OPENAI_API_KEY: "project-key", CODEX_API_KEY: "explicit-key" }, "explicit-key"],
+    [{ OPENAI_API_KEY: "project-key", CODEX_API_KEY: "" }, ""],
+    [{}, undefined],
+  ])("passes only the current request's Codex credential without mutating it", async (environment, expected) => {
+    const original = { ...environment };
+    const runtime = new EngineRuntime({
+      exitCode: 0,
+      stdout: '{"type":"thread.started","thread_id":"native"}\n',
+      stderr: "",
+      durationMs: 1,
+    });
+    await new CodexEngine(runtime).run({
+      turnId: "turn_credentials",
+      manifest: manifest("codex"),
+      workspace,
+      prompt: "work",
+      cwd: ".",
+      environment,
+    });
+    expect(runtime.command?.env?.CODEX_API_KEY).toBe(expected);
+    expect(environment).toEqual(original);
+    if (expected) expect(JSON.stringify(runtime.command?.args)).not.toContain(expected);
+  });
+
   it("parses chunked Claude stream-json and resumes with full access", async () => {
     const stdout = `${[
       JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session" }),

--- a/services/api/test/workspace-vercel-bootstrap.integration.test.ts
+++ b/services/api/test/workspace-vercel-bootstrap.integration.test.ts
@@ -1,0 +1,148 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type Sandbox, SandboxUser } from "@vercel/sandbox";
+import { afterEach, expect, it, vi } from "vitest";
+
+const sandboxApi = vi.hoisted(() => ({ getOrCreate: vi.fn() }));
+vi.mock("@vercel/sandbox", async (original) => ({
+  ...(await original<typeof import("@vercel/sandbox")>()),
+  Sandbox: sandboxApi,
+}));
+
+import { VercelWorkspaceRuntime } from "../src/workspaces/vercel.js";
+
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function localProvider(brokenGateway: boolean) {
+  const root = await mkdtemp(join(tmpdir(), "facility-vercel-bootstrap-"));
+  const bin = join(root, "bin");
+  await mkdir(bin);
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const server = createServer((_req, res) => res.end("preview app"));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(
+    () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server missing port");
+  // Reserve a separate local port for the provider's mapped gateway port.
+  const reserve = createServer();
+  await new Promise<void>((resolve) => reserve.listen(0, "127.0.0.1", resolve));
+  const reserved = reserve.address();
+  if (!reserved || typeof reserved === "string") throw new Error("test gateway missing port");
+  const gatewayPort = reserved.port;
+  await new Promise<void>((resolve) => reserve.close(() => resolve()));
+  const scripts: Record<string, string> = {
+    docker: "exit 0",
+    chown: "exit 0",
+    chmod: "exit 0",
+    // Model the provider's environment reset; the real SDK must inject env after this transition.
+    sudo: 'test "$1" = -u; shift 3; exec /usr/bin/env -i PATH="$PATH" "$@"',
+    runuser: 'test "$1" = --user; shift 4; exec "$@"',
+    // Ignore host login profiles while executing the unchanged bootstrap in its temporary root.
+    sh: 'if test "$1" = -lc; then shift; exec /bin/sh -c "$@"; fi; exec /bin/sh "$@"',
+    "facility-preview-gateway": brokenGateway
+      ? "exit 2"
+      : `test -z "$UNRELATED_SECRET" || exit 7\nexec '${process.execPath}' '${fileURLToPath(new URL("../../../runner/facility-preview-gateway.mjs", import.meta.url))}' "$@"`,
+  };
+  for (const [name, script] of Object.entries(scripts))
+    await writeFile(join(bin, name), `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+  const fixture = {
+    name: "ws_0123456789abcdef",
+    status: "running",
+    currentSnapshotId: "snapshot",
+    currentSession: () => ({ sessionId: "compute" }),
+    domain: () => `http://127.0.0.1:${gatewayPort}`,
+    stop: vi.fn(async () => {
+      fixture.status = "stopped";
+    }),
+    asUser: (username: string): SandboxUser =>
+      new SandboxUser({ sandbox: fixture as unknown as Sandbox, username }),
+    runCommand: async (params: {
+      cmd: string;
+      args?: string[];
+      env?: Record<string, string>;
+      sudo?: boolean;
+    }) => {
+      const args = (params.args ?? []).map((arg) =>
+        arg.replaceAll("/workspace", root).replaceAll("65535", String(gatewayPort)),
+      );
+      return new Promise<{ exitCode: number; stderr: () => Promise<string> }>((resolve, reject) => {
+        const child = spawn(params.cmd, args, {
+          env: { PATH: `${bin}:${process.env.PATH}`, ...(params.sudo ? {} : params.env) },
+        });
+        let stderr = "";
+        child.stderr.on("data", (data) => {
+          stderr += data;
+        });
+        child.stdout.resume();
+        child.on("error", reject);
+        child.on("close", (code) => resolve({ exitCode: code ?? 1, stderr: async () => stderr }));
+      });
+    },
+  };
+  cleanups.push(async () => {
+    const pid = Number(
+      await readFile(join(root, `.facility/preview-${gatewayPort}.pid`), "utf8").catch(() => ""),
+    );
+    if (pid > 0) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        /* Already exited. */
+      }
+    }
+  });
+  sandboxApi.getOrCreate.mockImplementation(async (options) => {
+    await options.onCreate?.(fixture);
+    return fixture;
+  });
+  return { fixture, gatewayPort, appPort: address.port };
+}
+
+it("starts the real authenticated gateway through the SDK user switch without exposing a bare app", async () => {
+  const { gatewayPort, appPort, fixture } = await localProvider(false);
+  const token = 'credential-with-$()-and-quote-"-characters';
+  await new VercelWorkspaceRuntime().create({
+    id: fixture.name,
+    image: "runner:test",
+    ports: [{ service: "web", port: appPort }],
+    environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: token, UNRELATED_SECRET: "must-not-forward" },
+  });
+  const url = `http://127.0.0.1:${gatewayPort}/`;
+  for (const value of [undefined, "malformed", "another-workspace-credential-0000000000"]) {
+    expect(
+      (await fetch(url, { headers: value ? { "x-facility-preview-token": value } : {} })).status,
+    ).toBe(401);
+  }
+  const response = await fetch(url, { headers: { "x-facility-preview-token": token } });
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe("preview app");
+  expect(fixture.stop).not.toHaveBeenCalled();
+});
+
+it("fails initialization and stops newly allocated compute when the background gateway exits", async () => {
+  const { appPort, fixture } = await localProvider(true);
+  await expect(
+    new VercelWorkspaceRuntime().create({
+      id: fixture.name,
+      image: "runner:test",
+      ports: [{ service: "web", port: appPort }],
+      environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+    }),
+  ).rejects.toMatchObject({
+    code: "workspace_initialize_failed",
+    message: expect.stringContaining("did not start"),
+  });
+  expect(fixture.stop).toHaveBeenCalledOnce();
+});

--- a/services/api/test/workspace-vercel-lifecycle.integration.test.ts
+++ b/services/api/test/workspace-vercel-lifecycle.integration.test.ts
@@ -45,6 +45,7 @@ function sandboxFixture(name: string) {
     files: new Map([[".facility/plan.md", "Keep this plan across failed starts"]]),
     failNextInitialization: true,
     failStop: false,
+    asUser: (_username: string) => ({ runCommand: sandbox.runCommand }),
     runCommand: vi.fn(async () => {
       const exitCode = sandbox.failNextInitialization ? 1 : 0;
       sandbox.failNextInitialization = false;

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -12,15 +12,17 @@ vi.mock("@vercel/sandbox", () => ({
 import { VercelWorkspaceRuntime } from "../src/workspaces/vercel.js";
 
 function fakeSandbox() {
+  const runCommand = vi.fn().mockResolvedValue({
+    exitCode: 0,
+    stderr: vi.fn().mockResolvedValue(""),
+  });
   return {
     name: "ws_0123456789abcdef",
     status: "running",
     currentSnapshotId: "snap_persistent",
     currentSession: () => ({ sessionId: "session_current" }),
-    runCommand: vi.fn().mockResolvedValue({
-      exitCode: 0,
-      stderr: vi.fn().mockResolvedValue(""),
-    }),
+    runCommand,
+    asUser: vi.fn().mockReturnValue({ runCommand }),
     stop: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn(),
     domain: (port: number) => `https://workspace-${port}.example.test`,
@@ -68,6 +70,14 @@ describe("Vercel persistent workspace runtime", () => {
     // The fake invokes the lifecycle hook: a bootstrap in both the hook and runtime would run twice.
     expect(sandboxApi.getOrCreate.mock.calls[0]?.[0].onCreate).toEqual(expect.any(Function));
     expect(sandbox.runCommand).toHaveBeenCalledTimes(1);
+    expect(sandbox.asUser).toHaveBeenCalledExactlyOnceWith("root");
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: "/",
+        env: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+      }),
+    );
+    expect(sandbox.runCommand.mock.calls[0]?.[0]).not.toHaveProperty("sudo");
     expect(sandbox.stop).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What changes

Forward credentials at the native-process boundary: Vercel bootstrap injects only the preview gateway token after switching to root, and Codex receives the current turn's `OPENAI_API_KEY` under the `CODEX_API_KEY` name its CLI expects. Explicit Codex credentials retain precedence, and the request environment is not mutated.

Bootstrap now waits for each authenticated gateway to listen and fails when its background process exits. Existing initialization cleanup preserves the workspace disk and stops only compute allocated or resumed by the failed operation.

## Why

A real Vercel workspace had a healthy application but an unavailable preview: `sudo: true` discarded the gateway credential and the background gateway exited silently. Separately, `codex exec` returned HTTP401 despite a valid project OpenAI key because the engine supplied the wrong environment-variable name.

## Verification

- [x] `pnpm verify` passes locally — `corepack pnpm verify` exited 0, including direct critical suites with skips forbidden, clean builds, typecheck, lint, guards, and the existing dependency audit policy.
- [ ] Behaviour verified beyond the test suite — both failures were reproduced live; automatic post-deployment acceptance is pending.
- [x] Documentation updated, or no user-facing change — workspace documentation describes authentication precedence and preview initialization failure.

Focused acceptance output:

```text
Test Files  6 passed (6)
     Tests  38 passed (38)
```

The bootstrap integration uses the real Vercel `SandboxUser` wrapper and real preview gateway with local platform fakes that reset the environment at sudo. It verifies authorized access, missing/wrong credential denial, and failed startup cleanup. Native CLI fakes verify Codex authentication, suspended-workspace resume, explicit override, invalid/revoked/other-project denial, and isolation from Claude. No live credentials or external service access are required by these tests.
