### PR TITLE
fix(api): keep artifacts when browser tests fail

### DIFF
--- a/apps/docs/docs/reference/project-manifest.md
+++ b/apps/docs/docs/reference/project-manifest.md
@@ -127,8 +127,9 @@ Facility's preview handoff provides authenticated browser access.
 ## Browser test artifacts
 
 When `browser_test` runs, Facility sets `FACILITY_ARTIFACT_DIR`. Write screenshots, traces, logs,
-and reports beneath that directory. Facility records the resulting files as story artifacts and
-returns their identifiers and URIs with the operation result.
+and reports beneath that directory. Facility records the resulting files as story artifacts,
+including files written before a failed command. Failed-test artifacts remain on the story timeline
+for retrieval afterward; successful operations also return their identifiers and URIs.
 
 ## Validation
 

--- a/services/api/src/workspaces/project-environment.ts
+++ b/services/api/src/workspaces/project-environment.ts
@@ -386,42 +386,57 @@ export class ProjectEnvironmentService {
       preparedInput.credentials.environment,
       preparedInput.manifest.environment.secrets,
     );
-    if (result.exitCode !== 0) throw commandFailure("environment.browser_test", script, safeResult);
-    const files = await this.runtime.exec(input.workspace, {
-      command: "find",
-      args: [artifactDirectory, "-type", "f", "-maxdepth", "2", "-print"],
-      cwd: primaryPath(preparedInput.credentials),
-      env: preparedInput.credentials.environment,
+    const failure =
+      result.exitCode === 0
+        ? undefined
+        : commandFailure("environment.browser_test", script, safeResult);
+    const collectArtifacts = async () => {
+      const files = await this.runtime.exec(input.workspace, {
+        command: "find",
+        args: [artifactDirectory, "-type", "f", "-maxdepth", "2", "-print"],
+        cwd: primaryPath(preparedInput.credentials),
+        env: preparedInput.credentials.environment,
+      });
+      const collected = files.stdout
+        .split("\n")
+        .map((path) => path.trim())
+        .filter(Boolean)
+        .map((path) => ({
+          id: newId("art"),
+          orgId: input.orgId,
+          projectId: input.projectId,
+          storyId: input.storyId,
+          turnId: input.turnId,
+          kind: path.endsWith(".png") ? "screenshot" : path.includes("trace") ? "trace" : "report",
+          label: path.split("/").at(-1) ?? "browser artifact",
+          uri: `workspace://${input.workspace.id}/${primaryPath(preparedInput.credentials)}/${path}`,
+          metadata: { path },
+        }));
+      if (collected.length > 0) await this.db.insert(storyArtifacts).values(collected);
+      return collected;
+    };
+    const artifacts = await collectArtifacts().catch((error) => {
+      if (!failure) throw error;
+      return [];
     });
-    const artifacts = files.stdout
-      .split("\n")
-      .map((path) => path.trim())
-      .filter(Boolean)
-      .map((path) => ({
-        id: newId("art"),
-        orgId: input.orgId,
-        projectId: input.projectId,
-        storyId: input.storyId,
-        turnId: input.turnId,
-        kind: path.endsWith(".png") ? "screenshot" : path.includes("trace") ? "trace" : "report",
-        label: path.split("/").at(-1) ?? "browser artifact",
-        uri: `workspace://${input.workspace.id}/${primaryPath(preparedInput.credentials)}/${path}`,
-        metadata: { path },
-      }));
-    if (artifacts.length > 0) await this.db.insert(storyArtifacts).values(artifacts);
-    await appendWorkspaceEvent(
-      this.db,
-      input.workspace.id,
-      input.orgId,
-      "environment.browser_test",
-      {
-        exitCode: result.exitCode,
-        stdout: tail(safeResult.stdout),
-        stderr: tail(safeResult.stderr),
-        durationMs: result.durationMs,
-        artifacts: artifacts.map((artifact) => artifact.uri),
-      },
-    );
+    try {
+      await appendWorkspaceEvent(
+        this.db,
+        input.workspace.id,
+        input.orgId,
+        "environment.browser_test",
+        {
+          exitCode: result.exitCode,
+          stdout: tail(safeResult.stdout),
+          stderr: tail(safeResult.stderr),
+          durationMs: result.durationMs,
+          artifacts: artifacts.map((artifact) => artifact.uri),
+        },
+      );
+    } catch (error) {
+      if (!failure) throw error;
+    }
+    if (failure) throw failure;
     return { result: safeResult, artifacts };
   }
 

--- a/services/api/test/project-environment.integration.test.ts
+++ b/services/api/test/project-environment.integration.test.ts
@@ -242,6 +242,116 @@ environment:
     ).toContain("shared");
   });
 
+  it("retains browser test artifacts and records the failed command", async () => {
+    const browserTestSecret = "browser-test-secret-value";
+    const environment = new ProjectEnvironmentService(
+      db,
+      runtime,
+      `file://${remotes}`,
+      (_projectId, name) => (name === "BROWSER_TEST_SECRET" ? browserTestSecret : undefined),
+    );
+    const failingManifest = {
+      ...manifest,
+      environment: {
+        ...manifest.environment,
+        browser_test: `
+          printf screenshot > "$FACILITY_ARTIFACT_DIR/failure.png"
+          printf trace > "$FACILITY_ARTIFACT_DIR/failure-trace.zip"
+          printf '%s' "$BROWSER_TEST_SECRET" >&2
+          exit 23
+        `,
+        secrets: ["BROWSER_TEST_SECRET"],
+      },
+    };
+
+    await expect(
+      environment.runBrowserTest({
+        orgId,
+        projectId,
+        storyId,
+        workspace,
+        manifest: failingManifest,
+        credentials,
+      }),
+    ).rejects.toMatchObject({
+      code: "environment_command_failed",
+      details: { exitCode: 23, stderr: "[REDACTED]" },
+    });
+
+    const artifacts = await db
+      .select()
+      .from(storyArtifacts)
+      .where(eq(storyArtifacts.storyId, storyId));
+    expect(artifacts.map((artifact) => artifact.label)).toEqual(
+      expect.arrayContaining(["failure.png", "failure-trace.zip"]),
+    );
+    const [event] = await db
+      .select()
+      .from(workspaceEvents)
+      .where(
+        and(
+          eq(workspaceEvents.workspaceId, workspaceId),
+          eq(workspaceEvents.type, "environment.browser_test"),
+        ),
+      )
+      .orderBy(desc(workspaceEvents.seq))
+      .limit(1);
+    const eventData = event?.data as { artifacts?: string[] } | undefined;
+    expect(eventData).toMatchObject({
+      exitCode: 23,
+      stderr: "[REDACTED]",
+    });
+    expect(eventData?.artifacts ?? []).toHaveLength(2);
+    expect(JSON.stringify(event)).not.toContain(browserTestSecret);
+  });
+
+  it("does not replace a browser test failure when artifact collection fails", async () => {
+    const environment = new ProjectEnvironmentService(db, runtime, `file://${remotes}`);
+    const failingManifest = {
+      ...manifest,
+      environment: {
+        ...manifest.environment,
+        browser_test: "exit 29",
+      },
+    };
+    const originalExec = runtime.exec.bind(runtime);
+    const exec = vi.spyOn(runtime, "exec").mockImplementation(async (locator, command) => {
+      if (command.command === "find") throw new Error("artifact scan unavailable");
+      return originalExec(locator, command);
+    });
+
+    try {
+      await expect(
+        environment.runBrowserTest({
+          orgId,
+          projectId,
+          storyId,
+          workspace,
+          manifest: failingManifest,
+          credentials,
+        }),
+      ).rejects.toMatchObject({
+        code: "environment_command_failed",
+        details: { exitCode: 29 },
+      });
+    } finally {
+      exec.mockRestore();
+    }
+
+    const [event] = await db
+      .select()
+      .from(workspaceEvents)
+      .where(
+        and(
+          eq(workspaceEvents.workspaceId, workspaceId),
+          eq(workspaceEvents.type, "environment.browser_test"),
+        ),
+      )
+      .orderBy(desc(workspaceEvents.seq))
+      .limit(1);
+    expect(event?.data).toMatchObject({ exitCode: 29, artifacts: [] });
+  });
+
   it("opens previews on the agent's changed workspace without checkout, setup, or reseeding", async () => {
     const environment = new ProjectEnvironmentService(db, runtime, `file://${remotes}`);
     const prepared = await environment.prepare({


### PR DESCRIPTION
## What changes

Save the screenshots, traces and reports a browser test writes, even when the test exits with an error. The service registers those files and records the redacted result event before returning the failure.

If saving the evidence also fails, keep the original test error so it doesn't get hidden by the second failure. The docs explain how to retrieve failed-test artifacts from the story, since a failed operation doesn't return the successful result's artifact list.

This is a nonbreaking fix using the existing artifact and event records. It needs no migration and doesn't change permissions, budgets or the API schema.

## Why

Closes https://github.com/theam/facility/issues/352

When a browser test fails, the screenshots and traces are often what you need to work out why. Throwing before registering them leaves that evidence out of the story.

## Verification

I ran the checks in a local Docker Sandbox microVM, with no host directories mounted.

- `pnpm --filter @facility/api exec vitest run test/project-environment.integration.test.ts --fileParallelism=false` passed all 10 tests. The new cases check that failed tests keep their screenshot and trace, secrets are redacted, and an artifact scan error doesn't replace the original test error.
- API typecheck, Biome checks, docs tests and the docs build passed.
- `pnpm verify` passed. The dependency audit still has the repo's two existing ignored high advisories; this PR adds no exceptions.

I couldn't complete the Docker workspace checks. The published runner is `linux/amd64`, and the local sandbox is ARM64. It exits with `exec /usr/local/bin/docker-entrypoint.sh: exec format error`; the test then gets HTTP 409 because the container has stopped. Trying emulation inside the sandbox didn't fix it. These checks still need to pass on a compatible runner before merge.

- [x] `pnpm verify` passes locally
- [ ] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
