### PR TITLE
fix(previews): re-check workspace execution on every preview request

### DIFF
--- a/services/api/src/workspaces/preview.ts
+++ b/services/api/src/workspaces/preview.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { newId } from "@facility/core";
+import { can, newId } from "@facility/core";
 import {
   type FacilityDb,
   orgMembers,
@@ -17,6 +17,9 @@ import type { ProjectEnvironmentService, ProjectManifestSource } from "./project
 import type { WorkspaceLocator, WorkspaceRuntime } from "./runtime.js";
 
 const SESSION_TTL_MS = 60 * 60 * 1_000;
+
+/** The permission the open route requires; a live session must keep holding it. */
+const PREVIEW_PERMISSION = "workspaces:execute";
 
 export class WorkspacePreviewError extends Error {
   constructor(
@@ -123,7 +126,7 @@ export class WorkspacePreviewService {
         .returning()
     )[0];
     if (!consumed) throw invalidAccess();
-    await this.assertMembership(consumed.orgId, consumed.userId);
+    await this.assertPreviewAccess(consumed.orgId, consumed.userId);
     return consumed;
   }
 
@@ -144,7 +147,7 @@ export class WorkspacePreviewService {
         .limit(1)
     )[0];
     if (!session) throw invalidAccess();
-    await this.assertMembership(session.orgId, session.userId);
+    await this.assertPreviewAccess(session.orgId, session.userId);
     return session;
   }
 
@@ -218,7 +221,11 @@ export class WorkspacePreviewService {
     return { story, workspace };
   }
 
-  private async assertMembership(orgId: string, userId: string) {
+  /**
+   * A preview session outlives the request that opened it, so the permission
+   * that opened it is re-read on every use: membership alone is not access.
+   */
+  private async assertPreviewAccess(orgId: string, userId: string) {
     const member = (
       await this.db
         .select({ permissions: roles.permissions })
@@ -234,7 +241,7 @@ export class WorkspacePreviewService {
         )
         .limit(1)
     )[0];
-    if (!member) throw invalidAccess();
+    if (!member || !can(member.permissions, PREVIEW_PERMISSION)) throw invalidAccess();
   }
 }
 

--- a/services/api/test/workspace-preview.integration.test.ts
+++ b/services/api/test/workspace-preview.integration.test.ts
@@ -212,6 +212,37 @@ describe("workspace preview session security", async () => {
     });
   });
 
+  it("stops proxying as soon as the member loses workspace execution", async () => {
+    const opened = await service.open({ orgId, projectId, storyId, userId, service: "web" });
+    const token = new URL(opened.url).searchParams.get("token");
+    if (!token) throw new Error("expected preview access token");
+    await service.exchange(opened.sessionId, token);
+    await expect(service.authorize(opened.sessionId, token)).resolves.toMatchObject({ storyId });
+
+    // The role keeps a read permission, so the membership row and the user stay
+    // active: the only thing revoked is the permission that opened the preview.
+    await db
+      .update(roles)
+      .set({ permissions: ["previews:read"] })
+      .where(eq(roles.id, roleId));
+    await expect(service.authorize(opened.sessionId, token)).rejects.toMatchObject({
+      code: "preview_access_invalid",
+    });
+
+    const reopened = await service.open({ orgId, projectId, storyId, userId, service: "web" });
+    const reopenedToken = new URL(reopened.url).searchParams.get("token");
+    if (!reopenedToken) throw new Error("expected preview access token");
+    await expect(service.exchange(reopened.sessionId, reopenedToken)).rejects.toMatchObject({
+      code: "preview_access_invalid",
+    });
+
+    await db
+      .update(roles)
+      .set({ permissions: ["workspaces:execute"] })
+      .where(eq(roles.id, roleId));
+    await expect(service.authorize(opened.sessionId, token)).resolves.toMatchObject({ storyId });
+  });
+
   it("rejects expired and malformed access tokens", async () => {
     const opened = await service.open({ orgId, projectId, storyId, userId, service: "web" });
     const token = new URL(opened.url).searchParams.get("token");


### PR DESCRIPTION
## The gap

A preview session lives for an hour and proxies **every HTTP method plus WebSocket traffic** into the running workspace. Authorization for it was decided once — by `config: { permission: "workspaces:execute" }` on the open route — and never asked again.

`WorkspacePreviewService.assertMembership` already selected the permissions and then dropped them on the floor:

```ts
const member = (
  await this.db
    .select({ permissions: roles.permissions })   // fetched…
    ...
)[0];
if (!member) throw invalidAccess();               // …and never read
```

So a member whose role is downgraded — or swapped for a read-only one — keeps driving the workspace until the session expires on its own. The membership row and the user row both stay valid in that state, which is exactly what the surrounding checks tolerate: `users.status = 'disabled'` is caught, a revoked session is caught, an expired token is caught. A revoked *permission* was not.

Two documented claims cover this and were not true:

- `apps/docs/docs/self-host/authentication.md`: "each proxied request revalidates the user, project membership, workspace, service, expiry, and revocation status."
- `apps/docs/docs/reference/security.md`: "HTTP and WebSocket requests are authorized continuously rather than only when a preview is opened."

`AGENTS.md` also names `revoked` as a denial path that authorization changes must cover.

## The change

Re-read the permission on `exchange` and `authorize`, and rename the helper to say what it now does. `workspaces:execute` is used because that is what the open route requires — this keeps the session's authority equal to the authority that created it, rather than widening or narrowing it.

The open route is deliberately left alone: it is already guarded, and duplicating the check there would add a query without adding safety.

## Test

`services/api/test/workspace-preview.integration.test.ts` gains one case that opens and consumes a session, then downgrades the role to `["previews:read"]` — leaving the user active and the membership row intact — and asserts the proxy path closes. It also asserts a fresh handoff cannot be exchanged while the permission is gone, and that restoring the permission restores access, so the test fails for the permission and not for a side effect.

Without the change, the test fails on the first assertion: `authorize` returns the live session.

## Verification

Run on Windows 11, Node 26, against the compose Postgres.

- `pnpm --filter @facility/api typecheck` — clean
- `pnpm lint` — clean
- `pnpm guards` — 2 guards, 0 failed
- `pnpm check:unused` — clean
- `vitest run test/workspace-preview.integration.test.ts test/workspace-preview.test.ts` — 13 passed
- Full `services/api` suite: 258 passed, 14 failed — every failure also fails on unmodified `main` in this environment (the POSIX-shell fakes in `workspace-vercel-bootstrap`, `agent-engines`, `facility-012.e2e`, `project-environment`, `turn-dispatcher`, i.e. the `#227`/`#241` Windows family), plus one load-dependent flake in `workspace-runtime.test.ts` that passes 3/3 in isolation and only touches `FakeWorkspaceRuntime`. I did not get a clean-baseline Linux run, so those are worth a second look on CI rather than taking my word for it.

> Claude Code helped
