### PR TITLE
fix(repositories): disconnect synchronized project repositories

### DIFF
--- a/apps/docs/docs/guides/existing-repo.md
+++ b/apps/docs/docs/guides/existing-repo.md
@@ -88,3 +88,26 @@ checklist](validate-workspace-loop.md) before relying on the repository for prod
 
 If the repository already has generated or local-only files, update `.gitignore` normally. Do not
 ignore `.facility.yml` or `.agents/`; they are reviewed product configuration.
+
+## Disconnect an unused repository
+
+Open the project's **Settings → repositories**. With `repos:write`, each row offers
+**disconnect**. Review the repository name and cleanup warning, check the explicit
+confirmation, then select **confirm disconnect**. A failed request stays visible
+without removing the row; a successful request refreshes the repository list.
+Readers cannot use the control. The same operation is available through the
+[repository DELETE API](../reference/api.md#disconnect-a-repository).
+
+This removes the Facility connection and its synchronized GitHub data, not the
+GitHub repository itself. The primary can be disconnected: the oldest remaining
+repository becomes primary, or the project is left empty. No spare repository is
+needed. Review `.facility.yml` and `.agents/` in the remaining primary before
+starting agents. Reconnect the repository through the existing connect flow, then
+synchronize it to rebuild its current GitHub mirror.
+
+If Facility reports `repository_in_use`, it has retained stories or workspaces,
+or another retained reference prevents removal. Archiving does not remove those
+dependencies. Review the work and arrange an explicit migration or separately
+confirmed workspace lifecycle action; do not delete useful history just to clear
+this error. Disconnect never deletes a story, conversation, turn, file or volume,
+and it does not change existing GitHub App installation permissions.

--- a/apps/docs/docs/reference/api.md
+++ b/apps/docs/docs/reference/api.md
@@ -49,6 +49,41 @@ at creation; store it as a secret.
 Repository connections are organization- and installation-bound. A project-scoped key requesting
 another project receives 404 rather than a distinguishable authorization error.
 
+### Disconnect a repository
+
+`DELETE /v1/projects/:projectId/repos/:repoId` requires `repos:write` and returns
+`200 { "ok": true }`. It is a scoped no-op if that connection is already absent;
+send `Idempotency-Key` to replay the same request safely. It never deletes or
+modifies the upstream GitHub repository, branches, issues or pull requests.
+
+The transaction removes the connection and its derived GitHub mirror rows:
+issues, PRs, branches, reviews, checks and CI events. Webhook receipts retain their
+payload and project attribution but lose the repository reference; pending receipts
+are marked processed with `repository_disconnected`. Bound receipt processing keeps
+the original project and repository IDs through mirror and trigger lookups, so
+queued, replayed or in-flight deliveries cannot target a later connection. Detached
+receipts are ignored without overwriting their cancellation state. The `repo.removed` audit event
+continues to record the operation. Reconnecting and synchronizing rebuilds current
+GitHub data, not necessarily every historical CI observation.
+
+Removing a primary promotes the oldest remaining connection (ID breaks creation-time
+ties). Removing the sole connection leaves an empty project. No placeholder is
+required. Update the primary's `.facility.yml` and agent catalog before new work.
+
+`409 repository_in_use` leaves all data unchanged when the repository has any
+retained Facility story (including archived history), the project has any workspace
+not in `destroyed` state, or another foreign-key dependency remains. Workspaces can
+contain related checkouts even without a story directly referencing that repository.
+Resolve their lifecycle or arrange an explicit history migration; this endpoint
+never removes conversations, turns, artifacts or volumes. Project archival alone
+does not resolve these dependencies. This is not a history-transfer endpoint.
+
+Readers receive 403. Project-scoped keys cannot use another project, and an ID
+belonging to a different project is never deleted. The route/body schema and
+permission are unchanged; no database migration or additional provider credentials
+are required. Unlink does not revoke already issued GitHub tokens or App access;
+credential revocation remains a separate operator action.
+
 ## Agents and stories
 
 - `/v1/projects/:projectId/story-agents` lists the catalog and schedule status.

--- a/apps/docs/test/documentation-contract.test.mjs
+++ b/apps/docs/test/documentation-contract.test.mjs
@@ -8,6 +8,25 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const docsRoot = resolve(repoRoot, "apps/docs/docs");
 const read = (path) => readFileSync(resolve(repoRoot, path), "utf8");
 
+test("repository unlink documents cleanup, retention, permissions and primary replacement", () => {
+  const reference = read("apps/docs/docs/reference/api.md");
+  for (const contract of [
+    "repos:write",
+    "repository_in_use",
+    "repository_disconnected",
+    "Idempotency-Key",
+    "oldest remaining",
+    "webhook",
+    "never removes conversations",
+  ]) {
+    assert.ok(reference.toLowerCase().includes(contract.toLowerCase()), contract);
+  }
+  const guide = read("apps/docs/docs/guides/existing-repo.md");
+  assert.match(guide, /confirm disconnect/);
+  assert.match(guide, /not the[\s\S]*GitHub repository itself/);
+  assert.match(guide, /Archiving does not remove/);
+});
+
 test("the published navigation covers user, operator, reference, and contributor paths", () => {
   const sidebar = read("apps/docs/sidebars.ts");
   const requiredPages = [

--- a/apps/web/app/(app)/projects/[projectId]/settings/page.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { Divider, Eyebrow, PillTag } from "@facility/ui";
 import Link from "next/link";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { DisconnectRepository } from "@/components/project/disconnect-repository";
 import { WorkspaceVariables } from "@/components/story/workspace-variables";
 import { api } from "@/lib/api";
 import { can } from "@/lib/permissions";
@@ -58,7 +59,7 @@ export default async function ProjectSettingsPage({
           </p>
         ) : (
           <div className="flex flex-col border border-(--line)">
-            {repos.data.map((repo, index) => (
+            {repos.data.map((repo) => (
               <div
                 key={repo.id}
                 className="flex flex-wrap items-center gap-3 border-b border-(--line) px-5 py-4 last:border-0"
@@ -71,10 +72,15 @@ export default async function ProjectSettingsPage({
                 >
                   {repo.owner}/{repo.name}
                 </a>
-                <PillTag>{index === 0 ? "primary" : "related"}</PillTag>
+                <PillTag>{repo.role}</PillTag>
                 <span className="ml-auto font-mono text-[11px] text-(--dim)">
                   {repo.defaultBranch}
                 </span>
+                <DisconnectRepository
+                  projectId={projectId}
+                  repository={repo}
+                  canWrite={can(me.ok ? me.data.permissions : [], "repos:write")}
+                />
               </div>
             ))}
           </div>

--- a/apps/web/components/project/disconnect-repository.tsx
+++ b/apps/web/components/project/disconnect-repository.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Button } from "@facility/ui";
+import { useRouter } from "next/navigation";
+import { useId, useRef, useState } from "react";
+import type { ProjectRepo } from "@/lib/api";
+import { clientApi } from "@/lib/client-api";
+
+export function DisconnectRepository({
+  projectId,
+  repository,
+  canWrite,
+}: {
+  projectId: string;
+  repository: Pick<ProjectRepo, "id" | "owner" | "name" | "role">;
+  canWrite: boolean;
+}) {
+  const router = useRouter();
+  const confirmationId = useId();
+  const requestKey = useRef("");
+  const [confirming, setConfirming] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [removed, setRemoved] = useState(false);
+  const [error, setError] = useState("");
+  if (!canWrite) return null;
+  if (removed)
+    return (
+      <p role="status" className="text-sm">
+        Repository disconnected.
+      </p>
+    );
+
+  async function disconnect() {
+    if (!confirmed || pending) return;
+    setPending(true);
+    setError("");
+    const result = await clientApi(
+      "DELETE",
+      `/v1/projects/${encodeURIComponent(projectId)}/repos/${encodeURIComponent(repository.id)}`,
+      { idempotency_key: requestKey.current },
+    );
+    setPending(false);
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+    setRemoved(true);
+    router.refresh();
+  }
+  return (
+    <div
+      className={confirming ? "flex basis-full flex-col gap-3 border-t border-(--line) pt-3" : ""}
+    >
+      {!confirming ? (
+        <Button
+          size="sm"
+          onClick={() => {
+            requestKey.current = `ui-disconnect-${crypto.randomUUID()}`;
+            setConfirming(true);
+            setConfirmed(false);
+            setError("");
+          }}
+        >
+          disconnect
+        </Button>
+      ) : (
+        <>
+          <p className="text-sm">
+            Disconnect{" "}
+            <strong>
+              {repository.owner}/{repository.name}
+            </strong>{" "}
+            from this project?
+          </p>
+          <p className="text-sm text-(--mut)">
+            This removes the connection and its synchronized GitHub issue, PR, branch, review and CI
+            data. The GitHub repository is not deleted or modified. Retained Facility stories or
+            workspaces block disconnection; they are never deleted by this action.
+          </p>
+          {repository.role === "primary" ? (
+            <p className="text-sm text-(--mut)">
+              The oldest remaining repository becomes primary. If none remains, the project has no
+              connected repository. Review .facility.yml and .agents/ before starting new work.
+            </p>
+          ) : null}
+          <label htmlFor={confirmationId} className="flex items-center gap-2 text-sm">
+            <input
+              id={confirmationId}
+              type="checkbox"
+              checked={confirmed}
+              disabled={pending}
+              onChange={(event) => setConfirmed(event.target.checked)}
+            />
+            I understand the connection and synchronized data will be removed.
+          </label>
+          {error ? (
+            <p role="alert" className="text-sm text-red-600">
+              {error}
+            </p>
+          ) : null}
+          <div className="flex gap-2">
+            <Button size="sm" disabled={!confirmed || pending} onClick={disconnect}>
+              {pending ? "disconnecting…" : "confirm disconnect"}
+            </Button>
+            <Button size="sm" disabled={pending} onClick={() => setConfirming(false)}>
+              cancel
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/test/disconnect-repository.test.tsx
+++ b/apps/web/test/disconnect-repository.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { DisconnectRepository } from "../components/project/disconnect-repository";
+
+const refresh = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+let container: HTMLDivElement;
+let root: Root;
+const repository = { id: "repo_test", owner: "example", name: "app", role: "primary" as const };
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  refresh.mockClear();
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+async function render(canWrite = true) {
+  await act(async () =>
+    root.render(
+      <DisconnectRepository projectId="proj_test" repository={repository} canWrite={canWrite} />,
+    ),
+  );
+}
+function button(text: string) {
+  const result = [...container.querySelectorAll("button")].find((b) => b.textContent === text);
+  if (!result) throw Error(`Missing ${text}`);
+  return result;
+}
+async function click(text: string) {
+  await act(async () => button(text).click());
+}
+async function confirm() {
+  await click("disconnect");
+  const input = container.querySelector("input");
+  if (!input) throw Error("Missing confirmation");
+  await act(async () => input.click());
+}
+
+it("requires an explicit confirmation and permits cancelling without a request", async () => {
+  const fetch = vi.fn();
+  vi.stubGlobal("fetch", fetch);
+  await render();
+  await click("disconnect");
+  expect(container.textContent).toContain("example/app");
+  expect(container.textContent).toContain("oldest remaining repository becomes primary");
+  expect(container.textContent).toContain("GitHub repository is not deleted");
+  expect(button("confirm disconnect").disabled).toBe(true);
+  await click("confirm disconnect");
+  await click("cancel");
+  expect(fetch).not.toHaveBeenCalled();
+  expect(button("disconnect")).toBeTruthy();
+});
+it("shows progress, sends the exact scoped DELETE, and refreshes after success", async () => {
+  let complete: (response: Response) => void = () => {
+    throw Error("Request not started");
+  };
+  const fetch = vi.fn(
+    () =>
+      new Promise<Response>((resolve) => {
+        complete = resolve;
+      }),
+  );
+  vi.stubGlobal("fetch", fetch);
+  await render();
+  await confirm();
+  await click("confirm disconnect");
+  expect(button("disconnecting…").disabled).toBe(true);
+  expect(button("cancel").disabled).toBe(true);
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledWith(
+    "/api/v1/projects/proj_test/repos/repo_test",
+    expect.objectContaining({
+      method: "DELETE",
+      headers: expect.objectContaining({
+        "idempotency-key": expect.stringMatching(/^ui-disconnect-/),
+      }),
+    }),
+  );
+  await act(async () => complete(Response.json({ ok: true })));
+  expect(container.querySelector("[role='status']")?.textContent).toBe("Repository disconnected.");
+  expect(refresh).toHaveBeenCalledTimes(1);
+});
+it.each([
+  403, 409, 500,
+])("shows a %s failure without claiming removal or refreshing", async (status) => {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({ error: { message: "Repository is still in use" } }, { status }),
+      ),
+  );
+  await render();
+  await confirm();
+  await click("confirm disconnect");
+  expect(container.querySelector("[role='alert']")?.textContent).toBe("Repository is still in use");
+  expect(container.querySelector("[role='status']")).toBeNull();
+  expect(button("confirm disconnect").disabled).toBe(false);
+  expect(refresh).not.toHaveBeenCalled();
+});
+it("does not expose the action to readers", async () => {
+  const fetch = vi.fn();
+  vi.stubGlobal("fetch", fetch);
+  await render(false);
+  expect(container.querySelector("button")).toBeNull();
+  expect(fetch).not.toHaveBeenCalled();
+});

--- a/services/api/src/agents/github-triggers.ts
+++ b/services/api/src/agents/github-triggers.ts
@@ -28,6 +28,8 @@ const SUPPORTED_EVENTS = new Set([
 type GithubEvent = {
   id: string;
   orgId: string;
+  projectId?: string;
+  repositoryId?: string;
   eventType: string;
   payload: Record<string, unknown>;
 };
@@ -54,30 +56,48 @@ export class GithubAgentTriggerService {
         .limit(1)
     )[0];
     if (!event?.verified) return { matched: 0, queued: 0, merged: 0 };
+    if (event.projectId && !event.repositoryId) return { matched: 0, queued: 0, merged: 0 };
+    return this.processInbound(event);
+  }
+
+  private async processInbound(event: typeof githubWebhookEvents.$inferSelect) {
+    const inboundEventId = event.id;
+    // Keep the original binding through every lookup, including deliveries already in flight.
+    // No transaction/connection is held while calling GitHub or nested domain services.
+    const binding = {
+      projectId: event.projectId ?? undefined,
+      repositoryId: event.repositoryId ?? undefined,
+    };
+    const receiptScope = and(
+      eq(githubWebhookEvents.id, inboundEventId),
+      event.repositoryId ? eq(githubWebhookEvents.repositoryId, event.repositoryId) : undefined,
+    );
     try {
       await this.mirror?.handleWebhook({
         id: event.id,
         orgId: event.orgId,
+        ...binding,
         eventType: event.eventType,
         payload: event.payload as Record<string, unknown>,
       });
       const result = await this.handle({
         id: event.id,
         orgId: event.orgId,
+        ...binding,
         eventType: event.eventType,
         payload: event.payload as Record<string, unknown>,
       });
       await this.db
         .update(githubWebhookEvents)
         .set({ processedAt: new Date(), error: null })
-        .where(eq(githubWebhookEvents.id, inboundEventId));
+        .where(receiptScope);
       return result;
     } catch (error) {
       // Provider errors may contain credential-bearing request headers; persist only a safe code.
       await this.db
         .update(githubWebhookEvents)
         .set({ processedAt: null, error: "github_webhook_processing_failed" })
-        .where(eq(githubWebhookEvents.id, inboundEventId));
+        .where(receiptScope);
       throw error;
     }
   }
@@ -109,6 +129,8 @@ export class GithubAgentTriggerService {
         .where(
           and(
             eq(projectRepositories.orgId, event.orgId),
+            event.projectId ? eq(projectRepositories.projectId, event.projectId) : undefined,
+            event.repositoryId ? eq(projectRepositories.id, event.repositoryId) : undefined,
             eq(projectRepositories.owner, owner),
             eq(projectRepositories.name, name),
             eq(projects.status, "active"),

--- a/services/api/src/github/mirror.ts
+++ b/services/api/src/github/mirror.ts
@@ -34,10 +34,12 @@ export class GithubMirrorService {
   async handleWebhook(input: {
     id: string;
     orgId: string;
+    projectId?: string;
+    repositoryId?: string;
     eventType: string;
     payload: JsonObject;
   }) {
-    const repository = await this.repositoryForPayload(input.orgId, input.payload);
+    const repository = await this.repositoryForPayload(input.orgId, input.payload, input);
     if (!repository) {
       return { mirrored: 0, branches: 0, reviews: 0, checks: 0, ciUpdated: 0 };
     }
@@ -193,7 +195,11 @@ export class GithubMirrorService {
     };
   }
 
-  private async repositoryForPayload(orgId: string, payload: JsonObject) {
+  private async repositoryForPayload(
+    orgId: string,
+    payload: JsonObject,
+    binding: { projectId?: string; repositoryId?: string },
+  ) {
     const repository = object(payload.repository);
     const fullName = string(repository.full_name)?.split("/") ?? [];
     const owner = string(object(repository.owner).login) ?? fullName[0];
@@ -207,6 +213,8 @@ export class GithubMirrorService {
           .where(
             and(
               eq(projectRepositories.orgId, orgId),
+              binding.projectId ? eq(projectRepositories.projectId, binding.projectId) : undefined,
+              binding.repositoryId ? eq(projectRepositories.id, binding.repositoryId) : undefined,
               eq(projectRepositories.owner, owner),
               eq(projectRepositories.name, name),
             ),

--- a/services/api/src/github/repository-connections.ts
+++ b/services/api/src/github/repository-connections.ts
@@ -1,0 +1,160 @@
+import {
+  type FacilityDb,
+  githubBranches,
+  githubChecks,
+  githubCiEvents,
+  githubIssues,
+  githubPullRequestReviews,
+  githubPullRequests,
+  githubWebhookEvents,
+  projectRepositories,
+  projects,
+  stories,
+  workspaces,
+} from "@facility/db";
+import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { ApiError, notFound } from "../errors.js";
+
+export function repositoryRemovalBlocker(hasStories: boolean, hasRetainedWorkspaces: boolean) {
+  if (hasStories) {
+    return "This repository has retained Facility stories. Disconnecting it requires an explicit history migration; no stories or synchronized data were removed.";
+  }
+  if (hasRetainedWorkspaces) {
+    return "This project has retained workspaces that may contain this repository. Resolve their lifecycle explicitly before disconnecting; no workspaces or synchronized data were removed.";
+  }
+  return null;
+}
+
+/** Unlink configuration and disposable mirrors, never durable work or GitHub itself. */
+export async function removeRepositoryConnection(
+  db: FacilityDb,
+  orgId: string,
+  projectId: string,
+  repoId: string,
+) {
+  try {
+    await db.transaction(async (transaction) => {
+      const tx = transaction as unknown as FacilityDb;
+      // The connect route takes this same lock. Primary replacement must be one topology change.
+      await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`${orgId}:${projectId}`}))`);
+      const project = await tx
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.orgId, orgId), eq(projects.id, projectId)))
+        .for("update");
+      if (!project.length) throw notFound("Project not found");
+      const scope = and(
+        eq(projectRepositories.orgId, orgId),
+        eq(projectRepositories.projectId, projectId),
+        eq(projectRepositories.id, repoId),
+      );
+      const repository = (
+        await tx.select().from(projectRepositories).where(scope).for("update")
+      )[0];
+      if (!repository) return;
+
+      // Row locks also fence new FK references while existing dependencies are checked.
+      const retainedStories = await tx
+        .select({ id: stories.id })
+        .from(stories)
+        .where(
+          and(
+            eq(stories.orgId, orgId),
+            eq(stories.projectId, projectId),
+            eq(stories.repositoryId, repoId),
+          ),
+        )
+        .limit(1);
+      const retainedWorkspaces = await tx
+        .select({ id: workspaces.id })
+        .from(workspaces)
+        .where(
+          and(
+            eq(workspaces.orgId, orgId),
+            eq(workspaces.projectId, projectId),
+            ne(workspaces.state, "destroyed"),
+          ),
+        )
+        .limit(1);
+      const blocker = repositoryRemovalBlocker(
+        retainedStories.length > 0,
+        retainedWorkspaces.length > 0,
+      );
+      if (blocker) throw new ApiError(409, "repository_in_use", blocker);
+
+      // These are derived GitHub read models, not Facility stories, turns or workspace evidence.
+      for (const table of [
+        githubIssues,
+        githubPullRequests,
+        githubBranches,
+        githubChecks,
+        githubPullRequestReviews,
+        githubCiEvents,
+      ]) {
+        await tx
+          .delete(table)
+          .where(
+            and(
+              eq(table.orgId, orgId),
+              eq(table.projectId, projectId),
+              eq(table.repositoryId, repoId),
+            ),
+          );
+      }
+      // Keep the signed-delivery audit payload and project attribution after unlinking.
+      await tx
+        .update(githubWebhookEvents)
+        .set({
+          repositoryId: null,
+          processedAt: sql`coalesce(${githubWebhookEvents.processedAt}, now())`,
+          error: sql`case when ${githubWebhookEvents.processedAt} is null then 'repository_disconnected' else ${githubWebhookEvents.error} end`,
+        })
+        .where(
+          and(
+            eq(githubWebhookEvents.orgId, orgId),
+            eq(githubWebhookEvents.projectId, projectId),
+            eq(githubWebhookEvents.repositoryId, repoId),
+          ),
+        );
+      await tx.delete(projectRepositories).where(scope);
+      if (repository.role === "primary") {
+        const replacement = (
+          await tx
+            .select({ id: projectRepositories.id })
+            .from(projectRepositories)
+            .where(
+              and(
+                eq(projectRepositories.orgId, orgId),
+                eq(projectRepositories.projectId, projectId),
+              ),
+            )
+            .orderBy(asc(projectRepositories.createdAt), asc(projectRepositories.id))
+            .limit(1)
+        )[0];
+        if (replacement) {
+          await tx
+            .update(projectRepositories)
+            .set({ role: "primary", updatedAt: new Date() })
+            .where(
+              and(
+                eq(projectRepositories.orgId, orgId),
+                eq(projectRepositories.projectId, projectId),
+                eq(projectRepositories.id, replacement.id),
+              ),
+            );
+        }
+      }
+    });
+  } catch (error) {
+    const failure = error as { code?: string; cause?: { code?: string } };
+    if ((failure.code ?? failure.cause?.code) === "23503") {
+      // Future/extension-owned dependencies must roll back the entire cleanup, not be cascaded.
+      throw new ApiError(
+        409,
+        "repository_in_use",
+        "This repository still has retained references. No data was removed; an explicit history migration is required before disconnecting.",
+      );
+    }
+    throw error;
+  }
+}

--- a/services/api/src/routes/v1/projects.ts
+++ b/services/api/src/routes/v1/projects.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { ApiError, notFound } from "../../errors.js";
 import { createGithubClientFactory } from "../../github/client.js";
+import { removeRepositoryConnection } from "../../github/repository-connections.js";
 import {
   AnyObject,
   DateValue,
@@ -305,42 +306,7 @@ export async function registerProjectRoutes(app: FastifyInstance, context: V1Rou
     async (request) => {
       const actor = principal(request);
       const { projectId: id, repoId } = request.params as { projectId: string; repoId: string };
-      await db.transaction(async (transaction) => {
-        const tx = transaction as unknown as FacilityDb;
-        const removed = (
-          await tx
-            .delete(projectRepositories)
-            .where(
-              and(
-                eq(projectRepositories.orgId, actor.orgId),
-                eq(projectRepositories.projectId, id),
-                eq(projectRepositories.id, repoId),
-              ),
-            )
-            .returning({ role: projectRepositories.role })
-        )[0];
-        if (removed?.role === "primary") {
-          const replacement = (
-            await tx
-              .select({ id: projectRepositories.id })
-              .from(projectRepositories)
-              .where(
-                and(
-                  eq(projectRepositories.orgId, actor.orgId),
-                  eq(projectRepositories.projectId, id),
-                ),
-              )
-              .orderBy(asc(projectRepositories.createdAt))
-              .limit(1)
-          )[0];
-          if (replacement) {
-            await tx
-              .update(projectRepositories)
-              .set({ role: "primary", updatedAt: new Date() })
-              .where(eq(projectRepositories.id, replacement.id));
-          }
-        }
-      });
+      await removeRepositoryConnection(db, actor.orgId, id, repoId);
       return { ok: true };
     },
   );

--- a/services/api/test/repository-connections.test.ts
+++ b/services/api/test/repository-connections.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { repositoryRemovalBlocker } from "../src/github/repository-connections.js";
+
+describe("repository removal policy", () => {
+  it("allows a repository without durable dependencies", () => {
+    expect(repositoryRemovalBlocker(false, false)).toBeNull();
+  });
+  it.each([false, true])("preserves retained stories with workspaces=%s", (workspaces) => {
+    expect(repositoryRemovalBlocker(true, workspaces)).toContain("retained Facility stories");
+  });
+  it("protects related checkouts even without a direct repository story", () => {
+    expect(repositoryRemovalBlocker(false, true)).toContain("retained workspaces");
+  });
+});

--- a/services/api/test/repository-unlink.integration.test.ts
+++ b/services/api/test/repository-unlink.integration.test.ts
@@ -1,0 +1,554 @@
+import { randomUUID } from "node:crypto";
+import { generateApiKey, newId } from "@facility/core";
+import {
+  apiKeys,
+  createDb,
+  githubBranches,
+  githubChecks,
+  githubCiEvents,
+  githubInstallations,
+  githubIssues,
+  githubPullRequestReviews,
+  githubPullRequests,
+  githubWebhookEvents,
+  migrate,
+  orgs,
+  projectRepositories,
+  projects,
+  roles,
+  seed,
+  stories,
+  workspaces,
+} from "@facility/db";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { buildApp } from "../src/app.js";
+import type { Octokit } from "../src/github/client.js";
+
+const databaseUrl =
+  process.env.DATABASE_URL ?? "postgres://facility:facility@127.0.0.1:5461/facility_test";
+const mirrorTables = [
+  githubIssues,
+  githubPullRequests,
+  githubBranches,
+  githubChecks,
+  githubPullRequestReviews,
+  githubCiEvents,
+];
+
+function deferred() {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("repository unlink API", () => {
+  const { db, client } = createDb(databaseUrl);
+  const suffix = randomUUID().slice(0, 8);
+  const writerRole = newId("role");
+  let app: Awaited<ReturnType<typeof buildApp>>;
+  const upstreamGet = vi.fn(async ({ owner, repo }: Record<string, unknown>) => ({
+    data: { owner: { login: String(owner) }, name: String(repo), default_branch: "main" },
+  }));
+
+  beforeAll(async () => {
+    await migrate(databaseUrl);
+    await seed(databaseUrl, { includeDemoData: true });
+    await db.insert(roles).values({
+      id: writerRole,
+      orgId: "org_local",
+      name: `repo-writer-${suffix}`,
+      permissions: ["repos:read", "repos:write"],
+    });
+    app = await buildApp(
+      {
+        databaseUrl,
+        secretMasterKey: Buffer.alloc(32, 7).toString("base64"),
+        port: 4400,
+        publicUrl: "http://localhost:4400",
+        webUrl: "http://localhost:3400",
+        workspaceImage: "facility-runner:test",
+        workspaceDriver: "docker",
+        facilityInsecureDev: true,
+        logLevel: "silent",
+      },
+      { rateLimitMax: 10_000 },
+    );
+    app.githubClientFactory = async () =>
+      ({ rest: { repos: { get: upstreamGet } } }) as unknown as Octokit;
+    await app.ready();
+  });
+  afterAll(async () => {
+    await app?.close();
+    await client.end();
+  });
+
+  async function key(projectId: string, roleId = writerRole, orgId = "org_local") {
+    const generated = await generateApiKey("fak");
+    await db.insert(apiKeys).values({
+      id: generated.id,
+      orgId,
+      name: "unlink test",
+      prefix: generated.lookup,
+      last4: generated.last4,
+      hash: generated.hash,
+      scopeType: "project",
+      projectId,
+      roleId,
+    });
+    return generated;
+  }
+  async function fixture(orgId = "org_local") {
+    const projectId = newId("proj");
+    const installationId = newId("ghi");
+    const owner = `example-${randomUUID().slice(0, 8)}`;
+    if (orgId !== "org_local")
+      await db.insert(orgs).values({ id: orgId, name: "Other tenant", slug: orgId });
+    await db
+      .insert(projects)
+      .values({ id: projectId, orgId, name: "Repository unlink", slug: projectId });
+    await db.insert(githubInstallations).values({
+      id: installationId,
+      orgId,
+      installationId: Math.floor(Math.random() * 1_000_000_000) + 10_000,
+      accountId: 1,
+      accountLogin: owner,
+      targetType: "Organization",
+    });
+    const repo = (
+      await db
+        .insert(projectRepositories)
+        .values({
+          id: newId("repo"),
+          orgId,
+          projectId,
+          installationId,
+          owner,
+          name: "app",
+          role: "primary",
+          defaultBranch: "main",
+        })
+        .returning()
+    )[0];
+    if (!repo) throw Error("Fixture repository missing");
+    return {
+      projectId,
+      repo,
+      credential: await key(
+        projectId,
+        orgId === "org_local" ? writerRole : "role_bundled_owner",
+        orgId,
+      ),
+    };
+  }
+  async function related(f: Awaited<ReturnType<typeof fixture>>, name: string) {
+    const row = (
+      await db
+        .insert(projectRepositories)
+        .values({ ...f.repo, id: newId("repo"), name, role: "related" })
+        .returning()
+    )[0];
+    if (!row) throw Error("Related fixture repository missing");
+    return row;
+  }
+  async function mirror(repo: typeof projectRepositories.$inferSelect) {
+    if (!repo.installationId) throw Error("Fixture installation missing");
+    const scope = { orgId: repo.orgId, projectId: repo.projectId, repositoryId: repo.id };
+    await db.insert(githubIssues).values({
+      ...scope,
+      id: newId("ghi"),
+      number: 1,
+      title: "Issue",
+      state: "open",
+      htmlUrl: "https://github.com/example/app/issues/1",
+    });
+    await db.insert(githubPullRequests).values({
+      ...scope,
+      id: newId("ghp"),
+      number: 2,
+      title: "PR",
+      state: "open",
+      headRef: "feature",
+      headSha: "a".repeat(40),
+      baseRef: "main",
+      htmlUrl: "https://github.com/example/app/pull/2",
+    });
+    await db
+      .insert(githubBranches)
+      .values({ ...scope, id: newId("ghb"), name: "main", headSha: "a".repeat(40) });
+    await db.insert(githubChecks).values({
+      ...scope,
+      id: newId("ghc"),
+      checkId: "check",
+      headSha: "a".repeat(40),
+      name: "CI",
+      status: "completed",
+    });
+    await db
+      .insert(githubPullRequestReviews)
+      .values({ ...scope, id: newId("ghr"), pullNumber: 2, reviewId: "review", state: "APPROVED" });
+    await db.insert(githubCiEvents).values({
+      ...scope,
+      id: newId("cie"),
+      pullNumber: 2,
+      headSha: "a".repeat(40),
+      state: "success",
+    });
+    const eventId = newId("evt");
+    await db.insert(githubWebhookEvents).values({
+      ...scope,
+      id: eventId,
+      installationId: repo.installationId,
+      eventType: "issues",
+      payload: { action: "opened" },
+      verified: true,
+      processedAt: new Date(),
+    });
+    return eventId;
+  }
+  function remove(projectId: string, repoId: string, secret: string, requestKey = randomUUID()) {
+    return app.inject({
+      method: "DELETE",
+      url: `/v1/projects/${projectId}/repos/${repoId}`,
+      headers: { authorization: `Bearer ${secret}`, "idempotency-key": requestKey },
+    });
+  }
+  async function rows(repoId: string) {
+    return Promise.all(
+      mirrorTables.map((table) =>
+        db.select({ id: table.id }).from(table).where(eq(table.repositoryId, repoId)),
+      ),
+    );
+  }
+  async function addStory(
+    f: Awaited<ReturnType<typeof fixture>>,
+    repositoryId: string | null = f.repo.id,
+  ) {
+    const id = newId("story");
+    await db.insert(stories).values({
+      id,
+      orgId: f.repo.orgId,
+      projectId: f.projectId,
+      repositoryId,
+      provider: "manual",
+      externalId: id,
+      title: "Retained work",
+      createdBy: { type: "test" },
+    });
+    return id;
+  }
+
+  it("unlinks a sole primary with all mirror data, preserves webhook evidence, and reconnects elsewhere", async () => {
+    const f = await fixture();
+    const other = await fixture();
+    const eventId = await mirror(f.repo);
+    await mirror(other.repo);
+    const requestsBefore = upstreamGet.mock.calls.length;
+    const requestKey = randomUUID();
+    const response = await remove(f.projectId, f.repo.id, f.credential.secret, requestKey);
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toEqual({ ok: true });
+    expect((await remove(f.projectId, f.repo.id, f.credential.secret, requestKey)).statusCode).toBe(
+      200,
+    );
+    expect(await rows(f.repo.id)).toEqual([[], [], [], [], [], []]);
+    expect((await rows(other.repo.id)).map((r) => r.length)).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(
+      await db.select().from(projectRepositories).where(eq(projectRepositories.id, f.repo.id)),
+    ).toEqual([]);
+    expect(
+      (await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, eventId)))[0],
+    ).toMatchObject({
+      repositoryId: null,
+      projectId: f.projectId,
+      payload: { action: "opened" },
+      verified: true,
+    });
+    expect(upstreamGet.mock.calls.length).toBe(requestsBefore);
+    const connected = await app.inject({
+      method: "POST",
+      url: `/v1/projects/${other.projectId}/repos`,
+      headers: {
+        authorization: `Bearer ${other.credential.secret}`,
+        "idempotency-key": randomUUID(),
+      },
+      payload: { owner: f.repo.owner, name: f.repo.name, mode: "connect", defaultBranch: "main" },
+    });
+    expect(connected.statusCode, connected.body).toBe(200);
+    expect(connected.json()).toMatchObject({
+      projectId: other.projectId,
+      owner: f.repo.owner,
+      name: f.repo.name,
+      role: "related",
+    });
+    const handle = vi.spyOn(app.storyDomain.githubTriggers, "handle");
+    try {
+      expect(await app.storyDomain.githubTriggers.handleInbound(eventId)).toEqual({
+        matched: 0,
+        queued: 0,
+        merged: 0,
+      });
+      expect(handle).not.toHaveBeenCalled();
+    } finally {
+      handle.mockRestore();
+    }
+  });
+
+  it("unlinks a primary even with a placeholder present and promotes the oldest related", async () => {
+    const f = await fixture();
+    const oldest = await related(f, "placeholder");
+    await db
+      .update(projectRepositories)
+      .set({ createdAt: new Date("2020-01-01Z") })
+      .where(eq(projectRepositories.id, oldest.id));
+    await related(f, "newer");
+    await mirror(f.repo);
+    const response = await remove(f.projectId, f.repo.id, f.credential.secret);
+    expect(response.statusCode, response.body).toBe(200);
+    const primary = await db
+      .select()
+      .from(projectRepositories)
+      .where(
+        and(
+          eq(projectRepositories.projectId, f.projectId),
+          eq(projectRepositories.role, "primary"),
+        ),
+      );
+    expect(primary.map((r) => r.id)).toEqual([oldest.id]);
+  });
+
+  it("unlinks a synchronized related repository without replacing the primary", async () => {
+    const f = await fixture();
+    const child = await related(f, "child");
+    await mirror(child);
+    expect((await remove(f.projectId, child.id, f.credential.secret)).statusCode).toBe(200);
+    expect(await rows(child.id)).toEqual([[], [], [], [], [], []]);
+    expect(
+      (await db.select().from(projectRepositories).where(eq(projectRepositories.id, f.repo.id)))[0]
+        ?.role,
+    ).toBe("primary");
+  });
+
+  it("denies retained stories, including archived history, before changing mirror rows", async () => {
+    const f = await fixture();
+    const event = await mirror(f.repo);
+    const storyId = await addStory(f);
+    await db
+      .update(stories)
+      .set({ status: "archived", archivedAt: new Date() })
+      .where(eq(stories.id, storyId));
+    const response = await remove(f.projectId, f.repo.id, f.credential.secret);
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("repository_in_use");
+    expect((await rows(f.repo.id)).map((r) => r.length)).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(
+      (await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, event)))[0]
+        ?.repositoryId,
+    ).toBe(f.repo.id);
+    expect((await db.select().from(stories).where(eq(stories.id, storyId)))[0]?.status).toBe(
+      "archived",
+    );
+  });
+
+  it.each([
+    "creating",
+    "running",
+    "sleeping",
+    "error",
+    "deleting",
+  ])("denies %s project workspaces even when the target has no direct story", async (state) => {
+    const f = await fixture();
+    const storyId = await addStory(f, null);
+    await mirror(f.repo);
+    await db.insert(workspaces).values({
+      id: newId("ws"),
+      orgId: "org_local",
+      projectId: f.projectId,
+      storyId,
+      provider: "fake",
+      volumeRef: "retained-test-volume",
+      state,
+    });
+    const response = await remove(f.projectId, f.repo.id, f.credential.secret);
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error.code).toBe("repository_in_use");
+    expect((await rows(f.repo.id)).map((r) => r.length)).toEqual([1, 1, 1, 1, 1, 1]);
+  });
+
+  it("does not treat an already destroyed workspace as a retained checkout", async () => {
+    const f = await fixture();
+    const storyId = await addStory(f, null);
+    await db.insert(workspaces).values({
+      id: newId("ws"),
+      orgId: "org_local",
+      projectId: f.projectId,
+      storyId,
+      provider: "fake",
+      volumeRef: "removed-test-volume",
+      state: "destroyed",
+      destroyedAt: new Date(),
+    });
+    await mirror(f.repo);
+    expect((await remove(f.projectId, f.repo.id, f.credential.secret)).statusCode).toBe(200);
+  });
+
+  it("denies missing write permission, invalid/revoked keys and cross-project/tenant access", async () => {
+    const f = await fixture();
+    const other = await fixture();
+    const foreign = await fixture(newId("org"));
+    const viewer = await key(f.projectId, "role_bundled_viewer");
+    const revoked = await key(f.projectId);
+    await db.update(apiKeys).set({ revokedAt: new Date() }).where(eq(apiKeys.id, revoked.id));
+    await mirror(f.repo);
+    expect((await remove(f.projectId, f.repo.id, viewer.secret)).statusCode).toBe(403);
+    expect((await remove(f.projectId, f.repo.id, "fak_invalid")).statusCode).toBe(401);
+    expect((await remove(f.projectId, f.repo.id, revoked.secret)).statusCode).toBe(401);
+    expect((await remove(other.projectId, other.repo.id, f.credential.secret)).statusCode).toBe(
+      404,
+    );
+    expect((await remove(foreign.projectId, foreign.repo.id, f.credential.secret)).statusCode).toBe(
+      404,
+    );
+    // A mismatched repository ID is an idempotent scoped no-op, never a cross-project delete.
+    expect((await remove(f.projectId, other.repo.id, f.credential.secret)).statusCode).toBe(200);
+    expect((await remove(f.projectId, foreign.repo.id, f.credential.secret)).statusCode).toBe(200);
+    expect((await rows(f.repo.id)).map((r) => r.length)).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(
+      await db.select().from(projectRepositories).where(eq(projectRepositories.id, other.repo.id)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(projectRepositories)
+        .where(eq(projectRepositories.id, foreign.repo.id)),
+    ).toHaveLength(1);
+  });
+
+  it("serializes simultaneous primary and related removals", async () => {
+    const f = await fixture();
+    const first = await related(f, "first");
+    const survivor = await related(f, "survivor");
+    await mirror(f.repo);
+    await mirror(first);
+    const responses = await Promise.all([
+      remove(f.projectId, f.repo.id, f.credential.secret),
+      remove(f.projectId, first.id, f.credential.secret),
+    ]);
+    expect(responses.map((r) => r.statusCode)).toEqual([200, 200]);
+    const remaining = await db
+      .select()
+      .from(projectRepositories)
+      .where(eq(projectRepositories.projectId, f.projectId));
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toMatchObject({ id: survivor.id, role: "primary" });
+  });
+
+  it("rolls back all cleanup for an unknown retained foreign-key dependency", async () => {
+    const f = await fixture();
+    const eventId = await mirror(f.repo);
+    await client`create table repository_unlink_test_guard (repository_id text references project_repositories(id))`;
+    try {
+      await client`insert into repository_unlink_test_guard values (${f.repo.id})`;
+      const response = await remove(f.projectId, f.repo.id, f.credential.secret);
+      expect(response.statusCode).toBe(409);
+      expect(response.json().error.code).toBe("repository_in_use");
+      expect((await rows(f.repo.id)).map((r) => r.length)).toEqual([1, 1, 1, 1, 1, 1]);
+      expect(
+        (await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, eventId)))[0]
+          ?.repositoryId,
+      ).toBe(f.repo.id);
+      expect(
+        await db.select().from(projectRepositories).where(eq(projectRepositories.id, f.repo.id)),
+      ).toHaveLength(1);
+    } finally {
+      await client`drop table repository_unlink_test_guard`;
+    }
+  });
+
+  it("cancels queued webhook processing while retaining its signed receipt", async () => {
+    const f = await fixture();
+    const eventId = await mirror(f.repo);
+    await db
+      .update(githubWebhookEvents)
+      .set({ processedAt: null, error: null })
+      .where(eq(githubWebhookEvents.id, eventId));
+    expect((await remove(f.projectId, f.repo.id, f.credential.secret)).statusCode).toBe(200);
+    const receipt = (
+      await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, eventId))
+    )[0];
+    expect(receipt).toMatchObject({
+      repositoryId: null,
+      projectId: f.projectId,
+      verified: true,
+      error: "repository_disconnected",
+    });
+    expect(receipt?.processedAt).toBeInstanceOf(Date);
+    expect(await app.storyDomain.githubTriggers.handleInbound(eventId)).toEqual({
+      matched: 0,
+      queued: 0,
+      merged: 0,
+    });
+  });
+
+  it("does not rebind an in-flight receipt to a later connection or overwrite cancellation", async () => {
+    const f = await fixture();
+    const other = await fixture();
+    const eventId = await mirror(f.repo);
+    const payload = {
+      action: "opened",
+      repository: { owner: { login: f.repo.owner }, name: f.repo.name },
+      issue: {
+        number: 90,
+        title: "Old delivery",
+        state: "open",
+        html_url: "https://github.com/example/app/issues/90",
+      },
+    };
+    await db
+      .update(githubWebhookEvents)
+      .set({ processedAt: null, payload })
+      .where(eq(githubWebhookEvents.id, eventId));
+    const entered = deferred();
+    const release = deferred();
+    const original = app.storyDomain.githubTriggers.handle.bind(app.storyDomain.githubTriggers);
+    const handle = vi
+      .spyOn(app.storyDomain.githubTriggers, "handle")
+      .mockImplementation(async (event) => {
+        entered.resolve();
+        await release.promise;
+        return original(event);
+      });
+    const delivery = app.storyDomain.githubTriggers.handleInbound(eventId);
+    await entered.promise;
+    try {
+      expect((await remove(f.projectId, f.repo.id, f.credential.secret)).statusCode).toBe(200);
+      const connected = await app.inject({
+        method: "POST",
+        url: `/v1/projects/${other.projectId}/repos`,
+        headers: { authorization: `Bearer ${other.credential.secret}` },
+        payload: { owner: f.repo.owner, name: f.repo.name, mode: "connect" },
+      });
+      expect(connected.statusCode).toBe(200);
+      const mirrored = await app.storyDomain.mirror.handleWebhook({
+        id: eventId,
+        orgId: f.repo.orgId,
+        projectId: f.projectId,
+        repositoryId: f.repo.id,
+        eventType: "issues",
+        payload,
+      });
+      expect(mirrored.mirrored).toBe(0);
+      expect(await rows(connected.json().id)).toEqual([[], [], [], [], [], []]);
+    } finally {
+      release.resolve();
+      handle.mockRestore();
+    }
+    expect(await delivery).toEqual({ matched: 0, queued: 0, merged: 0 });
+    expect(
+      (await db.select().from(githubWebhookEvents).where(eq(githubWebhookEvents.id, eventId)))[0]
+        ?.error,
+    ).toBe("repository_disconnected");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #350.

The repository DELETE route fails with `400 invalid_reference` once GitHub synchronization has created referencing rows. Being primary is not the cause: a database-backed regression reproduces the failure even when a second repository is available for promotion. Project Settings also lacked a disconnect control.

This change makes disconnection an explicit, scoped operation through the existing API and Settings UI.

## Changes

- Clean up only the selected connection's six derived GitHub mirror tables in one transaction; preserve webhook receipt payloads and project attribution.
- Cancel pending bound webhook receipts and preserve the original project/repository binding through mirror and trigger lookups, preventing late deliveries from being rebound to a newly connected project.
- Share the connection route's topology lock; lock the affected rows and promote the oldest remaining repository when removing a primary (ID breaks timestamp ties). A sole connection can be removed without a placeholder.
- Return actionable `409 repository_in_use` without removing data when retained Facility stories, non-destroyed project workspaces, or another FK dependency prevents unlinking.
- Add a permission-aware Settings control with explicit confirmation, pending/error feedback and refresh; display the stored repository role.
- Document permissions, cleanup, audit evidence, reconnection limitations and retained-history behavior.

## Boundaries

This does **not** delete or modify the GitHub repository, branches, issues or PRs. It does not delete Facility stories, turns, artifacts or workspace volumes, transfer history, or revoke previously issued GitHub credentials. No database migration, dependency change, additional permission or provider credential is required. Existing `repos:write` and project/organization authorization remain the boundary.

## Validation

- Full `pnpm verify`: passed — lint, typecheck, clean build, uncached critical integration tests, remaining tests, documentation, repository guards and audit under the existing policy.
- Targeted API regression run: **40 passed**, including 15 new unlink integration cases, four policy cases and existing automation/mirror coverage.
- New UI component tests: **6 passed**; full web suite: **42 passed**. Documentation contracts/build: **11 passed**.
- Cases include synchronized primary/related/sole removal, replay, reconnect to another project, simultaneous removals, permissions and tenant/project isolation, archived history, all retained workspace states, FK rollback, pending receipts and in-flight webhook rebinding.
- Manual browser pass against the source API and disposable local database: confirmation initially disabled, cancel preserves the connection, primary removal promotes the secondary, removing the final connection shows the empty state, and retained history yields a visible 409 while preserving its connection.
- `git diff --check`: passed.

The repository audit reports **two existing ignored high advisories**; no ignore or dependency was added here. No production mutation or live workspace/model run was performed. No workspace provider/runtime execution behavior is changed.

Human review and normal deployment are still required.