### PR TITLE
docs: state that human authorization is organization-wide

### DIFF
--- a/apps/docs/docs/contributors/architecture.md
+++ b/apps/docs/docs/contributors/architecture.md
@@ -47,7 +47,8 @@ similar handwritten versions.
 
 ## Main request path
 
-A UI or MCP request enters the API, resolves a principal, checks project scope and permissions, and
+A UI or MCP request enters the API, resolves a principal, checks its organization-wide role
+permissions and — for a project-scoped API key — that the key's project matches the request, and
 calls a domain service. Starting or continuing a story persists its message and turn in PostgreSQL.
 The worker claims the turn, resolves an exact agent manifest, wakes the workspace provider,
 prepares `.facility.yml`, issues repository credentials, and starts or resumes Claude Code or

--- a/apps/docs/docs/guides/operate-story.md
+++ b/apps/docs/docs/guides/operate-story.md
@@ -37,7 +37,7 @@ Messages sent while a turn is active wait in order.
 
 Use `facility_get_story` to inspect status and `next_operations`. Use
 `facility_get_conversation` with its cursor for durable message history. The UI renders the same
-conversation and can continue it under the current user's project membership.
+conversation and can continue it under the current user's organization role.
 
 The story timeline is the review path across the whole delivery. It shows which agent, model,
 session, workspace, branch, and initial SHA started each turn; the final SHA, commits, files, and

--- a/apps/docs/docs/reference/security.md
+++ b/apps/docs/docs/reference/security.md
@@ -37,10 +37,12 @@ Facility still enforces:
 - secret redaction from persisted command events and API responses; and
 - explicit confirmation and idempotency for durable workspace deletion.
 
-Authorization uses organization membership, roles, and route permissions. Project-scoped API keys
-are pinned to one project and cannot enumerate others. Organization administration rejects scoped
-keys. Audit events record successful privileged mutations with actor, target, project, and request
-id.
+Authorization uses organization membership, roles, and route permissions. A human role is
+organization-wide: its permissions apply to every project in the organization, and a project
+boundary does not contain a person. Project-scoped API keys are pinned to one project and cannot
+enumerate others, so a scoped key is the only mechanism that contains a principal to one project.
+Organization administration rejects scoped keys. Audit events record successful privileged
+mutations with actor, target, project, and request id.
 
 GitHub webhook signatures are verified over the raw body before JSON parsing. The installation id
 must map to one active organization, and delivery ids are deduplicated within that installation.

--- a/apps/docs/docs/self-host/authentication.md
+++ b/apps/docs/docs/self-host/authentication.md
@@ -97,9 +97,15 @@ the API from the deployment secret store.
 
 ## Authorization behavior
 
-Any active project maintainer can read and continue the same story. Every project operation checks
-organization and project scope. Cross-project lookups return 404 so scoped credentials cannot use
-the API as an enumeration oracle.
+Human authorization is organization-wide. A role grants its permissions across every project in the
+organization, so any active member holding `workspaces:execute` can read and continue any story in
+it. There is no project membership and no project dimension on a role: "maintainer on one
+repository" cannot be expressed.
+
+The project dimension exists for API keys. A project-scoped key is pinned to one project, and a
+cross-project lookup returns 404 rather than 403 so a key cannot use the API as an enumeration
+oracle. Reach for a scoped key when automation should be contained to one project, and note the
+trade-off: audit events then record the key rather than a person.
 
 Roles and route permissions govern humans and API keys. They do not change an agent manifest into
 a restricted workspace profile: once a principal is allowed to execute an agent in a project, the
@@ -111,13 +117,13 @@ requests remain available in structured service logs and can be correlated with 
 ## Preview authentication
 
 Preview cookies are separate from control-plane sessions. A one-time handoff issues an expiring
-preview cookie; each proxied request revalidates the user, project membership, workspace, service,
-expiry, and revocation status.
+preview cookie; each proxied request revalidates the user, organization membership, workspace,
+service, expiry, and revocation status.
 
 The preview origin must be on a different registered site from Facility control origins. Opening a
 service creates a one-time handoff; consuming it sets a host-only preview cookie. The preview proxy
-rechecks membership on each HTTP request and WebSocket upgrade, so revoking membership, the
-session, or the workspace stops continued access.
+rechecks organization membership on each HTTP request and WebSocket upgrade, so removing the member,
+revoking the session, or deleting the workspace stops continued access.
 
 Never send a Facility API key, OAuth token, or control-plane session cookie to the application
 running inside a preview.


### PR DESCRIPTION
## What changes

Four documentation pages describe a project dimension on the human authorization
path that the data model does not have. They now say what the code does.

- `self-host/authentication.md` — "Any active **project maintainer** can read and
  continue the same story. Every project operation checks organization and
  **project scope**."
- `self-host/authentication.md` — the preview proxy "revalidates the user,
  **project membership**, ...". `WorkspacePreviewService.assertMembership`
  queries `org_members`; the check is organization membership.
- `contributors/architecture.md` — the request path "checks **project scope** and
  permissions".
- `guides/operate-story.md` — the UI "can continue it under the current user's
  **project membership**".

`reference/security.md` was already the accurate page. Its sentence becomes the
canonical one and now says plainly that a project boundary does not contain a
person, and that a project-scoped API key is the only mechanism that contains a
principal to one project.

Documentation only. No behaviour changes, and no position is taken on whether the
model should gain a project dimension — that question stays open in #325.

## Why

There is no `project_members` table. `roles` is `(orgId, name, permissions[])`
with no project column, and permission strings carry no project either — so a
role granting `workspaces:execute` grants it in **every** project in the
organization. "Maintainer on one repository" cannot be written down, so it cannot
be reviewed, audited, or refused.

This matters because the pages sit next to a genuinely careful piece of work: a
project-scoped API key asking for another project gets **404, not 403**, so it
cannot be used as an enumeration oracle. A reader who has just read that will
reasonably assume the same containment applies to people. It does not, and
nothing in the model made the asymmetry visible. Provisioning against the
stronger reading is a security expectation set by documentation, which is why
this half is worth fixing regardless of how the model question in #325 is
answered.

**Out of scope, deliberately.** #325 also notes that the bundled `owner` and
`maintainer` roles are both `["*"]` — identical grants under different names, with
nothing between "read everything" and "administer the organization". Narrowing
`maintainer` removes access from existing instances on deploy, so it belongs in
its own change with an expand → migrate → contract path, not in a documentation
correction. `reference/hardening.md` already recommends project-scoped keys for
automation that needs only one project, so no change was needed there.

One claim listed in #325 is already gone: the README no longer says a "project
member" can open an authenticated local preview. Nothing to correct there.

## Verification

Each claim was checked against the code before rewriting it, not against the
issue text:

```
grep projectMembers|project_members packages/db/src/schema.ts   → no matches
roles           = (id, orgId, name, description, permissions[])
orgMembers      = (id, orgId, userId, roleId)
BUNDLED_ROLES   → owner ["*"], maintainer ["*"], viewer allReads
preview.ts:221  → assertMembership(orgId, userId) selects from org_members
permissions.ts  → SPECIAL_PERMISSIONS includes "workspaces:execute"
```

```
node guards/run.mjs                                     2 guards, 0 failed
pnpm --filter @facility/docs build                      [SUCCESS]
```

- [ ] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change

`pnpm verify` does not pass on this machine and not because of this change:
`test:dev` reports **116 tests, 92 pass, 24 fail** here, and the identical 92/24
on a clean `main` — Windows noise unrelated to documentation. The meaningful
gates for a docs change are the link guard and the Docusaurus build, both green
above; the substance was verified by reading the schema, the role table and the
preview membership query rather than by any test.

Refs #325.

> 🤖 Claude Code helped
