### PR TITLE
fix(workspaces): wait for the Docker bootstrap before using a woken workspace

### DIFF
--- a/services/api/src/workspaces/docker.ts
+++ b/services/api/src/workspaces/docker.ts
@@ -24,6 +24,9 @@ const KIND = "workspace-v2";
 export class DockerWorkspaceRuntime implements WorkspaceRuntime {
   readonly provider = "docker" as const;
 
+  /** Workspace container name → the container start already proven ready. */
+  private readonly readyStarts = new Map<string, string>();
+
   constructor(private readonly docker = new Docker()) {}
 
   async create(input: CreateWorkspace): Promise<WorkspaceHandle> {
@@ -35,7 +38,7 @@ export class DockerWorkspaceRuntime implements WorkspaceRuntime {
     if (existing) {
       this.assertOwned(existing, input.id, names.volume);
       if (!existing.State?.Running) await this.docker.getContainer(existing.Id).start();
-      await this.waitUntilReady(this.docker.getContainer(existing.Id));
+      await this.ensureReady(names.container, this.docker.getContainer(existing.Id));
       return this.handle(input, existing.Id, names);
     }
 
@@ -79,7 +82,7 @@ export class DockerWorkspaceRuntime implements WorkspaceRuntime {
     });
     try {
       await container.start();
-      await this.waitUntilReady(container);
+      await this.ensureReady(names.container, container);
     } catch (error) {
       await container.remove({ force: true, v: false }).catch(() => undefined);
       throw error;
@@ -92,7 +95,9 @@ export class DockerWorkspaceRuntime implements WorkspaceRuntime {
     const existing = await this.inspectContainer(names.container);
     if (!existing) return this.create(workspace);
     this.assertOwned(existing, workspace.id, names.volume);
-    if (!existing.State?.Running) await this.docker.getContainer(existing.Id).start();
+    const container = this.docker.getContainer(existing.Id);
+    if (!existing.State?.Running) await container.start();
+    await this.ensureReady(names.container, container);
     return this.handle(workspace, existing.Id, names);
   }
 
@@ -241,6 +246,7 @@ export class DockerWorkspaceRuntime implements WorkspaceRuntime {
 
   async destroy(workspace: WorkspaceLocator): Promise<void> {
     const names = this.assertLocator(workspace);
+    this.readyStarts.delete(names.container);
     const current = await this.inspectContainer(names.container);
     if (current) {
       this.assertOwned(current, workspace.id, names.volume);
@@ -397,6 +403,26 @@ export class DockerWorkspaceRuntime implements WorkspaceRuntime {
       AttachStderr: false,
     });
     await killer.start({}).catch(() => undefined);
+  }
+
+  /**
+   * A started container is not yet a usable workspace: the bootstrap removes its
+   * readiness marker on every start, then brings up dockerd, the socket
+   * permissions and the preview gateways. Readiness only ever moves forward
+   * within one start, so each start is proven once and then remembered.
+   */
+  private async ensureReady(containerName: string, container: Docker.Container) {
+    const state = await container.inspect();
+    if (!state.State.Running) {
+      throw new WorkspaceRuntimeError(
+        "workspace_initialize_failed",
+        `workspace bootstrap exited with status ${state.State.ExitCode}`,
+      );
+    }
+    const start = `${state.Id}:${state.State.StartedAt}`;
+    if (this.readyStarts.get(containerName) === start) return;
+    await this.waitUntilReady(container);
+    this.readyStarts.set(containerName, start);
   }
 
   private async waitUntilReady(container: Docker.Container) {

--- a/services/api/test/workspace-docker.test.ts
+++ b/services/api/test/workspace-docker.test.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+import type Docker from "dockerode";
+import { describe, expect, it, vi } from "vitest";
+import { DockerWorkspaceRuntime } from "../src/workspaces/docker.js";
+import type { WorkspaceLocator } from "../src/workspaces/runtime.js";
+
+const workspaceId = "ws_0123456789abcdef";
+const suffix = createHash("sha256").update(workspaceId).digest("hex").slice(0, 24);
+const workspace: WorkspaceLocator = {
+  id: workspaceId,
+  image: "facility-runner:test",
+  externalRef: `facility-ws-${suffix}`,
+  volumeRef: `facility-ws-volume-${suffix}`,
+};
+
+/**
+ * A container that boots the way the workspace bootstrap does: `start` returns
+ * immediately, and the readiness marker only appears after `readyAfterProbes`
+ * probes. Every probe is recorded so a test can prove one was made — or wasn't.
+ */
+function fakeDocker(options: {
+  running: boolean;
+  readyAfterProbes: number;
+  bootstrapExits?: boolean;
+}) {
+  const probes: string[][] = [];
+  const state = {
+    running: options.running,
+    startedAt: "2026-09-07T09:00:00.000000000Z",
+    remaining: options.readyAfterProbes,
+  };
+  const start = vi.fn(async () => {
+    // A bootstrap that dies on start leaves the container stopped again.
+    state.running = options.bootstrapExits !== true;
+    state.startedAt = "2026-09-07T10:00:00.000000000Z";
+  });
+  const container = {
+    id: "container-1",
+    inspect: async () => ({
+      Id: "container-1",
+      State: { Running: state.running, StartedAt: state.startedAt, ExitCode: 0 },
+      Config: {
+        Labels: { "facility.workspace.id": workspaceId, "facility.workload.kind": "workspace-v2" },
+      },
+      Mounts: [{ Destination: "/workspace", Name: workspace.volumeRef }],
+    }),
+    start,
+    exec: async (options: { Cmd: string[] }) => {
+      probes.push(options.Cmd);
+      const ready = state.remaining <= 0;
+      state.remaining -= 1;
+      return {
+        start: async () => undefined,
+        inspect: async () => ({ Running: false, ExitCode: ready ? 0 : 1 }),
+      };
+    },
+  };
+  const docker = { getContainer: vi.fn(() => container) } as unknown as Docker;
+  return { docker, container, start, probes };
+}
+
+describe("Docker workspace readiness", () => {
+  it("waits for the bootstrap before handing back a woken workspace", async () => {
+    const { docker, start, probes } = fakeDocker({ running: false, readyAfterProbes: 2 });
+    const runtime = new DockerWorkspaceRuntime(docker);
+
+    await expect(runtime.wake(workspace)).resolves.toMatchObject({
+      computeRef: "container-1",
+      state: "running",
+    });
+
+    expect(start).toHaveBeenCalledOnce();
+    // Two failing probes plus the one that finally observed the marker.
+    expect(probes).toHaveLength(3);
+    expect(probes.at(-1)?.at(-1)).toContain("/workspace/.facility/runtime-ready");
+  });
+
+  it("waits for a container someone else started and is still booting", async () => {
+    const { docker, start, probes } = fakeDocker({ running: true, readyAfterProbes: 1 });
+    const runtime = new DockerWorkspaceRuntime(docker);
+
+    await runtime.wake(workspace);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(probes).toHaveLength(2);
+  });
+
+  it("proves each container start once and reuses the result on later wakes", async () => {
+    const { docker, probes } = fakeDocker({ running: true, readyAfterProbes: 0 });
+    const runtime = new DockerWorkspaceRuntime(docker);
+
+    await runtime.wake(workspace);
+    await runtime.wake(workspace);
+    await runtime.wake(workspace);
+
+    expect(probes).toHaveLength(1);
+  });
+
+  it("refuses a workspace whose bootstrap exited instead of reporting it ready", async () => {
+    const { docker } = fakeDocker({
+      running: false,
+      readyAfterProbes: 0,
+      bootstrapExits: true,
+    });
+
+    await expect(new DockerWorkspaceRuntime(docker).wake(workspace)).rejects.toMatchObject({
+      code: "workspace_initialize_failed",
+    });
+  });
+});


### PR DESCRIPTION
## The gap

`DockerWorkspaceRuntime.create` proved a container ready before handing it back. `wake` only started it:

```ts
if (!existing.State?.Running) await this.docker.getContainer(existing.Id).start();
return this.handle(workspace, existing.Id, names);   // no readiness probe
```

But the bootstrap deletes its own readiness marker on **every** start, and only then brings up `dockerd`, `chown`s `/workspace`, fixes the socket permissions and launches the preview gateways:

```sh
rm -f /workspace/.facility/runtime-ready
chown -R node:node /workspace
rm -f /var/run/docker.sock
dockerd ... &
until docker info; do ...; done
... facility-preview-gateway ...
touch /workspace/.facility/runtime-ready
```

So `docker start` returning says nothing about whether the workspace can be used, and both callers of `wake` act on the handle immediately:

- `exec` → `wake` → run the agent's command. This is where `docker`, `docker compose` and a half-`chown`ed `/workspace` fail intermittently after a resume, a host restart, or an OOM restart — the socket has just been deleted and not yet recreated.
- `preview.open` → `wake` → read the published ports. Docker binds the host port at container start, so the endpoint URL is valid while the gateway process behind it is not yet listening.

`VercelWorkspaceRuntime.wake` already re-runs `initializeAndHandle`, so the two providers were not honouring the same contract — and Docker is the default for self-hosting and `docker-compose`.

This is the level-triggered version of the same bug shape as #319/#320: `wake` was reacting to the *edge* ("start returned") instead of observing the *state* ("the marker is there and dockerd answers").

## The change

`wake` proves readiness too, through a shared `ensureReady`.

Readiness only ever moves forward within one container start, so each start is proven once and remembered by container name → `${Id}:${StartedAt}`:

- a resumed or replaced container gets a new `StartedAt` (or a new `Id`) and is proven again;
- `exec` — which calls `wake` per command — does not pay for a probe per command, only the `inspect` it already needed;
- a container that someone else started and that is still booting is also waited for, which the narrower "only wait if *we* started it" fix would miss. `preview.open` and a turn's `exec` genuinely race here.

The map is keyed by the workspace's stable container name and cleared in `destroy`, so it is bounded by live workspaces.

`ensureReady` also fails loudly when the bootstrap exited instead of becoming ready, rather than returning a handle to a dead container.

## Test

New `services/api/test/workspace-docker.test.ts`, using an injected fake `dockerode` — the same shape as the existing `workspace-vercel.test.ts` — so it runs in the default suite with no Docker daemon:

- a stopped container is started and **not** returned until the readiness probe exits 0;
- a container someone else started and that is still booting is waited for, without a second `start`;
- three `wake` calls against the same container start probe once;
- a bootstrap that exits raises `workspace_initialize_failed` instead of returning a handle.

All four fail on unmodified `main` (`git stash`-ed the source file to check) and pass with the change.

## Verification

Run on Windows 11, Node 26, against the compose Postgres.

- `pnpm --filter @facility/api typecheck` — clean
- `pnpm lint` — clean
- `pnpm guards` — 2 guards, 0 failed
- `pnpm check:unused` — clean
- `vitest run test/workspace-docker.test.ts test/workspace-runtime.test.ts test/workspace-preview.integration.test.ts test/story-workspaces.integration.test.ts` — 21 passed
- Full `services/api` suite: 258 passed, 14 failed — every failure also fails on unmodified `main` in this environment (the POSIX-shell fakes in `workspace-vercel-bootstrap`, `agent-engines`, `facility-012.e2e`, `project-environment`, `turn-dispatcher`, i.e. the `#227`/`#241` Windows family), plus one load-dependent flake in `workspace-runtime.test.ts` that passes 3/3 in isolation and only exercises `FakeWorkspaceRuntime`.

What I could **not** verify here: the real Docker path. `FACILITY_E2E_DOCKER=1 pnpm test:e2e-workspace` needs a Linux daemon that can run the privileged runner image with nested `dockerd`, and this machine has rootless Podman. The probe itself is the one `create` has always used, so the risk is in `ensureReady`'s call sites rather than in the probe, but a real `suspend` → `wake` → `exec` on CI is the check that would actually close it.

> Claude Code helped
