### PR TITLE
fix(runner): refresh patched Chromium packages

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -219,7 +219,8 @@ FROM node:24-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf23286
 # Bump this audited epoch only when a scanner identifies a distro fix that the
 # official image has not incorporated yet; using it in the command makes that
 # refresh explicit and reproducible instead of disabling the whole build cache.
-ARG DEBIAN_SECURITY_REFRESH=20260905
+ARG DEBIAN_SECURITY_REFRESH=20260910
+ARG CHROMIUM_MIN_VERSION=152.0.7977.82-1~deb13u1
 RUN test -n "$DEBIAN_SECURITY_REFRESH" \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
@@ -272,6 +273,8 @@ RUN test -n "$DEBIAN_SECURITY_REFRESH" \
     util-linux \
     xfonts-scalable \
     xvfb \
+  && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' chromium)" ge "$CHROMIUM_MIN_VERSION" \
+  && dpkg --compare-versions "$(dpkg-query -W -f='${Version}' chromium-common)" ge "$CHROMIUM_MIN_VERSION" \
   && rm -rf /var/lib/apt/lists/*
 
 # npm is a runtime capability for repositories that use package-lock.json, so

--- a/scripts/images.test.mjs
+++ b/scripts/images.test.mjs
@@ -260,3 +260,14 @@ test("Vercel runner supports SDK user switching without granting node sudo privi
   assert.doesNotMatch(vercelStage, /NOPASSWD/);
   assert.match(ciWorkflow, /docker build --target vercel-runner -f runner\/Dockerfile \./);
 });
+
+test("runner rejects Chromium packages older than the reviewed security fix", () => {
+  assert.match(runnerDockerfile, /ARG CHROMIUM_MIN_VERSION=152\.0\.7977\.82-1~deb13u1/);
+  for (const name of ["chromium", "chromium-common"]) {
+    assert.ok(
+      runnerDockerfile.includes(
+        `dpkg --compare-versions "$(dpkg-query -W -f='\${Version}' ${name})" ge "$CHROMIUM_MIN_VERSION"`,
+      ),
+    );
+  }
+});


### PR DESCRIPTION
## What changes

Refresh the runner's Debian package layer and require both installed Chromium packages to be at least `152.0.7977.82-1~deb13u1`. A build fails if a package mirror supplies an older version.

## Why

The image scan after #364 caught fixed High/Critical Chromium vulnerabilities in the cached `152.0.7977.75` packages. Debian's security tracker identifies the patched version: https://security-tracker.debian.org/tracker/CVE-2026-85046. Preserve the scanner gate and existing policy without suppressions.

## Verification

- [ ] `pnpm verify` passes locally (full suite runs in required CI)
- [x] Behaviour verified beyond the test suite: the image build compares actual installed Debian package versions; CI's Docker workspace acceptance builds that image. Local image regression tests pass (11 tests).
- [x] Documentation updated, or no user-facing change: dependency refresh only.

Required CI passes, including the real image build and Docker workspace end-to-end acceptance. The first self-host build hit a TLS timeout downloading lz4; the failed job passed on retry. Production already runs source 9f732b2 with freshly built images that passed all three fixed High/Critical gates; this follow-up ensures cached public builds also refresh Chromium.
