### PR TITLE
fix(core): resolve aliases for dated provider model ids

### DIFF
--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -26,21 +26,26 @@ export type CostInput = {
   cacheWriteTokens?: number;
 };
 
-const MODEL_ALIASES: Record<string, keyof typeof MODEL_PRICES_USD_PER_1M> = {
+export const MODEL_ALIASES: Record<string, keyof typeof MODEL_PRICES_USD_PER_1M> = {
   "claude-3-5-haiku": "claude-haiku-4-5",
   "gpt-5.6": "gpt-5.6-sol",
 };
 
 /** Resolve aliases and provider date suffixes to a price-book entry. */
 export function normalizeModel(model: string): keyof typeof MODEL_PRICES_USD_PER_1M | null {
-  if (model in MODEL_PRICES_USD_PER_1M) {
-    return model as keyof typeof MODEL_PRICES_USD_PER_1M;
-  }
-  if (model in MODEL_ALIASES) return MODEL_ALIASES[model] ?? null;
   const undated = model.replace(/-\d{8}$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
-  return undated in MODEL_PRICES_USD_PER_1M
-    ? (undated as keyof typeof MODEL_PRICES_USD_PER_1M)
-    : null;
+  // Both forms run the same resolution chain, so the two rules compose: an alias
+  // is absent from the price book by definition, and a provider id that carries a
+  // date suffix still has to resolve through it.
+  for (const candidate of new Set([model, undated])) {
+    if (candidate in MODEL_PRICES_USD_PER_1M) {
+      return candidate as keyof typeof MODEL_PRICES_USD_PER_1M;
+    }
+    if (candidate in MODEL_ALIASES) {
+      return MODEL_ALIASES[candidate] ?? null;
+    }
+  }
+  return null;
 }
 
 /** Calculate cents with six decimal places so low-token turns are not rounded away. */

--- a/packages/core/test/pricing.test.ts
+++ b/packages/core/test/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { costCents, normalizeModel } from "../src/pricing.js";
+import { costCents, MODEL_ALIASES, normalizeModel } from "../src/pricing.js";
 
 describe("model pricing", () => {
   it("prices input, output, and cache tokens without rounding away small turns", () => {
@@ -17,5 +17,16 @@ describe("model pricing", () => {
   it("normalizes dated provider model ids and reports unknown models", () => {
     expect(normalizeModel("claude-opus-4-8-20260101")).toBe("claude-opus-4-8");
     expect(costCents({ model: "private-model", inputTokens: 1, outputTokens: 1 })).toBeNull();
+  });
+
+  // An alias is by definition absent from the price book, so stripping a date
+  // suffix has to consult the alias table too. Asserted over the table itself:
+  // the invariant is that resolution composes, whatever the aliases happen to be.
+  it("resolves every alias whether or not the id carries a date suffix", () => {
+    for (const [alias, canonical] of Object.entries(MODEL_ALIASES)) {
+      expect(normalizeModel(alias)).toBe(canonical);
+      expect(normalizeModel(`${alias}-20260115`)).toBe(canonical);
+      expect(normalizeModel(`${alias}-2026-01-15`)).toBe(canonical);
+    }
   });
 });

--- a/services/api/test/insights-and-mirror.integration.test.ts
+++ b/services/api/test/insights-and-mirror.integration.test.ts
@@ -192,6 +192,12 @@ describe("cost controls, GitHub mirror, and pipeline", async () => {
     await expect(
       costs.assertTurnAllowed(orgId, projectId, "private-unpriced-model"),
     ).rejects.toBeInstanceOf(BudgetPolicyError);
+    // A provider id that resolves through an alias is priced, so the preflight has
+    // to judge it on spend. Refusing it as unpriced would deny a turn the project
+    // is entitled to run.
+    await expect(
+      costs.assertTurnAllowed(orgId, projectId, "gpt-5.6-20260115"),
+    ).rejects.toMatchObject({ code: "budget_exceeded" });
     expect(await costs.budgetState(otherOrgId, projectId)).toMatchObject({
       budget: null,
       spentCents: 0,


### PR DESCRIPTION
## What changes

`normalizeModel` now runs one resolution chain over both the id it receives and its undated form, so alias resolution and date suffix stripping compose. A provider id such as `gpt-5.6-20260115` resolves to `gpt-5.6-sol` instead of returning `null`. Unknown models still resolve to `null`, and the alias table itself is unchanged.

## Why

An alias is absent from the price book by definition; that is what makes it an alias. The previous chain checked the price book, then the alias table, then stripped the date suffix and checked only the price book again, so a dated aliased id fell through to `null`.

| Model id | Before | After |
| --- | --- | --- |
| `claude-sonnet-5-20260115` | `claude-sonnet-5` | unchanged |
| `gpt-5.6` | `gpt-5.6-sol` | unchanged |
| `gpt-5.6-20260115` | `null` | `gpt-5.6-sol` |
| `private-model` | `null` | unchanged |

The consequence sits in `CostBudgetService` (`services/api/src/insights/costs.ts`):

* With a project budget enabled, `assertTurnAllowed` throws `BudgetPolicyError("budget_model_unpriced")`, so a turn is denied for a model that is priced.
* With no budget, `record` stores the turn as `priced: false` with a null cost, and the `coalesce(sum(cost_cents), 0)` in `budgetState` drops it, so project spend is under-counted.

The existing unit test covered a dated direct id (`claude-opus-4-8-20260101`) and an undated alias, which is why the composition of the two rules was never exercised.

I did not file an issue first: `CONTRIBUTING.md` asks for that before a substantial or behavior-changing feature, and this is a defect against behavior the function already documents ("Resolve aliases and provider date suffixes to a price-book entry"). Happy to move the discussion to an issue if you would prefer that.

## Verification

The unit test asserts the invariant over `MODEL_ALIASES` itself rather than over hard-coded ids, so it keeps holding as the table changes. That is why `MODEL_ALIASES` is now exported. Both new assertions fail on `main` and pass with the fix:

* `packages/core/test/pricing.test.ts` without the fix: `expected null to be 'claude-haiku-4-5'`.
* `services/api/test/insights-and-mirror.integration.test.ts` without the fix: `budget_model_unpriced` where `budget_exceeded` is expected, which is the preflight denying a priced model. This is the money-sensitive integration coverage `CONTRIBUTING.md` requires, and it runs against the isolated `facility_test` database.

Environment: Windows 11, Node 22.14.0, pnpm 11.20.0, Postgres from `docker-compose.dev.yml`.

* `biome check .`: clean, 225 files.
* `tsc --noEmit` for `@facility/core` and `@facility/api`: clean.
* `@facility/core`: 11 passed.
* `@facility/api` `insights-and-mirror.integration.test.ts`: 7 passed, and `budget-routes.integration.test.ts`: 3 passed. Both in isolated processes with the test databases recreated first, following `scripts/test-critical.mjs`.
* `@facility/agents` 10 passed, `@facility/mcp` 14 passed, `@facility/sdk` 10 passed.
* `node guards/run.mjs`: 2 guards ran, 0 failed. `node scripts/check-unused.mjs`: clean.

- [ ] `pnpm verify` passes locally

Left unchecked deliberately, because it would not be true. `pnpm verify` does not complete on this machine for reasons independent of this change, and the same suites fail on a pristine `main` checkout here: `scripts/dependencies-security.test.mjs` (needs registry access), `scripts/images.integration.test.mjs` and `scripts/release.integration.test.mjs` (need image builds and release tooling), and `services/api/test/turn-dispatcher.integration.test.ts`, which is non-deterministic in this environment (4 failed and 4 passed on pristine `main`, varying between runs; no failure mentions pricing, budgets or `normalizeModel`). I ran the individual `verify` steps instead, as listed above.

- [x] Behavior verified beyond the test suite

I reverted the fix, rebuilt `@facility/core`, and confirmed against a live database that the budget preflight refuses `gpt-5.6-20260115` as `budget_model_unpriced`. With the fix restored, the same call is judged on spend instead.

- [x] Documentation updated, or no user-facing change

No user-facing change. The doc comment already described the intended behavior.
