### PR TITLE
fix(workspaces): isolate Docker execution state by VM boot

### DIFF
--- a/apps/docs/docs/reference/lifecycle.md
+++ b/apps/docs/docs/reference/lifecycle.md
@@ -77,6 +77,11 @@ retained in the snapshot. It waits for a live daemon, or removes stale PID and s
 starting one. A recycled PID is never signaled. Bootstrap preserves ownership inside Docker layers
 and volumes so container data survives the resume.
 
+New daemons use an execution-state directory tied to the kernel boot ID. Restoring a snapshot
+therefore cannot reuse runc process state from an earlier VM, while Docker's persistent data stays
+in `/workspace/.facility/docker`. Container restart policies still apply: a container deliberately
+stopped with `unless-stopped` remains stopped. A missing or malformed boot ID prevents startup.
+
 Vercel agent commands start once and are tracked by bounded completion requests to the same command
 while their output streams. Each wait is limited to 30 seconds; an expired wait is renewed
 without restarting the command. Tracking does not hold one HTTP request open for the entire

--- a/services/api/src/workspaces/vercel.ts
+++ b/services/api/src/workspaces/vercel.ts
@@ -323,11 +323,18 @@ function workspaceBootstrapCommand(input: CreateWorkspace) {
     esac
   fi
   if test "$docker_running" = 0; then
+    # Snapshots retain runc/containerd process state, but the resumed VM has no
+    # corresponding processes. Keep execution state per boot and data persistent.
+    docker_boot_id="$(cat /proc/sys/kernel/random/boot_id)"
+    if test "\${#docker_boot_id}" -ne 36 || ! printf '%s\\n' "$docker_boot_id" | grep -Eq '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'; then
+      echo "Cannot start Docker without a valid kernel boot ID" >&2
+      exit 1
+    fi
     # A restored disk can contain a PID now owned by an unrelated process.
     # Remove only stale daemon artifacts; never signal that recycled PID.
     rm -f /var/run/docker.pid /var/run/docker.sock
     rm -rf /var/run/docker/containerd
-    nohup dockerd --host=unix:///var/run/docker.sock --data-root=/workspace/.facility/docker --storage-driver=vfs >/workspace/.facility/dockerd.log 2>&1 &
+    nohup dockerd --host=unix:///var/run/docker.sock --exec-root="/var/run/facility-docker-$docker_boot_id" --data-root=/workspace/.facility/docker --storage-driver=vfs >/workspace/.facility/dockerd.log 2>&1 &
   fi
 fi`,
     `attempt=0

--- a/services/api/test/workspace-vercel-bootstrap.integration.test.ts
+++ b/services/api/test/workspace-vercel-bootstrap.integration.test.ts
@@ -16,6 +16,7 @@ vi.mock("@vercel/sandbox", async (original) => ({
 import { VercelWorkspaceRuntime } from "../src/workspaces/vercel.js";
 
 const cleanups: (() => Promise<void>)[] = [];
+const bootId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
 });
@@ -23,11 +24,15 @@ afterEach(async () => {
 async function localProvider(
   brokenGateway: boolean,
   dockerState: "ready" | "stale-pid" | "starting" = "ready",
+  kernelBootId: string | null = bootId,
 ) {
   const root = await mkdtemp(join(tmpdir(), "facility-vercel-bootstrap-"));
   const bin = join(root, "bin");
   await mkdir(bin);
   await mkdir(join(root, "run"));
+  await mkdir(join(root, "proc/sys/kernel/random"), { recursive: true });
+  if (kernelBootId !== null)
+    await writeFile(join(root, "proc/sys/kernel/random/boot_id"), `${kernelBootId}\n`);
   // Own the colliding PID, so even a regression that signals it cannot touch
   // an unrelated host process. /proc itself remains a deterministic fake.
   const colliding = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
@@ -74,7 +79,21 @@ async function localProvider(
         : dockerState === "stale-pid"
           ? `test -f '${root}/docker-ready'`
           : `if test -f '${root}/docker-waited'; then exit 0; fi; touch '${root}/docker-waited'; exit 1`,
-    dockerd: `test ! -d '${root}/run/docker/containerd' || exit 8\ntest ! -f '${root}/run/docker.pid' || { echo 'stale daemon PID' >&2; exit 1; }\necho started > '${root}/docker-started'\ntouch '${root}/docker-ready'`,
+    dockerd: `test ! -d '${root}/run/docker/containerd' || exit 8
+test ! -f '${root}/run/docker.pid' || { echo 'stale daemon PID' >&2; exit 1; }
+exec_root='${root}/run/docker'
+for arg in "$@"; do
+  case "$arg" in --exec-root=*) exec_root="\${arg#--exec-root=}" ;; esac
+done
+if test -e "$exec_root/runtime-runc/moby/retained"; then
+  echo 'container with given ID already exists' >&2
+  exit 1
+fi
+mkdir -p "$exec_root/runtime-runc/moby"
+echo 'transient container state' > "$exec_root/runtime-runc/moby/retained"
+echo "$exec_root" >> '${root}/docker-exec-roots'
+echo started > '${root}/docker-started'
+touch '${root}/docker-ready'`,
     // Model the ownership boundary: recursively reassigning a persisted Docker
     // tree would corrupt container UIDs, even when daemon startup succeeds.
     chown: 'test "$1" != -R || { echo "recursive ownership reset" >&2; exit 1; }',
@@ -204,8 +223,64 @@ it("starts Docker after a restored PID collides with an unrelated process, prese
   expect(fixture.stop).not.toHaveBeenCalled();
 });
 
+it("restores containers with fresh execution state on each boot, preserving old state and data", async () => {
+  const { fixture, root } = await localProvider(false, "stale-pid");
+  const priorRoot = join(root, "run/docker/runtime-runc/moby");
+  const volume = join(root, ".facility/docker/volumes/database");
+  await mkdir(priorRoot, { recursive: true });
+  await writeFile(join(priorRoot, "retained"), "snapshot process state");
+  await mkdir(volume, { recursive: true });
+  await writeFile(join(volume, "retained"), "seeded database");
+  const runtime = new VercelWorkspaceRuntime();
+  const input = { id: fixture.name, image: "runner:test" };
+  await runtime.create(input);
+  // A second acquire in this boot must keep the already-running daemon.
+  await runtime.create(input);
+  const firstRoot = join(root, `run/facility-docker-${bootId}`);
+  expect(await readFile(join(root, "docker-exec-roots"), "utf8")).toBe(`${firstRoot}\n`);
+
+  // Model a snapshot restore: all disk files survive, but readiness and boot ID change.
+  const nextBootId = "11111111-2222-4333-8444-555555555555";
+  await rm(join(root, "docker-ready"));
+  await writeFile(join(root, "proc/sys/kernel/random/boot_id"), `${nextBootId}\n`);
+  await runtime.create(input);
+  expect(await readFile(join(root, "docker-exec-roots"), "utf8")).toBe(
+    `${firstRoot}\n${join(root, `run/facility-docker-${nextBootId}`)}\n`,
+  );
+  expect(await readFile(join(priorRoot, "retained"), "utf8")).toBe("snapshot process state");
+  expect(await readFile(join(firstRoot, "runtime-runc/moby/retained"), "utf8")).toBe(
+    "transient container state\n",
+  );
+  expect(await readFile(join(volume, "retained"), "utf8")).toBe("seeded database");
+  expect(fixture.stop).not.toHaveBeenCalled();
+});
+
+it.each([
+  null,
+  "",
+  "../../workspace",
+  "a".repeat(36),
+  `${bootId}\nanother-line`,
+])("refuses Docker startup with missing or malformed kernel boot ID %s", async (kernelBootId) => {
+  const { fixture, root, dockerPid, colliding } = await localProvider(
+    false,
+    "stale-pid",
+    kernelBootId,
+  );
+  await expect(
+    new VercelWorkspaceRuntime().create({ id: fixture.name, image: "runner:test" }),
+  ).rejects.toMatchObject({ code: "workspace_initialize_failed" });
+  expect(await readFile(join(root, "run/docker.pid"), "utf8")).toBe(String(dockerPid));
+  expect(await readFile(join(root, "run/docker.sock"), "utf8")).toBe("existing socket");
+  await expect(readFile(join(root, "docker-started"), "utf8")).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+  expect(colliding.signalCode).toBeNull();
+  expect(fixture.stop).toHaveBeenCalledOnce();
+});
+
 it("waits for an existing Docker daemon without removing its PID or launching another", async () => {
-  const { fixture, appPort, root, dockerPid } = await localProvider(false, "starting");
+  const { fixture, appPort, root, dockerPid } = await localProvider(false, "starting", null);
   await new VercelWorkspaceRuntime().create({
     id: fixture.name,
     image: "runner:test",

--- a/services/api/test/workspace-vercel.test.ts
+++ b/services/api/test/workspace-vercel.test.ts
@@ -111,6 +111,9 @@ describe("Vercel persistent workspace runtime", () => {
     expect(bootstrap).not.toMatch(/chown\s+-R/);
     expect(bootstrap).toContain('cat "/proc/$docker_pid/comm"');
     expect(bootstrap).not.toContain('kill "$docker_pid"');
+    expect(bootstrap).toContain("cat /proc/sys/kernel/random/boot_id");
+    expect(bootstrap).toContain('--exec-root="/var/run/facility-docker-$docker_boot_id"');
+    expect(bootstrap).toContain("--data-root=/workspace/.facility/docker");
   });
 
   const input = {


### PR DESCRIPTION
## What changes

Vercel workspace bootstrap starts Docker with an execution-state directory tied to the current kernel boot ID. Container data remains in the existing persistent directory, and Docker's restart policies still decide which containers start. Missing or malformed boot IDs fail initialization before stale daemon artifacts are removed.

## Why

A resumed snapshot can retain runc state for processes that no longer exist. Docker then fails to restore containers with `container with given ID already exists`, despite intact volumes and restart policies. Using fresh execution state per VM boot prevents that collision and preserves the existing live-daemon and recycled-PID protections.

## Verification

- [x] `pnpm verify` passes locally. The repository's two pre-existing ignored high advisories remain unchanged.
- [x] Behaviour verified beyond the test suite: a live Vercel snapshot created with the prior bootstrap resumed with this change. Both container IDs and a volume sentinel survived; the running `unless-stopped` container restarted automatically, and a deliberately stopped container remained stopped. The kernel boot ID changed, and trusted operator inspection confirmed Docker used the new execution directory. The disposable workspace was deleted afterward.
- [x] Documentation updated in the lifecycle reference; documentation build, lint, and repository guards pass.

Focused unit and deterministic integration checks:

```text
Test Files  3 passed (3)
     Tests  37 passed (37)
```

The integration fixtures exercise stale runc state across boots, repeated acquisition within one boot, retained volume data, absent/malformed boot IDs, and preservation of a live daemon. The missing-boot-ID regression was also run against the previous implementation and failed as expected. Existing gateway authorization and PID-identity checks remain covered and unchanged.
