### PR TITLE
fix(runner): rebuild tools with patched grpc 1.83.2

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -35,7 +35,7 @@ RUN archive=/tmp/moby.tar.gz \
   && cd /src \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && VERSION="$MOBY_VERSION" DOCKER_GITCOMMIT="$MOBY_COMMIT" \
     EXCLUDE_AUTO_BUILDTAG_JOURNALD=1 SOURCE_DATE_EPOCH=1785456000 \
     GOFLAGS=-mod=mod ./hack/make.sh binary-daemon binary-proxy \
@@ -78,7 +78,7 @@ RUN archive=/tmp/containerd.tar.gz \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/net=golang.org/x/net@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && make VERSION="v${CONTAINERD_VERSION}" REVISION="$CONTAINERD_COMMIT" STATIC=1 \
     GO_BUILD_FLAGS='-mod=mod -trimpath' \
     bin/containerd bin/containerd-shim-runc-v2 bin/ctr \
@@ -117,7 +117,7 @@ RUN archive=/tmp/buildx.tar.gz \
   && go mod edit -replace=github.com/moby/go-archive=github.com/moby/go-archive@v0.3.0 \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && CGO_ENABLED=0 go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/docker/buildx/version.Version=${BUILDX_VERSION} \
       -X github.com/docker/buildx/version.Revision=${BUILDX_COMMIT} \
@@ -139,7 +139,7 @@ RUN archive=/tmp/compose.tar.gz \
   && cd /src \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && CGO_ENABLED=0 GOMAXPROCS=1 go build -p=1 -mod=mod -trimpath -tags=e2e \
     -ldflags="-s -w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
     -o /out/docker-compose ./cmd \
@@ -174,7 +174,7 @@ RUN archive=/tmp/gh.tar.gz \
   && cd /src \
   && go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.56.0 \
   && go mod edit -replace=golang.org/x/mod=golang.org/x/mod@v0.40.0 \
-  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.1 \
+  && go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.83.2 \
   && CGO_ENABLED=0 GOTOOLCHAIN=local go build -mod=mod -trimpath \
     -ldflags="-s -w -X github.com/cli/cli/v2/internal/build.Version=${GH_VERSION} \
       -X github.com/cli/cli/v2/internal/build.Date=2026-07-31" \
@@ -199,7 +199,7 @@ RUN for binary in /out/*; do \
   done \
   && for binary in /out/dockerd /out/containerd /out/containerd-shim-runc-v2 /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \
-      '$1 == "=>" && $2 == "google.golang.org/grpc" && $3 == "v1.83.1" { found = 1 } END { exit !found }' || exit 1; \
+      '$1 == "=>" && $2 == "google.golang.org/grpc" && $3 == "v1.83.2" { found = 1 } END { exit !found }' || exit 1; \
   done \
   && for binary in /out/dockerd /out/containerd /out/ctr /out/docker-buildx /out/docker-compose /out/gh; do \
     go version -m "$binary" | awk \

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -235,6 +235,7 @@ test("workspace CI runs the persistent Docker acceptance path", () => {
 });
 
 test("runner Go binaries resolve the fixed cryptography and gRPC modules", () => {
+  assert.doesNotMatch(runnerDockerfile, /google\.golang\.org\/grpc@v1\.83\.1/);
   assert.doesNotMatch(runnerDockerfile, /golang\.org\/x\/crypto@v0\.55\.0/);
   assert.match(
     runnerDockerfile,
@@ -242,7 +243,7 @@ test("runner Go binaries resolve the fixed cryptography and gRPC modules", () =>
   );
   assert.match(
     runnerDockerfile,
-    /for binary in \/out\/dockerd \/out\/containerd \/out\/containerd-shim-runc-v2 \/out\/ctr \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*google\.golang\.org\/grpc" && \$3 == "v1\.83\.1"/,
+    /for binary in \/out\/dockerd \/out\/containerd \/out\/containerd-shim-runc-v2 \/out\/ctr \/out\/docker-buildx \/out\/docker-compose \/out\/gh; do[\s\S]*google\.golang\.org\/grpc" && \$3 == "v1\.83\.2"/,
   );
 });
 


### PR DESCRIPTION
## What changes

Rebuild the runner's Docker daemon, containerd tools, Buildx, Compose and GitHub CLI with gRPC 1.83.2. The image-build audit verifies the patched module version inside every affected executable.

## Why

The production runner scan found GHSA-2v4p-qf9q-27wj / CVE-2026-84445 in seven executables built with gRPC 1.83.1, blocking the automatic deployment that includes the story usability improvements. The upstream fix is 1.83.2: https://github.com/advisories/GHSA-2v4p-qf9q-27wj.

## Verification

- 10 image workflow tests pass, including rejection of the old gRPC override and verification of the binary-audit requirement.
- CI builds the actual binaries, checks their embedded dependency versions and exercises the Docker workspace lifecycle and Vercel user switching.
- Production promotion remains gated by the existing fixed High/Critical vulnerability scan; no suppression or threshold changes.

- [ ] `pnpm verify` passes locally — targeted image tests pass; full verification runs in CI.
- [x] Behaviour verified beyond the test suite — production run 34488187059 passed all three exact-digest scans and deployed successfully. ECS API 26, worker 19 and web 8 are stable on source 9f732b21b913b62c6bfdfcc5ff73c94c8f23a59f; /readyz returns 200. Authenticated browser verification confirms the new story UI and Insights load.
- [x] Documentation updated, or no user-facing change — dependency security fix only.
