### PR TITLE
fix(insights): avoid loading webhook payloads for metrics

### DIFF
--- a/services/api/src/insights/overview.ts
+++ b/services/api/src/insights/overview.ts
@@ -11,8 +11,30 @@ import {
   turnUsage,
   workspaces,
 } from "@facility/db";
-import { and, desc, eq, gte } from "drizzle-orm";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 import type { CostBudgetService } from "./costs.js";
+
+// Insights only reads metric dimensions. Large webhook bodies, issue text, workspace
+// setup output and agent manifests must never be materialized for this overview.
+type TurnRow = Pick<typeof turns.$inferSelect, "state" | "createdAt">;
+type UsageRow = Pick<
+  typeof turnUsage.$inferSelect,
+  | "createdAt"
+  | "agentName"
+  | "model"
+  | "inputTokens"
+  | "outputTokens"
+  | "cacheReadTokens"
+  | "cacheWriteTokens"
+  | "costCents"
+  | "priced"
+  | "durationMs"
+>;
+type PullRow = Pick<
+  typeof githubPullRequests.$inferSelect,
+  "state" | "ciState" | "mergedAt" | "githubCreatedAt" | "repositoryId" | "number"
+>;
+type CiRow = Pick<typeof githubCiEvents.$inferSelect, "state" | "repositoryId" | "pullNumber">;
 
 export class InsightsService {
   constructor(
@@ -36,13 +58,24 @@ export class InsightsService {
       recentAudit,
     ] = await Promise.all([
       this.db
-        .select()
+        .select({ state: turns.state, createdAt: turns.createdAt })
         .from(turns)
         .where(
           and(eq(turns.orgId, orgId), eq(turns.projectId, projectId), gte(turns.createdAt, from)),
         ),
       this.db
-        .select()
+        .select({
+          createdAt: turnUsage.createdAt,
+          agentName: turnUsage.agentName,
+          model: turnUsage.model,
+          inputTokens: turnUsage.inputTokens,
+          outputTokens: turnUsage.outputTokens,
+          cacheReadTokens: turnUsage.cacheReadTokens,
+          cacheWriteTokens: turnUsage.cacheWriteTokens,
+          costCents: turnUsage.costCents,
+          priced: turnUsage.priced,
+          durationMs: turnUsage.durationMs,
+        })
         .from(turnUsage)
         .where(
           and(
@@ -52,11 +85,11 @@ export class InsightsService {
           ),
         ),
       this.db
-        .select()
+        .select({ state: workspaces.state })
         .from(workspaces)
         .where(and(eq(workspaces.orgId, orgId), eq(workspaces.projectId, projectId))),
       this.db
-        .select()
+        .select({ id: attentionItems.id })
         .from(attentionItems)
         .where(
           and(
@@ -66,7 +99,10 @@ export class InsightsService {
           ),
         ),
       this.db
-        .select()
+        .select({
+          total: sql<number>`count(*)::int`,
+          failed: sql<number>`count(*) filter (where ${githubWebhookEvents.error} is not null and ${githubWebhookEvents.error} <> '')::int`,
+        })
         .from(githubWebhookEvents)
         .where(
           and(
@@ -76,17 +112,28 @@ export class InsightsService {
           ),
         ),
       this.db
-        .select()
+        .select({ state: githubIssues.state })
         .from(githubIssues)
         .where(and(eq(githubIssues.orgId, orgId), eq(githubIssues.projectId, projectId))),
       this.db
-        .select()
+        .select({
+          state: githubPullRequests.state,
+          ciState: githubPullRequests.ciState,
+          mergedAt: githubPullRequests.mergedAt,
+          githubCreatedAt: githubPullRequests.githubCreatedAt,
+          repositoryId: githubPullRequests.repositoryId,
+          number: githubPullRequests.number,
+        })
         .from(githubPullRequests)
         .where(
           and(eq(githubPullRequests.orgId, orgId), eq(githubPullRequests.projectId, projectId)),
         ),
       this.db
-        .select()
+        .select({
+          state: githubCiEvents.state,
+          repositoryId: githubCiEvents.repositoryId,
+          pullNumber: githubCiEvents.pullNumber,
+        })
         .from(githubCiEvents)
         .where(
           and(
@@ -96,7 +143,9 @@ export class InsightsService {
           ),
         ),
       this.db
-        .select()
+        .select({
+          enabled: sql<boolean>`coalesce(${agentManifests.manifest}->'enabled', 'true'::jsonb) <> 'false'::jsonb`,
+        })
         .from(agentManifests)
         .where(and(eq(agentManifests.orgId, orgId), eq(agentManifests.projectId, projectId))),
       this.costs.budgetState(orgId, projectId, now),
@@ -112,7 +161,7 @@ export class InsightsService {
     const usage = usageSummary(usageRows);
     const daily = dailySeries(turnRows, usageRows, pullRows, from, now);
     const delivery = deliverySummary(pullRows, ciRows, from);
-    const failedWebhooks = webhooks.filter((event) => event.error).length;
+    const failedWebhooks = webhooks[0]?.failed ?? 0;
     const failedChecks = pullRows.filter(
       (pull) => pull.state === "open" && pull.ciState === "failure",
     ).length;
@@ -149,13 +198,11 @@ export class InsightsService {
         openIssues: issueRows.filter((issue) => issue.state === "open").length,
         openPullRequests: pullRows.filter((pull) => pull.state === "open").length,
         failedChecks,
-        webhookEvents: webhooks.length,
+        webhookEvents: webhooks[0]?.total ?? 0,
         failedWebhooks,
       },
       analytics: {
-        activeAgents: manifestRows.filter(
-          (row) => (row.manifest as { enabled?: unknown }).enabled !== false,
-        ).length,
+        activeAgents: manifestRows.filter((row) => row.enabled !== false).length,
         ...delivery,
       },
       attention: { open: openAttention.length },
@@ -167,7 +214,7 @@ export class InsightsService {
   }
 }
 
-function usageSummary(rows: Array<typeof turnUsage.$inferSelect>) {
+function usageSummary(rows: UsageRow[]) {
   return rows.reduce(
     (summary, row) => {
       summary.turns += 1;
@@ -194,9 +241,9 @@ function usageSummary(rows: Array<typeof turnUsage.$inferSelect>) {
 }
 
 function dailySeries(
-  turnRows: Array<typeof turns.$inferSelect>,
-  usageRows: Array<typeof turnUsage.$inferSelect>,
-  pullRows: Array<typeof githubPullRequests.$inferSelect>,
+  turnRows: TurnRow[],
+  usageRows: UsageRow[],
+  pullRows: PullRow[],
   from: Date,
   to: Date,
 ) {
@@ -250,11 +297,7 @@ function dailySeries(
   return [...days.values()];
 }
 
-function deliverySummary(
-  pullRows: Array<typeof githubPullRequests.$inferSelect>,
-  ciRows: Array<typeof githubCiEvents.$inferSelect>,
-  from: Date,
-) {
+function deliverySummary(pullRows: PullRow[], ciRows: CiRow[], from: Date) {
   const merged = pullRows.filter((pull) => pull.mergedAt && pull.mergedAt >= from);
   const observed = new Set(ciRows.map((event) => `${event.repositoryId}:${event.pullNumber}`));
   const failed = new Set(
@@ -284,10 +327,7 @@ function deliverySummary(
   };
 }
 
-function groupedUsage(
-  rows: Array<typeof turnUsage.$inferSelect>,
-  key: (row: typeof turnUsage.$inferSelect) => string,
-) {
+function groupedUsage(rows: UsageRow[], key: (row: UsageRow) => string) {
   return [...new Set(rows.map(key))].map((name) => ({
     name,
     ...usageSummary(rows.filter((row) => key(row) === name)),

--- a/services/api/test/insights-and-mirror.integration.test.ts
+++ b/services/api/test/insights-and-mirror.integration.test.ts
@@ -10,6 +10,7 @@ import {
   githubIssues,
   githubPullRequestReviews,
   githubPullRequests,
+  githubWebhookEvents,
   migrate,
   orgs,
   projectBudgets,
@@ -29,6 +30,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { GithubMirrorService, restCiSignal, webhookCiSignal } from "../src/github/mirror.js";
 import { GithubPipelineService } from "../src/github/pipeline.js";
 import { BudgetPolicyError, CostBudgetService } from "../src/insights/costs.js";
+import { InsightsService } from "../src/insights/overview.js";
 
 const databaseUrl =
   process.env.DATABASE_URL ?? "postgres://facility:facility@localhost:5461/facility_test";
@@ -154,6 +156,62 @@ describe("cost controls, GitHub mirror, and pipeline", async () => {
 
   afterAll(async () => {
     await client.end();
+  });
+
+  it("summarizes large webhook bodies in SQL without transferring their payloads", async () => {
+    const otherProjectId = newId("proj");
+    await db.insert(projects).values({
+      id: otherProjectId,
+      orgId,
+      name: "Other project",
+      slug: `other-project-${suffix}`,
+      settings: {},
+    });
+    await db.insert(githubWebhookEvents).values([
+      ...Array.from({ length: 32 }, (_, index) => ({
+        id: randomUUID(),
+        orgId,
+        projectId,
+        installationId,
+        eventType: "check_run",
+        payload: { body: "large-ignored-payload".repeat(8192) },
+        error: index === 0 ? "failed delivery" : index === 1 ? "" : null,
+      })),
+      {
+        id: randomUUID(),
+        orgId,
+        projectId: otherProjectId,
+        installationId,
+        eventType: "check_run",
+        payload: {},
+        error: "another project",
+      },
+    ]);
+    const queries: string[] = [];
+    const unsafe = client.unsafe.bind(client);
+    const spy = vi
+      .spyOn(client, "unsafe")
+      .mockImplementation((...args: Parameters<typeof client.unsafe>) => {
+        queries.push(args[0]);
+        return unsafe(...args);
+      });
+    try {
+      const insights = new InsightsService(db, new CostBudgetService(db));
+      const overview = await insights.overview(orgId, projectId);
+      expect(overview.github.webhookEvents).toBe(32);
+      expect(overview.github.failedWebhooks).toBe(1);
+      expect(overview.health).toBe("degraded");
+      const query = queries.find((text) => text.includes('from "github_webhook_events"'));
+      expect(query).toContain("count(*)");
+      expect(query).not.toContain('"payload"');
+      expect(query).not.toContain("select *");
+      expect(JSON.stringify(overview)).not.toContain("large-ignored-payload");
+      const foreign = await insights.overview(otherOrgId, projectId);
+      expect(foreign.github.webhookEvents).toBe(0);
+      expect(foreign.github.failedWebhooks).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("accounts one turn idempotently and blocks later turns after the monthly limit", async () => {

--- a/services/api/test/insights-overview.test.ts
+++ b/services/api/test/insights-overview.test.ts
@@ -1,0 +1,59 @@
+import { auditEvents, type FacilityDb, githubWebhookEvents, turns } from "@facility/db";
+import { describe, expect, it } from "vitest";
+import type { CostBudgetService } from "../src/insights/costs.js";
+import { InsightsService } from "../src/insights/overview.js";
+
+describe("insights metric projections", () => {
+  it("keeps webhook totals exact while refusing unbounded payload reads", async () => {
+    const now = new Date("2026-09-10T12:00:00Z");
+    const db = {
+      select(fields?: Record<string, unknown>) {
+        return {
+          from(table: unknown) {
+            if (table !== auditEvents) {
+              expect(fields).toBeDefined();
+              expect(Object.keys(fields ?? {})).not.toContain("payload");
+              expect(Object.keys(fields ?? {})).not.toContain("manifest");
+            }
+            if (table === githubWebhookEvents) {
+              expect(Object.keys(fields ?? {}).sort()).toEqual(["failed", "total"]);
+            }
+            const rows =
+              table === githubWebhookEvents
+                ? [{ total: 26031, failed: 7 }]
+                : table === turns
+                  ? [{ state: "succeeded", createdAt: now }]
+                  : [];
+            return {
+              where() {
+                return Object.assign(Promise.resolve(rows), {
+                  orderBy() {
+                    return { limit: async () => [] };
+                  },
+                });
+              },
+            };
+          },
+        };
+      },
+    } as unknown as FacilityDb;
+    const costs = {
+      async budgetState() {
+        return {
+          budget: null,
+          windowStart: now,
+          windowEnd: now,
+          spentCents: 0,
+          remainingCents: null,
+          percentUsed: null,
+          state: "not_configured",
+        };
+      },
+    } as unknown as CostBudgetService;
+    const result = await new InsightsService(db, costs).overview("org", "project", 30, now);
+    expect(result.github.webhookEvents).toBe(26031);
+    expect(result.github.failedWebhooks).toBe(7);
+    expect(result.turns.succeeded).toBe(1);
+    expect(result.health).toBe("degraded");
+  });
+});


### PR DESCRIPTION
## What changes

Insights counts webhook events and failures in PostgreSQL and selects only metric dimensions from the other overview tables. Webhook payloads, issue/PR bodies, workspace output and complete agent manifests no longer enter API memory for these metrics. Counts, date filters and tenant/project scope remain unchanged.

## Why

Opening production Insights coincided with both 1 GiB API tasks exiting with OOM (137). The affected project has 26,031 webhook records occupying approximately 148 MB in PostgreSQL; the overview previously selected and decoded all payloads merely to count events and errors. The application then returned 502/504 while ECS replaced the tasks.

## Verification

- 10 focused unit/integration tests pass against local PostgreSQL 16.14; no external credentials. The new tests fail against the previous implementation and pass with this change. They verify server-side counting, absence of payload transfer, exact failure totals, and isolation from another project/organization.
- API TypeScript and focused Biome checks pass.
- Read-only production diagnosis established row counts and stored size. The corrected API image is deployed in production. Three browser reloads of the affected Insights page succeeded; both API tasks remained running with their original 1 GiB limit, and readiness returned HTTP 200. The temporary 4 GiB mitigation has been removed.
- [x] All six required CI checks passed, including full `verify`, minimum-node, self-host-build and workspace-e2e. Local validation used the focused checks above.
- [x] Behaviour verified beyond the test suite — three successful production browser reloads; unchanged task identities confirm no restart during these checks. Automatic deployment re-enabled after the rollout completed.
- [x] Documentation updated, or no user-facing change — restores existing Insights behavior and metric semantics.
