### PR TITLE
fix(agents): reuse complete catalog snapshots across refreshes

### DIFF
--- a/apps/docs/docs/concepts/agents-as-code.md
+++ b/apps/docs/docs/concepts/agents-as-code.md
@@ -34,6 +34,12 @@ assume a read-oriented agent has read-only credentials.
 The catalog is loaded from a specific Git commit and cached with content hashes. A turn snapshots
 the parsed manifest, so later repository edits do not rewrite execution history.
 
+Refreshes check repository access and the current branch commit. Concurrent reads of the same
+commit reuse a complete snapshot scoped to that project, repository, and GitHub installation.
+Only agent manifests and `SKILL.md` files are downloaded. A failed or incomplete refresh preserves
+the last valid catalog; successfully reading a commit that removes definitions removes them from
+the catalog.
+
 The default kickstart catalog includes `architect`, `builder`, `pr-reviewer`, `address-review`,
 `ci-doctor`, and `security-audit`. They are ordinary manifests rather than built-in runtime roles.
 You can edit, disable, or replace them and add more `.md` files using the same schema.

--- a/services/api/src/agents/catalog-files.ts
+++ b/services/api/src/agents/catalog-files.ts
@@ -1,0 +1,78 @@
+import type { FacilityGithubClient } from "../github/client.js";
+import { decodeContent } from "../github/repo-files.js";
+
+export const isAgentManifestPath = (path: string) =>
+  /^\.agents\/[a-z0-9]+(?:-[a-z0-9]+)*\.md$/.test(path);
+
+export const isProjectSkillPath = (path: string) =>
+  /^\.(?:agents|claude)\/skills\/(?:[^/]+\/)*SKILL\.md$/.test(path);
+
+type Content = {
+  type?: string;
+  path?: string;
+  content?: string;
+  encoding?: string;
+  target?: string;
+};
+
+/** Only missing optional roots are empty. An incomplete traversal is never a snapshot. */
+export async function readAgentCatalogFiles(
+  client: Pick<FacilityGithubClient, "getContent">,
+  ref: string,
+): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+  async function visit(path: string, optionalRoot = false): Promise<void> {
+    let content: Content | Content[];
+    try {
+      content = (await client.getContent(path, ref)) as Content | Content[];
+    } catch (error) {
+      if (optionalRoot && (error as { status?: number })?.status === 404) return;
+      throw error;
+    }
+    if (Array.isArray(content)) {
+      if (isAgentManifestPath(path) || isProjectSkillPath(path)) {
+        throw new Error("Invalid agent catalog file");
+      }
+      // Sequential traversal bounds requests even for repositories with many skills.
+      for (const child of content) {
+        const name = child.path?.slice(path.length + 1);
+        if (
+          !child.path?.startsWith(`${path}/`) ||
+          !name ||
+          name === "." ||
+          name === ".." ||
+          name.includes("/") ||
+          name.includes("\\")
+        ) {
+          throw new Error("Invalid agent catalog directory entry");
+        }
+        const skillDirectory =
+          child.path === ".agents/skills" ||
+          child.path.startsWith(".agents/skills/") ||
+          child.path.startsWith(".claude/skills/");
+        if (
+          (child.type === "dir" && skillDirectory) ||
+          isAgentManifestPath(child.path) ||
+          isProjectSkillPath(child.path)
+        ) {
+          await visit(child.path);
+        }
+      }
+      return;
+    }
+    if (!isAgentManifestPath(path) && !isProjectSkillPath(path)) {
+      throw new Error("Invalid agent catalog root");
+    }
+    if (content.type === "symlink" && typeof content.target === "string") {
+      files.set(path, content.target);
+      return;
+    }
+    if (content.type !== "file" || typeof content.content !== "string") {
+      throw new Error("Incomplete agent catalog file");
+    }
+    files.set(path, decodeContent(content.content, content.encoding));
+  }
+  await visit(".agents", true);
+  await visit(".claude/skills", true);
+  return files;
+}

--- a/services/api/src/agents/catalog.ts
+++ b/services/api/src/agents/catalog.ts
@@ -18,6 +18,7 @@ import {
 import { and, asc, eq, notInArray, sql } from "drizzle-orm";
 import { FacilityGithubClient, type GithubClientFactory } from "../github/client.js";
 import { readRepoFiles } from "../github/repo-files.js";
+import { isAgentManifestPath, isProjectSkillPath, readAgentCatalogFiles } from "./catalog-files.js";
 
 export type AgentCatalogSnapshot = {
   commitSha: string;
@@ -61,6 +62,9 @@ export class AgentCatalogError extends Error {
 
 /** Reads the canonical .agents directory from the project's primary repository. */
 export class GithubAgentCatalogSource implements AgentCatalogSource {
+  // Immutable commit snapshots, shared by concurrent readers and bounded per API process.
+  private readonly snapshots = new Map<string, Promise<AgentCatalogSnapshot>>();
+
   constructor(
     private readonly db: FacilityDb,
     private readonly factory: GithubClientFactory,
@@ -107,16 +111,46 @@ export class GithubAgentCatalogSource implements AgentCatalogSource {
         defaultBranch: repository.defaultBranch,
       });
       const commitSha = await client.getDefaultBranchSha();
-      const files = await readRepoFiles(client, commitSha, [".agents", ".claude/skills"]);
-      const sources = [...files.entries()]
-        .filter(([path]) => /^\.agents\/[a-z0-9]+(?:-[a-z0-9]+)*\.md$/.test(path))
-        .map(([file, source]) => ({ file, source }))
-        .sort((left, right) => left.file.localeCompare(right.file));
-      const skills = [...files.entries()]
-        .filter(([path]) => /^\.(?:agents|claude)\/skills\/(?:[^/]+\/)*SKILL\.md$/.test(path))
-        .map(([file, source]) => ({ file, source }))
-        .sort((left, right) => left.file.localeCompare(right.file));
-      return { commitSha, sources, skills };
+      // Authorization and the current ref are checked before every cache read. A changed
+      // repository, installation, or tenant can never reuse another scope's snapshot.
+      const key = JSON.stringify([
+        orgId,
+        projectId,
+        repository.id,
+        installation.installationId,
+        repository.owner,
+        repository.name,
+        repository.defaultBranch,
+        commitSha,
+      ]);
+      let snapshot = this.snapshots.get(key);
+      if (!snapshot) {
+        snapshot = readAgentCatalogFiles(client, commitSha).then((files) => {
+          const entries = [...files.entries()];
+          const sources = entries
+            .filter(([path]) => isAgentManifestPath(path))
+            .map(([file, source]) => ({ file, source }))
+            .sort((left, right) => left.file.localeCompare(right.file));
+          const skills = entries
+            .filter(([path]) => isProjectSkillPath(path))
+            .map(([file, source]) => ({ file, source }))
+            .sort((left, right) => left.file.localeCompare(right.file));
+          return { commitSha, sources, skills };
+        });
+      }
+      this.snapshots.delete(key);
+      this.snapshots.set(key, snapshot);
+      if (this.snapshots.size > 100) {
+        const oldest = this.snapshots.keys().next().value;
+        if (oldest !== undefined) this.snapshots.delete(oldest);
+      }
+      try {
+        return structuredClone(await snapshot);
+      } catch (error) {
+        // Failures must be retried, and must not erase the last complete DB projection.
+        if (this.snapshots.get(key) === snapshot) this.snapshots.delete(key);
+        throw error;
+      }
     } catch (error) {
       if (error instanceof AgentCatalogError) throw error;
       throw new AgentCatalogError(

--- a/services/api/test/agent-catalog-and-github-credentials.integration.test.ts
+++ b/services/api/test/agent-catalog-and-github-credentials.integration.test.ts
@@ -55,6 +55,47 @@ Execute the ${name} role and verify the result.
 `;
 }
 
+function catalogGithub() {
+  const state = { sha: "a".repeat(40), denied: 0, childFailure: 0, empty: false };
+  const reads: Array<{ path: string; ref: string }> = [];
+  let branchReads = 0;
+  const factory = (async () => ({
+    rest: {
+      repos: {
+        getBranch: async () => {
+          branchReads++;
+          if (state.denied)
+            throw Object.assign(new Error("Access denied"), { status: state.denied });
+          return { data: { commit: { sha: state.sha } } };
+        },
+        getContent: async ({ path, ref }: { path: string; ref: string }) => {
+          reads.push({ path, ref });
+          if (state.empty) throw Object.assign(new Error("Missing root"), { status: 404 });
+          if (path === ".agents") return { data: [{ type: "file", path: ".agents/builder.md" }] };
+          if (path === ".agents/builder.md")
+            return { data: { type: "file", content: source("builder") } };
+          if (path === ".claude/skills")
+            return { data: [{ type: "dir", path: ".claude/skills/review" }] };
+          if (path === ".claude/skills/review")
+            return { data: [{ type: "file", path: ".claude/skills/review/SKILL.md" }] };
+          if (path === ".claude/skills/review/SKILL.md") {
+            if (state.childFailure)
+              throw Object.assign(new Error("Failed child"), { status: state.childFailure });
+            return {
+              data: {
+                type: "file",
+                content: "---\nname: review\ndescription: Reviews changes.\n---\nReview.",
+              },
+            };
+          }
+          throw new Error("Unexpected path");
+        },
+      },
+    },
+  })) as unknown as GithubClientFactory;
+  return { state, reads, factory, branchReads: () => branchReads };
+}
+
 describe("agent catalog and full GitHub workspace credentials", async () => {
   const reachable = await canConnect();
   if (!reachable) {
@@ -261,9 +302,7 @@ describe("agent catalog and full GitHub workspace credentials", async () => {
                 },
               };
             }
-            return {
-              data: { type: "file", path, encoding: "base64", content: encoded("ignored") },
-            };
+            throw Object.assign(new Error("Optional directory missing"), { status: 404 });
           },
         },
       },
@@ -287,6 +326,92 @@ describe("agent catalog and full GitHub workspace credentials", async () => {
     expect(
       await db.select().from(projectSkills).where(eq(projectSkills.projectId, projectId)),
     ).toHaveLength(1);
+  });
+
+  it("shares complete immutable snapshots across concurrent refreshes while checking access and branch each time", async () => {
+    const github = catalogGithub();
+    const canonical = new GithubAgentCatalogSource(db, github.factory);
+    const snapshots = await Promise.all(
+      Array.from({ length: 20 }, () => canonical.load(orgId, projectId)),
+    );
+    expect(github.branchReads()).toBe(20);
+    expect(github.reads).toHaveLength(5);
+    expect(
+      snapshots.every((snapshot) => snapshot.sources.length === 1 && snapshot.skills?.length === 1),
+    ).toBe(true);
+    const first = snapshots[0];
+    if (!first) throw new Error("Expected a completed catalog snapshot");
+    first.sources.splice(0);
+    expect((await canonical.load(orgId, projectId)).sources).toHaveLength(1);
+    expect(github.reads).toHaveLength(5);
+
+    github.state.sha = "b".repeat(40);
+    expect((await canonical.load(orgId, projectId)).commitSha).toBe(github.state.sha);
+    expect(github.reads).toHaveLength(10);
+    expect(github.reads.slice(5).every((read) => read.ref === github.state.sha)).toBe(true);
+
+    for (const status of [401, 403, 404]) {
+      github.state.denied = status;
+      await expect(canonical.load(orgId, projectId)).rejects.toMatchObject({
+        code: "agent_catalog_unavailable",
+      });
+      expect(github.reads).toHaveLength(10);
+    }
+    github.state.denied = 0;
+    await db
+      .update(githubInstallations)
+      .set({ suspendedAt: new Date() })
+      .where(eq(githubInstallations.id, installationId));
+    try {
+      await expect(canonical.load(orgId, projectId)).rejects.toMatchObject({
+        code: "github_installation_unavailable",
+      });
+    } finally {
+      await db
+        .update(githubInstallations)
+        .set({ suspendedAt: null })
+        .where(eq(githubInstallations.id, installationId));
+    }
+    await expect(canonical.load(newId("org"), projectId)).rejects.toMatchObject({
+      code: "primary_repository_not_found",
+    });
+    await expect(canonical.load(orgId, newId("proj"))).rejects.toMatchObject({
+      code: "primary_repository_not_found",
+    });
+  });
+
+  it.each([
+    403, 404, 429, 500,
+  ])("preserves complete projections after a partial refresh failure (%s) and retries the same commit", async (status) => {
+    const github = catalogGithub();
+    const canonical = new GithubAgentCatalogSource(db, github.factory);
+    const catalog = new AgentCatalogService(db, canonical);
+    await catalog.sync(orgId, projectId);
+    github.state.sha = "b".repeat(40);
+    github.state.childFailure = status;
+    await expect(catalog.sync(orgId, projectId)).rejects.toMatchObject({
+      code: "agent_catalog_unavailable",
+    });
+    expect(await catalog.list(orgId, projectId)).toMatchObject([
+      { name: "builder", commitSha: "a".repeat(40) },
+    ]);
+    expect(await catalog.listSkills(orgId, projectId)).toMatchObject([
+      { name: "review", commitSha: "a".repeat(40) },
+    ]);
+    github.state.childFailure = 0;
+    await catalog.sync(orgId, projectId);
+    expect(await catalog.list(orgId, projectId, { refresh: false })).toMatchObject([
+      { name: "builder", commitSha: "b".repeat(40) },
+    ]);
+    expect(await catalog.listSkills(orgId, projectId, { refresh: false })).toMatchObject([
+      { name: "review", commitSha: "b".repeat(40) },
+    ]);
+    // A successfully read new commit that actually removes both optional roots is authoritative.
+    github.state.sha = "c".repeat(40);
+    github.state.empty = true;
+    await catalog.sync(orgId, projectId);
+    expect(await catalog.list(orgId, projectId, { refresh: false })).toEqual([]);
+    expect(await catalog.listSkills(orgId, projectId, { refresh: false })).toEqual([]);
   });
 
   it("validates an agent edit and writes it to a reviewable Git branch", async () => {

--- a/services/api/test/agent-catalog-files.test.ts
+++ b/services/api/test/agent-catalog-files.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { readAgentCatalogFiles } from "../src/agents/catalog-files.js";
+
+const failure = (status: number) => Object.assign(new Error("GitHub unavailable"), { status });
+
+function fixture() {
+  const calls: string[] = [];
+  const contents = new Map<string, unknown>([
+    [
+      ".agents",
+      [
+        { type: "file", path: ".agents/builder.md" },
+        { type: "file", path: ".agents/README.md" },
+      ],
+    ],
+    [
+      ".agents/builder.md",
+      { type: "file", encoding: "base64", content: Buffer.from("builder").toString("base64") },
+    ],
+    [".claude/skills", [{ type: "dir", path: ".claude/skills/review" }]],
+    [
+      ".claude/skills/review",
+      [
+        { type: "file", path: ".claude/skills/review/SKILL.md" },
+        { type: "file", path: ".claude/skills/review/large-reference.txt" },
+        { type: "dir", path: ".claude/skills/review/nested" },
+      ],
+    ],
+    [".claude/skills/review/SKILL.md", { type: "file", content: "review" }],
+    [
+      ".claude/skills/review/nested",
+      [{ type: "file", path: ".claude/skills/review/nested/SKILL.md" }],
+    ],
+    [".claude/skills/review/nested/SKILL.md", { type: "file", content: "nested review" }],
+  ]);
+  return {
+    calls,
+    contents,
+    client: {
+      getContent: async (path: string, ref: string) => {
+        expect(ref).toBe("a".repeat(40));
+        calls.push(path);
+        const value = contents.get(path);
+        if (value instanceof Error) throw value;
+        if (value === undefined) throw failure(404);
+        return value;
+      },
+    },
+  };
+}
+
+describe("complete agent catalog reads", () => {
+  it("reads manifests and nested skills at one commit without downloading support files", async () => {
+    const f = fixture();
+    expect(await readAgentCatalogFiles(f.client, "a".repeat(40))).toEqual(
+      new Map([
+        [".agents/builder.md", "builder"],
+        [".claude/skills/review/SKILL.md", "review"],
+        [".claude/skills/review/nested/SKILL.md", "nested review"],
+      ]),
+    );
+    expect(f.calls).not.toContain(".agents/README.md");
+    expect(f.calls).not.toContain(".claude/skills/review/large-reference.txt");
+  });
+
+  it("accepts missing optional roots as an empty catalog", async () => {
+    const f = fixture();
+    f.contents.clear();
+    expect(await readAgentCatalogFiles(f.client, "a".repeat(40))).toEqual(new Map());
+  });
+
+  it.each([
+    401, 403, 429, 500,
+  ])("rejects a failed root read (%s) instead of returning an empty snapshot", async (status) => {
+    const f = fixture();
+    f.contents.set(".agents", failure(status));
+    await expect(readAgentCatalogFiles(f.client, "a".repeat(40))).rejects.toMatchObject({ status });
+  });
+
+  it.each([
+    401, 403, 404, 429, 500,
+  ])("rejects partial child reads (%s) instead of deleting existing skills", async (status) => {
+    const f = fixture();
+    f.contents.set(".claude/skills/review/SKILL.md", failure(status));
+    await expect(readAgentCatalogFiles(f.client, "a".repeat(40))).rejects.toMatchObject({ status });
+  });
+
+  it.each([
+    { response: [{ type: "file", path: "../other-tenant/secret" }] },
+    { response: [{ type: "file" }] },
+    { response: [{ type: "dir", path: ".agents/.." }] },
+    { response: { type: "file", content: "unexpected root" } },
+  ])("rejects malformed catalog directory responses", async ({ response }) => {
+    const f = fixture();
+    f.contents.set(".agents", response);
+    await expect(readAgentCatalogFiles(f.client, "a".repeat(40))).rejects.toThrow(
+      "Invalid agent catalog",
+    );
+  });
+
+  it("rejects a directory masquerading as an agent manifest", async () => {
+    const f = fixture();
+    f.contents.set(".agents/builder.md", []);
+    await expect(readAgentCatalogFiles(f.client, "a".repeat(40))).rejects.toThrow(
+      "Invalid agent catalog file",
+    );
+  });
+
+  it("rejects incomplete file responses", async () => {
+    const f = fixture();
+    f.contents.set(".agents/builder.md", { type: "file" });
+    await expect(readAgentCatalogFiles(f.client, "a".repeat(40))).rejects.toThrow(
+      "Incomplete agent catalog file",
+    );
+  });
+});


### PR DESCRIPTION
## What changes

Agent catalog refreshes reuse a complete snapshot when the repository commit has not changed. Concurrent requests share the same fetch, and inventory reads download only agent manifests and SKILL.md files. Failed or incomplete GitHub reads preserve the last valid catalog instead of deleting definitions.

## Why

The story page refreshes every eight seconds. Previously, each refresh traversed and downloaded every file under both catalog directories, even at the same commit. Read failures were swallowed as absent files, so a rate limit could materialize an incomplete or empty catalog. Repository access, installation status, tenant scope, and the current branch are checked before each cached snapshot is used. Successful commits that remove definitions still remove them from the projection.

## Verification

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite: the candidate image read the production project catalog without changing it. The initial load used 14 GitHub requests; the same-commit repeat used one branch/access check and zero content reads. Both returned the same six agents and two skills.
- [x] Documentation updated, or no user-facing change

Focused acceptance: `Test Files  2 passed (2)` and `Tests  32 passed (32)`. Deterministic GitHub fakes and PostgreSQL cover concurrent reuse, changed commits, revoked access, suspended installations, tenant/project denial, partial 403/404/429/500 failures, retry, preservation, and intentional deletion. Unit tests cover optional missing roots, nested skills, ignored support files, malformed responses, and incomplete files. Five new integration regressions fail against the previous implementation.
