### PR TITLE
docs: install the pinned pnpm without Corepack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,17 @@ technical problem on its own terms and the private tracker links to it.
 ## Set up the repository
 
 The monorepo recommends Node.js 24 LTS and uses pnpm 11.20.0. Node.js 22 is
-also supported from 22.13.0. Docker is required for the local platform stack
-and workspace end-to-end tests. For nvm users, the repository's `.nvmrc` selects
-the recommended Node.js 24 line with `nvm use`.
+also supported from 22.13.0. Node.js 25 and later fall outside that range and
+no longer bundle Corepack, so `corepack enable` is not available there; the
+command below installs the pinned pnpm on every supported release. Docker is
+required for the local platform stack and workspace end-to-end tests. For nvm
+users, the repository's `.nvmrc` selects the recommended Node.js 24 line with
+`nvm use`.
 
 ```bash
 git clone https://github.com/theam/facility.git
 cd facility
-corepack install --global pnpm@11.20.0
+npm install --global pnpm@11.20.0
 pnpm dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -219,14 +219,15 @@ Bearer header.
 
 Running Facility locally takes one command for the stack, a runner image for story workspaces, and
 a GitHub App when you want to use a real repository. You need Docker, Node.js 24 LTS, and the
-repository-pinned pnpm 11.20.0. Node.js 22 is supported from 22.13.0.
+repository-pinned pnpm 11.20.0. Node.js 22 is supported from 22.13.0. Node.js 25 and later are
+outside the supported range and no longer bundle Corepack; `.nvmrc` selects a supported line.
 
 ### 1. Clone and boot the stack
 
 ```bash
 git clone https://github.com/theam/facility.git
 cd facility
-corepack install --global pnpm@11.20.0
+npm install --global pnpm@11.20.0
 pnpm dev
 ```
 
@@ -467,7 +468,7 @@ behavior and boundaries can be agreed on.
 ```bash
 git clone https://github.com/theam/facility.git
 cd facility
-corepack install --global pnpm@11.20.0
+npm install --global pnpm@11.20.0
 pnpm install --frozen-lockfile
 pnpm verify
 ```

--- a/apps/docs/docs/reference/reference-fixture.md
+++ b/apps/docs/docs/reference/reference-fixture.md
@@ -12,7 +12,7 @@ sample builder and scheduled-security agents. It has no network or credential de
 From a clean checkout, run:
 
 ```bash
-corepack install --global pnpm@11.20.0
+npm install --global pnpm@11.20.0
 pnpm install --frozen-lockfile
 docker build -f runner/Dockerfile -t facility-runner:dev .
 FACILITY_E2E_DOCKER=1 \

--- a/apps/docs/docs/self-host/local-development.md
+++ b/apps/docs/docs/self-host/local-development.md
@@ -12,12 +12,14 @@ This guide covers work on the Facility monorepo. If you only want to run the pro
 Install Node.js 24 LTS and pnpm 11.20.0 before running the repository:
 
 ```bash
-corepack install --global pnpm@11.20.0
+npm install --global pnpm@11.20.0
 ```
 
-The root `package.json` also accepts Node.js 22 from 22.13.0. Use the repository `.nvmrc` when
-working with nvm. Do not substitute npm or yarn: the lockfile, workspace filters, and verification
-scripts assume pnpm.
+The root `package.json` also accepts Node.js 22 from 22.13.0. Node.js 25 and later are outside that
+range and no longer bundle Corepack; use the repository `.nvmrc` to select a supported line when
+working with nvm. npm appears above only to install the pinned pnpm, which works on every supported
+release. Do not substitute npm or yarn for pnpm itself: the lockfile, workspace filters, and
+verification scripts assume pnpm.
 
 Clone the repository, then run:
 

--- a/apps/docs/docs/self-host/quickstart.md
+++ b/apps/docs/docs/self-host/quickstart.md
@@ -11,14 +11,15 @@ guide](production.md) before exposing an instance to other users or repositories
 
 Install Docker, Node.js 24, and the repository-pinned pnpm version.
 
-Node.js 22 is also supported from 22.13.0. Docker must be running and the current user must be able
-to use it. Local story workspaces require enough disk for repository checkouts, dependencies,
+Node.js 22 is also supported from 22.13.0. Node.js 25 and later are outside the supported range and
+no longer bundle Corepack; use `.nvmrc` to select a supported line. Docker must be running and the
+current user must be able to use it. Local story workspaces require enough disk for repository checkouts, dependencies,
 nested Docker images, and persistent volumes.
 
 ## Start the local stack
 
 ```bash
-corepack install --global pnpm@11.20.0
+npm install --global pnpm@11.20.0
 pnpm install --frozen-lockfile
 cp .env.example .env
 docker build -f runner/Dockerfile -t facility-runner:dev .


### PR DESCRIPTION
Closes #167.

## The dead end

Node.js 25 removed the bundled Corepack. The first command of every documented setup path is:

```bash
corepack install --global pnpm@11.20.0
```

On a current Node release that fails outright, and the contributor is left with neither pnpm nor a reason. Nothing in the docs says which Node line to use instead, so the next reasonable move — "my Node is too new, but the badge says 24 LTS and I have 26 installed" — is a guess.

I hit this while setting up the repository: no `corepack` on the machine, and the documented path had no continuation. I got moving with `npx pnpm@11.20.0`, which is not what the docs should be teaching.

## The change

Two parts, because swapping the command alone would leave the real constraint unsaid.

**Install the same pinned pnpm with npm**, which ships with every supported release, in the five places that documented the Corepack command:

- `README.md` (quick start, and the contributing block)
- `CONTRIBUTING.md`
- `apps/docs/docs/self-host/quickstart.md`
- `apps/docs/docs/self-host/local-development.md`
- `apps/docs/docs/reference/reference-fixture.md`

**Say the constraint where the prerequisites are listed.** `package.json` already pins `"node": "^22.13.0 || ^24.0.0"`, so Node 25+ is not a supported runtime here — the docs just never said so, which is why the Corepack failure reads as a broken checkout rather than a wrong Node. Three prose spots now state that Node.js 25 and later are outside the supported range, no longer bundle Corepack, and that `.nvmrc` selects a supported line.

One consequence worth flagging: `local-development.md` already told readers *"Do not substitute npm or yarn"*, which the new command would appear to contradict. It now distinguishes using npm to install pnpm from using npm to run the workspace.

## Deliberately unchanged

`apps/docs/docs/guides/existing-repo.md` and `reference/project-manifest.md` show `setup: corepack enable && pnpm install --frozen-lockfile` in `.facility.yml` examples. Those run inside the runner image, which is `node:24-trixie-slim` and does bundle Corepack, so they are correct today.

They will not stay correct: Dependabot #209 moves the runner to `node:26-trixie-slim`, and `corepack enable` in those examples breaks the moment it lands. That is #209's problem to solve, not this PR's, but it is worth knowing before merging it.

## Verification

- `pnpm guards` — `✓ actions-pinned`, `✓ markdown-links`, 0 failed (no link broken by the edits)
- `pnpm --filter @facility/docs test` — 10 passed, including the full Docusaurus build and the canonical-URL check
- `pnpm lint` — clean

Verified on the machine that produced the report: Windows 11, Node 26, no Corepack present. `npm install --global pnpm@11.20.0` installs the pinned version and `pnpm install --frozen-lockfile` then succeeds.

## Related

#167's sibling #240 (the `engines` range) already landed — `package.json` now pins `^22.13.0 || ^24.0.0` rather than `>=22`. That tightened the contract without updating the setup instructions it implies, which is the gap this closes. Note that pnpm only *warns* on an out-of-range Node rather than refusing, so a contributor on 26 gets a working install and an untested toolchain unless the docs say otherwise — now they do.

> Claude Code helped
