### PR TITLE
fix(stories): follow verified workspace branch changes

### DIFF
--- a/apps/docs/docs/concepts/stories-and-workspaces.md
+++ b/apps/docs/docs/concepts/stories-and-workspaces.md
@@ -36,6 +36,12 @@ PostgreSQL separately retains messages, turns, attention items, environment even
 snapshots, costs, audit records, and provider references. Losing either store can make a story
 incomplete, so production backup policy must cover both.
 
+If an agent renames its branch to follow repository conventions, Facility adopts the branch
+recorded in that workspace when the turn succeeds. The next turn continues on it, and matching
+GitHub pull requests can be associated with the story. The change appears in the story's evidence
+history. Facility preserves an existing pull-request association and refuses stale evidence,
+another story's branch, the repository default branch, or an incomplete Git capture.
+
 ## Conversation and turns
 
 Messages are persisted before dispatch. A story permits one queued or running turn; later messages

--- a/services/api/src/stories/branch.ts
+++ b/services/api/src/stories/branch.ts
@@ -1,0 +1,159 @@
+import {
+  type FacilityDb,
+  projectRepositories,
+  stories,
+  turnGitEvidence,
+  turns,
+  workspaces,
+} from "@facility/db";
+import { and, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
+import { isSafeGitBranch } from "../workspaces/git-branch.js";
+import { appendStoryEvidence } from "./evidence.js";
+
+type Story = typeof stories.$inferSelect;
+type Evidence = typeof turnGitEvidence.$inferSelect;
+
+export function observedStoryBranch(
+  story: Pick<Story, "branch" | "pullRequestNumber" | "status">,
+  evidence: Pick<Evidence, "initialBranch" | "finalBranch" | "captureError" | "completedAt">,
+  defaultBranch: string | undefined,
+): string | null {
+  const branch = evidence.finalBranch;
+  if (
+    story.pullRequestNumber !== null ||
+    ["done", "archived"].includes(story.status) ||
+    story.branch === null ||
+    evidence.initialBranch !== story.branch ||
+    evidence.captureError !== null ||
+    evidence.completedAt === null ||
+    !branch ||
+    branch === story.branch ||
+    branch === defaultBranch ||
+    !isSafeGitBranch(branch)
+  )
+    return null;
+  return branch;
+}
+
+/** Called inside the story transaction; only completed native Git evidence can move its branch. */
+export async function reconcileTurnBranch(
+  db: FacilityDb,
+  story: Story,
+  turn: typeof turns.$inferSelect,
+) {
+  if (turn.state !== "succeeded" || story.branch === null) return;
+  const latest = (
+    await db
+      .select({ id: turns.id })
+      .from(turns)
+      .where(
+        and(
+          eq(turns.orgId, story.orgId),
+          eq(turns.projectId, story.projectId),
+          eq(turns.storyId, story.id),
+        ),
+      )
+      .orderBy(desc(turns.createdAt), desc(turns.id))
+      .limit(1)
+  )[0];
+  if (latest?.id !== turn.id) return;
+  const observed = (
+    await db
+      .select({ evidence: turnGitEvidence })
+      .from(turnGitEvidence)
+      .innerJoin(
+        workspaces,
+        and(
+          eq(workspaces.id, turnGitEvidence.workspaceId),
+          eq(workspaces.orgId, story.orgId),
+          eq(workspaces.projectId, story.projectId),
+          eq(workspaces.storyId, story.id),
+          inArray(workspaces.state, ["running", "sleeping", "error"]),
+        ),
+      )
+      .where(
+        and(
+          eq(turnGitEvidence.orgId, story.orgId),
+          eq(turnGitEvidence.projectId, story.projectId),
+          eq(turnGitEvidence.storyId, story.id),
+          eq(turnGitEvidence.turnId, turn.id),
+          isNotNull(turnGitEvidence.completedAt),
+          isNull(turnGitEvidence.captureError),
+        ),
+      )
+      .limit(1)
+  )[0]?.evidence;
+  if (!observed) return;
+  const repository = (
+    await db
+      .select({
+        id: projectRepositories.id,
+        role: projectRepositories.role,
+        defaultBranch: projectRepositories.defaultBranch,
+      })
+      .from(projectRepositories)
+      .where(
+        and(
+          eq(projectRepositories.orgId, story.orgId),
+          eq(projectRepositories.projectId, story.projectId),
+          story.repositoryId
+            ? eq(projectRepositories.id, story.repositoryId)
+            : eq(projectRepositories.role, "primary"),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (!repository) return;
+  const branch = observedStoryBranch(story, observed, repository.defaultBranch);
+  if (!branch) return;
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${`facility:story-branch:${story.orgId}:${story.projectId}:${repository.id}:${branch}`}))`,
+  );
+  const conflict = (
+    await db
+      .select({ id: stories.id })
+      .from(stories)
+      .where(
+        and(
+          eq(stories.orgId, story.orgId),
+          eq(stories.projectId, story.projectId),
+          repository.role === "primary"
+            ? or(eq(stories.repositoryId, repository.id), isNull(stories.repositoryId))
+            : eq(stories.repositoryId, repository.id),
+          eq(stories.branch, branch),
+          ne(stories.id, story.id),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (conflict) return;
+  const changed = await db
+    .update(stories)
+    .set({ branch, updatedAt: new Date() })
+    .where(
+      and(
+        eq(stories.orgId, story.orgId),
+        eq(stories.projectId, story.projectId),
+        eq(stories.id, story.id),
+        eq(stories.branch, story.branch),
+        isNull(stories.pullRequestNumber),
+      ),
+    )
+    .returning({ id: stories.id });
+  if (!changed.length) return;
+  await appendStoryEvidence(db, {
+    orgId: story.orgId,
+    projectId: story.projectId,
+    storyId: story.id,
+    turnId: turn.id,
+    source: "workspace",
+    type: "story.branch_updated",
+    externalKey: `turn:${turn.id}:branch`,
+    data: {
+      workspaceId: observed.workspaceId,
+      initialBranch: observed.initialBranch,
+      branch,
+      finalSha: observed.finalSha,
+    },
+  });
+}

--- a/services/api/src/stories/service.ts
+++ b/services/api/src/stories/service.ts
@@ -24,6 +24,7 @@ import type {
   WorkspaceLocator,
   WorkspaceRuntime,
 } from "../workspaces/runtime.js";
+import { reconcileTurnBranch } from "./branch.js";
 
 export type StoryActor = { type: "user" | "service" | "system"; id: string };
 
@@ -400,7 +401,10 @@ export class StoryWorkspaceService {
       const turn = await scopedTurn(tx, input.orgId, input.projectId, input.turnId);
       await lockStory(tx, input.orgId, input.projectId, turn.storyId);
       const story = await scopedStory(tx, input.orgId, input.projectId, turn.storyId);
-      if (turn.state === "succeeded") return turn;
+      if (turn.state === "succeeded") {
+        await reconcileTurnBranch(tx, story, turn);
+        return turn;
+      }
       if (!["queued", "running"].includes(turn.state)) {
         throw new StoryServiceError("turn_not_active", "turn is not active");
       }
@@ -433,6 +437,7 @@ export class StoryWorkspaceService {
         })
         .where(and(eq(stories.orgId, input.orgId), eq(stories.id, turn.storyId)));
       if (!completed) throw new StoryServiceError("turn_not_found", "completed turn not found");
+      await reconcileTurnBranch(tx, story, completed);
       return completed;
     });
   }

--- a/services/api/src/workspaces/git-branch.ts
+++ b/services/api/src/workspaces/git-branch.ts
@@ -1,0 +1,17 @@
+export function isSafeGitBranch(branch: string) {
+  const hasControlOrForbiddenCharacter = [...branch].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x20 || code === 0x7f || "~^:?*[\\".includes(character);
+  });
+  return Boolean(
+    branch &&
+      branch.length <= 200 &&
+      !branch.startsWith("-") &&
+      !branch.startsWith("/") &&
+      !branch.endsWith("/") &&
+      !branch.endsWith(".") &&
+      !branch.includes("..") &&
+      !branch.includes("@{") &&
+      !hasControlOrForbiddenCharacter,
+  );
+}

--- a/services/api/src/workspaces/project-environment.ts
+++ b/services/api/src/workspaces/project-environment.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceRepository,
 } from "../github/workspace-credentials.js";
 import { appendWorkspaceEvent } from "./events.js";
+import { isSafeGitBranch } from "./git-branch.js";
 import type {
   PreviewEndpoint,
   WorkspaceCommandResult,
@@ -583,24 +584,6 @@ export function projectEnvironmentVariableName(projectId: string, name: string) 
     throw new ProjectEnvironmentError("project_id_invalid", "project id is invalid");
   }
   return `FACILITY_PROJECT_${projectId.toUpperCase()}_${EnvironmentName.parse(name)}`;
-}
-
-function isSafeGitBranch(branch: string) {
-  const hasControlOrForbiddenCharacter = [...branch].some((character) => {
-    const code = character.charCodeAt(0);
-    return code <= 0x20 || code === 0x7f || "~^:?*[\\".includes(character);
-  });
-  return Boolean(
-    branch &&
-      branch.length <= 200 &&
-      !branch.startsWith("-") &&
-      !branch.startsWith("/") &&
-      !branch.endsWith("/") &&
-      !branch.endsWith(".") &&
-      !branch.includes("..") &&
-      !branch.includes("@{") &&
-      !hasControlOrForbiddenCharacter,
-  );
 }
 
 function assertRepositoryContract(manifest: ProjectManifest, repositories: WorkspaceRepository[]) {

--- a/services/api/test/story-branch.test.ts
+++ b/services/api/test/story-branch.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { observedStoryBranch } from "../src/stories/branch.js";
+
+describe("verified story branch changes", () => {
+  const story = { branch: "facility/story", pullRequestNumber: null, status: "working" };
+  const evidence = {
+    initialBranch: "facility/story",
+    finalBranch: "chore/story",
+    captureError: null,
+    completedAt: new Date(),
+  };
+  it("follows the branch recorded after a completed workspace turn", () => {
+    expect(observedStoryBranch(story, evidence, "main")).toBe("chore/story");
+  });
+  it.each([
+    ["an existing PR", { ...story, pullRequestNumber: 42 }],
+    ["a concurrent branch change", { ...story, branch: "fix/other" }],
+    ["an unassigned branch", { ...story, branch: null }],
+    ["a completed story", { ...story, status: "done" }],
+    ["an archived story", { ...story, status: "archived" }],
+  ])("preserves %s", (_name, input) => {
+    expect(observedStoryBranch(input, evidence, "main")).toBeNull();
+  });
+  it.each([
+    ["failed capture", { ...evidence, captureError: "git failed" }],
+    ["incomplete capture", { ...evidence, completedAt: null }],
+    ["detached HEAD", { ...evidence, finalBranch: null }],
+    ["the repository default", { ...evidence, finalBranch: "main" }],
+    ["the original branch", { ...evidence, finalBranch: story.branch }],
+    ["an option-like branch", { ...evidence, finalBranch: "--force" }],
+    ["a malformed branch", { ...evidence, finalBranch: "chore/../other" }],
+    ["control characters", { ...evidence, finalBranch: "chore/story\nother" }],
+    ["the wrong initial branch", { ...evidence, initialBranch: "fix/other" }],
+  ])("rejects %s", (_name, input) => {
+    expect(observedStoryBranch(story, input, "main")).toBeNull();
+  });
+});

--- a/services/api/test/story-workspaces.integration.test.ts
+++ b/services/api/test/story-workspaces.integration.test.ts
@@ -7,11 +7,15 @@ import { newId } from "@facility/core";
 import {
   attentionItems,
   createDb,
+  githubInstallations,
   migrate,
   orgs,
+  projectRepositories,
   projects,
   stories,
+  storyEvidenceEvents,
   storyMessages,
+  turnGitEvidence,
   turns,
   workspaces,
 } from "@facility/db";
@@ -73,6 +77,7 @@ describe("persistent story workspace lifecycle", async () => {
   const projectId = newId("proj");
   const otherOrgId = newId("org");
   const otherProjectId = newId("proj");
+  const repositoryId = newId("repo");
 
   beforeAll(async () => {
     await migrate(databaseUrl);
@@ -96,6 +101,25 @@ describe("persistent story workspace lifecycle", async () => {
         settings: {},
       },
     ]);
+    const installationId = newId("ghi");
+    await db.insert(githubInstallations).values({
+      id: installationId,
+      orgId,
+      installationId: Math.floor(Math.random() * 1_000_000_000) + 20_000,
+      accountId: 123,
+      accountLogin: "acme",
+      targetType: "Organization",
+    });
+    await db.insert(projectRepositories).values({
+      id: repositoryId,
+      orgId,
+      projectId,
+      installationId,
+      owner: "acme",
+      name: `app-${suffix}`,
+      defaultBranch: "main",
+      role: "primary",
+    });
   });
 
   afterAll(async () => {
@@ -120,6 +144,172 @@ describe("persistent story workspace lifecycle", async () => {
       },
     };
   }
+
+  async function branchFixture(workspaceId?: string) {
+    const result = await service.start({
+      ...startInput(`branch-${randomUUID()}`),
+      branch: "facility/original",
+    });
+    if (!result.workspace || !result.queued.turn) throw new Error("branch fixture missing");
+    const turn = result.queued.turn;
+    const workspace = result.workspace;
+    const finalBranch = `chore/${result.story.id}`;
+    await db.insert(turnGitEvidence).values({
+      turnId: result.queued.turn.id,
+      orgId,
+      projectId,
+      storyId: result.story.id,
+      workspaceId: workspaceId ?? result.workspace.id,
+      engineSessionId: "test-session",
+      initialBranch: "facility/original",
+      initialSha: "a".repeat(40),
+      finalBranch,
+      finalSha: "b".repeat(40),
+      completedAt: new Date(),
+    });
+    const complete = () =>
+      service.completeTurn({
+        orgId,
+        projectId,
+        turnId: turn.id,
+        output: "done",
+        actor: { type: "system", id: "test-engine" },
+      });
+    return { result, finalBranch, complete, turn, workspace };
+  }
+
+  it("follows completed native branch evidence once and permits the matching draft PR", async () => {
+    const fixture = await branchFixture();
+    await fixture.complete();
+    expect((await service.get(orgId, projectId, fixture.result.story.id)).story.branch).toBe(
+      fixture.finalBranch,
+    );
+    await fixture.complete();
+    const events = await db
+      .select()
+      .from(storyEvidenceEvents)
+      .where(eq(storyEvidenceEvents.storyId, fixture.result.story.id));
+    expect(events.filter((event) => event.type === "story.branch_updated")).toHaveLength(1);
+    await service.associatePullRequest({
+      orgId,
+      projectId,
+      storyId: fixture.result.story.id,
+      branch: fixture.finalBranch,
+      pullRequestNumber: 1549,
+      pullRequestUrl: "https://github.com/acme/app/pull/1549",
+    });
+    expect(
+      (await service.get(orgId, projectId, fixture.result.story.id)).story.pullRequestNumber,
+    ).toBe(1549);
+  });
+
+  it("does not use another story's workspace evidence or cross-tenant calls", async () => {
+    const other = await branchFixture();
+    const fixture = await branchFixture(other.workspace.id);
+    await expect(
+      service.completeTurn({
+        orgId: otherOrgId,
+        projectId: otherProjectId,
+        turnId: fixture.turn.id,
+        output: "done",
+        actor: { type: "system", id: "test" },
+      }),
+    ).rejects.toMatchObject({ code: "turn_not_found" });
+    await fixture.complete();
+    expect((await service.get(orgId, projectId, fixture.result.story.id)).story.branch).toBe(
+      "facility/original",
+    );
+  });
+
+  it("preserves an existing PR and a concurrent operator branch change", async () => {
+    const linked = await branchFixture();
+    await service.associatePullRequest({
+      orgId,
+      projectId,
+      storyId: linked.result.story.id,
+      branch: "facility/original",
+      pullRequestNumber: 41,
+    });
+    await linked.complete();
+    expect((await service.get(orgId, projectId, linked.result.story.id)).story).toMatchObject({
+      branch: "facility/original",
+      pullRequestNumber: 41,
+    });
+    const changed = await branchFixture();
+    await db
+      .update(stories)
+      .set({ branch: "fix/operator" })
+      .where(eq(stories.id, changed.result.story.id));
+    await changed.complete();
+    expect((await service.get(orgId, projectId, changed.result.story.id)).story.branch).toBe(
+      "fix/operator",
+    );
+  });
+
+  it("does not claim a branch already assigned to another story", async () => {
+    const fixture = await branchFixture();
+    const other = await service.start({
+      ...startInput(`conflict-${randomUUID()}`),
+      repositoryId,
+      branch: fixture.finalBranch,
+    });
+    await fixture.complete();
+    expect((await service.get(orgId, projectId, fixture.result.story.id)).story.branch).toBe(
+      "facility/original",
+    );
+    expect((await service.get(orgId, projectId, other.story.id)).story.branch).toBe(
+      fixture.finalBranch,
+    );
+  });
+
+  it("does not replay an older turn's branch after a newer request", async () => {
+    const fixture = await branchFixture();
+    await fixture.complete();
+    await service.queueMessage({
+      orgId,
+      projectId,
+      storyId: fixture.result.story.id,
+      body: "Continue",
+      dedupeKey: randomUUID(),
+      agent: builder,
+      actor: { type: "user", id: "test" },
+      trigger: { type: "manual" },
+    });
+    await db
+      .update(stories)
+      .set({ branch: "facility/original" })
+      .where(eq(stories.id, fixture.result.story.id));
+    await fixture.complete();
+    expect((await service.get(orgId, projectId, fixture.result.story.id)).story.branch).toBe(
+      "facility/original",
+    );
+  });
+
+  it.each([
+    ["failed capture", { captureError: "git failed" }],
+    ["incomplete capture", { completedAt: null }],
+    ["default branch", { finalBranch: "main" }],
+    ["malformed branch", { finalBranch: "--force" }],
+  ])("does not follow %s in persisted evidence", async (_name, values) => {
+    const fixture = await branchFixture();
+    await db.update(turnGitEvidence).set(values).where(eq(turnGitEvidence.turnId, fixture.turn.id));
+    await fixture.complete();
+    expect((await service.get(orgId, projectId, fixture.result.story.id)).story.branch).toBe(
+      "facility/original",
+    );
+  });
+
+  it("does not follow evidence from a destroyed workspace", async () => {
+    const fixture = await branchFixture();
+    await db
+      .update(workspaces)
+      .set({ state: "destroyed", destroyedAt: new Date() })
+      .where(eq(workspaces.id, fixture.workspace.id));
+    await fixture.complete();
+    expect((await service.get(orgId, projectId, fixture.result.story.id)).story.branch).toBe(
+      "facility/original",
+    );
+  });
 
   it("starts idempotently and serializes messages behind the active turn", async () => {
     const externalId = `issue-${randomUUID()}`;

--- a/services/api/test/turn-dispatcher.integration.test.ts
+++ b/services/api/test/turn-dispatcher.integration.test.ts
@@ -113,6 +113,7 @@ environment:
     readonly name = "codex" as const;
     requests: AgentTurnRequest[] = [];
     outputOverride?: string;
+    renameNextBranch?: string;
     corruptResumeOnce = false;
     replacementPending = false;
     blockUntilCanceled = false;
@@ -152,6 +153,16 @@ environment:
           this.observedCancellation = true;
         }
         throw error;
+      }
+      if (this.renameNextBranch) {
+        const branch = this.renameNextBranch;
+        this.renameNextBranch = undefined;
+        const renamed = await runtime.exec(request.workspace, {
+          command: "git",
+          args: ["branch", "-m", branch],
+          cwd: request.cwd,
+        });
+        if (renamed.exitCode !== 0) throw new Error("branch rename failed");
       }
       const secret = request.environment?.GH_TOKEN ?? "missing";
       const projectSecret = request.environment?.FACILITY_DISPATCH_SECRET ?? "missing";
@@ -817,6 +828,55 @@ environment:
         (message) => message.body,
       ),
     ).toEqual(expect.arrayContaining(["Persist this message before the engine starts"]));
+  });
+
+  it("keeps the agent's renamed branch and native workspace on the next turn", async () => {
+    const branch = `chore/retained-${randomUUID()}`;
+    const started = await storiesService.start({
+      orgId,
+      projectId,
+      provider: "github",
+      externalId: `rename-${randomUUID()}`,
+      title: "Follow repository branch rules",
+      agent: builder,
+      message: "Rename the branch",
+      messageDedupeKey: randomUUID(),
+      actor: { type: "user", id: "test" },
+      workspace: { image: "facility-runner:test", ports: [] },
+    });
+    if (!started.queued.turn) throw new Error("missing turn");
+    engine.renameNextBranch = branch;
+    await expect(
+      dispatcher.dispatch({ orgId, projectId, turnId: started.queued.turn.id }),
+    ).resolves.toMatchObject({ state: "succeeded" });
+    expect((await storiesService.get(orgId, projectId, started.story.id)).story.branch).toBe(
+      branch,
+    );
+    const firstRequest = engine.requests.at(-1);
+    if (!firstRequest) throw new Error("missing request");
+    const next = await storiesService.queueMessage({
+      orgId,
+      projectId,
+      storyId: started.story.id,
+      body: "Continue on the same branch",
+      dedupeKey: randomUUID(),
+      agent: builder,
+      actor: { type: "user", id: "test" },
+      trigger: { type: "manual" },
+    });
+    if (!next.turn) throw new Error("missing next turn");
+    await expect(
+      dispatcher.dispatch({ orgId, projectId, turnId: next.turn.id }),
+    ).resolves.toMatchObject({ state: "succeeded" });
+    const request = engine.requests.at(-1);
+    expect(request?.workspace.id).toBe(firstRequest.workspace.id);
+    expect(request?.nativeSessionId).toBe("codex-native-session");
+    const actual = await runtime.exec(firstRequest.workspace, {
+      command: "git",
+      args: ["branch", "--show-current"],
+      cwd: firstRequest.cwd,
+    });
+    expect(actual.stdout.trim()).toBe(branch);
   });
 });
 


### PR DESCRIPTION
## What changes

After a successful agent turn, Facility follows a branch rename recorded by Git in that story's retained workspace. Follow-up turns use the renamed branch, and the existing GitHub mirror can associate its matching pull request. The story's evidence history records the change once.

## Why

An agent can rename a generated `facility/...` branch to follow repository conventions. Previously, Git evidence recorded the rename but the story kept the old branch. This prevented PR association and caused the next turn to switch back to the obsolete branch.

Only the latest successful turn's completed capture can update the branch. Tenant, project, workspace, existing PR, default branch, concurrent change, and conflicting story checks remain enforced. Existing pull-request mismatch guards are unchanged. Replaying successful completion can reconcile a retained story without duplicating its message or turn.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite: after normal UI suspension and resume, direct Git inspection confirmed the renamed branch in the same retained workspace. Replaying the successful turn completion recorded one branch event and preserved all turn, message, workspace, setup, and snapshot counts/state.
- [x] Documentation updated, or no user-facing change

Focused acceptance: `Test Files  4 passed (4)` and `Tests  50 passed (50)`. Unit tests cover incomplete, failed, detached, malformed, stale, default-branch and existing-PR evidence. PostgreSQL integration tests cover cross-tenant calls, another story's workspace, destroyed workspaces, replay, branch conflicts and preserved PR associations. A real Git dispatcher test renames a branch and resumes the same native workspace on the next turn; it failed against the previous service implementation before passing with this change. External systems use deterministic fakes or local repositories.
