### PR TITLE
test(guards): fail when a documented CLI flag is missing from the parser

### DIFF
--- a/guards/documented-cli-flags.mjs
+++ b/guards/documented-cli-flags.mjs
@@ -1,0 +1,82 @@
+// A documented CLI flag that the real parser silently rejects is not a typo
+// a reader notices — it fails at runtime with "Unknown option", after
+// someone already shipped an issue, a review comment, or a support answer
+// built on the doc. This guard reads the flag tables published in
+// apps/docs/docs/reference/cli.md and the flag allowlist inside
+// `validateLocalFlags` in packages/cli/src/cli.mjs, and fails when a
+// documented flag is missing from the real allowlist for that command.
+//
+// Scope: only the `| Flag | Purpose |` table cells under a `## `facility
+// <command>`` heading in cli.md are parsed — never README.md or free-flowing
+// prose. Facility's own flag values routinely embed other tools' flags as
+// literal strings, e.g. `--provision='pnpm install --frozen-lockfile'` and
+// `--preview-readiness-command='curl --fail http://localhost:3000/health'`
+// in README.md. A generic `--\w+` scan over prose would misread those as
+// documented Facility flags and fail on tools this repository does not own.
+// The structured table has no such embedded values in its cells.
+import { readText } from "./_kit.mjs";
+
+const CLI_DOC = "apps/docs/docs/reference/cli.md";
+const CLI_SOURCE = "packages/cli/src/cli.mjs";
+
+/** Flags documented in cli.md's `| Flag | Purpose |` tables, by command. */
+export function documentedFlags(markdown) {
+  const byCommand = new Map();
+  let command = null;
+  markdown.split("\n").forEach((line, index) => {
+    const heading = line.match(/^## `facility ([a-z]+)/);
+    if (heading) {
+      command = heading[1];
+      return;
+    }
+    if (!command || !line.startsWith("|")) return;
+    if (/^\|\s*-+\s*\|/.test(line) || /^\|\s*Flag\s*\|/i.test(line)) return;
+
+    const firstCell = line.split("|")[1] ?? "";
+    for (const match of firstCell.matchAll(/`--([a-z0-9-]+)(?:=[^`]*)?`/g)) {
+      if (!byCommand.has(command)) byCommand.set(command, []);
+      byCommand.get(command).push({ flag: match[1], line: index + 1 });
+    }
+  });
+  return byCommand;
+}
+
+/** The real per-command flag allowlist, read out of cli.mjs's own source. */
+export function realFlags(source, command) {
+  const match = source.match(new RegExp(`\\b${command}:\\s*new Set\\(\\[([\\s\\S]*?)\\]\\)`));
+  if (!match) return null;
+  return new Set([...match[1].matchAll(/"([a-z0-9-]+)"/g)].map((m) => m[1]));
+}
+
+export default {
+  name: "documented-cli-flags",
+  description: "CLI flags documented in cli.md exist in the real flag allowlist",
+  run() {
+    const markdown = readText(CLI_DOC);
+    const source = readText(CLI_SOURCE);
+    if (!markdown) return [{ file: CLI_DOC, message: "expected file not found" }];
+    if (!source) return [{ file: CLI_SOURCE, message: "expected file not found" }];
+
+    const violations = [];
+    for (const [command, flags] of documentedFlags(markdown)) {
+      const allowlist = realFlags(source, command);
+      if (!allowlist) {
+        violations.push({
+          file: CLI_SOURCE,
+          message: `cli.md documents \`facility ${command}\` but validateLocalFlags has no allowlist for it`,
+        });
+        continue;
+      }
+      for (const { flag, line } of flags) {
+        if (!allowlist.has(flag)) {
+          violations.push({
+            file: CLI_DOC,
+            line,
+            message: `--${flag} is documented for \`facility ${command}\` but is not in the real flag allowlist (packages/cli/src/cli.mjs)`,
+          });
+        }
+      }
+    }
+    return violations;
+  },
+};

--- a/scripts/documented-cli-flags-guard.test.mjs
+++ b/scripts/documented-cli-flags-guard.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { documentedFlags, realFlags } from "../guards/documented-cli-flags.mjs";
+
+const SAMPLE_DOC = [
+  "## `facility init`",
+  "",
+  "| Flag | Purpose |",
+  "| --- | --- |",
+  "| `--dir=<path>` | Configure another repository directory. |",
+  "| `--yes`, `-y` | Run without interactive confirmation. |",
+  "| `--auth=<mode>` | Set the authentication mode. |",
+  "",
+  "## `facility doctor`",
+  "",
+  "Use `--dir=<path>` to inspect another checkout.",
+].join("\n");
+
+const SAMPLE_SOURCE = [
+  "const allowed = {",
+  "    init: new Set([",
+  '      "yes",',
+  '      "force",',
+  '      "dir",',
+  "    ]),",
+  '    doctor: new Set(["dir", "json", "help"]),',
+  "  }[command];",
+].join("\n");
+
+test("documentedFlags reads only table cells under a `facility <command>` heading", () => {
+  const byCommand = documentedFlags(SAMPLE_DOC);
+  assert.deepEqual(
+    byCommand.get("init").map((f) => f.flag),
+    ["dir", "yes", "auth"],
+  );
+  // Prose outside a table (the doctor `--dir=<path>` sentence) is not a table row and is ignored.
+  assert.equal(byCommand.has("doctor"), false);
+});
+
+test("documentedFlags records the doc line number for each flag", () => {
+  const byCommand = documentedFlags(SAMPLE_DOC);
+  const auth = byCommand.get("init").find((f) => f.flag === "auth");
+  assert.equal(auth.line, 7);
+});
+
+test("realFlags reads the quoted flag names out of a command's allowlist Set", () => {
+  assert.deepEqual([...realFlags(SAMPLE_SOURCE, "init")].sort(), ["dir", "force", "yes"]);
+  assert.deepEqual([...realFlags(SAMPLE_SOURCE, "doctor")].sort(), ["dir", "help", "json"]);
+});
+
+test("realFlags returns null for a command absent from the allowlist", () => {
+  assert.equal(realFlags(SAMPLE_SOURCE, "instance"), null);
+});
+
+test("a flag documented but missing from the allowlist is exactly what the guard must catch", () => {
+  const documented = documentedFlags(SAMPLE_DOC).get("init");
+  const allowlist = realFlags(SAMPLE_SOURCE, "init");
+  const undocumented = documented.filter((f) => !allowlist.has(f.flag));
+  assert.deepEqual(
+    undocumented.map((f) => f.flag),
+    ["auth"],
+  );
+});


### PR DESCRIPTION
## What changes

Adds `guards/documented-cli-flags.mjs`, which fails when a CLI flag documented
in the `| Flag | Purpose |` table of `apps/docs/docs/reference/cli.md` is
missing from the real per-command flag allowlist enforced by
`validateLocalFlags` in `packages/cli/src/cli.mjs`. Adds
`scripts/documented-cli-flags-guard.test.mjs` (5 unit tests) for the guard's
two exported parsing helpers, following the existing
`scripts/markdown-links-guard.test.mjs` pattern.

After this merges, `node guards/run.mjs` (and CI's guard step) also fails
when someone documents a `facility init` flag in `cli.md` that the real flag
parser does not accept.

## Why

The repository has two guards today: `actions-pinned` checks GitHub Actions
SHA pins, and `markdown-links` checks that Markdown links resolve to real
files (confirmed by reading both files in full). Neither compares a
documentation claim against the CLI's actual behavior — this adds that class
of check for the first time.

`guards/run.mjs` states its own design goal: "adding a new safety invariant
is a single small file — easy for engineers and for agents to extend"
(`guards/run.mjs:27-28`). This PR is exactly that: one new guard file plus
its test.

This is not a fix for a broken state. `cli.md` and `cli.mjs` are consistent
right now:

```
$ node guards/run.mjs
✓ actions-pinned
✓ documented-cli-flags
✓ markdown-links

3 guards ran, 0 failed.
```

It's a preventive check for a comparison this repository has never
automated. No linked issue — this came out of reviewing the project rather
than from the tracker.

Scope is deliberately narrow: only the `| Flag | Purpose |` table cells
under a `## `facility <command>`` heading in `cli.md` are parsed — never
README.md or general prose. README.md's own CLI examples embed other tools'
flags as literal string values (`--provision='pnpm install
--frozen-lockfile'`, `--preview-readiness-command='curl --fail
http://localhost:3000/health'`); a generic `--\w+` regex over prose would
misreport `--frozen-lockfile` and `--fail` as undocumented Facility flags.
The structured table has no such embedded values in its cells, so this scope
avoids that entire class of false positive. The real allowlist is read as
literal source text out of `cli.mjs` (`command: new Set([...])`), not
imported or executed, keeping the guard read-only and consistent with the
"deterministic, read-only" guard contract in `guards/_kit.mjs`.

## Verification

Fault injection, to confirm the guard actually catches what it claims to
catch (applied manually, confirmed, then reverted — not part of this diff):
added `` | `--auth=<mode>` | Set the authentication mode. | `` as a
fictitious row to the `facility init` table in `cli.md`.

```
$ node guards/run.mjs
✓ actions-pinned
✗ documented-cli-flags
    apps/docs/docs/reference/cli.md:36  --auth is documented for `facility init` but is not in the real flag allowlist (packages/cli/src/cli.mjs)
✓ markdown-links

3 guards ran, 1 failed.
```

New test file:

```
$ node --test scripts/documented-cli-flags-guard.test.mjs
✔ documentedFlags reads only table cells under a `facility <command>` heading
✔ documentedFlags records the doc line number for each flag
✔ realFlags reads the quoted flag names out of a command's allowlist Set
✔ realFlags returns null for a command absent from the allowlist
✔ a flag documented but missing from the allowlist is exactly what the guard must catch
ℹ tests 5, pass 5, fail 0
```

`pnpm typecheck`: 14/14 packages pass.

`pnpm lint` and `node --test scripts/*.test.mjs` have pre-existing failures
on this Windows machine unrelated to this change — confirmed by removing the
two new files and reproducing the same failures. `pnpm lint`'s 275 errors
are CRLF line-ending diffs on files this PR does not touch (Windows checkout
without `core.autocrlf` enforcement); the two new files are not among them.
The `node --test` failures (npm-publish/registry, Docker image promotion,
gRPC binary audit suites) fail with `tar (child): Cannot connect to C:
resolve failed` — GNU tar (via Git Bash) misreading a Windows `C:\...` path
as a `host:path` remote-shell target — unrelated to this diff.

Known risks / follow-up: the guard only checks the `facility init` table
today, since it's the only command with a `| Flag | Purpose |` table in
`cli.md`; it extends automatically if a similar table is added for `doctor`
or `instance bootstrap` later. It does not flag the reverse case: a real
flag accepted but undocumented. `--org` is in `init`'s allowlist
(`packages/cli/src/cli.mjs:118`) but not in `cli.md`'s table or in
`facility --help`'s flag summary. Catching that direction would need a
different heuristic to avoid false positives on genuinely
internal/undocumented flags, so it's left out of scope here.

- [ ] `pnpm verify` passes locally — **not run to completion.** It fails
      immediately on this machine with `spawnSync docker ENOENT`: Docker is
      not installed here, and `pnpm verify` starts by checking/starting a
      Docker-backed PostgreSQL before anything else runs. `pnpm typecheck`,
      `pnpm lint`, `node guards/run.mjs`, and `node --test scripts/*.test.mjs`
      were run individually instead (see above); relying on CI, which has
      Docker, for the full `pnpm verify` pass.
- [x] Behaviour verified beyond the test suite (say how) — fault-injected a
      fictitious documented flag (`--auth=<mode>`) into `cli.md` and
      confirmed the guard fails with the expected message and file:line,
      then reverted it and confirmed the guard passes again. This exercises
      the actual failure path, not just the unit tests of its helpers.
- [x] Documentation updated, or no user-facing change — no user-facing
      change. This is repository-internal tooling (a guard under `guards/`),
      not a documented product feature; nothing in `apps/docs` describes
      guard internals.
