### PR TITLE
fix(web): restore command palette navigation

### DIFF
--- a/apps/docs/docs/guides/operate-story.md
+++ b/apps/docs/docs/guides/operate-story.md
@@ -8,6 +8,9 @@ MCP is the primary way to automate a Facility story. The web UI exposes the same
 useful for browsing conversations, inspecting environments, opening previews, and taking lifecycle
 actions.
 
+In the web UI, press Command+K on macOS or Ctrl+K to open navigation. Type to filter projects and
+sections, use the arrow keys and Enter to choose a destination, or press Escape to dismiss it.
+
 ## Start a story
 
 Before starting, identify the project, the agent, and the body of work. For GitHub work, use a

--- a/apps/web/app/(app)/(org)/layout.tsx
+++ b/apps/web/app/(app)/(org)/layout.tsx
@@ -1,3 +1,4 @@
+import { CommandPalette } from "@/components/shell/cmdk";
 import { MobileNav, Sidebar } from "@/components/shell/nav";
 import { Topbar } from "@/components/shell/topbar";
 import { api } from "@/lib/api";
@@ -8,6 +9,7 @@ export default async function OrgLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="flex min-h-dvh">
+      <CommandPalette projects={projectList} />
       <Sidebar />
       <div className="min-w-0 flex-1">
         <MobileNav />

--- a/apps/web/app/(app)/projects/[projectId]/layout.tsx
+++ b/apps/web/app/(app)/projects/[projectId]/layout.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { ErrorNotice, Offline } from "@/components/offline";
+import { CommandPalette } from "@/components/shell/cmdk";
 import { MobileNav, Sidebar } from "@/components/shell/nav";
 import { RememberProject } from "@/components/shell/remember-project";
 import { Topbar } from "@/components/shell/topbar";
@@ -44,6 +45,7 @@ export default async function ProjectLayout({
     // App shell: the viewport is the frame; only the work area (main) scrolls,
     // so full-height tabs like Product can fill it edge to edge.
     <div className="flex h-dvh">
+      <CommandPalette projects={projectList} currentProject={p} />
       <Sidebar project={navProject} />
       <div className="flex min-w-0 flex-1 flex-col">
         <MobileNav project={navProject} />

--- a/apps/web/components/shell/cmdk.tsx
+++ b/apps/web/components/shell/cmdk.tsx
@@ -4,6 +4,7 @@ import { cx } from "@facility/ui";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Project } from "@/lib/api";
+import { projectNav } from "./nav";
 
 type PaletteProject = Pick<Project, "id" | "slug" | "name">;
 
@@ -28,43 +29,15 @@ export function CommandPalette({
 
   const entries = useMemo<Entry[]>(() => {
     const scoped: Entry[] = currentProject
-      ? [
-          {
-            id: "p-overview",
-            label: `${currentProject.slug} · overview`,
-            hint: "project",
-            href: `/projects/${currentProject.id}`,
-          },
-          {
-            id: "p-stories",
-            label: `${currentProject.slug} · stories`,
-            hint: "project",
-            href: `/projects/${currentProject.id}/stories`,
-          },
-          {
-            id: "p-sessions",
-            label: `${currentProject.slug} · sessions`,
-            hint: "project",
-            href: `/projects/${currentProject.id}/sessions`,
-          },
-          {
-            id: "p-approvals",
-            label: `${currentProject.slug} · approvals`,
-            hint: "project",
-            href: `/projects/${currentProject.id}/approvals`,
-          },
-          {
-            id: "p-settings",
-            label: `${currentProject.slug} · settings`,
-            hint: "project",
-            href: `/projects/${currentProject.id}/settings`,
-          },
-        ]
+      ? projectNav(currentProject.id).map(({ href, label }) => ({
+          id: href,
+          label: `${currentProject.slug} · ${label.toLowerCase()}`,
+          hint: "project",
+          href,
+        }))
       : [];
     const org: Entry[] = [
       { id: "o-projects", label: "projects", hint: "org", href: "/projects" },
-      { id: "o-harness", label: "harness", hint: "org", href: "/harness" },
-      { id: "o-audit", label: "audit", hint: "org", href: "/audit" },
       { id: "o-settings", label: "org settings", hint: "org", href: "/settings" },
       { id: "o-kickstart", label: "kickstart a project", hint: "org", href: "/projects/new" },
     ];

--- a/apps/web/test/command-palette.test.tsx
+++ b/apps/web/test/command-palette.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { readdirSync } from "node:fs";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OrgLayout from "../app/(app)/(org)/layout";
+import ProjectLayout from "../app/(app)/projects/[projectId]/layout";
+import { CommandPalette } from "../components/shell/cmdk";
+
+const push = vi.hoisted(() => vi.fn());
+vi.mock("../lib/last-project", () => ({
+  rememberLastProject: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => "/projects",
+}));
+vi.mock("../lib/api", () => ({
+  api: {
+    me: async () => ({ ok: false }),
+    project: async () => ({ ok: true, data: projects[0] }),
+    projects: async () => ({ ok: true, data: projects }),
+  },
+}));
+
+const projects = [
+  { id: "project-a", slug: "alpha", name: "Alpha" },
+  { id: "project-b", slug: "beta", name: "Beta" },
+];
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  push.mockClear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function key(target: EventTarget, value: string, ctrlKey = false) {
+  await act(async () => {
+    target.dispatchEvent(new KeyboardEvent("keydown", { key: value, ctrlKey, bubbles: true }));
+  });
+}
+
+async function open(currentProject = projects[0]) {
+  await act(async () =>
+    root.render(<CommandPalette projects={projects} currentProject={currentProject} />),
+  );
+  await key(document, "k", true);
+}
+
+async function search(value: string) {
+  const input = container.querySelector("input");
+  if (!input) throw new Error("Command palette input is missing");
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  return input;
+}
+
+describe("command palette destinations", () => {
+  it("mounts the keyboard palette in the project shell", async () => {
+    const shell = await ProjectLayout({
+      children: null,
+      params: Promise.resolve({ projectId: "project-a" }),
+    });
+    await act(async () => root.render(shell));
+    await key(document, "k", true);
+    expect(container.querySelector("[role='dialog']")?.textContent).toContain("alpha · stories");
+  });
+
+  it("mounts the keyboard palette in the organization shell", async () => {
+    const shell = await OrgLayout({ children: null });
+    await act(async () => root.render(shell));
+    await key(document, "k", true);
+    expect(container.querySelector("[role='dialog']")?.textContent).toContain("org settings");
+  });
+
+  it("offers the current project sections and navigates to real application pages", async () => {
+    const routes = readdirSync("app", { recursive: true, encoding: "utf8" })
+      .filter((file) => file.endsWith("/page.tsx"))
+      .map((file) => `/${file.replace(/\([^/]+\)\//g, "").replace(/\/page\.tsx$/, "")}`);
+    await open();
+    const labels = [...container.querySelectorAll("button")].map((button) => button.textContent);
+    for (const section of ["overview", "stories", "pipeline", "insights", "agents", "settings"]) {
+      expect(labels.some((label) => label?.includes(`alpha · ${section}`))).toBe(true);
+    }
+    for (let index = 0; index < labels.length; index += 1) {
+      if (index > 0) await key(document, "k", true);
+      const button = container.querySelectorAll("button")[index];
+      if (!button) throw new Error(`Command palette entry ${index} is missing`);
+      await act(async () => button.click());
+      const href = push.mock.lastCall?.[0] as string;
+      const route = href.replace(/\/projects\/project-[ab](?=\/|$)/, "/projects/[projectId]");
+      expect(routes, href).toContain(route);
+    }
+  });
+
+  it("supports filtering and keyboard selection of current project sections", async () => {
+    await open();
+    const input = await search("alpha ·");
+    await key(input, "ArrowDown");
+    await key(input, "ArrowDown");
+    await key(input, "Enter");
+    expect(push).toHaveBeenLastCalledWith("/projects/project-a/pipeline");
+    expect(container.querySelector("[role='dialog']")).toBeNull();
+  });
+
+  it("updates project-scoped destinations when switching projects", async () => {
+    await open(projects[1]);
+    const input = await search("beta · agents");
+    await key(input, "Enter");
+    expect(push).toHaveBeenLastCalledWith("/projects/project-b/agents");
+    await key(document, "k", true);
+    const projectInput = await search("alpha");
+    await key(projectInput, "Enter");
+    expect(push).toHaveBeenLastCalledWith("/projects/project-a");
+  });
+
+  it("keeps organization navigation available without an active project", async () => {
+    await act(async () => root.render(<CommandPalette projects={projects} />));
+    await key(document, "k", true);
+    const labels = [...container.querySelectorAll("button")].map((button) => button.textContent);
+    expect(labels).toEqual([
+      "projectsorg",
+      "org settingsorg",
+      "kickstart a projectorg",
+      "alphaswitch project",
+      "betaswitch project",
+    ]);
+    const input = await search("org settings");
+    await key(input, "Enter");
+    expect(push).toHaveBeenLastCalledWith("/settings");
+  });
+});


### PR DESCRIPTION
## What changes

Mount the existing command palette in both the project and organization layouts so Command+K and Ctrl+K open it.

Use the sidebar's project navigation list for the palette entries and remove the organization links to pages that no longer exist. Filtering, arrow-key selection and project switching still work. The usage guide now documents the shortcut.

This is a nonbreaking UI fix. It adds no dependencies and doesn't change stored data, APIs, permissions or budgets.

## Why

Closes https://github.com/theam/facility/issues/355

The topbar shows a shortcut that does nothing because the palette is never mounted. Its old destinations also need updating before people can use it.

## Verification

I ran the checks in a local Docker Sandbox microVM, with no host directories mounted.

- All six Vitest/jsdom tests passed. They cover both layouts, existing routes, filtering, keyboard selection, organization navigation and project switching.
- Web typecheck, the production build and `pnpm verify` passed.
- I also checked the production build in a browser with a local API fixture that returns fixed responses. All 16 checks passed, including opening and dismissing the palette, keyboard navigation, project switching and organization pages. There were no browser errors.

- [x] `pnpm verify` passes locally
- [x] Behaviour verified beyond the test suite (say how)
- [x] Documentation updated, or no user-facing change
