### PR TITLE
fix(previews): preserve application origins and sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ ENV PATH=/pnpm:$PATH
 # Keep a digest-pinned base while still making a reviewed Debian security
 # refresh invalidate BuildKit's cached package layer.
 ARG DEBIAN_SECURITY_REFRESH=20260828
-RUN test -n "$DEBIAN_SECURITY_REFRESH" \
+# The slim base has Node's bundled trust roots but not the system CA package.
+# Bootstrap HTTPS with those roots; apt then installs the maintained OS bundle.
+RUN node -e "const fs = require('node:fs'); fs.mkdirSync('/etc/ssl/certs', {recursive:true}); fs.writeFileSync('/etc/ssl/certs/ca-certificates.crt', require('node:tls').rootCertificates.join('\\n'))" \
+  && test -n "$DEBIAN_SECURITY_REFRESH" \
   && sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
   && apt-get -o APT::Update::Error-Mode=any update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ ARG DEBIAN_SECURITY_REFRESH=20260828
 RUN node -e "const fs = require('node:fs'); fs.mkdirSync('/etc/ssl/certs', {recursive:true}); fs.writeFileSync('/etc/ssl/certs/ca-certificates.crt', require('node:tls').rootCertificates.join('\\n'))" \
   && test -n "$DEBIAN_SECURITY_REFRESH" \
   && sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
-  && apt-get -o APT::Update::Error-Mode=any update \
-  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends ca-certificates curl \
+  && apt-get -o Acquire::https::CAInfo=/etc/ssl/certs/ca-certificates.crt -o APT::Update::Error-Mode=any update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::https::CAInfo=/etc/ssl/certs/ca-certificates.crt upgrade -y \
+  && apt-get -o Acquire::https::CAInfo=/etc/ssl/certs/ca-certificates.crt install -y --no-install-recommends ca-certificates curl \
   && curl --fail --silent --show-error --location --retry 3 \
     https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
     --output /etc/ssl/certs/aws-rds-global.pem \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ENV PATH=/pnpm:$PATH
 # refresh invalidate BuildKit's cached package layer.
 ARG DEBIAN_SECURITY_REFRESH=20260828
 RUN test -n "$DEBIAN_SECURITY_REFRESH" \
-  && apt-get update \
+  && sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
+  && apt-get -o APT::Update::Error-Mode=any update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
   && apt-get install -y --no-install-recommends ca-certificates curl \
   && curl --fail --silent --show-error --location --retry 3 \

--- a/docs/workspace-preview-sites.md
+++ b/docs/workspace-preview-sites.md
@@ -1,0 +1,67 @@
+# Stable workspace preview origins
+
+Applications that use OAuth, root routes, cookies or server actions need a stable
+origin per workspace and service. The session-specific path proxy remains
+available for simple previews. Configure dedicated origins for complete apps.
+
+`FACILITY_PREVIEW_SITES` is a secret JSON array loaded by the API at startup:
+
+```json
+[
+  {
+    "id": "workspace-app",
+    "orgId": "org_example",
+    "projectId": "proj_example",
+    "workspaceId": "ws_example",
+    "service": "app",
+    "origin": "https://unique-distribution.cloudfront.net",
+    "surfaceToken": "REPLACE_WITH_AT_LEAST_32_RANDOM_CHARACTERS"
+  }
+]
+```
+
+Each entry requires a unique origin, credential, and workspace/service binding.
+In production, its registered site must differ from all Facility control-plane
+origins, the legacy preview origin, and every other configured preview site.
+CloudFront's assigned domains provide HTTPS and separate browser sites without
+requiring a purchased domain. Different subdomains of a shared registrable domain
+are insufficient. Do not configure a user-provided URL or forwarding header as
+an authoritative preview origin.
+
+For each service, provision a dedicated reverse proxy (for example, a CloudFront
+standard distribution) with:
+
+- The Facility API as its HTTPS origin.
+- Origin path `/workspace-preview-site/<id>`.
+- An origin header `X-Facility-Preview-Surface` equal to that entry's credential.
+  The proxy must overwrite a viewer-supplied header of the same name.
+- All seven HTTP methods, all cookies and query strings, and application request
+  headers. CloudFront's managed `AllViewerExceptHostHeader` request policy works.
+- Disabled caching, including error caching, and WebSocket forwarding.
+- Access logging disabled or query-string credentials reliably redacted.
+
+Load the JSON through the deployment's secret store, deploy the API, then enable
+the distribution. The Open app action automatically chooses the configured site.
+Provisioning is operator-managed; adding an entry does not create cloud resources.
+Keep the same distribution and binding when the workspace sleeps or wakes. Disable
+and remove its mapping/distribution when the workspace is permanently destroyed;
+never reassign that origin to another workspace, because browsers retain app data.
+
+Register the exact `<origin>/callback` in the application's development OAuth
+provider. Set the app's callback variable as a workspace environment override;
+project defaults remain shared. Restart only the application's process to load
+changed variables. Do not run Clean setup or reseed its database.
+
+A one-time launch grant becomes a root, host-only, Secure, HttpOnly preview cookie.
+Every HTTP request rechecks expiration, revocation and organization membership,
+then checks the exact organization/project/workspace/service binding. App cookies
+are forwarded separately; they cannot overwrite or read the Facility grant.
+Cookie Domain attributes are removed so app cookies remain on that preview host.
+The proxy preserves payload bytes, application headers and root paths, and supplies
+the configured external host/protocol to the app. Control-plane routes and Facility
+session resolution remain inaccessible through these origins.
+
+The API omits query strings from access logs because OAuth codes and launch tokens
+are credentials. External proxies and the application itself must follow the same
+rule. Default CI uses deterministic local HTTP/WebSocket servers and a disposable
+Postgres database; no live OAuth provider or cloud credentials are required.

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -39,6 +39,7 @@ import {
   type OpenApiRouteRecord,
 } from "./openapi-contract.js";
 import { assertPreviewOriginSurface } from "./origin-isolation.js";
+import { safeRequestLog } from "./request-log.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerGithubRoutes } from "./routes/github.js";
 import { registerMcpRoutes } from "./routes/mcp.js";
@@ -66,7 +67,7 @@ export async function buildApp(
 ): Promise<FastifyInstance> {
   const oauthConfig = oauthConfigFromApp(config);
   const app = Fastify({
-    logger: { level: config.logLevel },
+    logger: { level: config.logLevel, serializers: { req: safeRequestLog } },
     genReqId: () => uuidv7(),
   });
   const routeRecords: OpenApiRouteRecord[] = [];
@@ -239,6 +240,7 @@ export async function buildApp(
 
   app.addHook("onRequest", async (request, reply) => {
     reply.header("x-request-id", request.id);
+    if ((request.raw.url ?? request.url).startsWith("/workspace-preview-site/")) return;
     request.principal = await resolvePrincipal(request, db, config, oauthConfig, deps.oauthJwks);
     const permission = request.routeOptions.config?.permission as string | string[] | undefined;
     const isPublic = request.routeOptions.config?.public === true;

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -4,6 +4,7 @@ import { config as loadDotenv } from "dotenv";
 import { z } from "zod";
 import { registeredSite } from "./origin-isolation.js";
 import type { AppConfig } from "./types.js";
+import { parsePreviewSites } from "./workspaces/preview-sites.js";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 loadDotenv({ path: join(repoRoot, ".env"), quiet: true });
@@ -39,6 +40,7 @@ const EnvSchema = z
     PUBLIC_URL: z.string().url().default("http://localhost:4400"),
     WEB_URL: z.string().url().optional(),
     FACILITY_PREVIEW_URL: OptionalUrl,
+    FACILITY_PREVIEW_SITES: z.string().optional(),
     FACILITY_PREVIEW_SURFACE_TOKEN: z.preprocess(
       (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
       z.string().min(32).max(128).optional(),
@@ -260,6 +262,13 @@ export function readConfig(env = process.env): AppConfig {
     webUrl,
     previewUrl: parsed.FACILITY_PREVIEW_URL?.replace(/\/$/, ""),
     previewSurfaceToken: parsed.FACILITY_PREVIEW_SURFACE_TOKEN,
+    previewSites: parsePreviewSites(parsed.FACILITY_PREVIEW_SITES, {
+      publicUrl: parsed.PUBLIC_URL,
+      webUrl,
+      mcpPublicUrl: parsed.MCP_PUBLIC_URL,
+      previewUrl: parsed.FACILITY_PREVIEW_URL,
+      facilityInsecureDev: parsed.FACILITY_INSECURE_DEV === "1",
+    }),
     workspaceImage: parsed.FACILITY_WORKSPACE_IMAGE,
     workspaceDriver: parsed.FACILITY_WORKSPACE_DRIVER,
     authIdentityProvider: parsed.AUTH_IDENTITY_PROVIDER,

--- a/services/api/src/origin-isolation.ts
+++ b/services/api/src/origin-isolation.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from "node:crypto";
 import { getDomain } from "tldts";
 import { ApiError } from "./errors.js";
 import type { AppConfig } from "./types.js";
+import { isSiteSurface, SITE_PREFIX } from "./workspaces/preview-sites.js";
 
 export function registeredSite(hostname: string) {
   return getDomain(hostname, { allowPrivateDomains: true });
@@ -37,6 +38,22 @@ export function assertPreviewOriginSurface(
   rawPath: string,
   rawSurfaceToken?: string | string[],
 ) {
+  if (rawPath.startsWith(SITE_PREFIX)) {
+    if (!isSiteSurface(config, rawPath, rawSurfaceToken)) {
+      throw new ApiError(404, "not_found", "Route not found");
+    }
+    return;
+  }
+  // A dedicated proxy credential can never reach control-plane or legacy routes.
+  if (
+    config.previewSites?.some(
+      (site) =>
+        rawSurfaceToken === site.surfaceToken ||
+        hostname(rawHost) === new URL(site.origin).hostname,
+    )
+  ) {
+    throw new ApiError(404, "not_found", "Route not found");
+  }
   if (!isolatedPreviewOrigin(config) || !config.previewUrl) return;
   const requestHost = hostname(rawHost);
   const previewHost = new URL(config.previewUrl).hostname.toLowerCase();

--- a/services/api/src/request-log.ts
+++ b/services/api/src/request-log.ts
@@ -1,0 +1,5 @@
+// OAuth callbacks and preview launch URLs contain credentials. Access logs need
+// the route, never the query string or browser headers.
+export function safeRequestLog(request: { method?: string; url?: string }) {
+  return { method: request.method, url: request.url?.split("?", 1)[0] };
+}

--- a/services/api/src/routes/v1/workspace-preview-sites.ts
+++ b/services/api/src/routes/v1/workspace-preview-sites.ts
@@ -1,0 +1,240 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { request as upstreamRequest } from "undici";
+import WebSocket from "ws";
+import { ApiError } from "../../errors.js";
+import type { AppConfig } from "../../types.js";
+import {
+  assertSiteSession,
+  isSiteSurface,
+  type PreviewSite,
+  SITE_COOKIE,
+  SITE_PREFIX,
+} from "../../workspaces/preview-sites.js";
+
+const reservedCookie = (name: string) =>
+  name === SITE_COOKIE || name.startsWith("facility_") || name.startsWith("__Host-facility");
+const hopHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+export function siteRequestHeaders(
+  headers: FastifyRequest["headers"],
+  site: PreviewSite,
+  gatewayToken: string,
+) {
+  const forwarded: Record<string, string> = {};
+  const connectionHeaders = String(headers.connection ?? "")
+    .toLowerCase()
+    .split(",")
+    .map((value) => value.trim());
+  for (const [name, value] of Object.entries(headers)) {
+    if (
+      value === undefined ||
+      hopHeaders.has(name) ||
+      connectionHeaders.includes(name) ||
+      /^(?:x-facility-|x-forwarded-|forwarded$|sec-websocket-|cookie$|authorization$|proxy-)/.test(
+        name,
+      )
+    )
+      continue;
+    forwarded[name] = String(value);
+  }
+  const cookies = String(headers.cookie ?? "")
+    .split(";")
+    .filter((entry) => {
+      const name = entry.trim().split("=", 1)[0] ?? "";
+      return name && !reservedCookie(name);
+    })
+    .join(";");
+  if (cookies) forwarded.cookie = cookies;
+  // The application may use bearer auth; it is scoped to this isolated browser
+  // origin and never interpreted as a Facility credential on these routes.
+  if (headers.authorization) forwarded.authorization = headers.authorization;
+  forwarded["accept-encoding"] = "identity";
+  forwarded["x-facility-preview-token"] = gatewayToken;
+  forwarded["x-forwarded-host"] = new URL(site.origin).host;
+  forwarded["x-forwarded-proto"] = new URL(site.origin).protocol.slice(0, -1);
+  return forwarded;
+}
+
+export function siteResponseCookies(values: string[]) {
+  return values
+    .filter((value) => !reservedCookie(value.split("=", 1)[0]?.trim() ?? ""))
+    .map((value) =>
+      value
+        .split(";")
+        .filter((part) => !/^\s*domain\s*=/i.test(part))
+        .join(";"),
+    );
+}
+
+function siteRequest(config: AppConfig, request: FastifyRequest) {
+  const { siteId, "*": path = "" } = request.params as { siteId: string; "*"?: string };
+  if (!isSiteSurface(config, request.url, request.headers["x-facility-preview-surface"])) {
+    throw new ApiError(404, "not_found", "Route not found");
+  }
+  const site = config.previewSites?.find((entry) => entry.id === siteId);
+  if (!site) throw new ApiError(404, "not_found", "Route not found");
+  const raw = request.cookies[SITE_COOKIE] ?? "";
+  const [sessionId = "", token = "", extra] = raw.split(".");
+  if (extra !== undefined)
+    throw new ApiError(401, "preview_access_invalid", "Preview access is invalid or expired");
+  // Preserve the wire path and query: Fastify's wildcard params are decoded.
+  const wirePath = request.url.slice(`${SITE_PREFIX}${site.id}`.length) || "/";
+  return { site, path, wirePath, sessionId, token };
+}
+
+export async function registerWorkspacePreviewSiteRoutes(root: FastifyInstance, config: AppConfig) {
+  const previews = root.storyDomain.previews;
+  await root.register(async (app) => {
+    // Keep form, multipart, RSC/server-action and JSON payloads byte-for-byte.
+    app.removeAllContentTypeParsers();
+    app.addContentTypeParser("*", { parseAs: "buffer" }, (_request, body, done) =>
+      done(null, body),
+    );
+    const authorize = async (request: FastifyRequest) => {
+      const input = siteRequest(config, request);
+      if (input.path.startsWith(".facility/"))
+        throw new ApiError(404, "not_found", "Route not found");
+      const session = await previews.authorize(input.sessionId, input.token);
+      assertSiteSession(input.site, session);
+      const target = await previews.target(session, input.wirePath);
+      return { ...input, target };
+    };
+    const proxy = async (request: FastifyRequest, reply: FastifyReply) => {
+      const input = siteRequest(config, request);
+      if (input.path.startsWith(".facility/auth/")) {
+        if (request.method !== "GET")
+          throw new ApiError(405, "method_not_allowed", "Method not allowed");
+        const sessionId = input.path.slice(".facility/auth/".length);
+        const token = new URL(request.url, input.site.origin).searchParams.get("token") ?? "";
+        await previews.exchange(sessionId, token, input.site);
+        reply.setCookie(SITE_COOKIE, `${sessionId}.${token}`, {
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          path: "/",
+          maxAge: 3600,
+        });
+        return reply
+          .header("cache-control", "no-store")
+          .header("referrer-policy", "no-referrer")
+          .redirect("/");
+      }
+      const { site, target } = await authorize(request);
+      const upstream = await upstreamRequest(target.url, {
+        method: request.method as "GET",
+        headers: siteRequestHeaders(request.headers, site, target.gatewayToken),
+        body:
+          request.method === "GET" || request.method === "HEAD"
+            ? undefined
+            : (request.body as Buffer | undefined),
+        headersTimeout: 60_000,
+        bodyTimeout: 60_000,
+      });
+      reply.code(upstream.statusCode);
+      for (const [name, value] of Object.entries(upstream.headers)) {
+        if (
+          value === undefined ||
+          hopHeaders.has(name) ||
+          name === "set-cookie" ||
+          name === "location" ||
+          name.startsWith("x-facility-")
+        )
+          continue;
+        reply.header(name, value);
+      }
+      const cookies = upstream.headers["set-cookie"];
+      if (cookies)
+        reply.header(
+          "set-cookie",
+          siteResponseCookies(Array.isArray(cookies) ? cookies : [cookies]),
+        );
+      const location = upstream.headers.location;
+      if (typeof location === "string") {
+        let destination = location;
+        try {
+          const url = new URL(location, target.url);
+          if (url.origin === target.url.origin)
+            destination = `${site.origin}${url.pathname}${url.search}${url.hash}`;
+        } catch {
+          /* Preserve application redirects that are not absolute URLs. */
+        }
+        reply.header("location", destination);
+      }
+      // Session revocation/membership checks must run even for cached assets.
+      reply.header("cache-control", "private, no-store");
+      reply.header("referrer-policy", "no-referrer");
+      reply.header("x-content-type-options", "nosniff");
+      if (request.method === "HEAD") {
+        await upstream.body.dump();
+        return reply.send();
+      }
+      return reply.send(upstream.body);
+    };
+    app.route({
+      method: "GET",
+      exposeHeadRoute: false,
+      url: `${SITE_PREFIX}:siteId/*`,
+      config: { public: true, cors: false },
+      handler: proxy,
+      wsHandler: (socket, request) => {
+        let upstream: WebSocket | undefined;
+        let pendingBytes = 0;
+        const pending: Array<{ data: WebSocket.RawData; binary: boolean }> = [];
+        socket.on("message", (data, binary) => {
+          if (upstream?.readyState === WebSocket.OPEN) upstream.send(data, { binary });
+          else {
+            pendingBytes += Buffer.byteLength(data.toString());
+            if (pendingBytes > 1024 * 1024) {
+              socket.close(1009, "Message too large");
+              return;
+            }
+            pending.push({ data, binary });
+          }
+        });
+        socket.on("close", () => upstream?.terminate());
+        void authorize(request)
+          .then(({ site, target }) => {
+            if (socket.readyState !== WebSocket.OPEN) return;
+            const url = new URL(target.url);
+            url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+            const protocols = String(request.headers["sec-websocket-protocol"] ?? "")
+              .split(",")
+              .map((value) => value.trim())
+              .filter(Boolean);
+            upstream = new WebSocket(url, protocols, {
+              headers: siteRequestHeaders(request.headers, site, target.gatewayToken),
+            });
+            upstream.on("open", () => {
+              for (const message of pending.splice(0))
+                upstream?.send(message.data, { binary: message.binary });
+            });
+            upstream.on("message", (data, binary) => {
+              if (socket.readyState === WebSocket.OPEN) socket.send(data, { binary });
+            });
+            upstream.on("close", () => socket.close());
+            upstream.on("error", () => socket.close(1011, "Preview service unavailable"));
+          })
+          .catch(() => socket.close(1008, "Preview access invalid"));
+      },
+    });
+    for (const method of ["HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"] as const) {
+      app.route({
+        method,
+        url: `${SITE_PREFIX}:siteId/*`,
+        config: { public: true, cors: false },
+        handler: proxy,
+      });
+    }
+  });
+}

--- a/services/api/src/routes/v1/workspace-previews.ts
+++ b/services/api/src/routes/v1/workspace-previews.ts
@@ -6,6 +6,7 @@ import { ApiError } from "../../errors.js";
 import type { AppConfig } from "../../types.js";
 import { previewCookieName, previewCookieOptions } from "../../workspaces/preview.js";
 import { principal as authenticatedPrincipal } from "./shared.js";
+import { registerWorkspacePreviewSiteRoutes } from "./workspace-preview-sites.js";
 
 const OpenParams = z.object({ projectId: z.string(), storyId: z.string(), service: z.string() });
 const SessionParams = z.object({ sessionId: z.string() });
@@ -14,6 +15,7 @@ const ExchangeQuery = z.object({ token: z.string() });
 
 export async function registerWorkspacePreviewRoutes(app: FastifyInstance, config: AppConfig) {
   const previews = app.storyDomain.previews;
+  await registerWorkspacePreviewSiteRoutes(app, config);
 
   app.post(
     "/v1/projects/:projectId/workspace-stories/:storyId/preview/:service/open",

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -29,6 +29,7 @@ export type AppConfig = {
   // classify preview-surface requests even when that proxy replaces Host with
   // its origin hostname.
   previewSurfaceToken?: string;
+  previewSites?: import("./workspaces/preview-sites.js").PreviewSite[];
   workspaceImage: string;
   workspaceDriver: "docker" | "vercel";
   authIdentityProvider?: "github" | "oidc";
@@ -88,6 +89,7 @@ declare module "fastify" {
     ) => Promise<void>;
   }
   interface FastifyContextConfig {
+    cors?: false;
     permission?: string | string[];
     auditAction?: string;
     public?: boolean;

--- a/services/api/src/workspaces/preview-sites.ts
+++ b/services/api/src/workspaces/preview-sites.ts
@@ -1,0 +1,113 @@
+import { timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import { ApiError } from "../errors.js";
+import { registeredSite } from "../origin-isolation.js";
+import type { AppConfig } from "../types.js";
+
+const Site = z
+  .object({
+    id: z.string().regex(/^[a-z0-9-]{1,64}$/),
+    orgId: z.string().min(1),
+    projectId: z.string().min(1),
+    workspaceId: z.string().min(1),
+    service: z.string().min(1),
+    origin: z.string().url(),
+    surfaceToken: z.string().min(32).max(128),
+  })
+  .strict();
+export type PreviewSite = z.infer<typeof Site>;
+export const SITE_COOKIE = "__Host-facility-preview";
+export const SITE_PREFIX = "/workspace-preview-site/";
+
+// Operator configuration, never supplied by a workspace or inferred from Host.
+// Every site must have its own browser site and reverse-proxy credential.
+export function parsePreviewSites(
+  raw: string | undefined,
+  config: Pick<
+    AppConfig,
+    "publicUrl" | "webUrl" | "mcpPublicUrl" | "previewUrl" | "facilityInsecureDev"
+  >,
+): PreviewSite[] {
+  if (!raw?.trim()) return [];
+  try {
+    const sites = z.array(Site).max(200).parse(JSON.parse(raw));
+    const origins = new Set<string>();
+    const ids = new Set<string>();
+    const tokens = new Set<string>();
+    const bindings = new Set<string>();
+    const registered = new Set(
+      [config.publicUrl, config.webUrl, config.mcpPublicUrl, config.previewUrl]
+        .filter((url): url is string => Boolean(url))
+        .map((url) => registeredSite(new URL(url).hostname)),
+    );
+    for (const site of sites) {
+      const url = new URL(site.origin);
+      const domain = registeredSite(url.hostname);
+      const binding = JSON.stringify([site.orgId, site.projectId, site.workspaceId, site.service]);
+      if (
+        url.origin !== site.origin ||
+        url.username ||
+        url.password ||
+        (!config.facilityInsecureDev &&
+          (url.protocol !== "https:" || !domain || registered.has(domain))) ||
+        origins.has(site.origin) ||
+        ids.has(site.id) ||
+        tokens.has(site.surfaceToken) ||
+        bindings.has(binding)
+      ) {
+        throw new Error("invalid site");
+      }
+      origins.add(site.origin);
+      ids.add(site.id);
+      tokens.add(site.surfaceToken);
+      bindings.add(binding);
+      registered.add(domain);
+    }
+    return sites;
+  } catch {
+    // Do not include Zod input or the credential-bearing JSON in startup logs.
+    throw new Error(
+      "FACILITY_PREVIEW_SITES must contain unique, isolated workspace service origins and credentials",
+    );
+  }
+}
+
+export function previewSiteFor(
+  config: AppConfig,
+  binding: Pick<PreviewSite, "orgId" | "projectId" | "workspaceId" | "service">,
+) {
+  return config.previewSites?.find(
+    (site) =>
+      site.orgId === binding.orgId &&
+      site.projectId === binding.projectId &&
+      site.workspaceId === binding.workspaceId &&
+      site.service === binding.service,
+  );
+}
+
+export function assertSiteSession(
+  site: PreviewSite,
+  session: Pick<PreviewSite, "orgId" | "projectId" | "workspaceId" | "service">,
+) {
+  if (
+    site.orgId !== session.orgId ||
+    site.projectId !== session.projectId ||
+    site.workspaceId !== session.workspaceId ||
+    site.service !== session.service
+  ) {
+    throw new ApiError(401, "preview_access_invalid", "Preview access is invalid or expired");
+  }
+}
+
+export function isSiteSurface(
+  config: AppConfig,
+  path: string,
+  token: string | string[] | undefined,
+) {
+  const siteId = path.slice(SITE_PREFIX.length).split("/", 1)[0];
+  const site = config.previewSites?.find((entry) => entry.id === siteId);
+  if (!path.startsWith(SITE_PREFIX) || !site || typeof token !== "string") return false;
+  const actual = Buffer.from(token);
+  const expected = Buffer.from(site.surfaceToken);
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}

--- a/services/api/src/workspaces/preview.ts
+++ b/services/api/src/workspaces/preview.ts
@@ -13,6 +13,7 @@ import { and, eq, gt, isNotNull, isNull } from "drizzle-orm";
 import type { GithubWorkspaceCredentialBroker } from "../github/workspace-credentials.js";
 import { assertWorkspacePreviewAvailable } from "../origin-isolation.js";
 import type { AppConfig } from "../types.js";
+import { type PreviewSite, previewSiteFor } from "./preview-sites.js";
 import type { ProjectEnvironmentService, ProjectManifestSource } from "./project-environment.js";
 import type { WorkspaceLocator, WorkspaceRuntime } from "./runtime.js";
 
@@ -46,8 +47,9 @@ export class WorkspacePreviewService {
     userId: string;
     service: string;
   }) {
-    assertWorkspacePreviewAvailable(this.config);
     const { story, workspace } = await this.bundle(input.orgId, input.projectId, input.storyId);
+    const site = previewSiteFor(this.config, { ...input, workspaceId: workspace.id });
+    if (!site) assertWorkspacePreviewAvailable(this.config);
     if (story.deletedAt || workspace.state === "destroyed" || !workspace.externalRef) {
       throw new WorkspacePreviewError("workspace_not_available", "Workspace is not available");
     }
@@ -99,14 +101,16 @@ export class WorkspacePreviewService {
       expiresAt,
     });
     const url = new URL(
-      `/workspace-preview-auth/${encodeURIComponent(sessionId)}`,
-      this.config.previewUrl,
+      site
+        ? `/.facility/auth/${encodeURIComponent(sessionId)}`
+        : `/workspace-preview-auth/${encodeURIComponent(sessionId)}`,
+      site?.origin ?? this.config.previewUrl,
     );
     url.searchParams.set("token", token);
     return { sessionId, url: url.toString(), expiresAt };
   }
 
-  async exchange(sessionId: string, token: string) {
+  async exchange(sessionId: string, token: string, site?: PreviewSite) {
     const consumed = (
       await this.db
         .update(previewSessions)
@@ -115,6 +119,14 @@ export class WorkspacePreviewService {
           and(
             eq(previewSessions.id, sessionId),
             eq(previewSessions.tokenHash, tokenHash(token)),
+            site
+              ? and(
+                  eq(previewSessions.orgId, site.orgId),
+                  eq(previewSessions.projectId, site.projectId),
+                  eq(previewSessions.workspaceId, site.workspaceId),
+                  eq(previewSessions.service, site.service),
+                )
+              : undefined,
             isNull(previewSessions.consumedAt),
             isNull(previewSessions.revokedAt),
             gt(previewSessions.expiresAt, new Date()),
@@ -285,7 +297,7 @@ function tokenHash(token: string) {
 function normalizeProxyPath(path: string) {
   let decoded: string;
   try {
-    decoded = decodeURIComponent(path);
+    decoded = decodeURIComponent(path.split("?", 1)[0] ?? "");
   } catch {
     throw new WorkspacePreviewError("preview_path_invalid", "Preview path is invalid", 400);
   }
@@ -296,7 +308,7 @@ function normalizeProxyPath(path: string) {
   ) {
     throw new WorkspacePreviewError("preview_path_invalid", "Preview path is invalid", 400);
   }
-  return new URL(`http://preview/${decoded.replace(/^\/+/, "")}`);
+  return new URL(`http://preview/${path.replace(/^\/+/, "")}`);
 }
 
 function invalidAccess() {

--- a/services/api/test/request-log.test.ts
+++ b/services/api/test/request-log.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from "vitest";
+import { safeRequestLog } from "../src/request-log.js";
+
+it("omits callback codes, launch grants and browser credentials from access logs", () => {
+  for (const path of ["/callback?code=secret", "/.facility/auth/psess_test?token=secret"]) {
+    const result = safeRequestLog({
+      method: "GET",
+      url: path,
+      headers: { cookie: "secret" },
+    } as Parameters<typeof safeRequestLog>[0]);
+    expect(JSON.stringify(result)).not.toContain("secret");
+    expect(result.url).toBe(path.split("?", 1)[0]);
+  }
+});

--- a/services/api/test/workspace-preview-sites.integration.test.ts
+++ b/services/api/test/workspace-preview-sites.integration.test.ts
@@ -1,0 +1,208 @@
+import { createServer } from "node:http";
+import cookie from "@fastify/cookie";
+import websocket from "@fastify/websocket";
+import Fastify from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { registerWorkspacePreviewSiteRoutes } from "../src/routes/v1/workspace-preview-sites.js";
+import type { StoryDomain } from "../src/story-domain.js";
+import type { AppConfig } from "../src/types.js";
+import { assertSiteSession, SITE_COOKIE } from "../src/workspaces/preview-sites.js";
+
+const site = {
+  id: "app",
+  orgId: "org_a",
+  projectId: "proj_a",
+  workspaceId: "ws_a",
+  service: "app",
+  origin: "https://one.cloudfront.net",
+  surfaceToken: "a".repeat(43),
+};
+const sessionId = "psess_1234567890abcdef";
+const token = "t".repeat(43);
+const grantCookie = `${SITE_COOKIE}=${sessionId}.${token}`;
+const invalid = () =>
+  Object.assign(new Error("invalid"), { statusCode: 401, code: "preview_access_invalid" });
+let state = "new";
+let calls = 0;
+const app = Fastify({ logger: false });
+const backend = createServer(async (request, response) => {
+  calls++;
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  if (request.url === "/callback") {
+    response.writeHead(302, {
+      location: "/clients",
+      "set-cookie": [
+        "app_session=authenticated; Domain=localhost; Path=/; HttpOnly; Secure; SameSite=Lax",
+        `${SITE_COOKIE}=forged; Path=/; Secure`,
+      ],
+    });
+    response.end();
+    return;
+  }
+  response.setHeader("content-type", "application/json");
+  response.end(
+    JSON.stringify({
+      url: request.url,
+      method: request.method,
+      body: Buffer.concat(chunks).toString("base64"),
+      cookie: request.headers.cookie,
+      host: request.headers["x-forwarded-host"],
+      proto: request.headers["x-forwarded-proto"],
+      nextAction: request.headers["next-action"],
+    }),
+  );
+});
+const wsServer = new WebSocketServer({ server: backend });
+wsServer.on("connection", (socket, request) =>
+  socket.on("message", () => socket.send(String(request.headers.cookie))),
+);
+let origin = "";
+let backendOrigin = "";
+const prefix = "/workspace-preview-site/app";
+const headers = { "x-facility-preview-surface": site.surfaceToken, cookie: grantCookie };
+
+describe("stable preview HTTP and WebSocket integration", () => {
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => backend.listen(0, "127.0.0.1", resolve));
+    backendOrigin = `http://127.0.0.1:${(backend.address() as { port: number }).port}`;
+    await app.register(cookie);
+    await app.register(websocket);
+    app.decorate("storyDomain", {
+      previews: {
+        exchange: async (id: string, received: string, binding: typeof site) => {
+          assertSiteSession(site, binding);
+          if (id !== sessionId || received !== token || state !== "new") throw invalid();
+          state = "active";
+          return { ...site, id };
+        },
+        authorize: async (id: string, received: string) => {
+          if (id !== sessionId || received !== token || state !== "active") throw invalid();
+          return { ...site, id, workspaceId: state === "active" ? site.workspaceId : "other" };
+        },
+        target: async (_session: unknown, path: string) => ({
+          url: new URL(path, backendOrigin),
+          gatewayToken: "gateway",
+        }),
+      },
+    } as unknown as StoryDomain);
+    await registerWorkspacePreviewSiteRoutes(app, {
+      previewSites: [
+        site,
+        {
+          ...site,
+          id: "other",
+          workspaceId: "ws_other",
+          origin: "https://two.cloudfront.net",
+          surfaceToken: "b".repeat(43),
+        },
+      ],
+    } as AppConfig);
+    await app.listen({ host: "127.0.0.1", port: 0 });
+    origin = `http://127.0.0.1:${(app.server.address() as { port: number }).port}`;
+  });
+  afterAll(async () => {
+    await app.close();
+    wsServer.close();
+    await new Promise<void>((resolve) => backend.close(() => resolve()));
+  });
+
+  it("exchanges once, uses a root HttpOnly cookie, and preserves root callback routing", async () => {
+    const launch = `${origin}${prefix}/.facility/auth/${sessionId}?token=${token}`;
+    const response = await fetch(launch, { headers, redirect: "manual" });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/");
+    expect(response.headers.get("set-cookie")).toContain("Path=/; HttpOnly; Secure; SameSite=Lax");
+    expect((await fetch(launch, { headers, redirect: "manual" })).status).toBe(401);
+    const callback = await fetch(`${origin}${prefix}/callback`, { headers, redirect: "manual" });
+    expect(callback.headers.get("location")).toBe(`${site.origin}/clients`);
+    expect(callback.headers.getSetCookie()).toEqual([
+      "app_session=authenticated; Path=/; HttpOnly; Secure; SameSite=Lax",
+    ]);
+    const page = await fetch(`${origin}${prefix}/clients`, {
+      headers: { ...headers, cookie: `${grantCookie}; app_session=authenticated` },
+    });
+    expect(await page.json()).toMatchObject({
+      url: "/clients",
+      cookie: "app_session=authenticated",
+      host: "one.cloudfront.net",
+      proto: "https",
+    });
+    expect(page.headers.get("cache-control")).toBe("private, no-store");
+  });
+  it.each([
+    "application/json",
+    "application/x-www-form-urlencoded",
+    "multipart/form-data; boundary=example",
+    "text/x-component",
+  ])("preserves %s bodies and encoded URLs", async (type) => {
+    const body = Buffer.from("test=one%26two\r\n\u0000\u00ff");
+    const response = await fetch(`${origin}${prefix}/action?return=%2Fclients%3Fx%3D1`, {
+      method: "POST",
+      headers: { ...headers, "content-type": type, "next-action": "abc" },
+      body,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      body: body.toString("base64"),
+      url: "/action?return=%2Fclients%3Fx%3D1",
+      nextAction: "abc",
+    });
+  });
+  it("denies missing, malformed, expired and revoked grants before contacting the app", async () => {
+    const before = calls;
+    for (const cookieValue of ["", `${SITE_COOKIE}=malformed`, `${grantCookie}.extra`]) {
+      expect(
+        (
+          await fetch(`${origin}${prefix}/clients`, {
+            headers: { ...headers, cookie: cookieValue },
+          })
+        ).status,
+      ).toBe(401);
+    }
+    for (const deniedState of ["expired", "revoked"]) {
+      state = deniedState;
+      expect((await fetch(`${origin}${prefix}/clients`, { headers })).status).toBe(401);
+    }
+    state = "active";
+    expect(calls).toBe(before);
+  });
+  it("denies cross-workspace sessions and forged distribution routing", async () => {
+    const before = calls;
+    expect(
+      (
+        await fetch(`${origin}/workspace-preview-site/other/clients`, {
+          headers: { ...headers, "x-facility-preview-surface": "b".repeat(43) },
+        })
+      ).status,
+    ).toBe(401);
+    expect(
+      (
+        await fetch(`${origin}${prefix}/clients`, {
+          headers: { ...headers, "x-facility-preview-surface": "forged" },
+        })
+      ).status,
+    ).toBe(404);
+    expect(calls).toBe(before);
+  });
+  it("forwards WebSocket app cookies while removing the Facility grant", async () => {
+    const result = await new Promise<string>((resolve, reject) => {
+      const socket = new WebSocket(`${origin.replace("http:", "ws:")}${prefix}/socket`, {
+        headers: { ...headers, cookie: `${grantCookie}; app_session=authenticated` },
+      });
+      const timer = setTimeout(() => {
+        socket.terminate();
+        reject(new Error("timeout"));
+      }, 3000);
+      socket.once("open", () => socket.send("ping"));
+      socket.once("message", (data) => {
+        clearTimeout(timer);
+        socket.close();
+        resolve(data.toString());
+      });
+      socket.once("error", reject);
+    });
+    expect(result.trim()).toBe("app_session=authenticated");
+  });
+});

--- a/services/api/test/workspace-preview-sites.test.ts
+++ b/services/api/test/workspace-preview-sites.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { assertPreviewOriginSurface } from "../src/origin-isolation.js";
+import {
+  siteRequestHeaders,
+  siteResponseCookies,
+} from "../src/routes/v1/workspace-preview-sites.js";
+import type { AppConfig } from "../src/types.js";
+import {
+  assertSiteSession,
+  parsePreviewSites,
+  SITE_COOKIE,
+} from "../src/workspaces/preview-sites.js";
+
+const site = {
+  id: "app",
+  orgId: "org_a",
+  projectId: "proj_a",
+  workspaceId: "ws_a",
+  service: "app",
+  origin: "https://one.cloudfront.net",
+  surfaceToken: "a".repeat(43),
+};
+const config = {
+  publicUrl: "https://api.example.com",
+  webUrl: "https://example.com",
+  previewUrl: "https://legacy.cloudfront.net",
+  previewSurfaceToken: "l".repeat(43),
+  previewSites: [site],
+} as AppConfig;
+describe("isolated stable preview sites", () => {
+  it("accepts provider-assigned sites without requiring a custom domain", () => {
+    expect(parsePreviewSites(JSON.stringify([site]), config)).toEqual([site]);
+  });
+  it.each([
+    { origin: "https://preview.example.com" },
+    { origin: "http://one.cloudfront.net" },
+    { origin: "https://one.cloudfront.net/path" },
+    { origin: "https://legacy.cloudfront.net" },
+    { surfaceToken: "short" },
+    { id: "../app" },
+  ])("rejects unsafe operator configuration without leaking secrets: %j", (change) => {
+    expect(() => parsePreviewSites(JSON.stringify([{ ...site, ...change }]), config)).toThrow(
+      "FACILITY_PREVIEW_SITES",
+    );
+  });
+  it("rejects shared sites, credentials, and workspace-service bindings", () => {
+    for (const change of [
+      { origin: site.origin },
+      { surfaceToken: site.surfaceToken },
+      { workspaceId: site.workspaceId },
+    ]) {
+      const other = {
+        ...site,
+        id: "other",
+        origin: "https://two.cloudfront.net",
+        surfaceToken: "b".repeat(43),
+        workspaceId: "ws_b",
+        ...change,
+      };
+      expect(() => parsePreviewSites(JSON.stringify([site, other]), config)).toThrow();
+    }
+  });
+  it("requires the exact proxy credential and cannot expose control-plane routes", () => {
+    expect(() =>
+      assertPreviewOriginSurface(
+        config,
+        "api.example.com",
+        "/workspace-preview-site/app/clients",
+        site.surfaceToken,
+      ),
+    ).not.toThrow();
+    for (const token of [undefined, "invalid", config.previewSurfaceToken]) {
+      expect(() =>
+        assertPreviewOriginSurface(
+          config,
+          "api.example.com",
+          "/workspace-preview-site/app/",
+          token,
+        ),
+      ).toThrow();
+    }
+    for (const path of [
+      "/v1/projects",
+      "/workspace-preview-auth/test",
+      "/workspace-preview-site/other/",
+    ]) {
+      expect(() =>
+        assertPreviewOriginSurface(config, "api.example.com", path, site.surfaceToken),
+      ).toThrow();
+    }
+    expect(() =>
+      assertPreviewOriginSurface(config, "one.cloudfront.net", "/v1/projects"),
+    ).toThrow();
+  });
+  it.each([
+    "orgId",
+    "projectId",
+    "workspaceId",
+    "service",
+  ] as const)("binds sessions to %s", (key) => {
+    expect(() => assertSiteSession(site, { ...site, [key]: "other" })).toThrow();
+  });
+  it("forwards app cookies and trusted external origin without leaking Facility credentials", () => {
+    const result = siteRequestHeaders(
+      {
+        cookie: `${SITE_COOKIE}=secret; app=session; facility_session=control`,
+        "x-forwarded-host": "attacker.test",
+        "x-facility-preview-surface": "secret",
+        connection: "x-private",
+        "x-private": "hidden",
+        "next-action": "action",
+        origin: site.origin,
+      },
+      site,
+      "gateway",
+    );
+    expect(result.cookie?.trim()).toBe("app=session");
+    expect(result["x-forwarded-host"]).toBe("one.cloudfront.net");
+    expect(result["x-forwarded-proto"]).toBe("https");
+    expect(result["next-action"]).toBe("action");
+    expect(result).not.toHaveProperty("x-facility-preview-surface");
+    expect(result).not.toHaveProperty("x-private");
+  });
+  it("keeps application cookies host-only and prevents preview-grant replacement", () => {
+    expect(
+      siteResponseCookies([
+        "app=token; Domain=localhost; Path=/; HttpOnly; Secure; SameSite=Lax",
+        `${SITE_COOKIE}=forged; Path=/; Secure`,
+        "facility_session=forged",
+      ]),
+    ).toEqual(["app=token; Path=/; HttpOnly; Secure; SameSite=Lax"]);
+  });
+});

--- a/services/api/test/workspace-preview.integration.test.ts
+++ b/services/api/test/workspace-preview.integration.test.ts
@@ -170,6 +170,44 @@ describe("workspace preview session security", async () => {
     await client.end();
   });
 
+  it("binds the stable origin exchange in the database before consuming the grant", async () => {
+    const site = {
+      id: "app",
+      orgId,
+      projectId,
+      workspaceId,
+      service: "web",
+      origin: "https://one.cloudfront.net",
+      surfaceToken: "s".repeat(43),
+    };
+    config.previewSites = [site];
+    try {
+      const opened = await service.open({ orgId, projectId, storyId, userId, service: "web" });
+      const url = new URL(opened.url);
+      expect(url.origin).toBe(site.origin);
+      expect(url.pathname).toBe(`/.facility/auth/${opened.sessionId}`);
+      const token = url.searchParams.get("token");
+      if (!token) throw new Error("missing grant");
+      for (const field of ["orgId", "projectId", "workspaceId", "service"] as const) {
+        await expect(
+          service.exchange(opened.sessionId, token, { ...site, [field]: "other" }),
+        ).rejects.toMatchObject({ code: "preview_access_invalid" });
+      }
+      const session = await service.exchange(opened.sessionId, token, site);
+      expect(session.workspaceId).toBe(workspaceId);
+      await expect(service.exchange(opened.sessionId, token, site)).rejects.toMatchObject({
+        code: "preview_access_invalid",
+      });
+      const target = await service.target(
+        session,
+        "/callback?return=%2Fclients%3Fx%3D1&code=a%2Bb",
+      );
+      expect(target.url.search).toBe("?return=%2Fclients%3Fx%3D1&code=a%2Bb");
+    } finally {
+      config.previewSites = [];
+    }
+  });
+
   it("requires a one-time exchange and remains bound to an active organization member", async () => {
     const opened = await service.open({ orgId, projectId, storyId, userId, service: "web" });
     const accessUrl = new URL(opened.url);


### PR DESCRIPTION
## What changes

Previews can use a stable, isolated origin per workspace and service. The authenticated proxy preserves root routes, application cookies, form/JSON/multipart/server-action bodies, forwarded host/protocol and WebSockets. Launch grants remain one-time and are bound to the exact organization, project, workspace and service before consumption.

Dedicated origins are operator-configured through encrypted deployment configuration and authenticated reverse-proxy headers. The existing path preview remains available. Access logs omit query credentials. The API image downloads Debian security updates over HTTPS and fails when its package indexes cannot refresh, supporting build networks that allow HTTPS only. Node’s bundled roots bootstrap the slim image’s CA trust until the OS CA package is installed; TLS verification remains enabled.

## Why

An OAuth application cannot complete login when its callback points to localhost or a changing session prefix, and dropping application cookies loses the authenticated session. Next.js also needs root assets and client routes to work without HTML-only rewrites.

## Verification

- [x] `pnpm verify` passes locally, including all critical suites without skips.
- [x] Behaviour verified beyond the test suite: Chromium against the actual Fastify app and local proxy/OAuth fakes completed a root callback, retained the app session, loaded a root script and submitted a form. Direct control-plane routing was denied; no JavaScript errors.
- [x] Documentation updated in `docs/workspace-preview-sites.md`, including explicit operator provisioning and lifecycle.

Unit and deterministic HTTP/WebSocket integration tests cover cookie and header isolation, byte-preserving payloads, replay/expired/revoked/malformed denial and cross-workspace access. A real disposable-Postgres regression verifies that a mismatched binding cannot consume a grant. No live credentials are needed by CI.

The native amd64 AWS build of the final source succeeded, including verified Debian HTTPS downloads. The 10 image-policy checks also pass.
