### PR TITLE
fix(workspaces): bound Vercel command completion waits

### DIFF
--- a/apps/docs/docs/reference/lifecycle.md
+++ b/apps/docs/docs/reference/lifecycle.md
@@ -77,6 +77,11 @@ retained in the snapshot. It waits for a live daemon, or removes stale PID and s
 starting one. A recycled PID is never signaled. Bootstrap preserves ownership inside Docker layers
 and volumes so container data survives the resume.
 
+Vercel agent commands start once and are tracked by short status requests to the same compute
+session while their output streams. Tracking does not hold one HTTP request open for the entire
+agent run, so a long command can finish within its configured provider timeout. Cancel still
+signals the existing command; a failed status or output read is reported without resubmitting it.
+
 ## Operations
 
 ### Send message

--- a/apps/docs/docs/reference/lifecycle.md
+++ b/apps/docs/docs/reference/lifecycle.md
@@ -77,8 +77,9 @@ retained in the snapshot. It waits for a live daemon, or removes stale PID and s
 starting one. A recycled PID is never signaled. Bootstrap preserves ownership inside Docker layers
 and volumes so container data survives the resume.
 
-Vercel agent commands start once and are tracked by short status requests to the same compute
-session while their output streams. Tracking does not hold one HTTP request open for the entire
+Vercel agent commands start once and are tracked by bounded completion requests to the same command
+while their output streams. Each wait is limited to 30 seconds; an expired wait is renewed
+without restarting the command. Tracking does not hold one HTTP request open for the entire
 agent run, so a long command can finish within its configured provider timeout. Cancel still
 signals the existing command; a failed status or output read is reported without resubmitting it.
 

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -1,5 +1,4 @@
 import { PassThrough } from "node:stream";
-import { setTimeout as delay } from "node:timers/promises";
 import { Sandbox } from "@vercel/sandbox";
 import {
   assertWorkspaceId,
@@ -100,7 +99,6 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
       detached: true,
     });
     const observation = new AbortController();
-    const session = sandbox.currentSession();
     let canceled = command.signal?.aborted ?? false;
     const cancel = () => {
       canceled = true;
@@ -116,15 +114,18 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
       }
     })();
     const completion = (async () => {
-      // A blocking SDK wait keeps its HTTP response open for the entire command.
-      // Poll the original session instead: transport timeouts must not relaunch agents.
+      // Metadata reads do not reliably include an exit status. Bound each wait
+      // on this original command so no HTTP request lasts for the whole agent run.
       while (true) {
-        const status = await session.getCommand(running.cmdId, {
-          signal: AbortSignal.any([observation.signal, AbortSignal.timeout(30_000)]),
-        });
-        if (status.exitCode !== null)
-          return { exitCode: status.exitCode, durationMs: status.durationMs };
-        await delay(1_000, undefined, { signal: observation.signal });
+        const timeout = AbortSignal.timeout(30_000);
+        try {
+          return await running.wait({
+            signal: AbortSignal.any([observation.signal, timeout]),
+          });
+        } catch (error) {
+          if (timeout.aborted && !observation.signal.aborted) continue;
+          throw error;
+        }
       }
     })();
     let result: Awaited<typeof completion>;

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -1,4 +1,5 @@
 import { PassThrough } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
 import { Sandbox } from "@vercel/sandbox";
 import {
   assertWorkspaceId,
@@ -98,33 +99,51 @@ export class VercelWorkspaceRuntime implements WorkspaceRuntime {
           : Math.min(command.timeoutMs, MAX_COMMAND_TIMEOUT_MS),
       detached: true,
     });
+    const observation = new AbortController();
+    const session = sandbox.currentSession();
     let canceled = command.signal?.aborted ?? false;
     const cancel = () => {
       canceled = true;
+      observation.abort();
       void running.kill("SIGTERM").catch(() => undefined);
     };
     command.signal?.addEventListener("abort", cancel, { once: true });
     if (canceled) cancel();
     const logs = (async () => {
-      for await (const log of running.logs()) {
+      for await (const log of running.logs({ signal: observation.signal })) {
         if (log.stream === "stdout") stdoutStream.write(log.data);
         else stderrStream.write(log.data);
       }
     })();
-    const result = await (async () => {
-      const finished = await running.wait();
-      await logs;
-      return finished;
-    })().finally(() => {
+    const completion = (async () => {
+      // A blocking SDK wait keeps its HTTP response open for the entire command.
+      // Poll the original session instead: transport timeouts must not relaunch agents.
+      while (true) {
+        const status = await session.getCommand(running.cmdId, {
+          signal: AbortSignal.any([observation.signal, AbortSignal.timeout(30_000)]),
+        });
+        if (status.exitCode !== null)
+          return { exitCode: status.exitCode, durationMs: status.durationMs };
+        await delay(1_000, undefined, { signal: observation.signal });
+      }
+    })();
+    let result: Awaited<typeof completion>;
+    try {
+      [result] = await Promise.all([completion, logs]);
+      if (canceled) throw new Error("command canceled");
+    } catch (error) {
+      if (canceled) {
+        throw new WorkspaceRuntimeError(
+          "workspace_command_canceled",
+          "workspace command was canceled",
+        );
+      }
+      throw error;
+    } finally {
+      observation.abort();
       command.signal?.removeEventListener("abort", cancel);
       stdoutStream.end();
       stderrStream.end();
-    });
-    if (canceled) {
-      throw new WorkspaceRuntimeError(
-        "workspace_command_canceled",
-        "workspace command was canceled",
-      );
     }
     return {
       exitCode: result.exitCode,

--- a/services/api/test/agent-vercel.integration.test.ts
+++ b/services/api/test/agent-vercel.integration.test.ts
@@ -30,6 +30,7 @@ function provider(engine: "claude_code" | "codex", exitCode = 0, onLog?: () => v
       throw new Error("Invalid request: `timeout` should be <= 18000000.");
     }
     return {
+      cmdId: "cmd_agent",
       kill,
       logs: async function* () {
         onLog?.();
@@ -39,8 +40,12 @@ function provider(engine: "claude_code" | "codex", exitCode = 0, onLog?: () => v
       wait: async () => ({ exitCode, durationMs: 10 }),
     };
   });
-  sandboxApi.get.mockResolvedValue({ asUser: () => ({ runCommand }) });
-  return { runCommand, kill };
+  const getCommand = vi.fn().mockResolvedValue({ exitCode, durationMs: 10 });
+  sandboxApi.get.mockResolvedValue({
+    asUser: () => ({ runCommand }),
+    currentSession: () => ({ getCommand }),
+  });
+  return { runCommand, kill, getCommand };
 }
 
 function request(engine: "claude_code" | "codex") {
@@ -90,6 +95,22 @@ describe.each(["claude_code", "codex"] as const)("%s through the Vercel runtime"
         args: expect.arrayContaining([engine === "codex" ? "codex" : "claude", "native-session"]),
       }),
     );
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("keeps the original native session while its command outlives an HTTP wait", async () => {
+    const { runCommand, kill, getCommand } = provider(engine);
+    getCommand
+      .mockResolvedValueOnce({ exitCode: null })
+      .mockResolvedValue({ exitCode: 0, durationMs: 1_200_000 });
+    await expect(createEngine().run(request(engine))).resolves.toMatchObject({
+      nativeSessionId: "native-session",
+      output: "ready",
+      exitCode: 0,
+    });
+    expect(getCommand).toHaveBeenCalledTimes(2);
+    expect(getCommand).toHaveBeenCalledWith("cmd_agent", { signal: expect.any(AbortSignal) });
+    expect(runCommand).toHaveBeenCalledOnce();
     expect(kill).not.toHaveBeenCalled();
   });
 

--- a/services/api/test/agent-vercel.integration.test.ts
+++ b/services/api/test/agent-vercel.integration.test.ts
@@ -24,6 +24,7 @@ function provider(engine: "claude_code" | "codex", exitCode = 0, onLog?: () => v
           { type: "item.completed", item: { type: "agent_message", text: "ready" } },
           { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
         ];
+  const wait = vi.fn().mockResolvedValue({ exitCode, durationMs: 10 });
   const runCommand = vi.fn(async (params: { timeoutMs?: number; detached?: boolean }) => {
     // Reproduce the provider contract that rejected the real default engine request.
     if ((params.timeoutMs ?? 0) > 18_000_000) {
@@ -37,7 +38,7 @@ function provider(engine: "claude_code" | "codex", exitCode = 0, onLog?: () => v
         for (const event of events) yield { stream: "stdout", data: `${JSON.stringify(event)}\n` };
         if (exitCode) yield { stream: "stderr", data: "command terminated" };
       },
-      wait: async () => ({ exitCode, durationMs: 10 }),
+      wait,
     };
   });
   const getCommand = vi.fn().mockResolvedValue({ exitCode, durationMs: 10 });
@@ -45,7 +46,7 @@ function provider(engine: "claude_code" | "codex", exitCode = 0, onLog?: () => v
     asUser: () => ({ runCommand }),
     currentSession: () => ({ getCommand }),
   });
-  return { runCommand, kill, getCommand };
+  return { runCommand, kill, wait };
 }
 
 function request(engine: "claude_code" | "codex") {
@@ -99,17 +100,14 @@ describe.each(["claude_code", "codex"] as const)("%s through the Vercel runtime"
   });
 
   it("keeps the original native session while its command outlives an HTTP wait", async () => {
-    const { runCommand, kill, getCommand } = provider(engine);
-    getCommand
-      .mockResolvedValueOnce({ exitCode: null })
-      .mockResolvedValue({ exitCode: 0, durationMs: 1_200_000 });
+    const { runCommand, kill, wait } = provider(engine);
+    wait.mockResolvedValue({ exitCode: 0, durationMs: 1_200_000 });
     await expect(createEngine().run(request(engine))).resolves.toMatchObject({
       nativeSessionId: "native-session",
       output: "ready",
       exitCode: 0,
     });
-    expect(getCommand).toHaveBeenCalledTimes(2);
-    expect(getCommand).toHaveBeenCalledWith("cmd_agent", { signal: expect.any(AbortSignal) });
+    expect(wait).toHaveBeenCalledExactlyOnceWith({ signal: expect.any(AbortSignal) });
     expect(runCommand).toHaveBeenCalledOnce();
     expect(kill).not.toHaveBeenCalled();
   });

--- a/services/api/test/vercel-command-observation.integration.test.ts
+++ b/services/api/test/vercel-command-observation.integration.test.ts
@@ -1,0 +1,127 @@
+import { Command } from "@vercel/sandbox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sandboxApi = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("@vercel/sandbox", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@vercel/sandbox")>()),
+  Sandbox: sandboxApi,
+}));
+
+import { VercelWorkspaceRuntime } from "../src/workspaces/vercel.js";
+
+const workspace = {
+  id: "ws_0123456789abcdef",
+  externalRef: "ws_0123456789abcdef",
+  volumeRef: "snap_retained",
+  image: "facility-runner:test",
+};
+const metadata = {
+  id: "cmd_original",
+  name: "codex",
+  args: [],
+  cwd: "/workspace",
+  sessionId: "session_original",
+  exitCode: null,
+  startedAt: 0,
+};
+
+function provider() {
+  const getCommand = vi.fn();
+  const killCommand = vi.fn().mockResolvedValue(undefined);
+  const client = {
+    getCommand,
+    killCommand,
+    getLogs: async function* () {
+      yield { stream: "stdout", data: "native output" };
+    },
+  };
+  // Exercise the real SDK Command.wait/CommandFinished path. Live metadata reads
+  // can keep returning exitCode:null even after a command has finished.
+  const command = new Command({
+    client: client as unknown as NonNullable<ConstructorParameters<typeof Command>[0]["client"]>,
+    sessionId: metadata.sessionId,
+    cmd: metadata,
+  });
+  const runCommand = vi.fn().mockResolvedValue(command);
+  const metadataRead = vi.fn().mockResolvedValue(command);
+  sandboxApi.get.mockResolvedValue({
+    asUser: () => ({ runCommand }),
+    currentSession: () => ({ getCommand: metadataRead }),
+  });
+  return { getCommand, killCommand, runCommand, metadataRead };
+}
+
+describe("Vercel command observation through the actual SDK", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renews an expired bounded wait on the same command and receives its exit status", async () => {
+    const { getCommand, killCommand, runCommand, metadataRead } = provider();
+    const actualTimeout = AbortSignal.timeout;
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => actualTimeout(5));
+    getCommand
+      .mockImplementationOnce((input: { wait?: boolean; signal?: AbortSignal }) => {
+        if (!input.wait || !input.signal) throw new Error("Completion must use a bounded wait");
+        return new Promise((_resolve, reject) => {
+          input.signal?.addEventListener("abort", () => reject(input.signal?.reason), {
+            once: true,
+          });
+        });
+      })
+      .mockResolvedValue({
+        json: { command: { ...metadata, exitCode: 0, durationMs: 1_200_000 } },
+      });
+
+    await expect(
+      new VercelWorkspaceRuntime().exec(workspace, { command: "codex" }),
+    ).resolves.toEqual({
+      exitCode: 0,
+      stdout: "native output",
+      stderr: "",
+      durationMs: 1_200_000,
+    });
+    expect(timeout).toHaveBeenCalledTimes(2);
+    expect(timeout).toHaveBeenNthCalledWith(1, 30_000);
+    expect(timeout).toHaveBeenNthCalledWith(2, 30_000);
+    expect(getCommand).toHaveBeenCalledTimes(2);
+    for (const [input] of getCommand.mock.calls) {
+      expect(input).toMatchObject({
+        sessionId: "session_original",
+        cmdId: "cmd_original",
+        wait: true,
+      });
+      expect(input.signal).toBeInstanceOf(AbortSignal);
+    }
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(metadataRead).not.toHaveBeenCalled();
+    expect(killCommand).not.toHaveBeenCalled();
+  });
+
+  it("propagates revoked access without retrying a wait or resubmitting the command", async () => {
+    const { getCommand, runCommand } = provider();
+    const denied = Object.assign(new Error("access revoked"), { status: 403 });
+    getCommand.mockRejectedValue(denied);
+    await expect(new VercelWorkspaceRuntime().exec(workspace, { command: "codex" })).rejects.toBe(
+      denied,
+    );
+    expect(getCommand).toHaveBeenCalledOnce();
+    expect(runCommand).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the command once without mistaking cancellation for an observation timeout", async () => {
+    const { getCommand, killCommand, runCommand } = provider();
+    const controller = new AbortController();
+    getCommand.mockImplementation(
+      (input: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          input.signal.addEventListener("abort", () => reject(input.signal.reason), { once: true });
+          controller.abort();
+        }),
+    );
+    await expect(
+      new VercelWorkspaceRuntime().exec(workspace, { command: "codex", signal: controller.signal }),
+    ).rejects.toMatchObject({ code: "workspace_command_canceled" });
+    expect(getCommand).toHaveBeenCalledOnce();
+    expect(killCommand).toHaveBeenCalledOnce();
+    expect(runCommand).toHaveBeenCalledOnce();
+  });
+});

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -20,7 +20,10 @@ function fakeSandbox() {
     name: "ws_0123456789abcdef",
     status: "running",
     currentSnapshotId: "snap_persistent",
-    currentSession: () => ({ sessionId: "session_current" }),
+    currentSession: () => ({
+      sessionId: "session_current",
+      getCommand: vi.fn().mockResolvedValue({ exitCode: 0, durationMs: 12 }),
+    }),
     runCommand,
     asUser: vi.fn().mockReturnValue({ runCommand }),
     stop: vi.fn().mockResolvedValue(undefined),
@@ -152,6 +155,86 @@ describe("Vercel persistent workspace runtime", () => {
       [{ stream: "stdout", data: "ready" }],
       [{ stream: "stderr", data: "warning" }],
     ]);
+  });
+
+  it("observes one long-running command without opening a blocking wait or relaunching it", async () => {
+    const wait = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const running = {
+      cmdId: "cmd_long",
+      wait,
+      logs: async function* () {
+        yield { stream: "stdout", data: "still working" };
+      },
+    };
+    const runCommand = vi.fn().mockResolvedValue(running);
+    const getCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ exitCode: null })
+      .mockResolvedValue({ exitCode: 0, durationMs: 1_200_000 });
+    const sandbox = {
+      ...fakeSandbox(),
+      asUser: () => ({ runCommand }),
+      currentSession: () => ({ sessionId: "session_original", getCommand }),
+    };
+    sandboxApi.get.mockResolvedValue(sandbox);
+    const output = await new VercelWorkspaceRuntime().exec(input, {
+      command: "codex",
+      timeoutMs: 1_800_000,
+    });
+    expect(output).toMatchObject({ exitCode: 0, stdout: "still working", durationMs: 1_200_000 });
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(wait).not.toHaveBeenCalled();
+    expect(getCommand).toHaveBeenCalledTimes(2);
+    expect(getCommand).toHaveBeenCalledWith("cmd_long", { signal: expect.any(AbortSignal) });
+    expect(sandboxApi.get).toHaveBeenCalledOnce();
+    expect(sandbox.stop).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a denied status read without retrying command submission", async () => {
+    const denied = Object.assign(new Error("access revoked"), { status: 403 });
+    const runCommand = vi
+      .fn()
+      .mockResolvedValue({ cmdId: "cmd_denied", logs: async function* () {} });
+    const getCommand = vi.fn().mockRejectedValue(denied);
+    sandboxApi.get.mockResolvedValue({
+      ...fakeSandbox(),
+      asUser: () => ({ runCommand }),
+      currentSession: () => ({ getCommand }),
+    });
+    await expect(new VercelWorkspaceRuntime().exec(input, { command: "codex" })).rejects.toBe(
+      denied,
+    );
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(getCommand).toHaveBeenCalledOnce();
+  });
+
+  it("aborts pending status observation when the output stream fails", async () => {
+    const streamError = new Error("output stream disconnected");
+    const runCommand = vi.fn().mockResolvedValue({
+      cmdId: "cmd_stream",
+      logs: async function* () {
+        yield { stream: "stdout", data: "partial output" };
+        throw streamError;
+      },
+    });
+    const getCommand = vi.fn(
+      (_id: string, options: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener("abort", () => reject(options.signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    sandboxApi.get.mockResolvedValue({
+      ...fakeSandbox(),
+      asUser: () => ({ runCommand }),
+      currentSession: () => ({ getCommand }),
+    });
+    await expect(new VercelWorkspaceRuntime().exec(input, { command: "codex" })).rejects.toBe(
+      streamError,
+    );
+    expect(getCommand.mock.calls[0]?.[1].signal.aborted).toBe(true);
+    expect(runCommand).toHaveBeenCalledOnce();
   });
 
   it("uses the SDK's full HTTPS URL for exposed and inspected preview endpoints", async () => {

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -157,8 +157,8 @@ describe("Vercel persistent workspace runtime", () => {
     ]);
   });
 
-  it("observes one long-running command without opening a blocking wait or relaunching it", async () => {
-    const wait = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+  it("bounds observation of one long-running command without relaunching it", async () => {
+    const wait = vi.fn().mockResolvedValue({ exitCode: 0, durationMs: 1_200_000 });
     const running = {
       cmdId: "cmd_long",
       wait,
@@ -167,73 +167,59 @@ describe("Vercel persistent workspace runtime", () => {
       },
     };
     const runCommand = vi.fn().mockResolvedValue(running);
-    const getCommand = vi
-      .fn()
-      .mockResolvedValueOnce({ exitCode: null })
-      .mockResolvedValue({ exitCode: 0, durationMs: 1_200_000 });
-    const sandbox = {
-      ...fakeSandbox(),
-      asUser: () => ({ runCommand }),
-      currentSession: () => ({ sessionId: "session_original", getCommand }),
-    };
+    const sandbox = { ...fakeSandbox(), asUser: () => ({ runCommand }) };
     sandboxApi.get.mockResolvedValue(sandbox);
-    const output = await new VercelWorkspaceRuntime().exec(input, {
-      command: "codex",
-      timeoutMs: 1_800_000,
-    });
-    expect(output).toMatchObject({ exitCode: 0, stdout: "still working", durationMs: 1_200_000 });
-    expect(runCommand).toHaveBeenCalledOnce();
-    expect(wait).not.toHaveBeenCalled();
-    expect(getCommand).toHaveBeenCalledTimes(2);
-    expect(getCommand).toHaveBeenCalledWith("cmd_long", { signal: expect.any(AbortSignal) });
-    expect(sandboxApi.get).toHaveBeenCalledOnce();
-    expect(sandbox.stop).not.toHaveBeenCalled();
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    try {
+      const output = await new VercelWorkspaceRuntime().exec(input, {
+        command: "codex",
+        timeoutMs: 1_800_000,
+      });
+      expect(output).toMatchObject({ exitCode: 0, stdout: "still working", durationMs: 1_200_000 });
+      expect(runCommand).toHaveBeenCalledOnce();
+      expect(wait).toHaveBeenCalledExactlyOnceWith({ signal: expect.any(AbortSignal) });
+      expect(timeout).toHaveBeenCalledWith(30_000);
+      expect(sandboxApi.get).toHaveBeenCalledOnce();
+      expect(sandbox.stop).not.toHaveBeenCalled();
+    } finally {
+      timeout.mockRestore();
+    }
   });
 
-  it("surfaces a denied status read without retrying command submission", async () => {
+  it("surfaces a denied completion read without retrying command submission", async () => {
     const denied = Object.assign(new Error("access revoked"), { status: 403 });
-    const runCommand = vi
-      .fn()
-      .mockResolvedValue({ cmdId: "cmd_denied", logs: async function* () {} });
-    const getCommand = vi.fn().mockRejectedValue(denied);
-    sandboxApi.get.mockResolvedValue({
-      ...fakeSandbox(),
-      asUser: () => ({ runCommand }),
-      currentSession: () => ({ getCommand }),
-    });
+    const wait = vi.fn().mockRejectedValue(denied);
+    const runCommand = vi.fn().mockResolvedValue({ wait, logs: async function* () {} });
+    sandboxApi.get.mockResolvedValue({ ...fakeSandbox(), asUser: () => ({ runCommand }) });
     await expect(new VercelWorkspaceRuntime().exec(input, { command: "codex" })).rejects.toBe(
       denied,
     );
     expect(runCommand).toHaveBeenCalledOnce();
-    expect(getCommand).toHaveBeenCalledOnce();
+    expect(wait).toHaveBeenCalledOnce();
   });
 
-  it("aborts pending status observation when the output stream fails", async () => {
+  it("aborts a pending completion read when the output stream fails", async () => {
     const streamError = new Error("output stream disconnected");
-    const runCommand = vi.fn().mockResolvedValue({
-      cmdId: "cmd_stream",
-      logs: async function* () {
-        yield { stream: "stdout", data: "partial output" };
-        throw streamError;
-      },
-    });
-    const getCommand = vi.fn(
-      (_id: string, options: { signal: AbortSignal }) =>
+    const wait = vi.fn(
+      (options: { signal: AbortSignal }) =>
         new Promise((_resolve, reject) => {
           options.signal.addEventListener("abort", () => reject(options.signal.reason), {
             once: true,
           });
         }),
     );
-    sandboxApi.get.mockResolvedValue({
-      ...fakeSandbox(),
-      asUser: () => ({ runCommand }),
-      currentSession: () => ({ getCommand }),
+    const runCommand = vi.fn().mockResolvedValue({
+      wait,
+      logs: async function* () {
+        yield { stream: "stdout", data: "partial output" };
+        throw streamError;
+      },
     });
+    sandboxApi.get.mockResolvedValue({ ...fakeSandbox(), asUser: () => ({ runCommand }) });
     await expect(new VercelWorkspaceRuntime().exec(input, { command: "codex" })).rejects.toBe(
       streamError,
     );
-    expect(getCommand.mock.calls[0]?.[1].signal.aborted).toBe(true);
+    expect(wait.mock.calls[0]?.[0].signal.aborted).toBe(true);
     expect(runCommand).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## What changes

Observe each Vercel command with consecutive, bounded 30-second completion waits while streaming its output. Every wait targets the original command; an expired observation does not restart it. Cancellation signals that command once, and completion/output failures abort the companion observer without resubmitting work.

## Why

An unbounded completion request can exceed the HTTP transport timeout while the agent command remains healthy. Plain command metadata can also keep returning a null exit code after completion, so observation must use the SDK completion endpoint.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change

Focused acceptance: `Test Files  3 passed (3)` and `Tests  32 passed (32)`. Deterministic integration coverage exercises the actual SDK Command implementation against a fake provider, including an expired wait, a completed original command, revoked access, and cancellation. The native engine tests preserve session identity for both supported engines. Output-stream failure aborts the pending completion read.

Live acceptance on an existing sandbox: one command slept for 32 seconds and exited 0. Its first completion wait aborted after 30,004 ms; the second completed after 2,004 ms with the same command ID. Total runtime was 32,628 ms and the expected output was returned. A separate read-only check confirmed that plain metadata had a null exit code while the same command's completion endpoint returned 0.

Lifecycle documentation describes bounded observation and unchanged cancellation/submission semantics. Open questions: none for this change.
