### PR TITLE
fix(turns): carry the asked question into a rebuilt prompt

### DIFF
--- a/services/api/src/turns/dispatcher.ts
+++ b/services/api/src/turns/dispatcher.ts
@@ -1,6 +1,7 @@
 import { type AgentManifest, AgentManifestSchema } from "@facility/agents";
 import { newId } from "@facility/core";
 import {
+  attentionItems,
   engineSessions,
   type FacilityDb,
   stories,
@@ -108,7 +109,7 @@ export class TurnDispatcher {
         });
       }
       await appendTurnEvent(this.db, { ...eventBase, type: "turn.started", data: {} });
-      const [story, workspace, conversation, messages] = await Promise.all([
+      const [story, workspace, conversation, messages, attention] = await Promise.all([
         this.scopedStory(input.orgId, input.projectId, turn.storyId),
         this.activeWorkspace(input.orgId, input.projectId, turn.storyId),
         this.db
@@ -134,6 +135,17 @@ export class TurnDispatcher {
             ),
           )
           .orderBy(asc(storyMessages.seq)),
+        this.db
+          .select()
+          .from(attentionItems)
+          .where(
+            and(
+              eq(attentionItems.orgId, input.orgId),
+              eq(attentionItems.projectId, input.projectId),
+              eq(attentionItems.storyId, turn.storyId),
+            ),
+          )
+          .orderBy(asc(attentionItems.createdAt)),
       ]);
       if (!workspace || !conversation)
         throw new Error("story workspace or conversation is missing");
@@ -202,7 +214,7 @@ export class TurnDispatcher {
         turnId: turn.id,
         manifest,
         workspace: workspaceLocator(workspace),
-        prompt: buildPrompt(manifest, story, conversation.summary, messages, turn.id),
+        prompt: buildPrompt(manifest, story, conversation.summary, messages, attention, turn.id),
         cwd: prepared.primaryCwd,
         nativeSessionId: session?.nativeSessionId,
         environment: prepared.processEnvironment,
@@ -593,6 +605,7 @@ function buildPrompt(
   story: typeof stories.$inferSelect,
   summary: string | null,
   messages: Array<typeof storyMessages.$inferSelect>,
+  attention: Array<typeof attentionItems.$inferSelect>,
   turnId: string,
 ) {
   const currentSequence = messages.find(
@@ -601,10 +614,16 @@ function buildPrompt(
   const relevant = messages.filter(
     (message) => currentSequence === undefined || message.seq <= currentSequence,
   );
+  const questions = askedQuestions(attention);
   const transcript = relevant
-    .map(
-      (message) => `${message.role.toUpperCase()} (${actorLabel(message.actor)}):\n${message.body}`,
-    )
+    .map((message) => {
+      const body = `${message.role.toUpperCase()} (${actorLabel(message.actor)}):\n${message.body}`;
+      // Both the user and the agent message of a turn carry its `turnId`, so the
+      // question is placed on the agent message that actually asked it.
+      const asked =
+        message.role === "agent" && message.turnId ? questions.get(message.turnId) : undefined;
+      return asked ? `${body}\n\n${QUESTION_HEADING}\n${asked.join("\n")}` : body;
+    })
     .join("\n\n");
   return [
     manifest.prompt,
@@ -616,6 +635,27 @@ function buildPrompt(
   ]
     .filter(Boolean)
     .join("\n\n");
+}
+
+const QUESTION_HEADING = "Question this turn asked the human:";
+
+// `agentOutcome` strips the <facility-needs-attention> question out of the agent's
+// message before it is persisted, so the question survives only on the attention
+// item. An engine resuming its own native session still holds it in context, but a
+// prompt rebuilt for a session that does not exist — a reply routed to a different
+// agent, or a replaced session — would otherwise show the human's answer with
+// nothing it answers. Status is deliberately not filtered: dispatch resolves the
+// item as `replied` before the prompt is built, so an open-only filter would drop
+// exactly the question being answered.
+function askedQuestions(attention: Array<typeof attentionItems.$inferSelect>) {
+  const questions = new Map<string, string[]>();
+  for (const item of attention) {
+    if (item.kind !== "agent_waiting" || !item.turnId || !item.detail) continue;
+    const asked = questions.get(item.turnId);
+    if (asked) asked.push(item.detail);
+    else questions.set(item.turnId, [item.detail]);
+  }
+  return questions;
 }
 
 function actorLabel(actor: unknown) {

--- a/services/api/test/turn-dispatcher.integration.test.ts
+++ b/services/api/test/turn-dispatcher.integration.test.ts
@@ -491,6 +491,70 @@ environment:
     ]);
   });
 
+  it("carries the asked question into a prompt rebuilt for a different agent", async () => {
+    const reviewer = parseAgentManifest(
+      `---
+name: reviewer
+description: Reviews stories.
+engine: codex
+model: gpt-5.5-codex
+enabled: true
+triggers:
+  - type: manual
+---
+Review the request.
+`,
+      ".agents/reviewer.md",
+    );
+    engine.outputOverride =
+      "Blocked on one decision.\n\n<facility-needs-attention>Should existing JSON exports remain available?</facility-needs-attention>";
+    const started = await storiesService.start({
+      orgId,
+      projectId,
+      provider: "github",
+      externalId: `handoff-${suffix}`,
+      title: "Decide the export policy",
+      agent: builder,
+      message: "Plan the export change",
+      messageDedupeKey: `handoff-start-${suffix}`,
+      actor: { type: "user", id: "user_test" },
+      workspace: { image: "facility-runner:test", ports: [] },
+    });
+    const askingTurn = started.queued.turn;
+    if (!askingTurn) throw new Error("expected the asking turn");
+    await dispatcher.dispatch({ orgId, projectId, turnId: askingTurn.id });
+
+    engine.outputOverride = undefined;
+    // A different agent has no engine session of its own, so the engine is handed a
+    // rebuilt prompt rather than resuming native context.
+    const reply = await storiesService.queueMessage({
+      orgId,
+      projectId,
+      storyId: started.story.id,
+      body: "No, continue.",
+      dedupeKey: `handoff-reply-${suffix}`,
+      agent: reviewer,
+      actor: { type: "user", id: "user_test" },
+      trigger: { type: "manual" },
+    });
+    if (!reply.turn) throw new Error("expected the reply turn");
+    await dispatcher.dispatch({ orgId, projectId, turnId: reply.turn.id });
+
+    const rebuilt = engine.requests.at(-1);
+    expect(rebuilt?.nativeSessionId).toBeUndefined();
+    expect(rebuilt?.prompt).toContain("Should existing JSON exports remain available?");
+    expect(rebuilt?.prompt).toContain("No, continue.");
+    // The question belongs to the agent turn that asked it, once.
+    expect(rebuilt?.prompt.match(/Should existing JSON exports remain available\?/g)?.length).toBe(
+      1,
+    );
+    const askedIndex =
+      rebuilt?.prompt.indexOf("Should existing JSON exports remain available?") ?? -1;
+    const repliedIndex = rebuilt?.prompt.indexOf("No, continue.") ?? -1;
+    expect(askedIndex).toBeGreaterThan(-1);
+    expect(repliedIndex).toBeGreaterThan(askedIndex);
+  });
+
   it("claims a turn once even when dispatch is repeated", async () => {
     const rows = await db
       .select()


### PR DESCRIPTION
## What changes

A prompt rebuilt for an agent with no native session now carries the
`<facility-needs-attention>` question that the human's reply is answering. The
question is rendered against the agent message that asked it, so the transcript
reads question then answer.

## Why

Closes #344.

`agentOutcome` (`dispatcher.ts:669-674`) strips the question out of the output, and
`completeTurn` persists only the stripped body, so the question survives on the
attention item alone. `buildPrompt` builds its transcript purely from
`story_messages`. An engine resuming its own native session still holds the
question in context, which is why this is invisible on the common path. When the
reply goes to a different agent, the session lookup keys on
`agentName + engine + model` (`dispatcher.ts:169-177`), no session matches, and the
rebuilt prompt is all the agent gets: `No, continue.` with nothing it answers.

Two details are worth naming, because both are easy to get wrong.

Attention status is deliberately not filtered. Dispatch resolves the item as
`replied` at `dispatcher.ts:100-107`, *before* the prompt is built, so an
`status === "open"` filter would drop precisely the question being answered.

The question is placed on the agent message only. Both the user and the agent
message of a turn carry that turn's `turnId` (`stories/service.ts:367`), so keying
on `turnId` alone renders the question twice and once in the wrong place.

Only `agent_waiting` items are rendered; `queued_turn_dispatch_error` is an
operational failure rather than a question. Details are already redacted at write
time via `redactString`, so nothing new is exposed.

## Verification

New integration test: a builder asks a question, the reply is routed to a
different agent, and the rebuilt prompt is asserted to contain the question, the
answer, the question exactly once, and in that order. It also asserts
`nativeSessionId` is undefined, so the test fails rather than silently passing if
the fresh-session premise ever stops holding.

Mutating `dispatcher.ts` on this branch, running `turn-dispatcher.integration.test.ts`:

| mutation | new test | other 9 tests |
|---|---|---|
| drop the question rendering | fails | pass |
| filter attention to `status === "open"` | fails | pass |
| drop the `role === "agent"` guard (question renders twice) | fails | pass |

Each mutation is caught only by the new test, so the assertion is load-bearing
rather than incidental. The middle row is the one the existing suite could never
have caught.

Full runs, `services/api`, split across the databases the suite expects:

- `facility_test` (all but the e2e journey): 43 files passed, 407 tests.
- `facility_ws` (`facility-012.e2e.integration.test.ts`): 2/2, exit 0.
- `pnpm verify`: exit 0. Guards 2/2, audit clean against the ignore list.

One pre-existing failure, `test/oauth.test.ts` (`500` on dev login), is unrelated
and reproduces without this change. Same command, same freshly created database,
this branch stashed: `main` gives 406 passed with that same single failure, this
branch 407 with the same single failure. The delta is exactly the one added test.

## Note for @Yeeway69

The reproducer in the issue asserts a sha256 of `dispatcher.ts` to pin the
revision, and the file has changed since `c14bc6d` (in `b2a9b47`), so the script
now aborts on that assertion rather than running. The defect itself was untouched
by that commit and reproduces on current `main`. Thanks for isolating the seam so
precisely, it made this a small change.
