### PR TITLE
fix(cli): use the server manifest validation in doctor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,8 @@ RUN test -f /app/node_modules/@facility/db/dist/bin/deploy.js \
 # tasks inside the VPC. `facility instance bootstrap` needs the database, and in
 # a reference deployment the database accepts connections only from the service
 # security group — there is nowhere else to run it from. The package is a few
-# hundred kilobytes of plain ESM whose only dependency, `postgres`, is already
-# here for @facility/db.
+# hundred kilobytes of plain ESM whose production dependencies are already
+# installed for the API image.
 COPY --from=build-api /app/packages/cli /app/cli
 # Operator commands read as `facility …` inside the image, the way they read
 # everywhere else, instead of as a path into it. A wrapper rather than a symlink
@@ -119,7 +119,7 @@ RUN printf '%s\n' \
 # resolves `facility` the way the container runtime does for an ECS command
 # override, with no shell in between, so the guard exercises the same lookup the
 # runbook depends on. Reaching the command proves the PATH entry, and importing
-# it proves that its production `postgres` dependency resolves.
+# it proves that its production dependencies resolve.
 RUN ["facility", "instance", "bootstrap", "--help"]
 EXPOSE 4400
 CMD ["node", "dist/start.js"]

--- a/apps/docs/docs/reference/project-manifest.md
+++ b/apps/docs/docs/reference/project-manifest.md
@@ -132,6 +132,6 @@ returns their identifiers and URIs with the operation result.
 
 ## Validation
 
-Run `facility doctor` for local feedback. The server parser is authoritative and loads the merged
-file from the primary repository. A changed manifest affects future environment preparation; it
-does not mutate historical turn records or delete an existing workspace.
+Run `facility doctor` for local feedback. It uses the same parser and schema as the server, which
+loads the merged file from the primary repository. A changed manifest affects future environment
+preparation; it does not mutate historical turn records or delete an existing workspace.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,9 @@
     "node": "^22.13.0 || ^24.0.0"
   },
   "dependencies": {
-    "postgres": "^3.4.7"
+    "postgres": "^3.4.7",
+    "yaml": "^2.8.1",
+    "zod": "^4.1.13"
   },
   "scripts": {
     "test": "node --test test/*.test.mjs"

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { ProjectManifestError, parseProjectManifest } from "./project-manifest.mjs";
 import { banner, heading, item, ok, warn } from "./ui.mjs";
 
 const AGENTS = [
@@ -36,16 +37,15 @@ function checkProjectManifest(dir) {
   const path = join(dir, ".facility.yml");
   if (!existsSync(path)) return failed("start command", ".facility.yml is missing");
   const source = readFileSync(path, "utf8");
-  if (!/^version:\s*1\s*$/m.test(source)) return failed("start command", "version must be 1");
-  if (!/^\s{2}primary:\s*["']?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+["']?\s*$/m.test(source)) {
-    return failed("start command", "repositories.primary must be github.com/owner/repository");
+  try {
+    parseProjectManifest(source);
+    return passed("start command", ".facility.yml declares the repository and development environment");
+  } catch (error) {
+    return failed(
+      "start command",
+      error instanceof ProjectManifestError ? error.message : "could not parse .facility.yml",
+    );
   }
-  if (!/^\s{2}start:\s*["']?.+$/m.test(source)) return failed("start command", "environment.start is missing");
-  const servicePort = /^\s{6}port:\s*([1-9]\d{0,4})\s*$/m.exec(source);
-  if (!servicePort || Number(servicePort[1]) > 65_535) {
-    return failed("start command", "a service port between 1 and 65535 is required");
-  }
-  return passed("start command", ".facility.yml declares the repository and development environment");
 }
 
 function checkAgent(dir, name) {

--- a/packages/cli/src/project-manifest.mjs
+++ b/packages/cli/src/project-manifest.mjs
@@ -1,0 +1,82 @@
+import { parseDocument } from "yaml";
+import { z } from "zod";
+
+const RepositoryName = z
+  .string()
+  .min(3)
+  .max(240)
+  .transform((value, context) => {
+    const match =
+      /^(?:https:\/\/)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/.exec(value);
+    if (!match) {
+      context.addIssue({ code: "custom", message: "must be github.com/owner/repository" });
+      return z.NEVER;
+    }
+    return `${match[1]}/${match[2]}`;
+  });
+
+const ServiceSchema = z
+  .object({
+    port: z.number().int().min(1).max(65_535),
+    protocol: z.enum(["http", "https"]).default("http"),
+    websocket: z.boolean().default(true),
+  })
+  .strict();
+
+const EnvironmentName = z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/);
+
+export const ProjectManifestSchema = z
+  .object({
+    version: z.literal(1).default(1),
+    repositories: z
+      .object({
+        primary: RepositoryName,
+        related: z.array(RepositoryName).default([]),
+      })
+      .strict(),
+    environment: z
+      .object({
+        image: z.string().min(1).max(500).optional(),
+        setup: z.string().min(1).max(4_000).optional(),
+        start: z.string().min(1).max(4_000),
+        ready: z.string().min(1).max(4_000).optional(),
+        stop: z.string().min(1).max(4_000).optional(),
+        seed: z.string().min(1).max(4_000).optional(),
+        browser_test: z.string().min(1).max(4_000).optional(),
+        secrets: z.array(EnvironmentName).default([]),
+        variables: z.array(EnvironmentName).default([]),
+        services: z.record(z.string().regex(/^[a-z][a-z0-9-]{0,62}$/), ServiceSchema).default({}),
+      })
+      .strict(),
+  })
+  .strict();
+
+export class ProjectManifestError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ProjectManifestError";
+  }
+}
+
+/** @param {string} source */
+export function parseProjectManifest(source) {
+  const document = parseDocument(source, { prettyErrors: false, uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw new ProjectManifestError(document.errors.map((error) => error.message).join("; "));
+  }
+
+  const result = ProjectManifestSchema.safeParse(document.toJS({ maxAliasCount: 0 }));
+  if (!result.success) {
+    throw new ProjectManifestError(
+      result.error.issues
+        .map((issue) => `${issue.path.join(".") || "manifest"}: ${issue.message}`)
+        .join("; "),
+    );
+  }
+  return result.data;
+}
+
+/** @param {string} name */
+export function parseEnvironmentName(name) {
+  return EnvironmentName.parse(name);
+}

--- a/packages/cli/test/init.test.mjs
+++ b/packages/cli/test/init.test.mjs
@@ -195,7 +195,40 @@ test("local doctor validates the 0.12 contract and preserves its JSON output", (
   );
   const invalidPort = runCli(["doctor", `--dir=${dir}`, "--json"], dir);
   assert.equal(invalidPort.status, 1);
-  assert.match(invalidPort.stdout, /between 1 and 65535/);
+  assert.match(JSON.parse(invalidPort.stdout).checks[0].detail, /expected number to be <=65535/);
+});
+
+test("doctor applies the server project manifest contract", (t) => {
+  const dir = makeTargetRepo();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const init = runCli(
+    ["init", "--yes", `--dir=${dir}`, "--repo=acme/demo-app", "--start=npm run dev"],
+    dir,
+  );
+  assert.equal(init.status, 0, init.stdout + init.stderr);
+
+  const manifestPath = join(dir, ".facility.yml");
+  const validWithoutVersion = readFileSync(manifestPath, "utf8").replace("version: 1\n", "");
+  writeFileSync(manifestPath, validWithoutVersion);
+  assert.equal(runCli(["doctor", `--dir=${dir}`, "--json"], dir).status, 0);
+
+  writeFileSync(manifestPath, `${validWithoutVersion}  extra: true\n`);
+  const unknownProperty = runCli(["doctor", `--dir=${dir}`, "--json"], dir);
+  assert.equal(unknownProperty.status, 1);
+  assert.match(
+    JSON.parse(unknownProperty.stdout).checks[0].detail,
+    /environment: Unrecognized key: "extra"/,
+  );
+
+  writeFileSync(manifestPath, `${validWithoutVersion}repositories:\n  primary: github.com/acme/other\n`);
+  const duplicateKey = runCli(["doctor", `--dir=${dir}`, "--json"], dir);
+  assert.equal(duplicateKey.status, 1);
+  assert.match(JSON.parse(duplicateKey.stdout).checks[0].detail, /Map keys must be unique/);
+
+  writeFileSync(manifestPath, "repositories: [\nenvironment:\n  start: npm run dev\n");
+  const malformed = runCli(["doctor", `--dir=${dir}`, "--json"], dir);
+  assert.equal(malformed.status, 1);
+  assert.match(JSON.parse(malformed.stdout).checks[0].detail, /Flow sequence in block collection/);
 });
 
 test("local commands reject unknown and valueless flags and legacy commands", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,12 @@ importers:
       postgres:
         specifier: ^3.4.7
         version: 3.4.9
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
+      zod:
+        specifier: ^4.1.13
+        version: 4.4.3
 
   packages/core:
     dependencies:

--- a/services/api/src/workspaces/project-environment.ts
+++ b/services/api/src/workspaces/project-environment.ts
@@ -3,8 +3,11 @@ import { newId } from "@facility/core";
 import type { FacilityDb } from "@facility/db";
 import { githubInstallations, projectRepositories, storyArtifacts, workspaces } from "@facility/db";
 import { and, eq } from "drizzle-orm";
-import { parseDocument } from "yaml";
-import { z } from "zod";
+import {
+  ProjectManifestError,
+  parseEnvironmentName,
+  parseProjectManifest as parseSharedProjectManifest,
+} from "../../../../packages/cli/src/project-manifest.mjs";
 import { FacilityGithubClient, type GithubClientFactory } from "../github/client.js";
 import { decodeContent } from "../github/repo-files.js";
 import type {
@@ -20,57 +23,7 @@ import type {
   WorkspaceRuntime,
 } from "./runtime.js";
 
-const RepositoryName = z
-  .string()
-  .min(3)
-  .max(240)
-  .transform((value, context) => {
-    const match =
-      /^(?:https:\/\/)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/.exec(value);
-    if (!match) {
-      context.addIssue({ code: "custom", message: "must be github.com/owner/repository" });
-      return z.NEVER;
-    }
-    return `${match[1]}/${match[2]}`;
-  });
-
-const ServiceSchema = z
-  .object({
-    port: z.number().int().min(1).max(65_535),
-    protocol: z.enum(["http", "https"]).default("http"),
-    websocket: z.boolean().default(true),
-  })
-  .strict();
-
-const EnvironmentName = z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/);
-
-export const ProjectManifestSchema = z
-  .object({
-    version: z.literal(1).default(1),
-    repositories: z
-      .object({
-        primary: RepositoryName,
-        related: z.array(RepositoryName).default([]),
-      })
-      .strict(),
-    environment: z
-      .object({
-        image: z.string().min(1).max(500).optional(),
-        setup: z.string().min(1).max(4_000).optional(),
-        start: z.string().min(1).max(4_000),
-        ready: z.string().min(1).max(4_000).optional(),
-        stop: z.string().min(1).max(4_000).optional(),
-        seed: z.string().min(1).max(4_000).optional(),
-        browser_test: z.string().min(1).max(4_000).optional(),
-        secrets: z.array(EnvironmentName).default([]),
-        variables: z.array(EnvironmentName).default([]),
-        services: z.record(z.string().regex(/^[a-z][a-z0-9-]{0,62}$/), ServiceSchema).default({}),
-      })
-      .strict(),
-  })
-  .strict();
-
-export type ProjectManifest = z.infer<typeof ProjectManifestSchema> & { hash: string };
+export type ProjectManifest = ReturnType<typeof parseSharedProjectManifest> & { hash: string };
 
 export class ProjectEnvironmentError extends Error {
   constructor(
@@ -84,26 +37,17 @@ export class ProjectEnvironmentError extends Error {
 }
 
 export function parseProjectManifest(source: string): ProjectManifest {
-  const document = parseDocument(source, { prettyErrors: false, uniqueKeys: true });
-  if (document.errors.length > 0) {
-    throw new ProjectEnvironmentError(
-      "project_manifest_invalid",
-      document.errors.map((error) => error.message).join("; "),
-    );
+  try {
+    return {
+      ...parseSharedProjectManifest(source),
+      hash: createHash("sha256").update(source.replace(/\r\n?/g, "\n")).digest("hex"),
+    };
+  } catch (error) {
+    if (error instanceof ProjectManifestError) {
+      throw new ProjectEnvironmentError("project_manifest_invalid", error.message);
+    }
+    throw error;
   }
-  const result = ProjectManifestSchema.safeParse(document.toJS({ maxAliasCount: 0 }));
-  if (!result.success) {
-    throw new ProjectEnvironmentError(
-      "project_manifest_invalid",
-      result.error.issues
-        .map((issue) => `${issue.path.join(".") || "manifest"}: ${issue.message}`)
-        .join("; "),
-    );
-  }
-  return {
-    ...result.data,
-    hash: createHash("sha256").update(source.replace(/\r\n?/g, "\n")).digest("hex"),
-  };
 }
 
 export interface ProjectManifestSource {
@@ -603,7 +547,7 @@ export function projectEnvironmentVariableName(projectId: string, name: string) 
   if (!/^[a-z0-9_]{1,100}$/.test(projectId)) {
     throw new ProjectEnvironmentError("project_id_invalid", "project id is invalid");
   }
-  return `FACILITY_PROJECT_${projectId.toUpperCase()}_${EnvironmentName.parse(name)}`;
+  return `FACILITY_PROJECT_${projectId.toUpperCase()}_${parseEnvironmentName(name)}`;
 }
 
 function assertRepositoryContract(manifest: ProjectManifest, repositories: WorkspaceRepository[]) {

--- a/services/api/test/project-manifest.test.ts
+++ b/services/api/test/project-manifest.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  ProjectEnvironmentError,
+  parseProjectManifest,
+} from "../src/workspaces/project-environment.js";
+
+const manifest = `
+repositories:
+  primary: github.com/acme/app
+environment:
+  start: npm run dev
+  services:
+    app:
+      port: 3000
+`;
+
+describe("project manifest", () => {
+  it("uses the shared schema when defaults are omitted", () => {
+    expect(parseProjectManifest(manifest)).toMatchObject({
+      version: 1,
+      repositories: { related: [] },
+      environment: { secrets: [], variables: [], services: { app: { websocket: true } } },
+    });
+  });
+
+  it("reports malformed and unknown configuration as a project manifest error", () => {
+    expect(() => parseProjectManifest(`${manifest}  unknown: true\n`)).toThrow(
+      ProjectEnvironmentError,
+    );
+    expect(() =>
+      parseProjectManifest("repositories: [\nenvironment:\n  start: npm run dev\n"),
+    ).toThrow(ProjectEnvironmentError);
+  });
+});

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "allowJs": true,
+    "rootDir": "../..",
     "outDir": "dist",
     "types": ["node", "vitest/globals"]
   },

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["packages/cli/src/project-manifest.mjs"],
   "globalPassThroughEnv": ["FACILITY_GITHUB_CREDENTIALS", "FACILITY_PREVIEW_GATEWAY_TOKEN"],
   "tasks": {
     "build": {


### PR DESCRIPTION
## What changes

Have `facility doctor` and the API use the same YAML parser and Zod schema for `.facility.yml`, so doctor catches manifests the server would reject.

The shared parser stays in the published CLI package. The API imports it, derives its types from it, and includes the file in Turbo's cache inputs so parser changes invalidate cached builds. The API keeps its existing error code and manifest hash behavior.

The CLI adds `yaml` and `zod`, which the API already uses and the lockfile already contains. This is a nonbreaking validation fix: invalid manifests fail earlier, with no data migration or changes to permissions or budgets.

## Why

Closes https://github.com/theam/facility/issues/354

A successful doctor check should mean the manifest passes the server's validation. The current regular expressions let unsupported fields and malformed structures through, so users only find out later when they try to create a workspace.

## Verification

I ran the checks in a local Docker Sandbox microVM, with no host directories mounted.

- All 11 CLI tests and both API manifest tests passed, including checks for generated manifests, unknown fields, duplicate keys and malformed YAML.
- I installed the packed CLI into a fresh temporary fixture, ran `init`, and checked it with `doctor --json`. It accepted the generated manifest and rejected it after I added an unknown environment field.
- API typecheck, the production build and declaration build passed. Changing the shared parser changed the API's Turbo task hash as expected.
- The production API Docker image built successfully, including the CLI entrypoint/import check. The packed CLI includes the parser.
- `pnpm verify` passed.

I couldn't complete the Docker workspace checks. The published runner is `linux/amd64`, and the local sandbox is ARM64. It exits with `exec /usr/local/bin/docker-entrypoint.sh: exec format error`; the test then gets HTTP 409 because the container has stopped. Trying emulation inside the sandbox didn't fix it. These checks still need to pass on a compatible runner before merge.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
