### PR TITLE
fix: reject unsafe repository default branches before git switch

### DIFF
--- a/services/api/src/workspaces/project-environment.ts
+++ b/services/api/src/workspaces/project-environment.ts
@@ -203,6 +203,14 @@ export class ProjectEnvironmentService {
   ) {
     assertRepositoryContract(input.manifest, input.credentials.repositories);
     const preparedInput = this.withDeclaredEnvironment(input);
+    for (const repository of preparedInput.credentials.repositories) {
+      if (!isSafeGitBranch(repository.defaultBranch)) {
+        throw new ProjectEnvironmentError(
+          "repository_branch_invalid",
+          "repository default branch is invalid",
+        );
+      }
+    }
     await this.run(preparedInput, "mkdir -p repos", ".", "environment.repositories");
     for (const repository of preparedInput.credentials.repositories) {
       await this.runCommand(
@@ -477,6 +485,12 @@ export class ProjectEnvironmentService {
   ) {
     if (!isSafeGitBranch(input.branch)) {
       throw new ProjectEnvironmentError("story_branch_invalid", "story branch is invalid");
+    }
+    if (!isSafeGitBranch(repository.defaultBranch)) {
+      throw new ProjectEnvironmentError(
+        "repository_branch_invalid",
+        "repository default branch is invalid",
+      );
     }
     const local = await this.runtime.exec(input.workspace, {
       command: "git",

--- a/services/api/test/git-branch.test.ts
+++ b/services/api/test/git-branch.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isSafeGitBranch } from "../src/workspaces/git-branch.js";
+
+describe("isSafeGitBranch", () => {
+  it("accepts ordinary refs and hostile-but-valid Git names", () => {
+    expect(isSafeGitBranch("main")).toBe(true);
+    expect(isSafeGitBranch("release/2026")).toBe(true);
+    expect(isSafeGitBranch("$(id)")).toBe(true);
+    expect(isSafeGitBranch('foo"bar')).toBe(true);
+  });
+
+  it("rejects refs that become git revision syntax or control characters", () => {
+    expect(isSafeGitBranch("foo..bar")).toBe(false);
+    expect(isSafeGitBranch("foo@{upstream}")).toBe(false);
+    expect(isSafeGitBranch("-force")).toBe(false);
+    expect(isSafeGitBranch("chore/../other")).toBe(false);
+    expect(isSafeGitBranch("main\nother")).toBe(false);
+    expect(isSafeGitBranch("")).toBe(false);
+  });
+});

--- a/services/api/test/project-environment.integration.test.ts
+++ b/services/api/test/project-environment.integration.test.ts
@@ -690,6 +690,27 @@ environment:
       return !serialized.includes(secret) && serialized.includes("[REDACTED]");
     });
   });
+
+  it("rejects a repository default branch that is git revision syntax", async () => {
+    const environment = new ProjectEnvironmentService(db, runtime, `file://${remotes}`);
+    await expect(
+      environment.prepare({
+        orgId,
+        projectId,
+        workspace,
+        manifest,
+        credentials: {
+          ...credentials,
+          repositories: credentials.repositories.map((repository) =>
+            repository.role === "primary"
+              ? { ...repository, defaultBranch: "main..evil" }
+              : repository,
+          ),
+        },
+        branch: "facility/story-environment",
+      }),
+    ).rejects.toMatchObject({ code: "repository_branch_invalid" });
+  });
 });
 
 async function createBareRepository(root: string, owner: string, name: string) {


### PR DESCRIPTION
Addresses unsafe git start-points from a stored repository default branch.

Workspace prepare already rejected unsafe story branches, then passed `origin/${defaultBranch}` to `git switch` without the same check. A default of `main..evil` is git range syntax.

Prepare now rejects that class of default branch before clone. Valid hostile names such as `$(id)` still pass because git is invoked as argv, not a shell string.

## Test plan
- [x] `pnpm --filter @facility/api exec vitest run test/git-branch.test.ts`
- [x] `pnpm --filter @facility/api test`
- [x] Confirm `$(id)`, `release/2026`, and `foo"bar` remain accepted
- [x] Confirm `main..evil`, `foo@{upstream}`, and `chore/../other` are rejected