### PR TITLE
fix(github): preserve throttled commands and reuse terminal CI

### DIFF
--- a/apps/docs/docs/reference/webhooks.md
+++ b/apps/docs/docs/reference/webhooks.md
@@ -49,6 +49,11 @@ installation tokens with [Metadata read access](https://docs.github.com/en/rest/
 Provider outages retry the affected delivery independently without granting permission. Processing
 failures are recorded in the webhook event; authorization denials are recorded as
 `github.agent_trigger.denied` audit events without provider response bodies or credentials.
+If GitHub throttles a delivery, its receipt remains unprocessed and the worker durably defers it
+until the provider's reset or retry deadline (at least one minute, bounded to one day for invalid
+far-future values). Repository permission is
+checked again when processing resumes; a rate limit never grants access or becomes a permanent
+authorization denial. The worker logs the deferred job and its retry time.
 
 An optional `command` on an `issue_comment` trigger restricts activation to a new explicit command
 on an open issue. See [the agent manifest reference](agent-manifest.md) for command syntax and
@@ -66,6 +71,9 @@ run deliveries update the project mirror where applicable. CI state attaches to 
 request only when the event's head SHA is current. The worker reconciles every connected repository
 every ten minutes, and maintainers can request an immediate sync through MCP, API, or the Pipeline
 page.
+Reconciliation keeps current terminal CI results for unchanged closed or merged pull requests.
+Open pulls, changed heads, missing or pending results, and pulls updated after the last CI refresh
+still request fresh CI. Webhook signals continue to update matching heads, including closed pulls.
 
 The mirror is a local operating view, not a replacement for GitHub. Issue, branch, pull-request,
 review, and check records retain GitHub identity and current state. Check suites and workflow runs

--- a/services/api/src/agents/github-command-policy.ts
+++ b/services/api/src/agents/github-command-policy.ts
@@ -1,4 +1,5 @@
 import type { GithubClientFactory } from "../github/client.js";
+import { githubRateLimitRetryAt } from "../github/rate-limit.js";
 
 type GithubObject = Record<string, unknown>;
 
@@ -71,6 +72,7 @@ export async function githubSenderCanStartAgent(input: {
     // GitHub reports maintain as "write" here; the distinct role is in role_name.
     return permission === "admin" || permission === "write";
   } catch (error) {
+    if (githubRateLimitRetryAt(error)) throw error;
     const status = object(error).status;
     if (status === 401 || status === 403 || status === 404) return false;
     // Retry transient provider failures; never interpret them as permission.

--- a/services/api/src/github/mirror.ts
+++ b/services/api/src/github/mirror.ts
@@ -138,7 +138,8 @@ export class GithubMirrorService {
         direction: "desc",
       });
       for (const pull of pullScan.rows) {
-        if (await this.upsertPullRequest(repository, pull)) pullRequests += 1;
+        const saved = await this.upsertPullRequest(repository, pull);
+        if (saved) pullRequests += 1;
         const pullNumber = positiveInteger(pull.number);
         const headSha = string(object(pull.head).sha);
         if (pullNumber && (await this.linkedStory(repository, { pullNumber, headSha }))) {
@@ -151,7 +152,7 @@ export class GithubMirrorService {
             reviews += await this.upsertReview(repository, review, pullNumber, headSha);
           }
         }
-        if (headSha) {
+        if (headSha && saved && shouldRefreshPullRequestCi(saved)) {
           const refreshed = await this.refreshCi(repository, client, pull);
           ciUpdates += refreshed.ciUpdates;
           checks += refreshed.checks;
@@ -984,6 +985,25 @@ export class GithubMirrorService {
       )
       .then((rows) => rows.map((row) => row.number));
   }
+}
+
+export function shouldRefreshPullRequestCi(pull: {
+  state: string;
+  headSha: string;
+  ciHeadSha: string | null;
+  ciState: string | null;
+  githubUpdatedAt: Date | null;
+  ciUpdatedAt: Date | null;
+}): boolean {
+  // Closed history with current, terminal CI is already reconciled. Open,
+  // changed, and unfinished pulls still refresh, as do later webhook signals.
+  return (
+    pull.state === "open" ||
+    pull.ciHeadSha !== pull.headSha ||
+    (pull.ciState !== "success" && pull.ciState !== "failure") ||
+    !pull.ciUpdatedAt ||
+    Boolean(pull.githubUpdatedAt && pull.githubUpdatedAt > pull.ciUpdatedAt)
+  );
 }
 
 async function paginated(

--- a/services/api/src/github/rate-limit.ts
+++ b/services/api/src/github/rate-limit.ts
@@ -1,0 +1,48 @@
+type ObjectValue = Record<string, unknown>;
+
+/** Provider throttling must not become a permanent authorization decision. */
+export function githubRateLimitRetryAt(error: unknown, now = Date.now()): Date | undefined {
+  const failure = object(error);
+  if (failure.status !== 403 && failure.status !== 429) return undefined;
+  const response = object(failure.response);
+  const headers = object(response.headers);
+  const retryAfter = seconds(headers["retry-after"]);
+  const exhausted = headers["x-ratelimit-remaining"] === "0";
+  const message = object(response.data).message;
+  if (
+    failure.status !== 429 &&
+    !exhausted &&
+    retryAfter === undefined &&
+    !(typeof message === "string" && /\brate limit\b/i.test(message))
+  )
+    return undefined;
+
+  // Honor supplied deadlines within a day, including the hourly reset. Bound
+  // corrupt but parseable values so the only durable retry cannot be stranded
+  // centuries in the future. Missing or elapsed values wait at least a minute.
+  const reset = exhausted ? seconds(headers["x-ratelimit-reset"]) : undefined;
+  return new Date(
+    Math.min(
+      now + 24 * 60 * 60 * 1_000,
+      Math.max(
+        now + 60_000,
+        validDeadline(retryAfter === undefined ? 0 : now + retryAfter * 1_000),
+        validDeadline(reset === undefined ? 0 : reset * 1_000 + 1_000),
+      ),
+    ),
+  );
+}
+
+function seconds(value: unknown): number | undefined {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function validDeadline(value: number): number {
+  return Number.isFinite(new Date(value).getTime()) ? value : 0;
+}
+
+function object(value: unknown): ObjectValue {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as ObjectValue) : {};
+}

--- a/services/api/src/github/webhook-worker.ts
+++ b/services/api/src/github/webhook-worker.ts
@@ -1,8 +1,9 @@
 import type PgBoss from "pg-boss";
 import type { Logger } from "pino";
+import { githubRateLimitRetryAt } from "./rate-limit.js";
 
 export function registerGithubWebhookWorker(
-  boss: Pick<PgBoss, "work">,
+  boss: Pick<PgBoss, "work" | "send">,
   handleInbound: (inboundEventId: string) => Promise<unknown>,
   logger: Pick<Logger, "info">,
 ) {
@@ -15,7 +16,21 @@ export function registerGithubWebhookWorker(
       if (!job) return;
       const startedAt = Date.now();
       if (job.data.inboundEventId) {
-        await handleInbound(job.data.inboundEventId);
+        try {
+          await handleInbound(job.data.inboundEventId);
+        } catch (error) {
+          const retryAt = githubRateLimitRetryAt(error);
+          if (!retryAt) throw error;
+          // The durable receipt stays unprocessed. Complete this attempt only
+          // after its replacement is persisted; permission is checked again.
+          const replacement = await boss.send("github.webhook", job.data, { startAfter: retryAt });
+          if (!replacement) throw new Error("GitHub rate-limit retry was not enqueued");
+          logger.info(
+            { queue: "github.webhook", jobId: job.id, retryAt },
+            "deferred GitHub webhook until provider rate limit resets",
+          );
+          return;
+        }
       }
       logger.info(
         {

--- a/services/api/test/agent-automation.integration.test.ts
+++ b/services/api/test/agent-automation.integration.test.ts
@@ -89,6 +89,7 @@ describe("agent automations use persistent story workspaces", async () => {
   const installationNumber = 12_000_000 + Math.floor(Math.random() * 100_000);
   let permission = "write";
   let failPermissionFor: string | undefined;
+  let rateLimitFor: string | undefined;
   const permissionRequests: Array<Record<string, unknown> | undefined> = [];
   const githubFactory: GithubClientFactory = async (requestedInstallation) => {
     if (requestedInstallation !== installationNumber)
@@ -98,6 +99,18 @@ describe("agent automations use persistent story workspaces", async () => {
         if (route !== "GET /repos/{owner}/{repo}/collaborators/{username}/permission")
           throw new Error("unexpected GitHub route");
         permissionRequests.push(args);
+        if (args?.username === rateLimitFor) {
+          rateLimitFor = undefined;
+          throw {
+            status: 403,
+            response: {
+              headers: {
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": String(Math.floor(Date.now() / 1_000) + 3_600),
+              },
+            },
+          };
+        }
         if (args?.username === failPermissionFor) {
           failPermissionFor = undefined;
           throw Object.assign(new Error("provider failure with private headers"), { status: 503 });
@@ -493,6 +506,104 @@ describe("agent automations use persistent story workspaces", async () => {
       await client.unsafe(`DROP SCHEMA "${schema}" CASCADE`);
     }
   }, 25_000);
+
+  it.each([
+    "write",
+    "read",
+  ])("defers throttled receipts durably and rechecks %s permission after reset", async (afterReset) => {
+    const schema = `rate_${suffix.replaceAll("-", "")}_${afterReset}`;
+    const boss = new PgBoss({ connectionString: databaseUrl, schema });
+    boss.on("error", () => undefined);
+    const event = commandEvent("/builder", afterReset === "write" ? 550 : 551);
+    event.payload.sender.login = "throttled-contributor";
+    const before = await persistedCounts();
+    await db.insert(githubWebhookEvents).values({
+      id: event.id,
+      orgId,
+      projectId,
+      repositoryId,
+      installationId: installationRowId,
+      eventType: event.eventType,
+      payload: event.payload,
+      verified: true,
+    });
+    try {
+      await boss.start();
+      await boss.createQueue("github.webhook");
+      const initialJob = await boss.send("github.webhook", { inboundEventId: event.id });
+      if (!initialJob) throw new Error("expected initial delivery job");
+      rateLimitFor = event.payload.sender.login;
+      await registerGithubWebhookWorker(boss, (id) => github.handleInbound(id), {
+        info: () => undefined,
+      });
+      await vi.waitFor(
+        async () => {
+          expect((await boss.getJobById("github.webhook", initialJob))?.state).toBe("completed");
+        },
+        { timeout: 5_000, interval: 100 },
+      );
+      const deferred = await client.unsafe(
+        `SELECT id, data, start_after FROM "${schema}".job WHERE id <> $1 AND name = 'github.webhook'`,
+        [initialJob],
+      );
+      expect(deferred).toHaveLength(1);
+      expect(deferred[0]?.data).toEqual({ inboundEventId: event.id });
+      expect(new Date(deferred[0]?.start_after).getTime()).toBeGreaterThan(Date.now() + 3_500_000);
+      expect(await boss.fetch("github.webhook")).toEqual([]);
+      expect(await persistedCounts()).toEqual(before);
+      expect(
+        (
+          await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, event.id))
+        )[0],
+      ).toMatchObject({ processedAt: null, error: "github_webhook_processing_failed" });
+      expect(
+        await db
+          .select()
+          .from(auditEvents)
+          .where(eq(auditEvents.id, `github-trigger-denied:${orgId}:${event.id}`)),
+      ).toHaveLength(0);
+
+      // Advance only this isolated queue's persisted deadline; external calls
+      // remain deterministic fakes, and no wall-clock hour elapses in CI.
+      permission = afterReset;
+      await client.unsafe(`UPDATE "${schema}".job SET start_after = now() WHERE id = $1`, [
+        deferred[0]?.id,
+      ]);
+      await vi.waitFor(
+        async () => {
+          expect((await boss.getJobById("github.webhook", deferred[0]?.id))?.state).toBe(
+            "completed",
+          );
+        },
+        { timeout: 5_000, interval: 100 },
+      );
+      const after = await persistedCounts();
+      expect(after.turns).toBe(before.turns + (afterReset === "write" ? 1 : 0));
+      if (afterReset === "read") expect(after).toEqual(before);
+      const denials = await db
+        .select()
+        .from(auditEvents)
+        .where(eq(auditEvents.id, `github-trigger-denied:${orgId}:${event.id}`));
+      expect(denials).toHaveLength(afterReset === "read" ? 1 : 0);
+      if (afterReset === "read")
+        expect(denials[0]?.payload).toEqual({
+          reason: "github_sender_not_authorized",
+          eventType: "issue_comment",
+        });
+      expect(
+        (
+          await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, event.id))
+        )[0],
+      ).toMatchObject({ processedAt: expect.any(Date), error: null });
+      await github.handleInbound(event.id);
+      expect(await persistedCounts()).toEqual(after);
+    } finally {
+      permission = "write";
+      rateLimitFor = undefined;
+      await boss.stop({ graceful: true, timeout: 5_000 });
+      await client.unsafe(`DROP SCHEMA "${schema}" CASCADE`);
+    }
+  }, 15_000);
 
   it("maintains linked PR metadata on comments that match no agent", async () => {
     const agent = agents[0];

--- a/services/api/test/github-command-policy.test.ts
+++ b/services/api/test/github-command-policy.test.ts
@@ -168,4 +168,14 @@ describe("authoritative GitHub sender permission", () => {
     request.mockRejectedValue(failure);
     await expect(githubSenderCanStartAgent(input)).rejects.toBe(failure);
   });
+
+  it("keeps a throttled permission lookup retryable and rechecks current permission", async () => {
+    const { request, input } = fixture();
+    const failure = { status: 403, response: { headers: { "x-ratelimit-remaining": "0" } } };
+    request.mockRejectedValueOnce(failure);
+    await expect(githubSenderCanStartAgent(input)).rejects.toBe(failure);
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(true);
+    request.mockResolvedValueOnce({ data: { permission: "read" } });
+    await expect(githubSenderCanStartAgent(input)).resolves.toBe(false);
+  });
 });

--- a/services/api/test/github-rate-limit.test.ts
+++ b/services/api/test/github-rate-limit.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { shouldRefreshPullRequestCi } from "../src/github/mirror.js";
+import { githubRateLimitRetryAt } from "../src/github/rate-limit.js";
+
+describe("GitHub retry deadlines", () => {
+  const now = Date.parse("2026-09-01T12:00:00Z");
+  it("honors the hourly reset without treating a rate limit as permission denial", () => {
+    const reset = now / 1_000 + 3_000;
+    expect(
+      githubRateLimitRetryAt(
+        {
+          status: 403,
+          response: {
+            headers: {
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": String(reset),
+              "retry-after": "120",
+            },
+          },
+        },
+        now,
+      )?.getTime(),
+    ).toBe(reset * 1_000 + 1_000);
+  });
+  it("honors secondary Retry-After and falls back for missing or malformed deadlines", () => {
+    expect(
+      githubRateLimitRetryAt(
+        { status: 403, response: { headers: { "retry-after": "120" } } },
+        now,
+      )?.getTime(),
+    ).toBe(now + 120_000);
+    for (const headers of [
+      {},
+      { "retry-after": "NaN" },
+      { "retry-after": "-1" },
+      { "retry-after": "99999999999999999999999" },
+    ]) {
+      expect(githubRateLimitRetryAt({ status: 429, response: { headers } }, now)?.getTime()).toBe(
+        now + 60_000,
+      );
+    }
+    expect(
+      githubRateLimitRetryAt(
+        {
+          status: 403,
+          response: { data: { message: "You have exceeded a secondary rate limit." } },
+        },
+        now,
+      )?.getTime(),
+    ).toBe(now + 60_000);
+  });
+
+  it("bounds parseable but implausible provider dates instead of stranding the receipt", () => {
+    for (const headers of [
+      { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "99999999999" },
+      { "retry-after": "99999999999" },
+    ]) {
+      expect(githubRateLimitRetryAt({ status: 403, response: { headers } }, now)?.getTime()).toBe(
+        now + 86_400_000,
+      );
+    }
+    expect(
+      githubRateLimitRetryAt(
+        { status: 429, response: { headers: { "retry-after": "7200" } } },
+        now,
+      )?.getTime(),
+    ).toBe(now + 7_200_000);
+  });
+  it.each([
+    null,
+    { status: 403 },
+    { status: 403, response: { data: { message: "Resource not accessible by integration" } } },
+    { status: 401, response: { headers: { "retry-after": "120" } } },
+    { status: 404 },
+    { status: 503 },
+  ])("does not reclassify unrelated errors: %s", (error) => {
+    expect(githubRateLimitRetryAt(error, now)).toBeUndefined();
+  });
+});
+
+describe("historical pull request CI polling", () => {
+  const terminal = {
+    state: "closed",
+    headSha: "a",
+    ciHeadSha: "a",
+    ciState: "success",
+    githubUpdatedAt: new Date("2026-09-01"),
+    ciUpdatedAt: new Date("2026-09-02"),
+  };
+  it("retains current terminal CI for unchanged closed and merged pulls", () => {
+    expect(shouldRefreshPullRequestCi(terminal)).toBe(false);
+    expect(shouldRefreshPullRequestCi({ ...terminal, state: "merged", ciState: "failure" })).toBe(
+      false,
+    );
+  });
+  it.each([
+    { state: "open" },
+    { ciHeadSha: "b" },
+    { ciState: "pending" },
+    { ciState: null },
+    { ciUpdatedAt: null },
+    { githubUpdatedAt: new Date("2026-09-03") },
+  ])("refreshes active, changed, missing, or unfinished CI: %s", (change) => {
+    expect(shouldRefreshPullRequestCi({ ...terminal, ...change })).toBe(true);
+  });
+});

--- a/services/api/test/github-webhook-worker.test.ts
+++ b/services/api/test/github-webhook-worker.test.ts
@@ -7,7 +7,11 @@ describe("GitHub webhook retry boundary", () => {
     const work = vi.fn().mockResolvedValue("worker-id");
     const handle = vi.fn().mockResolvedValue({ queued: 1 });
     const logger = { info: vi.fn() };
-    await registerGithubWebhookWorker({ work } as unknown as Pick<PgBoss, "work">, handle, logger);
+    await registerGithubWebhookWorker(
+      { work } as unknown as Pick<PgBoss, "work" | "send">,
+      handle,
+      logger,
+    );
     expect(work).toHaveBeenCalledWith(
       "github.webhook",
       expect.objectContaining({ batchSize: 1, includeMetadata: true }),
@@ -22,5 +26,36 @@ describe("GitHub webhook retry boundary", () => {
     await callback([{ ...job, id: "job-2", data: { inboundEventId: "delivery-2" } }]);
     expect(handle).toHaveBeenLastCalledWith("delivery-2");
     expect(logger.info).toHaveBeenCalledOnce();
+  });
+
+  it("durably defers only the throttled receipt until the provider deadline", async () => {
+    const work = vi.fn().mockResolvedValue("worker-id");
+    const send = vi.fn().mockResolvedValue("replacement-id");
+    const reset = Math.floor(Date.now() / 1_000) + 3_000;
+    const failure = {
+      status: 403,
+      response: {
+        headers: {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(reset),
+        },
+      },
+    };
+    const handle = vi.fn().mockRejectedValue(failure);
+    await registerGithubWebhookWorker(
+      { work, send } as unknown as Pick<PgBoss, "work" | "send">,
+      handle,
+      { info: vi.fn() },
+    );
+    const callback = work.mock.calls[0]?.[2];
+    const job = { id: "job-1", data: { inboundEventId: "delivery-1" }, createdOn: new Date() };
+    await callback([job]);
+    expect(send).toHaveBeenCalledWith("github.webhook", job.data, {
+      startAfter: new Date(reset * 1_000 + 1_000),
+    });
+    send.mockResolvedValueOnce(null);
+    await expect(callback([job])).rejects.toThrow("retry was not enqueued");
+    send.mockRejectedValueOnce(new Error("queue unavailable"));
+    await expect(callback([job])).rejects.toThrow("queue unavailable");
   });
 });

--- a/services/api/test/insights-and-mirror.integration.test.ts
+++ b/services/api/test/insights-and-mirror.integration.test.ts
@@ -25,7 +25,7 @@ import {
 } from "@facility/db";
 import { and, eq } from "drizzle-orm";
 import postgres from "postgres";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { GithubMirrorService, restCiSignal, webhookCiSignal } from "../src/github/mirror.js";
 import { GithubPipelineService } from "../src/github/pipeline.js";
 import { BudgetPolicyError, CostBudgetService } from "../src/insights/costs.js";
@@ -508,6 +508,60 @@ describe("cost controls, GitHub mirror, and pipeline", async () => {
         }),
       ]),
     );
+  });
+
+  it("does not repeatedly fetch terminal CI for unchanged closed history", async () => {
+    const pulls = [
+      { number: 801, state: "closed", sha: "8".repeat(40) },
+      { number: 802, state: "open", sha: "9".repeat(40) },
+    ];
+    const request = vi.fn(async (route: string) => {
+      if (route.endsWith("/branches") || route.endsWith("/issues") || route.endsWith("/reviews"))
+        return { data: [] };
+      if (route.endsWith("/pulls"))
+        return {
+          data: pulls.map((pull) => ({
+            number: pull.number,
+            title: "Reconcile CI",
+            state: pull.state,
+            html_url: `https://github.com/acme/app/pull/${pull.number}`,
+            head: { ref: `work/${pull.number}`, sha: pull.sha },
+            base: { ref: "main" },
+            updated_at: "2026-09-01T10:00:00Z",
+          })),
+        };
+      if (route.endsWith("/status")) return { data: { state: "success", statuses: [] } };
+      if (route.endsWith("/check-runs")) return { data: { check_runs: [] } };
+      throw new Error(`unexpected route ${route}`);
+    });
+    const mirror = new GithubMirrorService(db, async () => ({ request, rest: {} as never }));
+    const ciRequests = () =>
+      request.mock.calls.filter(
+        ([route]) => route.endsWith("/status") || route.endsWith("/check-runs"),
+      ).length;
+    await mirror.syncProject(orgId, projectId);
+    expect(ciRequests()).toBe(4);
+    request.mockClear();
+    await mirror.syncProject(orgId, projectId);
+    expect(ciRequests()).toBe(2);
+    const closed = (
+      await db
+        .select()
+        .from(githubPullRequests)
+        .where(
+          and(
+            eq(githubPullRequests.repositoryId, repositoryId),
+            eq(githubPullRequests.number, 801),
+          ),
+        )
+    )[0];
+    expect(closed).toMatchObject({ ciState: "success", ciHeadSha: pulls[0]?.sha });
+    const closedPull = pulls[0];
+    if (!closedPull) throw new Error("expected closed pull fixture");
+    closedPull.sha = "7".repeat(40);
+    request.mockClear();
+    await mirror.syncProject(orgId, projectId);
+    expect(ciRequests()).toBe(4);
   });
 
   it("recognizes reconciled merged pull requests from merged_at without a merged boolean", async () => {


### PR DESCRIPTION
## What changes

GitHub-throttled webhook receipts remain unprocessed and are durably rescheduled for the provider's reset or retry deadline. Permission is checked again on retry. Closed or merged PRs retain terminal CI already reconciled for their unchanged head; open, changed, missing, and pending results still refresh.

## Why

Periodic reconciliation previously fetched CI for up to 1,000 historical PRs every ten minutes. Repeated reads can exhaust an installation's hourly allowance, and a permission lookup returning GitHub's rate-limit 403 was then recorded as a permanent authorization denial. This change reduces repeated reads and preserves the affected command until GitHub allows its permission check.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change

The five focused Vitest files passed all 73 tests. Real local Postgres and pg-boss tests verify that the deferred receipt stays unprocessed, persists its future deadline, cannot be fetched early, rechecks current access, creates exactly one turn after successful authorization, and still denies revoked access. Mirror integration tests verify initial reconciliation, no repeated terminal closed-PR CI reads, continuing open-PR reads, and refresh after a head change. External systems use deterministic fakes.

Before the fix, a running worker's GitHub reconciliation reported installation API-rate exhaustion and a human command was recorded as an authorization denial without creating a turn. Live recovery verification follows deployment after review and required checks.

Closed PRs with missing or pending CI and reviews on linked stories still poll; the optimization specifically removes repeated reads of unchanged terminal CI. Retry deadlines retain valid provider delays and are bounded to one day to prevent corrupt far-future values from stranding receipts.
