### PR TITLE
fix(web): add baseline accessibility landmarks and skip navigation

### DIFF
--- a/apps/web/app/(app)/(org)/layout.tsx
+++ b/apps/web/app/(app)/(org)/layout.tsx
@@ -1,4 +1,5 @@
 import { MobileNav, Sidebar } from "@/components/shell/nav";
+import { MAIN_CONTENT_ID, SkipLink } from "@/components/shell/skip-link";
 import { Topbar } from "@/components/shell/topbar";
 import { api } from "@/lib/api";
 
@@ -8,11 +9,14 @@ export default async function OrgLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="flex min-h-dvh">
+      <SkipLink />
       <Sidebar />
       <div className="min-w-0 flex-1">
         <MobileNav />
         {me.ok ? <Topbar me={me.data} projects={projectList} /> : null}
-        <main className="px-5 py-8 sm:px-8 lg:px-10">{children}</main>
+        <main id={MAIN_CONTENT_ID} tabIndex={-1} className="px-5 py-8 sm:px-8 lg:px-10">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/apps/web/app/(app)/projects/[projectId]/layout.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/layout.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { ErrorNotice, Offline } from "@/components/offline";
 import { MobileNav, Sidebar } from "@/components/shell/nav";
 import { RememberProject } from "@/components/shell/remember-project";
+import { MAIN_CONTENT_ID, SkipLink } from "@/components/shell/skip-link";
 import { Topbar } from "@/components/shell/topbar";
 import { api } from "@/lib/api";
 
@@ -44,11 +45,18 @@ export default async function ProjectLayout({
     // App shell: the viewport is the frame; only the work area (main) scrolls,
     // so full-height tabs like Product can fill it edge to edge.
     <div className="flex h-dvh">
+      <SkipLink />
       <Sidebar project={navProject} />
       <div className="flex min-w-0 flex-1 flex-col">
         <MobileNav project={navProject} />
         {me.ok ? <Topbar me={me.data} projects={projectList} current={p} /> : null}
-        <main className="app-main min-h-0 flex-1 overflow-y-auto">{children}</main>
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="app-main min-h-0 flex-1 overflow-y-auto"
+        >
+          {children}
+        </main>
       </div>
       <RememberProject projectId={p.id} />
     </div>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,13 +1,17 @@
-import { ButtonLink } from "@facility/ui";
+import { ButtonLink, VisuallyHidden } from "@facility/ui";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Sign in" };
 
 export default function LoginPage() {
   const localDevelopment = process.env.NODE_ENV !== "production";
   return (
-    <div className="mx-auto flex min-h-dvh w-full max-w-sm flex-col justify-center gap-10 px-6">
+    <main className="mx-auto flex min-h-dvh w-full max-w-sm flex-col justify-center gap-10 px-6">
       <div className="flex flex-col gap-3">
-        <span className="font-mono text-[22px] font-semibold tracking-tight">
+        <h1 className="font-mono text-[22px] font-semibold tracking-tight">
           facility<span className="text-(--accent)">.</span>
-        </span>
+          <VisuallyHidden> sign in</VisuallyHidden>
+        </h1>
         <p className="text-sm leading-relaxed text-(--mut)">
           One persistent workspace and shared agent conversation for every story.
         </p>
@@ -29,6 +33,6 @@ export default function LoginPage() {
           The Agile Monkeys
         </a>
       </p>
-    </div>
+    </main>
   );
 }

--- a/apps/web/components/shell/skip-link.tsx
+++ b/apps/web/components/shell/skip-link.tsx
@@ -1,0 +1,12 @@
+export const MAIN_CONTENT_ID = "main-content";
+
+export function SkipLink() {
+  return (
+    <a
+      href={`#${MAIN_CONTENT_ID}`}
+      className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:border focus:border-(--line-strong) focus:bg-(--bg) focus:px-4 focus:py-3 focus:text-[13px] focus:text-(--ink)"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/apps/web/test/accessibility-baseline.test.tsx
+++ b/apps/web/test/accessibility-baseline.test.tsx
@@ -1,0 +1,29 @@
+import { VisuallyHidden } from "@facility/ui";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import LoginPage, { metadata as loginMetadata } from "../app/login/page";
+import { MAIN_CONTENT_ID, SkipLink } from "../components/shell/skip-link";
+
+describe("accessibility baseline", () => {
+  it("provides a reusable visually hidden primitive", () => {
+    const html = renderToStaticMarkup(<VisuallyHidden>Additional context</VisuallyHidden>);
+
+    expect(html).toBe('<span class="sr-only">Additional context</span>');
+  });
+
+  it("renders a skip link to the shared main-content target", () => {
+    const html = renderToStaticMarkup(<SkipLink />);
+
+    expect(html).toContain(`href="#${MAIN_CONTENT_ID}"`);
+    expect(html).toContain("Skip to main content");
+  });
+
+  it("gives the login page a main landmark, heading, and descriptive title", () => {
+    const html = renderToStaticMarkup(<LoginPage />);
+
+    expect(html.match(/<main/g) ?? []).toHaveLength(1);
+    expect(html).toContain("<h1");
+    expect(html).toContain('<span class="sr-only"> sign in</span>');
+    expect(loginMetadata).toEqual({ title: "Sign in" });
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export {
   PillTag,
   StatusDot,
   toneFor,
+  VisuallyHidden,
 } from "./primitives";
 export type { TerminalLine } from "./terminal";
 export { Terminal } from "./terminal";

--- a/packages/ui/src/primitives.tsx
+++ b/packages/ui/src/primitives.tsx
@@ -1,6 +1,11 @@
 import type { HTMLAttributes, ReactNode } from "react";
 import { cx } from "./cx";
 
+/** Content that remains available to assistive technology without affecting layout. */
+export function VisuallyHidden({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return <span className={cx("sr-only", className)} {...props} />;
+}
+
 /** Calm sans section label. Mono stays reserved for technical tokens. */
 export function Eyebrow({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
   return <p className={cx("eyebrow", className)} {...props} />;


### PR DESCRIPTION
Refs #331.

## What changes

- adds an exported `VisuallyHidden` primitive to `@facility/ui`
- adds a keyboard-first skip link to both authenticated app shells
- gives both skip-link targets a shared `main-content` id and `tabIndex={-1}` so the destination can receive focus reliably
- gives the login page a `<main>` landmark, a real `<h1>` with visually hidden page-purpose text, and a descriptive `Sign in · facility` document title
- adds deterministic `renderToStaticMarkup` regression coverage for the primitive, skip-link target, and login semantics

## Scope

This intentionally leaves the story-timeline announcement strategy for a separate follow-up. It also does not add axe coverage because #332 is already handling the automated accessibility guard.

## Verification

- branch is based directly on current `main` (`c14bc6d`)
- no dependencies or lockfile changes
- no API, database, security, or money-sensitive surface touched
- focused tests are included; repository CI is expected to run the full project checks on this PR
