### PR TITLE
fix(runner): rebuild Go tools with patched gRPC 1.83.2

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -35,7 +35,7 @@ RUN archive=/tmp/moby.tar.gz \
   && cd /src \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && VERSION="$MOBY_VERSION" DOCKER_GITCOMMIT="$MOBY_COMMIT" \
     EXCLUDE_AUTO_BUILDTAG_JOURNALD=1 SOURCE_DATE_EPOCH=1785456000 \
     GOFLAGS=-mod=mod ./hack/make.sh binary-daemon binary-proxy \
@@ -78,7 +78,7 @@ RUN archive=/tmp/containerd.tar.gz \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && make VERSION="v${CONTAINERD_VERSION}" REVISION="$CONTAINERD_COMMIT" STATIC=1 \
     GO_BUILD_FLAGS='-mod=mod -trimpath' \
     bin/containerd bin/containerd-shim-runc-v2 bin/ctr \
@@ -117,7 +117,7 @@ RUN archive=/tmp/buildx.tar.gz \
   && go mod edit -replace=github.com/moby/go-archive=github.com/moby/go-archive@v0.3.0 \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && CGO_ENABLED=0 go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/docker/buildx/version.Version=${BUILDX_VERSION} \
       -X github.com/docker/buildx/version.Revision=${BUILDX_COMMIT} \
@@ -139,7 +139,7 @@ RUN archive=/tmp/compose.tar.gz \
   && cd /src \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && CGO_ENABLED=0 GOMAXPROCS=1 go build -p=1 -mod=mod -trimpath -tags=e2e \
     -ldflags="-s -w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
     -o /out/docker-compose ./cmd \
@@ -174,7 +174,7 @@ RUN archive=/tmp/gh.tar.gz \
   && cd /src \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && CGO_ENABLED=0 GOTOOLCHAIN=local go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/cli/cli/v2/internal/build.Version=${GH_VERSION} \
       -X github.com/cli/cli/v2/internal/build.Date=2026-07-31" \
@@ -199,7 +199,7 @@ RUN for binary in /out/*; do \
   done \
   && for binary in /out/dockerd /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \
-      '$1 == "=>" && $2 == "google.golang.org/grpc" && $3 == "v1.83.1" { found = 1 } END { exit !found }' || exit 1; \
+      '$1 == "=>" && $2 == "google.golang.org/grpc" && $3 == "v1.83.2" { found = 1 } END { exit !found }' || exit 1; \
   done \
   && for binary in /out/dockerd /out/containerd /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -242,8 +243,68 @@ test("runner Go binaries resolve the fixed cryptography and gRPC modules", () =>
   );
   assert.match(
     runnerDockerfile,
-    /for binary in \/out\/dockerd \/out\/containerd \/out\/containerd-shim-runc-v2 \/out\/ctr \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*google\.golang\.org\/grpc" && \$3 == "v1\.83\.1"/,
+    /for binary in \/out\/dockerd \/out\/containerd \/out\/containerd-shim-runc-v2 \/out\/ctr \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*google\.golang\.org\/grpc" && \$3 == "v1\.83\.2"/,
   );
+});
+
+test("every gRPC-bearing source build replaces the vulnerable module", () => {
+  assert.doesNotMatch(runnerDockerfile, /google\.golang\.org\/grpc[^\n]*v1\.83\.1/);
+  for (const stage of [
+    "moby-build",
+    "containerd-build",
+    "buildx-build",
+    "compose-build",
+    "gh-build",
+  ]) {
+    const sourceBuild = runnerDockerfile.split(` AS ${stage}\n`)[1]?.split("\nFROM ")[0];
+    assert.ok(sourceBuild, `missing source build ${stage}`);
+    assert.match(
+      sourceBuild,
+      /go mod edit -replace=google\.golang\.org\/grpc=google\.golang\.org\/grpc@v1\.83\.2\s/,
+      `${stage} must rebuild against the fixed gRPC module`,
+    );
+  }
+});
+
+test("the executable gRPC audit accepts fixed modules and rejects unsafe binaries", () => {
+  // Execute the Dockerfile's actual shell loop with deterministic go-version output.
+  // This checks the gate itself without requiring registries or a Go toolchain.
+  const audit = [...runnerDockerfile.matchAll(/for binary in ([^;]+); do[\s\S]*?\n {2}done/g)].find(
+    ([loop]) => loop.includes('"google.golang.org/grpc"'),
+  );
+  assert.ok(audit, "missing executable gRPC audit");
+  const binaries = audit[1].split(" ");
+  assert.equal(binaries.length, 7);
+  const command = `
+    go() {
+      if [ "$3" = "$AUDIT_TEST_BINARY" ]; then
+        case "$AUDIT_TEST_FAILURE" in
+          outdated) printf '=> google.golang.org/grpc v1.83.1\\n'; return ;;
+          missing) printf 'dep example.com/unrelated v1.0.0\\n'; return ;;
+          error) return 1 ;;
+        esac
+      fi
+      printf '=> google.golang.org/grpc v1.83.2\\n'
+    }
+    ${audit[0].replaceAll(/\\\n/g, " ")}
+  `;
+  const runAudit = (binary = "", failure = "") =>
+    spawnSync("sh", ["-c", command], {
+      encoding: "utf8",
+      env: { ...process.env, AUDIT_TEST_BINARY: binary, AUDIT_TEST_FAILURE: failure },
+    });
+  const accepted = runAudit();
+  assert.equal(accepted.status, 0, accepted.stderr);
+  for (const binary of binaries) {
+    for (const failure of ["outdated", "missing", "error"]) {
+      const rejected = runAudit(binary, failure);
+      assert.equal(
+        rejected.status,
+        1,
+        `${binary}: ${failure} must fail closed: ${rejected.stderr}`,
+      );
+    }
+  }
 });
 
 test("Vercel runner supports SDK user switching without granting node sudo privileges", () => {


### PR DESCRIPTION
## Summary

Rebuild the runner's Go tools with `google.golang.org/grpc` **v1.83.2** instead of v1.83.1. This fixes the dependency finding that currently prevents the runner image from passing the existing High/Critical security gate.

The upstream advisory [GHSA-2v4p-qf9q-27wj / CVE-2026-84445](https://github.com/grpc/grpc-go/security/advisories/GHSA-2v4p-qf9q-27wj) marks versions through v1.83.1 as affected and identifies [v1.83.2](https://github.com/grpc/grpc-go/releases/tag/v1.83.2) as a patched release. This is evidence of an affected embedded dependency, not a claim that the vulnerable xDS server path is reachable in Facility.

## Evidence and change

A fresh image scan of source `3df64040e070d5d0fc33ff60d5bda2c7770add2e` passed for API and web but failed for the runner. The finding identified gRPC v1.83.1 in seven binaries: `dockerd`, `containerd`, `containerd-shim-runc-v2`, `ctr`, `docker-buildx`, `docker-compose`, and `gh`.

- Update all five relevant source-build module replacements: Moby, containerd, Buildx, Compose, and GitHub CLI.
- Update the existing executable build-info audit to require v1.83.2 in all seven binaries.
- Test every source-build pin and execute the actual Dockerfile audit loop with deterministic Go build-info fixtures: all patched binaries succeed; an outdated module, missing module, or inspection failure in any one binary fails the gate.
- Preserve source commits/checksums, compiler and image pins, other module versions, runner permissions, and scanner policy. **No vulnerability exceptions are added.**

## Validation

- `node --test scripts/images.test.mjs`: **12 passed**, no skips.
- Regression check: the executable-audit test fails against the previous v1.83.1 Dockerfile, then passes after the update. Negative fixtures cover all seven binaries.
- `pnpm exec biome check scripts/images.test.mjs`: passed.
- `git diff --check`: passed.
- Full `pnpm verify`: **passed** locally against uniquely scoped disposable PostgreSQL test databases, including uncached build/typecheck, critical integration suites, remaining tests, repository guards, and the existing dependency-audit policy. The final dependency audit reports two existing ignored High findings; this PR adds no exceptions and does not claim a zero-finding dependency tree.
- Required CI image builds and Docker workspace E2E: pending PR checks.
- Fresh runner vulnerability scan: pending rebuild; this PR does not itself establish a successful production rollout.

## Release and rollout

Patch release (`fix(runner)`). Human review and merge remain required. After merge and green required main checks, rebuild/rescan through the existing deployment pipeline; proceed to migration and rollout only if the unchanged security gate passes.
