### PR TITLE
fix(workspaces): attribute commits to the configured GitHub App

### DIFF
--- a/apps/docs/docs/self-host/github-app.md
+++ b/apps/docs/docs/self-host/github-app.md
@@ -102,6 +102,12 @@ removing a repository stops future credentials and reconciliation; it does not e
 Facility conversations or workspace files. Treat retained clones and local credentials according
 to your incident and retention policy.
 
+Workspace commits use the configured App's bot identity, including its GitHub user ID in the
+`ID+APP[bot]@users.noreply.github.com` address. Facility verifies this identity with GitHub and
+configures it when preparing new or retained repositories. This lets GitHub associate automated
+commits with the App so deployment integrations can recognize their author. Existing commits are
+not rewritten. If the identity lookup fails, preparation fails instead of using an invented email.
+
 ## Validate the integration
 
 Before production use:

--- a/services/api/src/github/client.ts
+++ b/services/api/src/github/client.ts
@@ -1,6 +1,7 @@
 import { App } from "@octokit/app";
 import { Octokit as RestOctokit } from "@octokit/rest";
 import type { AppConfig } from "../types.js";
+import { createGithubGitIdentityLoader, type GithubGitIdentity } from "./git-identity.js";
 
 export type Octokit = {
   request?: (route: string, args?: Record<string, unknown>) => Promise<{ data: unknown }>;
@@ -48,6 +49,7 @@ export type GithubMaintainerTokenFactory = (input: {
 }) => Promise<{
   token: string;
   expiresAt: string;
+  gitIdentity: GithubGitIdentity;
 }>;
 
 export function createGithubClientFactory(config: AppConfig): GithubClientFactory {
@@ -75,6 +77,17 @@ export function createGithubMaintainerTokenFactory(
     throw new Error("GitHub App credentials are not configured");
   }
   const app = new App({ appId: config.githubAppId, privateKey: config.githubAppPrivateKey });
+  const identityClient = new RestOctokit();
+  const identity = createGithubGitIdentityLoader({
+    app: async () => (await app.octokit.request("GET /app")).data ?? {},
+    user: async (username, token) =>
+      (
+        await identityClient.request("GET /users/{username}", {
+          username,
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).data,
+  });
   return async ({ installationId, repositories }) => {
     const response = await app.octokit.request(
       "POST /app/installations/{installation_id}/access_tokens",
@@ -90,7 +103,7 @@ export function createGithubMaintainerTokenFactory(
     ) {
       throw new Error("GitHub installation token response omitted an exact expiry");
     }
-    return { token, expiresAt };
+    return { token, expiresAt, gitIdentity: await identity(token) };
   };
 }
 

--- a/services/api/src/github/git-identity.ts
+++ b/services/api/src/github/git-identity.ts
@@ -1,0 +1,37 @@
+export type GithubGitIdentity = { name: string; email: string };
+
+type IdentitySource = {
+  app: () => Promise<{ slug?: string }>;
+  user: (login: string, token: string) => Promise<{ id?: number; login?: string; type?: string }>;
+};
+
+/** Resolve the authenticated App's bot, rather than inventing a commit email. */
+export function createGithubGitIdentityLoader(source: IdentitySource) {
+  let pending: Promise<GithubGitIdentity> | undefined;
+  return (token: string): Promise<GithubGitIdentity> => {
+    pending ??= load(token).catch((error: unknown) => {
+      pending = undefined;
+      throw error;
+    });
+    return pending;
+  };
+
+  async function load(token: string): Promise<GithubGitIdentity> {
+    const app = await source.app();
+    if (typeof app.slug !== "string" || !/^[a-z0-9][a-z0-9-]*$/i.test(app.slug)) {
+      throw new Error("GitHub App omitted a valid bot slug");
+    }
+    const login = `${app.slug}[bot]`;
+    const user = await source.user(login, token);
+    if (
+      user.type !== "Bot" ||
+      typeof user.login !== "string" ||
+      user.login.toLowerCase() !== login.toLowerCase() ||
+      !Number.isSafeInteger(user.id) ||
+      (user.id ?? 0) <= 0
+    ) {
+      throw new Error("GitHub App bot identity could not be verified");
+    }
+    return { name: user.login, email: `${user.id}+${user.login}@users.noreply.github.com` };
+  }
+}

--- a/services/api/src/github/workspace-credentials.ts
+++ b/services/api/src/github/workspace-credentials.ts
@@ -1,6 +1,7 @@
 import { type FacilityDb, githubInstallations, projectRepositories } from "@facility/db";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import type { GithubMaintainerTokenFactory } from "./client.js";
+import type { GithubGitIdentity } from "./git-identity.js";
 
 export type WorkspaceRepository = {
   owner: string;
@@ -13,6 +14,7 @@ export type GithubWorkspaceCredentials = {
   repositories: WorkspaceRepository[];
   environment: Record<string, string>;
   expiresAt: Date;
+  gitIdentity: GithubGitIdentity;
 };
 
 export class GithubWorkspaceCredentialError extends Error {
@@ -118,18 +120,22 @@ export class GithubWorkspaceCredentialBroker {
       );
     }
     const primaryToken = credentialMap[`${primary.owner}/${primary.name}`.toLowerCase()];
+    const primaryCredential = primary.installationId
+      ? tokens.get(primary.installationId)
+      : undefined;
     const expiresAt = new Date(
       Math.min(
         ...[...tokens.values()].map((credential) => new Date(credential.expiresAt).getTime()),
       ),
     );
-    if (!primaryToken || !Number.isFinite(expiresAt.getTime())) {
+    if (!primaryToken || !primaryCredential || !Number.isFinite(expiresAt.getTime())) {
       throw new GithubWorkspaceCredentialError(
         "github_token_invalid",
         "GitHub returned an invalid workspace credential",
       );
     }
     return {
+      gitIdentity: primaryCredential.gitIdentity,
       repositories: repositories.map((repository) => ({
         owner: repository.owner,
         name: repository.name,

--- a/services/api/src/workspaces/project-environment.ts
+++ b/services/api/src/workspaces/project-environment.ts
@@ -230,14 +230,14 @@ export class ProjectEnvironmentService {
       await this.runCommand(
         preparedInput,
         "git",
-        ["config", "user.name", "Facility Agent"],
+        ["config", "user.name", preparedInput.credentials.gitIdentity.name],
         cwd,
         "git identity",
       );
       await this.runCommand(
         preparedInput,
         "git",
-        ["config", "user.email", "facility-agent@users.noreply.github.com"],
+        ["config", "user.email", preparedInput.credentials.gitIdentity.email],
         cwd,
         "git identity",
       );

--- a/services/api/test/agent-catalog-and-github-credentials.integration.test.ts
+++ b/services/api/test/agent-catalog-and-github-credentials.integration.test.ts
@@ -485,6 +485,7 @@ describe("agent catalog and full GitHub workspace credentials", async () => {
       calls.push(request);
       return {
         token: "full-installation-token",
+        gitIdentity: { name: "my-app[bot]", email: "12345+my-app[bot]@users.noreply.github.com" },
         expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
       };
     });
@@ -496,6 +497,10 @@ describe("agent catalog and full GitHub workspace credentials", async () => {
       },
     ]);
     expect(issued.repositories).toHaveLength(2);
+    expect(issued.gitIdentity).toEqual({
+      name: "my-app[bot]",
+      email: "12345+my-app[bot]@users.noreply.github.com",
+    });
     const serializedCredentials = issued.environment.FACILITY_GITHUB_CREDENTIALS;
     if (!serializedCredentials) throw new Error("expected serialized GitHub credentials");
     expect(JSON.parse(serializedCredentials)).toEqual({
@@ -529,5 +534,12 @@ describe("agent catalog and full GitHub workspace credentials", async () => {
       env: { ...process.env, FACILITY_GITHUB_CREDENTIALS: credentials },
     });
     expect(denied).toMatchObject({ status: 0, stdout: "" });
+  });
+
+  it("does not issue workspace credentials when the App identity lookup fails", async () => {
+    const broker = new GithubWorkspaceCredentialBroker(db, async () => {
+      throw new Error("GitHub App bot identity could not be verified");
+    });
+    await expect(broker.issue(orgId, projectId)).rejects.toThrow("could not be verified");
   });
 });

--- a/services/api/test/facility-012.e2e.integration.test.ts
+++ b/services/api/test/facility-012.e2e.integration.test.ts
@@ -102,6 +102,7 @@ describe("Facility 0.12 reference journey", async () => {
   };
   const catalog = new AgentCatalogService(db, catalogSource);
   const credentials = new GithubWorkspaceCredentialBroker(db, async () => ({
+    gitIdentity: { name: "my-app[bot]", email: "12345+my-app[bot]@users.noreply.github.com" },
     token: "e2e-maintainer-installation-token",
     expiresAt: new Date(Date.now() + 60 * 60 * 1_000).toISOString(),
   }));

--- a/services/api/test/github-git-identity.test.ts
+++ b/services/api/test/github-git-identity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGithubGitIdentityLoader } from "../src/github/git-identity.js";
+
+function fixture(user = { id: 12345, login: "my-app[bot]", type: "Bot" }) {
+  const source = {
+    app: vi.fn(async () => ({ slug: "my-app" })),
+    user: vi.fn(async (_login: string, _token: string) => user),
+  };
+  return { source, load: createGithubGitIdentityLoader(source) };
+}
+
+describe("GitHub App commit identity", () => {
+  it("uses the authenticated App's bot ID and login, sharing successful lookups", async () => {
+    const { source, load } = fixture();
+    const expected = {
+      name: "my-app[bot]",
+      email: "12345+my-app[bot]@users.noreply.github.com",
+    };
+    await expect(
+      Promise.all([load("installation-token"), load("installation-token")]),
+    ).resolves.toEqual([expected, expected]);
+    await expect(load("installation-token")).resolves.toEqual(expected);
+    expect(source.app).toHaveBeenCalledTimes(1);
+    expect(source.user).toHaveBeenCalledExactlyOnceWith("my-app[bot]", "installation-token");
+  });
+
+  it.each([
+    "",
+    "../another-app",
+    "app\nname",
+    "app@evil.test",
+  ])("rejects malformed App slug %j before looking up a user", async (slug) => {
+    const { source, load } = fixture();
+    source.app.mockResolvedValue({ slug });
+    await expect(load("installation-token")).rejects.toThrow("valid bot slug");
+    expect(source.user).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { id: 12345, login: "my-app[bot]", type: "User" },
+    { id: 12345, login: "another-app[bot]", type: "Bot" },
+    { id: 0, login: "my-app[bot]", type: "Bot" },
+    { id: -1, login: "my-app[bot]", type: "Bot" },
+    { id: 1.5, login: "my-app[bot]", type: "Bot" },
+    { id: Number.MAX_SAFE_INTEGER + 1, login: "my-app[bot]", type: "Bot" },
+  ])("rejects an unverified bot record: %j", async (user) => {
+    await expect(fixture(user).load("installation-token")).rejects.toThrow("could not be verified");
+  });
+
+  it.each([
+    401, 403, 404, 429,
+  ])("fails closed on HTTP %s and allows a later retry", async (status) => {
+    const { source, load } = fixture();
+    const error = Object.assign(new Error("GitHub lookup failed"), { status });
+    source.user.mockRejectedValueOnce(error);
+    await expect(load("installation-token")).rejects.toBe(error);
+    await expect(load("installation-token")).resolves.toMatchObject({ name: "my-app[bot]" });
+    expect(source.app).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/api/test/project-environment.integration.test.ts
+++ b/services/api/test/project-environment.integration.test.ts
@@ -89,6 +89,7 @@ environment:
 `);
 
   const credentials: GithubWorkspaceCredentials = {
+    gitIdentity: { name: "my-app[bot]", email: "12345+my-app[bot]@users.noreply.github.com" },
     repositories: [
       { owner: "acme", name: "app", defaultBranch: "main", role: "primary" },
       { owner: "acme", name: "shared", defaultBranch: "main", role: "related" },
@@ -177,6 +178,17 @@ environment:
       cwd: "repos/acme/app",
     });
     expect(branch.stdout.trim()).toBe("facility/story-environment");
+    for (const cwd of ["repos/acme/app", "repos/acme/shared"]) {
+      const author = await runtime.exec(locator, {
+        command: "git",
+        args: ["var", "GIT_AUTHOR_IDENT"],
+        cwd,
+      });
+      expect(author.exitCode).toBe(0);
+      expect(author.stdout).toMatch(
+        /^my-app\[bot\] <12345\+my-app\[bot\]@users\.noreply\.github\.com> /,
+      );
+    }
     expect(
       await readFile(join(workspace.volumeRef, "repos/acme/app/.facility-test/seed"), "utf8"),
     ).toBe("seeded");
@@ -197,6 +209,12 @@ environment:
       await db.select().from(storyArtifacts).where(eq(storyArtifacts.storyId, storyId)),
     ).toHaveLength(2);
 
+    // Repair existing workspaces created with the old unassociated address too.
+    await runtime.exec(locator, {
+      command: "git",
+      args: ["config", "user.email", "facility-agent@users.noreply.github.com"],
+      cwd: "repos/acme/app",
+    });
     await runtime.replaceCompute(locator);
     await environment.prepare({
       orgId,
@@ -208,6 +226,14 @@ environment:
       previousSetupChecksum: first.setupChecksum,
       readinessTimeoutMs: 2_000,
     });
+    const resumedAuthor = await runtime.exec(locator, {
+      command: "git",
+      args: ["var", "GIT_AUTHOR_IDENT"],
+      cwd: "repos/acme/app",
+    });
+    expect(resumedAuthor.stdout).toMatch(
+      /^my-app\[bot\] <12345\+my-app\[bot\]@users\.noreply\.github\.com> /,
+    );
     expect(await readFile(join(workspace.volumeRef, "repos/acme/app/.setup-count"), "utf8")).toBe(
       "1",
     );

--- a/services/api/test/turn-dispatcher.integration.test.ts
+++ b/services/api/test/turn-dispatcher.integration.test.ts
@@ -229,6 +229,7 @@ environment:
       storiesService,
       new AgentCatalogService(db, catalogSource),
       new GithubWorkspaceCredentialBroker(db, async () => ({
+        gitIdentity: { name: "my-app[bot]", email: "12345+my-app[bot]@users.noreply.github.com" },
         token: "secret-installation-token",
         expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
       })),

--- a/services/api/test/workspace-preview.test.ts
+++ b/services/api/test/workspace-preview.test.ts
@@ -21,6 +21,7 @@ environment:
       port: 3000
 `);
 const credentials = {
+  gitIdentity: { name: "my-app[bot]", email: "12345+my-app[bot]@users.noreply.github.com" },
   repositories: [{ owner: "acme", name: "app", defaultBranch: "main", role: "primary" as const }],
   environment: {},
   expiresAt: new Date(Date.now() + 60_000),


### PR DESCRIPTION
## What changes

Workspace preparation configures Git with the authenticated GitHub App’s verified bot name and ID-based noreply address. Successful identity lookups are shared within the process; failed lookups fail preparation and can be retried. Retained repositories are corrected on their next preparation without rewriting commits.

## Why

The fixed `facility-agent@users.noreply.github.com` address has no GitHub account association. During the automatic TAM-OS migration test, GitHub could not identify the author and Vercel rejected the draft preview. Deriving the real App identity fixes attribution without changing installation permissions or repository scope.

## Verification

- [x] `pnpm verify` passes locally — clean build, types, deterministic unit/integration tests, repository guards, and audit completed with exit 0. Two existing ignored high dependency advisories remain unchanged.
- [x] Behaviour verified beyond the test suite — the actual configured App resolved to its bot identity; a fast-forward correction on the existing private draft PR was recognized by GitHub as that Bot and accepted by Vercel for deployment. Its temporary installation token was revoked afterward.
- [x] Documentation updated in the GitHub App guide.

The focused suite passed 51 tests. Coverage includes invalid App slugs, mismatched or non-bot users, invalid IDs, failed/retried lookups, scoped credential propagation, actual Git author identity in primary and related repositories, and repair of an existing repository. The Git integration regression fails against the old hardcoded identity. External systems use deterministic fakes in the default suite; live credentials are not required.
