### PR TITLE
fix(github): name the kickstart failure instead of returning a bare 500

### DIFF
--- a/services/api/src/github/kickstart.ts
+++ b/services/api/src/github/kickstart.ts
@@ -1,6 +1,7 @@
 import { renderWorkspaceKickstart, sha256Hex } from "@facility/core";
 import { type FacilityDb, githubInstallations } from "@facility/db";
 import { eq } from "drizzle-orm";
+import { ApiError } from "../errors.js";
 import type { AppConfig, Principal } from "../types.js";
 import { FacilityGithubClient, type GithubClientFactory, type TreeItem } from "./client.js";
 import { readRepoFiles } from "./repo-files.js";
@@ -35,7 +36,13 @@ export async function createGithubClientForRepo(
   factory: GithubClientFactory,
   repository: GithubRepositoryRow,
 ): Promise<FacilityGithubClient> {
-  if (!repository.installationId) throw new Error("Repository has no GitHub installation");
+  if (!repository.installationId) {
+    throw new ApiError(
+      409,
+      "github_installation_missing",
+      `${slug(repository)} is not connected to a GitHub App installation. Reconnect the repository before running kickstart.`,
+    );
+  }
   const installation = (
     await db
       .select()
@@ -44,7 +51,11 @@ export async function createGithubClientForRepo(
       .limit(1)
   )[0];
   if (!installation || installation.orgId !== repository.orgId || installation.suspendedAt) {
-    throw new Error("GitHub installation is unavailable");
+    throw new ApiError(
+      409,
+      "github_installation_unavailable",
+      `The GitHub App installation for ${slug(repository)} is suspended or belongs to another organization.`,
+    );
   }
   return new FacilityGithubClient(await factory(installation.installationId), {
     owner: repository.owner,
@@ -59,9 +70,12 @@ export async function kickstartPreview(
   repository: GithubRepositoryRow,
   answers: KickstartAnswers,
 ) {
+  const ref = answers.defaultBranch ?? repository.defaultBranch;
   const client = await createGithubClientForRepo(db, factory, repository);
-  const existing = await readRepoFiles(client, repository.defaultBranch);
-  const detection = detectWorkspace(existing, answers.defaultBranch ?? repository.defaultBranch);
+  const existing = await readRepoFiles(client, repository.defaultBranch).catch((error) => {
+    throw kickstartFailure(error, repository, ref);
+  });
+  const detection = detectWorkspace(existing, ref);
   const workspaceAnswers = workspaceKickstartAnswers(
     repository,
     answers,
@@ -97,18 +111,32 @@ export async function kickstartRepo(args: {
   repo: GithubRepositoryRow;
   answers: KickstartAnswers;
 }) {
+  const ref = args.answers.defaultBranch ?? args.repo.defaultBranch;
   const client = await createGithubClientForRepo(args.db, args.factory, args.repo);
+  try {
+    return await applyKickstart(args, client, ref);
+  } catch (error) {
+    throw kickstartFailure(error, args.repo, ref);
+  }
+}
+
+async function applyKickstart(
+  args: Parameters<typeof kickstartRepo>[0],
+  client: FacilityGithubClient,
+  ref: string,
+) {
   const existing = await readRepoFiles(client, args.repo.defaultBranch);
-  const detection = detectWorkspace(
-    existing,
-    args.answers.defaultBranch ?? args.repo.defaultBranch,
-  );
+  const detection = detectWorkspace(existing, ref);
   const rendered = renderWorkspaceKickstart(
     workspaceKickstartAnswers(args.repo, args.answers, existing, detection.packageManager),
     existing,
   );
   if (rendered.files.length === 0) {
-    throw new Error("Repository already contains the Facility 0.12 kickstart files");
+    throw new ApiError(
+      409,
+      "kickstart_already_applied",
+      `${slug(args.repo)} already contains the Facility 0.12 kickstart files. Remove or update them in a normal pull request instead.`,
+    );
   }
 
   const branch = "facility/kickstart-0.12";
@@ -146,6 +174,53 @@ export async function kickstartRepo(args: {
     files: rendered.files,
     manifest: rendered.manifest,
   };
+}
+
+function slug(repository: GithubRepositoryRow) {
+  return `${repository.owner}/${repository.name}`;
+}
+
+/**
+ * Octokit reports HTTP failures on `status`, while the API error handler reads
+ * `statusCode`. Every refusal GitHub returned therefore reached the operator as
+ * "Internal server error", which is the least useful answer possible for the
+ * first flow a new installation runs. Name the condition and the remedy.
+ *
+ * Statuses that are genuinely ours — or that we have no advice for — are passed
+ * through untouched so they keep being masked and logged as server errors.
+ */
+function kickstartFailure(error: unknown, repository: GithubRepositoryRow, ref: string): unknown {
+  if (error instanceof ApiError) return error;
+  const status = (error as { status?: unknown }).status;
+  if (typeof status !== "number") return error;
+  switch (status) {
+    case 404:
+      return new ApiError(
+        404,
+        "kickstart_repository_unreachable",
+        `Facility cannot read ${slug(repository)} at ${ref}. The repository may have no commits yet, the branch may not exist, or the GitHub App installation may no longer include this repository.`,
+      );
+    case 409:
+      return new ApiError(
+        409,
+        "kickstart_repository_empty",
+        `${slug(repository)} has no commits on ${ref}. Push an initial commit before running kickstart.`,
+      );
+    case 403:
+      return new ApiError(
+        403,
+        "kickstart_repository_forbidden",
+        `The GitHub App installation for ${slug(repository)} refused the request. Confirm it still grants contents and pull request write access, and that no organization policy blocks it.`,
+      );
+    case 429:
+      return new ApiError(
+        429,
+        "kickstart_github_rate_limited",
+        `GitHub is rate limiting Facility's installation for ${slug(repository)}. Retry once the installation's rate limit resets.`,
+      );
+    default:
+      return error;
+  }
 }
 
 function workspaceKickstartAnswers(

--- a/services/api/test/kickstart-failures.test.ts
+++ b/services/api/test/kickstart-failures.test.ts
@@ -1,0 +1,204 @@
+import type { FacilityDb } from "@facility/db";
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../src/errors.js";
+import type { Octokit } from "../src/github/client.js";
+import {
+  type GithubRepositoryRow,
+  kickstartPreview,
+  kickstartRepo,
+} from "../src/github/kickstart.js";
+import type { AppConfig, Principal } from "../src/types.js";
+
+const repository: GithubRepositoryRow = {
+  id: "repo_test",
+  orgId: "org_test",
+  projectId: "proj_test",
+  installationId: "ghi_test",
+  owner: "panteraimperial-hub",
+  name: "facility-test",
+  defaultBranch: "main",
+};
+
+const installation = {
+  id: "ghi_test",
+  orgId: "org_test",
+  installationId: 4242,
+  suspendedAt: null,
+};
+
+function fakeDb(row: unknown = installation) {
+  return {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => (row ? [row] : []) }) }),
+    }),
+  } as unknown as FacilityDb;
+}
+
+/** An Octokit failure carries `status`, the way `@octokit/request-error` reports it. */
+function githubError(status: number, message: string) {
+  return Object.assign(new Error(message), { status });
+}
+
+/**
+ * `getContent` is the only call kickstart makes before it needs a base commit,
+ * and `readRepoFiles` swallows its failures, so a repository is only observed to
+ * be unusable when the base ref is resolved.
+ */
+function fakeOctokit(options: {
+  getBranch?: () => Promise<{ data: { commit: { sha: string } } }>;
+  contents?: Map<string, unknown>;
+}): Octokit {
+  const contents = options.contents ?? new Map();
+  return {
+    rest: {
+      git: {
+        getCommit: async () => ({ data: { sha: "a".repeat(40), tree: { sha: "b".repeat(40) } } }),
+        createBlob: async () => ({ data: { sha: "c".repeat(40) } }),
+        createTree: async () => ({ data: { sha: "d".repeat(40) } }),
+        createCommit: async () => ({ data: { sha: "e".repeat(40) } }),
+        createRef: async () => ({ data: {} }),
+        updateRef: async () => ({ data: {} }),
+      },
+      repos: {
+        getContent: async (args: Record<string, unknown>) => {
+          const path = String(args.path);
+          if (!contents.has(path)) throw githubError(404, "Not Found");
+          return { data: contents.get(path) };
+        },
+        getBranch:
+          options.getBranch ?? (async () => ({ data: { commit: { sha: "a".repeat(40) } } })),
+      },
+      pulls: {
+        create: async () => ({ data: { number: 1, html_url: "https://github.test/pr/1" } }),
+        list: async () => ({ data: [] }),
+      },
+    },
+  } as unknown as Octokit;
+}
+
+/** Every file the 0.12 kickstart would create, so nothing is left to render. */
+function alreadyKickstarted() {
+  const file = (path: string) => ({
+    type: "file",
+    path,
+    encoding: "base64",
+    content: Buffer.from(`# ${path}\n`).toString("base64"),
+  });
+  const agents = [
+    "architect",
+    "builder",
+    "pr-reviewer",
+    "address-review",
+    "ci-doctor",
+    "security-audit",
+  ].map((name) => `.agents/${name}.md`);
+  const contents = new Map<string, unknown>([
+    [".facility.yml", file(".facility.yml")],
+    [".agents", agents.map((path) => ({ path }))],
+    ...agents.map((path) => [path, file(path)] as const),
+  ]);
+  return contents;
+}
+
+function applyArgs(db: FacilityDb, octokit: Octokit) {
+  return {
+    db,
+    factory: async () => octokit,
+    config: {} as AppConfig,
+    principal: { type: "user", id: "user_test", orgId: "org_test" } as Principal,
+    projectId: "proj_test",
+    repo: repository,
+    answers: {},
+  };
+}
+
+describe("kickstart failures name the condition", () => {
+  it("reports a repository whose base ref cannot be read, instead of a 500", async () => {
+    const octokit = fakeOctokit({
+      getBranch: async () => {
+        throw githubError(404, "Branch not found");
+      },
+    });
+
+    await expect(kickstartRepo(applyArgs(fakeDb(), octokit))).rejects.toMatchObject({
+      statusCode: 404,
+      code: "kickstart_repository_unreachable",
+      message: expect.stringContaining("panteraimperial-hub/facility-test"),
+    });
+  });
+
+  it("names an empty repository when GitHub reports the conflict", async () => {
+    const octokit = fakeOctokit({
+      getBranch: async () => {
+        throw githubError(409, "Git Repository is empty.");
+      },
+    });
+
+    await expect(kickstartRepo(applyArgs(fakeDb(), octokit))).rejects.toMatchObject({
+      statusCode: 409,
+      code: "kickstart_repository_empty",
+      message: expect.stringContaining("main"),
+    });
+  });
+
+  it("separates a refused installation from a rate-limited one", async () => {
+    const forbidden = fakeOctokit({
+      getBranch: async () => {
+        throw githubError(403, "Resource not accessible by integration");
+      },
+    });
+    await expect(kickstartRepo(applyArgs(fakeDb(), forbidden))).rejects.toMatchObject({
+      statusCode: 403,
+      code: "kickstart_repository_forbidden",
+    });
+
+    const throttled = fakeOctokit({
+      getBranch: async () => {
+        throw githubError(429, "Too Many Requests");
+      },
+    });
+    await expect(kickstartRepo(applyArgs(fakeDb(), throttled))).rejects.toMatchObject({
+      statusCode: 429,
+      code: "kickstart_github_rate_limited",
+    });
+  });
+
+  it("treats an already-kickstarted repository as a conflict, not a server fault", async () => {
+    const octokit = fakeOctokit({ contents: alreadyKickstarted() });
+
+    await expect(kickstartRepo(applyArgs(fakeDb(), octokit))).rejects.toMatchObject({
+      statusCode: 409,
+      code: "kickstart_already_applied",
+    });
+  });
+
+  it("reports a missing or suspended installation before calling GitHub", async () => {
+    const octokit = fakeOctokit({});
+
+    await expect(kickstartRepo(applyArgs(fakeDb(null), octokit))).rejects.toMatchObject({
+      statusCode: 409,
+      code: "github_installation_unavailable",
+    });
+
+    await expect(
+      kickstartPreview(fakeDb(), async () => octokit, { ...repository, installationId: null }, {}),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "github_installation_missing",
+    });
+  });
+
+  it("leaves a failure it has no advice for masked as a server error", async () => {
+    const octokit = fakeOctokit({
+      getBranch: async () => {
+        throw githubError(502, "Bad gateway");
+      },
+    });
+
+    const failure = await kickstartRepo(applyArgs(fakeDb(), octokit)).catch((error) => error);
+
+    // Not an ApiError, so the handler keeps logging it and answering a masked 500.
+    expect(failure).not.toBeInstanceOf(ApiError);
+    expect(failure).toMatchObject({ status: 502 });
+  });
+});


### PR DESCRIPTION
Closes #211.

## The report, and what actually happens

#211 reaches kickstart with working GitHub authentication, selects a repository, and gets `Internal server error`. There is nothing else to go on — not whether the repository, the installation, or Facility is at fault. That is the first flow a new installation runs, so it is the worst possible place for an opaque answer.

There are two causes behind the one symptom.

**1. Octokit reports `status`; the error handler reads `statusCode`.**

```ts
// services/api/src/app.ts
const status = typeof err.statusCode === "number" ? err.statusCode : 500;
if (status >= 500) { /* logged, masked as "Internal server error" */ }
```

`@octokit/request-error` sets `status`, not `statusCode`. So every refusal GitHub can give — 404, 403, 409, 429 — falls into the 500 branch and is masked. The codebase already knows this in one place; `kickstartRepo` reads `(error as { status?: number }).status` when handling a 422 from `createBranch`, and nowhere else.

For the reported case the failing call is `getDefaultBranchSha()` → `repos.getBranch`, which answers 404 on a repository with no commits. `facility-test` reads like a freshly created repository, which fits: `readRepoFiles` swallows every `getContent` failure, so preview renders happily, and the first call that actually needs a base commit is the one that dies.

**2. Kickstart's own refusals were bare `Error`s**, which have no `statusCode` at all — including `"Repository already contains the Facility 0.12 kickstart files"`. That is a conflict the caller can act on, delivered as a server fault.

## The change

Map both, in the one boundary that owns the GitHub call.

| Condition | Before | After |
|---|---|---|
| Base ref unreadable (no commits, missing branch, repo no longer in the installation) | 500 | 404 `kickstart_repository_unreachable` |
| GitHub reports the repository empty | 500 | 409 `kickstart_repository_empty` |
| Installation refuses the request | 500 | 403 `kickstart_repository_forbidden` |
| Installation rate limited | 500 | 429 `kickstart_github_rate_limited` |
| Repository has no installation | 500 | 409 `github_installation_missing` |
| Installation suspended or foreign | 500 | 409 `github_installation_unavailable` |
| Kickstart files already present | 500 | 409 `kickstart_already_applied` |

Each message names the repository, the ref, and the remedy. **Statuses with no advice attached are passed through untouched**, so a genuine upstream fault is still logged and masked by `sendError` — the fix narrows what gets a 500, it does not stop masking.

## Test

New `services/api/test/kickstart-failures.test.ts`, six cases against a fake Octokit that throws `status`-carrying errors the way `@octokit/request-error` does — no daemon, no network, runs in the default suite. Five fail on unmodified `main`; the sixth is the regression guard that an unmapped status *stays* masked, and it passes both ways by design.

## Found but not fixed

`readRepoFiles` swallows every `getContent` error, so **kickstart preview succeeds on a repository that apply cannot use**. #211's reporter gets all the way through "preview the assets" before the failure appears. Making preview resolve the base ref would surface the same diagnosable error one step earlier, which reads like the right behaviour and matches #280's "invalid contracts fail before any partial setup command runs". I left it out to keep this to one change; happy to add it here or open it separately, whichever you prefer.

Distinguishing "empty repository" from "branch does not exist" would need one extra `repos.get` call on the error path. I did not add it — the 404 message names both possibilities rather than inventing a diagnosis.

## Verification

Windows 11, Node 26, compose Postgres.

- `pnpm --filter @facility/api typecheck` — clean
- `pnpm lint` — clean
- `vitest run test/kickstart-failures.test.ts test/github-client.test.ts` — 8 passed
- Full `services/api` suite: 261 passed, 13 failed — the same 13 that fail on unmodified `main` in this environment (the POSIX-shell fakes in `workspace-vercel-bootstrap`, `agent-engines`, `facility-012.e2e`, `project-environment`, `turn-dispatcher`, i.e. the #227/#241 Windows family). Verified by stashing the change and re-running.

I could not reproduce against a live GitHub App, so the status-to-condition mapping is from the REST documentation and Octokit's error shape rather than from observed responses. The fake reproduces the shape; a real empty-repository run would confirm the 404 path end to end.

> Claude Code helped
