### PR TITLE
fix(workspaces): reuse prepared story environments for previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,12 @@ Secret names are committed in `.facility.yml`; their values come from the operat
 environment and are injected only while setup, services, or agents run. Use the provider variable
 names supported by the selected Claude Code and Codex authentication method.
 Declared services are available through short-lived, authenticated preview sessions routed to the
-live workspace. Facility does not build a second preview deployment.
+live workspace. Facility does not build a second preview deployment. Once the story workspace is
+prepared, opening a preview uses the agents' current branch, uncommitted files, and local data.
+With `environment.ready` declared, it reuses healthy services and starts them only when needed.
+Without a readiness command, it runs the declared start command on each open. Neither path fetches
+or switches Git, reruns setup, or reseeds. Use the explicit **Clean setup** action when a setup
+reset is required, including when repository or setup changes need to be applied.
 
 ## MCP surface
 

--- a/apps/docs/docs/reference/lifecycle.md
+++ b/apps/docs/docs/reference/lifecycle.md
@@ -94,6 +94,15 @@ or external GitHub effects that already occurred.
 Retry asks Facility to attempt recoverable work again. Dismiss closes an obsolete attention item.
 A waiting-agent item is normally resolved by a user reply.
 
+### Open preview
+
+Opens the service in the same persistent workspace used by the story's agents. Once prepared,
+preview access preserves the current Git branch, uncommitted files, native sessions, and local
+data. It does not fetch or switch Git, rerun setup, or reseed. A declared `environment.ready`
+command lets Facility reuse healthy services; otherwise it runs `environment.start` on each open.
+A sleeping workspace wakes with its retained files. First-time preparation still runs normally;
+use **Clean setup** to apply repository or setup changes that require preparation again.
+
 ### Clean setup
 
 Prepares the existing workspace with setup forced even when the checksum matches. It does not

--- a/services/api/src/workspaces/preview.ts
+++ b/services/api/src/workspaces/preview.ts
@@ -63,15 +63,19 @@ export class WorkspacePreviewService {
         .where(and(eq(stories.orgId, input.orgId), eq(stories.id, story.id)));
     }
     await this.runtime.wake(locator(workspace));
-    const prepared = await this.environment.prepare({
+    const environmentInput = {
       orgId: input.orgId,
       projectId: input.projectId,
       workspace: locator(workspace),
       manifest,
       credentials,
-      branch,
-      previousSetupChecksum: workspace.setupChecksum,
-    });
+    };
+    const prepared = workspace.setupChecksum
+      ? await this.environment.startPrepared({
+          ...environmentInput,
+          setupChecksum: workspace.setupChecksum,
+        })
+      : await this.environment.prepare({ ...environmentInput, branch });
     if (!prepared.endpoints.some((endpoint) => endpoint.service === input.service)) {
       throw new WorkspacePreviewError(
         "preview_service_not_found",

--- a/services/api/src/workspaces/project-environment.ts
+++ b/services/api/src/workspaces/project-environment.ts
@@ -173,6 +173,15 @@ export class GithubProjectManifestSource implements ProjectManifestSource {
   }
 }
 
+type EnvironmentInput = {
+  orgId: string;
+  projectId: string;
+  workspace: WorkspaceLocator;
+  manifest: ProjectManifest;
+  credentials: GithubWorkspaceCredentials;
+  readinessTimeoutMs?: number;
+};
+
 export class ProjectEnvironmentService {
   constructor(
     private readonly db: FacilityDb,
@@ -184,17 +193,13 @@ export class ProjectEnvironmentService {
     ) => process.env[projectEnvironmentVariableName(projectId, name)],
   ) {}
 
-  async prepare(input: {
-    orgId: string;
-    projectId: string;
-    workspace: WorkspaceLocator;
-    manifest: ProjectManifest;
-    credentials: GithubWorkspaceCredentials;
-    branch: string;
-    previousSetupChecksum?: string | null;
-    cleanSetup?: boolean;
-    readinessTimeoutMs?: number;
-  }) {
+  async prepare(
+    input: EnvironmentInput & {
+      branch: string;
+      previousSetupChecksum?: string | null;
+      cleanSetup?: boolean;
+    },
+  ) {
     assertRepositoryContract(input.manifest, input.credentials.repositories);
     const preparedInput = this.withDeclaredEnvironment(input);
     await this.run(preparedInput, "mkdir -p repos", ".", "environment.repositories");
@@ -241,20 +246,22 @@ export class ProjectEnvironmentService {
 
     const setupChecksum = await this.setupChecksum(preparedInput);
     const setupRequired = input.cleanSetup || input.previousSetupChecksum !== setupChecksum;
-    if (preparedInput.manifest.environment.setup && setupRequired) {
-      await this.run(
-        preparedInput,
-        preparedInput.manifest.environment.setup,
-        primaryPath(preparedInput.credentials),
-        "environment.setup",
-      );
-      if (preparedInput.manifest.environment.seed) {
+    if (setupRequired) {
+      if (preparedInput.manifest.environment.setup) {
         await this.run(
           preparedInput,
-          preparedInput.manifest.environment.seed,
+          preparedInput.manifest.environment.setup,
           primaryPath(preparedInput.credentials),
-          "environment.seed",
+          "environment.setup",
         );
+        if (preparedInput.manifest.environment.seed) {
+          await this.run(
+            preparedInput,
+            preparedInput.manifest.environment.seed,
+            primaryPath(preparedInput.credentials),
+            "environment.seed",
+          );
+        }
       }
       await this.db
         .update(workspaces)
@@ -266,13 +273,35 @@ export class ProjectEnvironmentService {
           ),
         );
     }
-    await this.run(
-      preparedInput,
-      preparedInput.manifest.environment.start,
-      primaryPath(preparedInput.credentials),
-      "environment.start",
-    );
-    if (preparedInput.manifest.environment.ready) await this.waitUntilReady(preparedInput);
+    return this.startServices(preparedInput, setupChecksum);
+  }
+
+  /** Reuse the agent's files and data; preview access must never prepare Git or reseed. */
+  async startPrepared(input: EnvironmentInput & { setupChecksum: string }) {
+    assertRepositoryContract(input.manifest, input.credentials.repositories);
+    const preparedInput = this.withDeclaredEnvironment(input);
+    const ready = preparedInput.manifest.environment.ready;
+    const alreadyReady = ready
+      ? (await this.command(preparedInput, ready, primaryPath(preparedInput.credentials)))
+          .exitCode === 0
+      : false;
+    return this.startServices(preparedInput, input.setupChecksum, alreadyReady);
+  }
+
+  private async startServices(
+    preparedInput: EnvironmentInput,
+    setupChecksum: string,
+    alreadyReady = false,
+  ) {
+    if (!alreadyReady) {
+      await this.run(
+        preparedInput,
+        preparedInput.manifest.environment.start,
+        primaryPath(preparedInput.credentials),
+        "environment.start",
+      );
+      if (preparedInput.manifest.environment.ready) await this.waitUntilReady(preparedInput);
+    }
     const endpoints = await this.runtime.expose(
       preparedInput.workspace,
       services(preparedInput.manifest),
@@ -421,7 +450,7 @@ export class ProjectEnvironmentService {
     };
   }
 
-  private async setupChecksum(input: Parameters<ProjectEnvironmentService["prepare"]>[0]) {
+  private async setupChecksum(input: EnvironmentInput) {
     const head = await this.runtime.exec(input.workspace, {
       command: "git",
       args: ["rev-parse", "HEAD"],
@@ -473,7 +502,7 @@ export class ProjectEnvironmentService {
     );
   }
 
-  private async waitUntilReady(input: Parameters<ProjectEnvironmentService["prepare"]>[0]) {
+  private async waitUntilReady(input: EnvironmentInput) {
     const ready = input.manifest.environment.ready;
     if (!ready) return;
     const deadline = Date.now() + (input.readinessTimeoutMs ?? 120_000);
@@ -496,12 +525,7 @@ export class ProjectEnvironmentService {
     });
   }
 
-  private async run(
-    input: Parameters<ProjectEnvironmentService["prepare"]>[0],
-    script: string,
-    cwd: string,
-    phase: string,
-  ) {
+  private async run(input: EnvironmentInput, script: string, cwd: string, phase: string) {
     const result = await this.command(input, script, cwd);
     const safeResult = redactResult(
       result,
@@ -519,11 +543,7 @@ export class ProjectEnvironmentService {
     return result;
   }
 
-  private command(
-    input: Parameters<ProjectEnvironmentService["prepare"]>[0],
-    script: string,
-    cwd: string,
-  ) {
+  private command(input: EnvironmentInput, script: string, cwd: string) {
     return this.runtime.exec(input.workspace, {
       command: "sh",
       args: ["-lc", script],
@@ -534,7 +554,7 @@ export class ProjectEnvironmentService {
   }
 
   private async runCommand(
-    input: Parameters<ProjectEnvironmentService["prepare"]>[0],
+    input: EnvironmentInput,
     command: string,
     args: string[],
     cwd: string,

--- a/services/api/test/project-environment.integration.test.ts
+++ b/services/api/test/project-environment.integration.test.ts
@@ -6,18 +6,26 @@ import { newId } from "@facility/core";
 import {
   createDb,
   migrate,
+  orgMembers,
   orgs,
   projects,
+  roles,
   stories,
   storyArtifacts,
+  users,
   workspaceEvents,
   workspaces,
 } from "@facility/db";
 import { and, desc, eq } from "drizzle-orm";
 import postgres from "postgres";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { GithubWorkspaceCredentials } from "../src/github/workspace-credentials.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  GithubWorkspaceCredentialBroker,
+  GithubWorkspaceCredentials,
+} from "../src/github/workspace-credentials.js";
+import type { AppConfig } from "../src/types.js";
 import { FakeWorkspaceRuntime } from "../src/workspaces/fake.js";
+import { WorkspacePreviewService } from "../src/workspaces/preview.js";
 import {
   ProjectEnvironmentService,
   parseProjectManifest,
@@ -206,6 +214,155 @@ environment:
     expect(
       await readFile(join(workspace.volumeRef, "repos/acme/shared/README.md"), "utf8"),
     ).toContain("shared");
+  });
+
+  it("opens previews on the agent's changed workspace without checkout, setup, or reseeding", async () => {
+    const environment = new ProjectEnvironmentService(db, runtime, `file://${remotes}`);
+    const prepared = await environment.prepare({
+      orgId,
+      projectId,
+      workspace,
+      manifest,
+      credentials,
+      branch: "facility/story-environment",
+      cleanSetup: true,
+    });
+    expect(prepared.setupChecksum).toMatch(/^[a-f0-9]{64}$/);
+    const repository = join(workspace.volumeRef, "repos/acme/app");
+    const git = async (args: string[]) => {
+      const result = await runtime.exec(workspace, { command: "git", args, cwd: "repos/acme/app" });
+      expect(result.exitCode, result.stderr).toBe(0);
+      return result.stdout.trim();
+    };
+    await git(["switch", "-c", "facility/agent-current-work"]);
+    await writeFile(join(repository, "README.md"), "Agent's committed implementation\n");
+    await git(["add", "README.md"]);
+    await git(["commit", "-m", "fix: implement the story"]);
+    const head = await git(["rev-parse", "HEAD"]);
+    await writeFile(join(repository, "uncommitted.txt"), "Work in progress\n");
+    await writeFile(join(repository, ".facility-test/seed"), "user-created-data");
+    await writeFile(join(workspace.volumeRef, ".facility/claude/session.json"), "claude-session");
+    await writeFile(join(workspace.volumeRef, ".facility/codex/session.json"), "codex-session");
+    const setupCount = await readFile(join(repository, ".setup-count"), "utf8");
+    const userId = newId("user");
+    const roleId = newId("role");
+    await db
+      .insert(users)
+      .values({ id: userId, email: `preview-reuse-${suffix}@example.com`, status: "active" });
+    await db.insert(roles).values({
+      id: roleId,
+      orgId,
+      name: `preview-reuse-${suffix}`,
+      permissions: ["workspaces:execute"],
+    });
+    await db.insert(orgMembers).values({ id: newId("member"), orgId, userId, roleId });
+    const previews = new WorkspacePreviewService(
+      db,
+      {
+        publicUrl: "https://api.example.com",
+        previewUrl: "https://preview.example.net",
+      } as AppConfig,
+      runtime,
+      {
+        issue: async () => credentials,
+      } as unknown as GithubWorkspaceCredentialBroker,
+      { load: async () => manifest },
+      environment,
+    );
+
+    for (const sleeping of [false, true]) {
+      if (sleeping) {
+        await runtime.replaceCompute(workspace);
+        await rm(join(repository, ".facility-test/status"));
+        await db
+          .update(workspaces)
+          .set({ state: "sleeping" })
+          .where(eq(workspaces.id, workspaceId));
+      }
+      const originalExec = runtime.exec.bind(runtime);
+      const exec = vi.spyOn(runtime, "exec").mockImplementation(async (locator, command) => {
+        const result = await originalExec(locator, command);
+        // A concurrent preparation may finish after preview open read its checksum.
+        await db
+          .update(workspaces)
+          .set({ setupChecksum: "concurrent-preparation-checksum" })
+          .where(eq(workspaces.id, workspaceId));
+        return result;
+      });
+      try {
+        const opened = await previews.open({ orgId, projectId, storyId, userId, service: "app" });
+        expect(
+          exec.mock.calls.every(
+            ([locator]) => locator.id === workspaceId && locator.volumeRef === workspace.volumeRef,
+          ),
+        ).toBe(true);
+        const scripts = exec.mock.calls.map(([, command]) => {
+          expect(command.command).toBe("sh");
+          return command.args?.[1];
+        });
+        expect(scripts).toEqual(
+          sleeping
+            ? [manifest.environment.ready, manifest.environment.start, manifest.environment.ready]
+            : [manifest.environment.ready],
+        );
+        const token = new URL(opened.url).searchParams.get("token");
+        if (!token) throw new Error("expected one-time preview token");
+        await expect(previews.exchange(opened.sessionId, token)).resolves.toMatchObject({
+          workspaceId,
+        });
+        await expect(previews.exchange(opened.sessionId, token)).rejects.toMatchObject({
+          code: "preview_access_invalid",
+        });
+        await expect(previews.authorize(opened.sessionId, token)).resolves.toMatchObject({
+          workspaceId,
+        });
+      } finally {
+        exec.mockRestore();
+      }
+      expect(await git(["rev-parse", "HEAD"])).toBe(head);
+      expect(await git(["branch", "--show-current"])).toBe("facility/agent-current-work");
+      expect(await readFile(join(repository, "uncommitted.txt"), "utf8")).toBe(
+        "Work in progress\n",
+      );
+      expect(await readFile(join(repository, ".facility-test/seed"), "utf8")).toBe(
+        "user-created-data",
+      );
+      expect(await readFile(join(repository, ".setup-count"), "utf8")).toBe(setupCount);
+      expect(
+        await readFile(join(workspace.volumeRef, ".facility/claude/session.json"), "utf8"),
+      ).toBe("claude-session");
+      expect(
+        await readFile(join(workspace.volumeRef, ".facility/codex/session.json"), "utf8"),
+      ).toBe("codex-session");
+      const persisted = (
+        await db.select().from(workspaces).where(eq(workspaces.id, workspaceId))
+      )[0];
+      expect(persisted).toMatchObject({
+        state: "running",
+        setupChecksum: "concurrent-preparation-checksum",
+      });
+    }
+    await expect(
+      previews.open({ orgId: newId("org"), projectId, storyId, userId, service: "app" }),
+    ).rejects.toMatchObject({ code: "story_not_found" });
+  });
+
+  it("marks successful preparation without a setup script for future preview reuse", async () => {
+    const environment = new ProjectEnvironmentService(db, runtime, `file://${remotes}`);
+    const noSetup = {
+      ...manifest,
+      environment: { ...manifest.environment, setup: undefined, seed: undefined },
+    };
+    const prepared = await environment.prepare({
+      orgId,
+      projectId,
+      workspace,
+      manifest: noSetup,
+      credentials,
+      branch: "facility/story-environment",
+    });
+    const persisted = (await db.select().from(workspaces).where(eq(workspaces.id, workspaceId)))[0];
+    expect(persisted?.setupChecksum).toBe(prepared.setupChecksum);
   });
 
   it("validates declared environment before running setup and injects it ephemerally", async () => {

--- a/services/api/test/workspace-preview.integration.test.ts
+++ b/services/api/test/workspace-preview.integration.test.ts
@@ -127,6 +127,7 @@ describe("workspace preview session security", async () => {
       externalRef: `fake:${workspaceId}`,
       volumeRef: `fake-volume:${workspaceId}`,
       state: "running",
+      setupChecksum: "prepared-workspace-checksum",
       environment: {
         image: "facility-runner:test",
         variables: { FACILITY_PREVIEW_GATEWAY_TOKEN: gatewayToken },
@@ -160,7 +161,7 @@ describe("workspace preview session security", async () => {
       }),
     } as ProjectManifestSource;
     const environment = {
-      prepare: async () => ({ endpoints: [endpoint], primaryCwd: "repos/theam/example" }),
+      startPrepared: async () => ({ endpoints: [endpoint], primaryCwd: "repos/theam/example" }),
     } as unknown as ProjectEnvironmentService;
     service = new WorkspacePreviewService(db, config, runtime, credentials, manifests, environment);
   });

--- a/services/api/test/workspace-preview.test.ts
+++ b/services/api/test/workspace-preview.test.ts
@@ -1,0 +1,184 @@
+import type { FacilityDb } from "@facility/db";
+import { describe, expect, it, vi } from "vitest";
+import type { GithubWorkspaceCredentialBroker } from "../src/github/workspace-credentials.js";
+import type { AppConfig } from "../src/types.js";
+import { WorkspacePreviewService } from "../src/workspaces/preview.js";
+import {
+  ProjectEnvironmentService,
+  parseProjectManifest,
+} from "../src/workspaces/project-environment.js";
+import type { WorkspaceRuntime } from "../src/workspaces/runtime.js";
+
+const manifest = parseProjectManifest(`
+repositories:
+  primary: github.com/acme/app
+environment:
+  setup: reset-database
+  start: start-app
+  ready: check-app
+  services:
+    app:
+      port: 3000
+`);
+const credentials = {
+  repositories: [{ owner: "acme", name: "app", defaultBranch: "main", role: "primary" as const }],
+  environment: {},
+  expiresAt: new Date(Date.now() + 60_000),
+};
+const input = {
+  orgId: "org_test",
+  projectId: "proj_test",
+  storyId: "story_test",
+  userId: "user_test",
+  service: "app",
+};
+
+function fixture(state: string, setupChecksum: string | null) {
+  const story = { id: input.storyId, branch: "facility/story-test", deletedAt: null };
+  const workspace = {
+    id: "ws_test",
+    state,
+    setupChecksum,
+    externalRef: "compute-test",
+    volumeRef: "retained-volume",
+    environment: { image: "runner:test" },
+  };
+  const rows = [story, workspace];
+  const insert = vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) }));
+  const db = {
+    select: vi.fn(() => ({
+      from: () => ({ where: () => ({ limit: async () => [rows.shift()] }) }),
+    })),
+    insert,
+  } as unknown as FacilityDb;
+  const runtime = { wake: vi.fn().mockResolvedValue({ state: "running" }) };
+  const result = { endpoints: [{ service: "app", port: 3000, url: "http://127.0.0.1:3000" }] };
+  const environment = {
+    prepare: vi.fn().mockResolvedValue(result),
+    startPrepared: vi.fn().mockResolvedValue(result),
+  };
+  const service = new WorkspacePreviewService(
+    db,
+    {
+      publicUrl: "https://api.example.com",
+      previewUrl: "https://preview.example.net",
+    } as AppConfig,
+    runtime as unknown as WorkspaceRuntime,
+    { issue: async () => credentials } as unknown as GithubWorkspaceCredentialBroker,
+    { load: async () => manifest },
+    environment as unknown as ProjectEnvironmentService,
+  );
+  return { service, environment, runtime, insert, workspace, db };
+}
+
+describe("preview workspace preparation", () => {
+  it.each([
+    "running",
+    "sleeping",
+  ])("reuses the prepared %s workspace and checksum", async (state) => {
+    const f = fixture(state, "prepared-at-original-commit");
+    await f.service.open(input);
+    expect(f.runtime.wake).toHaveBeenCalledWith(
+      expect.objectContaining({ id: f.workspace.id, volumeRef: "retained-volume" }),
+    );
+    expect(f.environment.prepare).not.toHaveBeenCalled();
+    expect(f.environment.startPrepared).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({ id: f.workspace.id, volumeRef: "retained-volume" }),
+        setupChecksum: "prepared-at-original-commit",
+      }),
+    );
+    expect(f.insert).toHaveBeenCalledOnce();
+  });
+
+  it("prepares a workspace that has never completed setup", async () => {
+    const f = fixture("running", null);
+    await f.service.open(input);
+    expect(f.environment.startPrepared).not.toHaveBeenCalled();
+    expect(f.environment.prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ branch: "facility/story-test" }),
+    );
+  });
+
+  it.each(["wake", "startPrepared"])("does not mint a session when %s fails", async (phase) => {
+    const f = fixture("sleeping", "prepared");
+    const error = new Error("workspace unavailable");
+    (phase === "wake" ? f.runtime.wake : f.environment.startPrepared).mockRejectedValue(error);
+    await expect(f.service.open(input)).rejects.toBe(error);
+    expect(f.insert).not.toHaveBeenCalled();
+    expect(f.environment.prepare).not.toHaveBeenCalled();
+  });
+
+  it("does not mint a session for an undeclared service", async () => {
+    const f = fixture("running", "prepared");
+    await expect(f.service.open({ ...input, service: "other" })).rejects.toMatchObject({
+      code: "preview_service_not_found",
+    });
+    expect(f.insert).not.toHaveBeenCalled();
+  });
+
+  it("never writes a preview's previously read setup checksum back to the workspace", async () => {
+    const set = vi.fn((_values: Record<string, unknown>) => ({
+      where: () => ({ returning: async () => [{ nextEventSeq: 1 }] }),
+    }));
+    const db = {
+      update: () => ({ set }),
+      insert: () => ({ values: async () => undefined }),
+    } as unknown as FacilityDb;
+    const runtime = {
+      exec: async () => ({ exitCode: 0 }),
+      expose: async () => [{ service: "app", port: 3000, url: "http://127.0.0.1:3000" }],
+    } as unknown as WorkspaceRuntime;
+    await new ProjectEnvironmentService(db, runtime).startPrepared({
+      orgId: input.orgId,
+      projectId: input.projectId,
+      workspace: {
+        id: "ws_test",
+        image: "runner:test",
+        externalRef: "compute-test",
+        volumeRef: "retained-volume",
+      },
+      manifest,
+      credentials,
+      setupChecksum: "stale-checksum",
+    });
+    expect(set).toHaveBeenCalled();
+    for (const [update] of set.mock.calls) expect(update).not.toHaveProperty("setupChecksum");
+  });
+
+  it("validates repository scope and required environment before touching prepared services", async () => {
+    const exec = vi.fn();
+    const f = fixture("running", "prepared");
+    const environment = new ProjectEnvironmentService(
+      f.db,
+      { exec } as unknown as WorkspaceRuntime,
+      undefined,
+      () => undefined,
+    );
+    const base = {
+      ...input,
+      workspace: {
+        id: "ws_test",
+        image: "runner:test",
+        externalRef: "compute-test",
+        volumeRef: "retained-volume",
+      },
+      manifest,
+      credentials,
+      setupChecksum: "prepared",
+    };
+    await expect(
+      environment.startPrepared({ ...base, credentials: { ...credentials, repositories: [] } }),
+    ).rejects.toMatchObject({ code: "project_repository_mismatch" });
+    await expect(
+      environment.startPrepared({
+        ...base,
+        manifest: {
+          ...manifest,
+          environment: { ...manifest.environment, secrets: ["DATABASE_URL"] },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "project_environment_missing" });
+    expect(exec).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changes

Opening a preview of a prepared story workspace now uses the agents’ current branch, uncommitted files, native sessions, and local data. It checks declared readiness first, starts services when needed, and exposes the existing workspace without fetching or switching Git, rerunning setup, or reseeding. First-time preparation and explicit Clean setup keep their existing behavior; successful preparation without a setup script also records its checksum.

## Why

Preview access previously invoked full preparation. Its setup checksum includes Git HEAD, so an agent commit could cause opening the app to rerun setup and reset the database. Fetching and switching branches could also interfere with an active agent.

## Verification

- [x] Final `corepack pnpm verify` passes locally (exit 0), including all direct critical integration suites. An earlier reference-journey timeout passed unchanged after the concurrent image build finished; no timeout or check was weakened.
- [ ] Behaviour verified beyond the test suite: live workspace verification follows the API rollout; hosted Docker workspace E2E is required for this change.
- [x] Documentation updated in README.

Focused acceptance: `corepack pnpm --filter @facility/api exec vitest run --fileParallelism=false test/workspace-preview.test.ts test/workspace-preview.integration.test.ts test/project-environment.integration.test.ts` — **3 files, 20 tests passed**. The real PostgreSQL/local Git/fake runtime regression opens running and replaced-compute workspaces after an agent commit and branch change, checks uncommitted files, edited seed data and native session files, and verifies no checkout/setup/seed command runs. It also updates the stored setup checksum during preview execution and proves the concurrent update is preserved. Existing preview HTTP/WebSocket, one-time exchange, expiry, revocation and membership checks remain covered.

Claude final shipping review: **No blockers.** The review’s checksum race was fixed and covered by both unit and real PostgreSQL regression checks.
