### PR TITLE
fix(workspaces): restore Vercel services without stale process state

### DIFF
--- a/apps/docs/docs/reference/lifecycle.md
+++ b/apps/docs/docs/reference/lifecycle.md
@@ -72,6 +72,11 @@ The runtime provider implements create, wake, execute, expose, inspect, suspend,
 Docker workspace uses a named volume independent of its replaceable container. Vercel uses durable
 snapshot-backed state while renewing finite compute leases.
 
+When a Vercel workspace resumes, Docker startup distinguishes a live daemon from a stale PID file
+retained in the snapshot. It waits for a live daemon, or removes stale PID and socket files before
+starting one. A recycled PID is never signaled. Bootstrap preserves ownership inside Docker layers
+and volumes so container data survives the resume.
+
 ## Operations
 
 ### Send message
@@ -128,3 +133,8 @@ Facility does not automatically delete workspaces after merge, archive, error, o
 Operators must monitor active compute and retained storage, define backup and retention rules, and
 use deletion deliberately. Project budgets and cost views support that decision but do not turn
 unknown provider pricing into zero.
+
+Vercel resume removes stale Docker/containerd runtime files only when the recorded
+Docker daemon is absent. A retained preview PID is signaled only when its command
+line matches the gateway and both ports. Docker readiness failures identify the
+retained daemon log. Existing container-file ownership is preserved, not repaired.

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -289,16 +289,57 @@ function workspaceBootstrapCommand(input: CreateWorkspace) {
   return [
     "set -eu",
     "mkdir -p /workspace/.facility/home /workspace/.facility/claude /workspace/.facility/codex /workspace/.facility/docker",
-    "chown -R node:node /workspace",
-    "if ! docker info >/dev/null 2>&1; then rm -f /var/run/docker.sock; nohup dockerd --host=unix:///var/run/docker.sock --data-root=/workspace/.facility/docker --storage-driver=vfs >/workspace/.facility/dockerd.log 2>&1 & fi",
-    "attempt=0; until docker info >/dev/null 2>&1; do attempt=$((attempt + 1)); test $attempt -lt 120; sleep 1; done",
+    // Reassign only the directories we create. Docker layers and volume files
+    // retain the owners required by the containers stored in this workspace.
+    "chown -h node:node /workspace /workspace/.facility /workspace/.facility/home /workspace/.facility/claude /workspace/.facility/codex",
+    "chown -h root:root /workspace/.facility/docker",
+    `if ! docker info >/dev/null 2>&1; then
+  docker_running=0
+  if test -r /var/run/docker.pid; then
+    docker_pid="$(cat /var/run/docker.pid)"
+    case "$docker_pid" in
+      ''|*[!0-9]*) ;;
+      *) if test "$(cat "/proc/$docker_pid/comm" 2>/dev/null || true)" = dockerd; then docker_running=1; fi ;;
+    esac
+  fi
+  if test "$docker_running" = 0; then
+    # A restored disk can contain a PID now owned by an unrelated process.
+    # Remove only stale daemon artifacts; never signal that recycled PID.
+    rm -f /var/run/docker.pid /var/run/docker.sock
+    rm -rf /var/run/docker/containerd
+    nohup dockerd --host=unix:///var/run/docker.sock --data-root=/workspace/.facility/docker --storage-driver=vfs >/workspace/.facility/dockerd.log 2>&1 &
+  fi
+fi`,
+    `attempt=0
+until docker info >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if test "$attempt" -ge 120; then
+    echo "Docker did not become ready within 120 seconds; inspect /workspace/.facility/dockerd.log" >&2
+    exit 1
+  fi
+  sleep 1
+done`,
     "chown root:node /var/run/docker.sock",
     "chmod 0660 /var/run/docker.sock",
     ...gatewayPorts.map(({ port, gatewayPort }) => {
-      return `runuser --user node --preserve-environment -- sh -lc '
-set -eu
+      const gatewayCommand = `set -eu
 pid_file=/workspace/.facility/preview-${gatewayPort}.pid
-if test -f "$pid_file"; then kill "$(cat "$pid_file")" >/dev/null 2>&1 || true; fi
+# A retained PID is only a hint: verify the full gateway invocation before signaling it.
+node - "$pid_file" ${gatewayPort} ${port.port} <<'NODE'
+const fs = require("node:fs");
+try {
+  const pid = fs.readFileSync(process.argv[2], "utf8").trim();
+  if (!/^[1-9][0-9]*$/.test(pid)) process.exit(0);
+  const argv = fs.readFileSync("/proc/" + pid + "/cmdline", "utf8").split("\\0");
+  if (argv.length === 7 && argv[1] === "/usr/local/bin/facility-preview-gateway" &&
+      argv[2] === "--listen" && argv[3] === process.argv[3] &&
+      argv[4] === "--target" && argv[5] === process.argv[4] && argv[6] === "") {
+    process.kill(Number(pid), "SIGTERM");
+  }
+} catch (error) {
+  if (!["ENOENT", "ESRCH"].includes(error.code)) throw error;
+}
+NODE
 nohup facility-preview-gateway --listen ${gatewayPort} --target ${port.port} >>/workspace/.facility/preview-${gatewayPort}.log 2>&1 &
 pid=$!
 echo "$pid" > "$pid_file"
@@ -313,7 +354,8 @@ until test "$(curl --silent --output /dev/null --write-out "%{http_code}" --max-
   sleep 0.1
 done
 kill -0 "$pid" 2>/dev/null || { echo "Preview gateway on port ${gatewayPort} exited during startup" >&2; exit 1; }
-'`;
+`;
+      return `runuser --user node --preserve-environment -- sh -lc ${shellQuote(gatewayCommand)}`;
     }),
   ].join("\n");
 }
@@ -322,4 +364,8 @@ function isVercelNotFound(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const value = error as { code?: unknown; status?: unknown; statusCode?: unknown };
   return value.code === "not_found" || value.status === 404 || value.statusCode === 404;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/services/api/test/workspace-vercel-bootstrap.integration.test.ts
+++ b/services/api/test/workspace-vercel-bootstrap.integration.test.ts
@@ -20,10 +20,35 @@ afterEach(async () => {
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
 });
 
-async function localProvider(brokenGateway: boolean) {
+async function localProvider(
+  brokenGateway: boolean,
+  dockerState: "ready" | "stale-pid" | "starting" = "ready",
+) {
   const root = await mkdtemp(join(tmpdir(), "facility-vercel-bootstrap-"));
   const bin = join(root, "bin");
   await mkdir(bin);
+  await mkdir(join(root, "run"));
+  // Own the colliding PID, so even a regression that signals it cannot touch
+  // an unrelated host process. /proc itself remains a deterministic fake.
+  const colliding = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    stdio: "ignore",
+  });
+  const dockerPid = colliding.pid;
+  if (!dockerPid) throw new Error("missing fixture process PID");
+  cleanups.push(async () => {
+    colliding.kill();
+  });
+  await mkdir(join(root, "proc", String(dockerPid)), { recursive: true });
+  if (dockerState !== "ready") {
+    await writeFile(join(root, "run/docker.pid"), String(dockerPid));
+    await writeFile(join(root, "run/docker.sock"), "existing socket");
+    await mkdir(join(root, "run/docker/containerd"), { recursive: true });
+    await writeFile(join(root, "run/docker/containerd/containerd.pid"), String(dockerPid));
+    await writeFile(
+      join(root, "proc", String(dockerPid), "comm"),
+      dockerState === "starting" ? "dockerd\n" : "unrelated\n",
+    );
+  }
   cleanups.push(() => rm(root, { recursive: true, force: true }));
   const server = createServer((_req, res) => res.end("preview app"));
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -43,8 +68,16 @@ async function localProvider(brokenGateway: boolean) {
   const gatewayPort = reserved.port;
   await new Promise<void>((resolve) => reserve.close(() => resolve()));
   const scripts: Record<string, string> = {
-    docker: "exit 0",
-    chown: "exit 0",
+    docker:
+      dockerState === "ready"
+        ? "exit 0"
+        : dockerState === "stale-pid"
+          ? `test -f '${root}/docker-ready'`
+          : `if test -f '${root}/docker-waited'; then exit 0; fi; touch '${root}/docker-waited'; exit 1`,
+    dockerd: `test ! -d '${root}/run/docker/containerd' || exit 8\ntest ! -f '${root}/run/docker.pid' || { echo 'stale daemon PID' >&2; exit 1; }\necho started > '${root}/docker-started'\ntouch '${root}/docker-ready'`,
+    // Model the ownership boundary: recursively reassigning a persisted Docker
+    // tree would corrupt container UIDs, even when daemon startup succeeds.
+    chown: 'test "$1" != -R || { echo "recursive ownership reset" >&2; exit 1; }',
     chmod: "exit 0",
     // Model the provider's environment reset; the real SDK must inject env after this transition.
     sudo: 'test "$1" = -u; shift 3; exec /usr/bin/env -i PATH="$PATH" "$@"',
@@ -75,7 +108,11 @@ async function localProvider(brokenGateway: boolean) {
       sudo?: boolean;
     }) => {
       const args = (params.args ?? []).map((arg) =>
-        arg.replaceAll("/workspace", root).replaceAll("65535", String(gatewayPort)),
+        arg
+          .replaceAll("/workspace", root)
+          .replaceAll("/var/run", join(root, "run"))
+          .replaceAll("/proc/", `${root}/proc/`)
+          .replaceAll("65535", String(gatewayPort)),
       );
       return new Promise<{ exitCode: number; stderr: () => Promise<string> }>((resolve, reject) => {
         const child = spawn(params.cmd, args, {
@@ -107,7 +144,7 @@ async function localProvider(brokenGateway: boolean) {
     await options.onCreate?.(fixture);
     return fixture;
   });
-  return { fixture, gatewayPort, appPort: address.port };
+  return { fixture, gatewayPort, appPort: address.port, root, dockerPid, colliding };
 }
 
 it("starts the real authenticated gateway through the SDK user switch without exposing a bare app", async () => {
@@ -145,4 +182,102 @@ it("fails initialization and stops newly allocated compute when the background g
     message: expect.stringContaining("did not start"),
   });
   expect(fixture.stop).toHaveBeenCalledOnce();
+});
+
+it("starts Docker after a restored PID collides with an unrelated process, preserving the volume tree", async () => {
+  const { fixture, appPort, root, dockerPid, colliding } = await localProvider(false, "stale-pid");
+  await mkdir(join(root, ".facility/docker/volumes/database"), { recursive: true });
+  await writeFile(join(root, ".facility/docker/volumes/database/retained"), "seeded database");
+  await new VercelWorkspaceRuntime().create({
+    id: fixture.name,
+    image: "runner:test",
+    ports: [{ service: "web", port: appPort }],
+    environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+  });
+  expect(await readFile(join(root, "docker-started"), "utf8")).toBe("started\n");
+  expect(await readFile(join(root, "proc", String(dockerPid), "comm"), "utf8")).toBe("unrelated\n");
+  expect(colliding.exitCode).toBeNull();
+  expect(colliding.signalCode).toBeNull();
+  expect(await readFile(join(root, ".facility/docker/volumes/database/retained"), "utf8")).toBe(
+    "seeded database",
+  );
+  expect(fixture.stop).not.toHaveBeenCalled();
+});
+
+it("waits for an existing Docker daemon without removing its PID or launching another", async () => {
+  const { fixture, appPort, root, dockerPid } = await localProvider(false, "starting");
+  await new VercelWorkspaceRuntime().create({
+    id: fixture.name,
+    image: "runner:test",
+    ports: [{ service: "web", port: appPort }],
+    environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+  });
+  expect(await readFile(join(root, "run/docker.pid"), "utf8")).toBe(String(dockerPid));
+  expect(await readFile(join(root, "run/docker.sock"), "utf8")).toBe("existing socket");
+  expect(await readFile(join(root, "run/docker/containerd/containerd.pid"), "utf8")).toBe(
+    String(dockerPid),
+  );
+  await expect(readFile(join(root, "docker-started"), "utf8")).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+  expect(fixture.stop).not.toHaveBeenCalled();
+});
+
+it.each([
+  "unrelated",
+  "different-port",
+  "malformed",
+])("preserves a process referenced by a %s preview PID file", async (kind) => {
+  const { fixture, appPort, root, gatewayPort, dockerPid, colliding } = await localProvider(false);
+  await mkdir(join(root, ".facility"));
+  await writeFile(
+    join(root, `.facility/preview-${gatewayPort}.pid`),
+    kind === "malformed" ? "-1" : String(dockerPid),
+  );
+  const args =
+    kind === "different-port"
+      ? [
+          "node",
+          "/usr/local/bin/facility-preview-gateway",
+          "--listen",
+          "1",
+          "--target",
+          String(appPort),
+          "",
+        ]
+      : ["node", "/workspace/native-agent.js", ""];
+  await writeFile(join(root, "proc", String(dockerPid), "cmdline"), args.join("\0"));
+  await new VercelWorkspaceRuntime().create({
+    id: fixture.name,
+    image: "runner:test",
+    ports: [{ service: "web", port: appPort }],
+    environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+  });
+  expect(colliding.exitCode).toBeNull();
+  expect(colliding.signalCode).toBeNull();
+});
+
+it("replaces only the recorded gateway invocation for this port", async () => {
+  const { fixture, appPort, root, gatewayPort, dockerPid, colliding } = await localProvider(false);
+  await mkdir(join(root, ".facility"));
+  await writeFile(join(root, `.facility/preview-${gatewayPort}.pid`), String(dockerPid));
+  await writeFile(
+    join(root, "proc", String(dockerPid), "cmdline"),
+    [
+      "node",
+      "/usr/local/bin/facility-preview-gateway",
+      "--listen",
+      String(gatewayPort),
+      "--target",
+      String(appPort),
+      "",
+    ].join("\0"),
+  );
+  await new VercelWorkspaceRuntime().create({
+    id: fixture.name,
+    image: "runner:test",
+    ports: [{ service: "web", port: appPort }],
+    environment: { FACILITY_PREVIEW_GATEWAY_TOKEN: "x".repeat(32) },
+  });
+  expect(colliding.signalCode).toBe("SIGTERM");
 });

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -103,6 +103,11 @@ describe("Vercel persistent workspace runtime", () => {
     );
     expect(sandbox.runCommand).toHaveBeenCalledTimes(1);
     expect(sandbox.stop).not.toHaveBeenCalled();
+    const bootstrap = sandbox.runCommand.mock.calls[0]?.[0].args[1];
+    expect(bootstrap).toContain("chown -h root:root /workspace/.facility/docker");
+    expect(bootstrap).not.toMatch(/chown\s+-R/);
+    expect(bootstrap).toContain('cat "/proc/$docker_pid/comm"');
+    expect(bootstrap).not.toContain('kill "$docker_pid"');
   });
 
   const input = {


### PR DESCRIPTION
## What changes

Persistent Vercel workspaces restart Docker after a snapshot restores a stale PID file. Bootstrap checks whether the recorded PID is actually a Docker daemon, waits for a live daemon, and otherwise removes only stale PID/socket and nested containerd runtime artifacts without signaling an unrelated process. Preview restart verifies the recorded process command and both ports before signaling it. Directory ownership setup preserves the owners inside retained Docker layers and volumes.

## Why

A restored workspace can reuse a former Docker PID for another process. Docker then refuses to start, and environment preparation never reaches the app or preview gateway. Recursively assigning the whole workspace to the agent user also overwrites ownership required by stored container files.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change

The three focused Vitest files passed all 28 tests. The bootstrap integration executes the real SDK user transition and real authenticated preview gateway against a temporary filesystem and deterministic Docker fakes. It covers a restored PID pointing at an owned unrelated child process, preservation of that process and volume contents, a live daemon becoming ready without replacement, and failed-start cleanup. Unit coverage checks that resume no longer recursively changes retained ownership. Existing gateway credential denial and compute-preservation tests still pass.

A live retained workspace's Docker log reproduced the stale-PID failure before this change. Live resume and app-preview acceptance follows deployment after review and required checks.

This repair is scoped to Vercel persistence. It preserves existing ownership but does not reconstruct UIDs already overwritten by an earlier recursive setup. The separate self-host Docker bootstrap is unchanged.

Final Claude review found no blockers after checking shell quoting, the installed gateway argv layout, PID validation, retained files, and credential-safe diagnostics. Full local verification and the candidate image scan passed. Required hosted verification passed; Docker build/E2E jobs are pending.
