### PR TITLE
fix(mcp): route resource discovery past the authorization server

### DIFF
--- a/apps/docs/docs/reference/mcp.md
+++ b/apps/docs/docs/reference/mcp.md
@@ -8,6 +8,11 @@ Facility serves Streamable HTTP MCP at `POST /mcp` from the control API. OAuth c
 resource metadata at `/.well-known/oauth-protected-resource/mcp`. API keys use the same endpoint
 with `Authorization: Bearer <key>`.
 
+With OAuth enabled, the resource metadata names the canonical MCP endpoint and its authorization
+server. Authorization-server metadata remains available at `/.well-known/oauth-authorization-server`
+and `/.well-known/openid-configuration`; all three discovery endpoints are public. MCP tool requests
+still require a valid bearer token.
+
 The server exposes twenty task-oriented tools:
 
 | Tool | Result |

--- a/services/api/src/auth/authorization-server.ts
+++ b/services/api/src/auth/authorization-server.ts
@@ -110,10 +110,7 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
   let registrationWindow = { startedAt: Date.now(), count: 0 };
   app.use((req, res, next) => {
     const path = req.url?.split("?")[0] ?? "";
-    if (
-      (path.startsWith("/oauth/") && !path.startsWith("/oauth/interaction/")) ||
-      path.startsWith("/.well-known/")
-    ) {
+    if (isAuthorizationServerPath(path)) {
       if (path === "/oauth/register") {
         if (Date.now() - registrationWindow.startedAt >= 60_000)
           registrationWindow = { startedAt: Date.now(), count: 0 };
@@ -206,6 +203,15 @@ export async function registerAuthorizationServer(app: FastifyInstance, config: 
       );
       return reply.hijack();
     },
+  );
+}
+
+// Resource-server metadata belongs to its Fastify route, not oidc-provider.
+export function isAuthorizationServerPath(path: string): boolean {
+  return (
+    (path.startsWith("/oauth/") && !path.startsWith("/oauth/interaction/")) ||
+    path === "/.well-known/openid-configuration" ||
+    path === "/.well-known/oauth-authorization-server"
   );
 }
 

--- a/services/api/test/oauth.test.ts
+++ b/services/api/test/oauth.test.ts
@@ -14,6 +14,7 @@ import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildApp, mintSessionCookie } from "../src/app.js";
 import {
+  isAuthorizationServerPath,
   oauthBrowserOrigin,
   oauthScopes,
   oidcScopesForConsent,
@@ -78,6 +79,28 @@ async function token(
   if (input.exp !== false) jwt.setExpirationTime(input.exp ?? "15m");
   return jwt.sign(input.key ?? privateKey);
 }
+
+describe("authorization-server route ownership", () => {
+  it.each([
+    "/oauth/authorize",
+    "/oauth/token",
+    "/oauth/register",
+    "/oauth/jwks",
+    "/.well-known/openid-configuration",
+    "/.well-known/oauth-authorization-server",
+  ])("delegates %s to the authorization server", (path) => {
+    expect(isAuthorizationServerPath(path)).toBe(true);
+  });
+  it.each([
+    "/.well-known/oauth-protected-resource/mcp",
+    "/.well-known/unknown",
+    "/oauth/interaction/consent",
+    "/mcp",
+    "/v1/projects",
+  ])("leaves %s to the application router", (path) => {
+    expect(isAuthorizationServerPath(path)).toBe(false);
+  });
+});
 
 describe("Facility OAuth access-token verification", () => {
   it("enables OAuth only when issuer, resource, and keys are all configured", () => {
@@ -266,6 +289,48 @@ describe("Facility OAuth resource-server integration", async () => {
   afterAll(async () => {
     await app.close();
     await client.end();
+  });
+
+  it("serves canonical MCP resource discovery alongside the enabled authorization server", async () => {
+    const challenge = await app.inject({ method: "POST", url: "/mcp", payload: {} });
+    expect(challenge.statusCode).toBe(401);
+    const resourceMetadata = String(challenge.headers["www-authenticate"]).match(
+      /resource_metadata="([^"]+)"/,
+    )?.[1];
+    expect(resourceMetadata).toBe(
+      "https://mcp.facility.test/.well-known/oauth-protected-resource/mcp",
+    );
+    const metadata = await app.inject({
+      method: "GET",
+      url: new URL(resourceMetadata as string).pathname,
+      headers: {
+        host: "evil.example",
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-proto": "http",
+      },
+    });
+    expect(metadata.statusCode).toBe(200);
+    expect(metadata.json()).toEqual({
+      resource: audience,
+      authorization_servers: [issuer],
+      bearer_methods_supported: ["header"],
+      scopes_supported: ["facility:mcp"],
+    });
+    for (const authorization of [
+      "Bearer malformed",
+      `Bearer ${await token({ aud: "https://other.example" })}`,
+    ]) {
+      const denied = await app.inject({
+        method: "POST",
+        url: "/mcp",
+        payload: {},
+        headers: { authorization },
+      });
+      expect(denied.statusCode).toBe(401);
+    }
+    const oidc = await app.inject({ method: "GET", url: "/.well-known/openid-configuration" });
+    expect(oidc.statusCode).toBe(200);
+    expect(oidc.json().issuer).toBe(issuer);
   });
 
   it("publishes authorization metadata and registers a public PKCE client", async () => {


### PR DESCRIPTION
## What changes

OAuth clients can follow the MCP bearer challenge to `/.well-known/oauth-protected-resource/mcp` when Facility's authorization server is enabled. The authorization middleware delegates only its own two discovery endpoints to oidc-provider, leaving MCP resource metadata with the existing application route.

## Why

The broad `/.well-known/` interception returned oidc-provider's 404 before the registered resource-metadata handler could run. MCP clients could not discover the configured authorization server. Token validation and consent handling are unchanged.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change

Live preflight reproduced a resource-metadata 404 while authorization-server metadata returned 200. Unit tests cover route ownership. The full-application OAuth integration uses local PostgreSQL and follows the unauthenticated MCP challenge to canonical metadata, checks hostile forwarding headers cannot alter it, verifies malformed and wrong-audience tokens remain denied, and checks OIDC discovery still works. Existing OAuth security tests remain in the required suite.

Full local verification passed, including the direct critical integration suite with skips forbidden. Final Claude review found no blockers. The candidate image scan passed. All required hosted checks passed, including the self-host image build. The workspace-e2e gate passed through its path filter; this change did not rerun Docker workspace tests. Live discovery and SDK OAuth acceptance follow deployment.
